### PR TITLE
set everything up to use a private gitops repo that lacks glue code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ hack-kind-up:
 		--values hack/argo-cd-config/values.yaml \
 		--wait \
 		--timeout 300s
+	kubectl apply -f hack/argo-cd-apps/repositories.yaml
 	kubectl apply -f hack/argo-cd-apps/apps.yaml
 
 .PHONY: hack-kind-down

--- a/charts/k8sta/values.yaml
+++ b/charts/k8sta/values.yaml
@@ -172,7 +172,7 @@ config:
   - name: guestbook
     ## Images pushed to this repository will kick of a deployment that
     ## progresses through the line's environments.
-    imageRepository: krancour/guestbook
+    imageRepository: krancour/k8sta-guestbook
     ## Environments are represented by Argo CD Application resources. Those
     ## resources can be located in this namespace.
     namespace: argocd

--- a/hack/argo-cd-apps/apps.yaml
+++ b/hack/argo-cd-apps/apps.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/krancour/akuity-guestbook-deploy
+    repoURL: https://github.com/akuityio/k8sta-guestbook-deploy
     targetRevision: env/dev
     path: .
   destination:
@@ -29,7 +29,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/krancour/akuity-guestbook-deploy
+    repoURL: https://github.com/akuityio/k8sta-guestbook-deploy
     targetRevision: env/stage
     path: .
   destination:
@@ -50,7 +50,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/krancour/akuity-guestbook-deploy
+    repoURL: https://github.com/akuityio/k8sta-guestbook-deploy
     targetRevision: env/prod
     path: .
   destination:

--- a/hack/argo-cd-apps/repositories.yaml
+++ b/hack/argo-cd-apps/repositories.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: repo-1777030974
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  annotations:
+    managed-by: argocd.argoproj.io
+stringData:
+  type: git
+  project: default
+  url: https://github.com/akuityio/k8sta-guestbook-deploy
+  username: # Use your own GitHub handle here
+  password: # Use your own personal access token here


### PR DESCRIPTION
This PR moves the prototype on from using the normal Akuity Guestbook and its corresponding gitops repo because we _don't_ want all of the automation and bespoke glue code (GitHub Actions) that is included there. We use private forks of those instead wherein all of the glue has been stripped away.