### PR TITLE
assume argocd and k8sta live in the same namespace

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,16 +7,6 @@ if 'ENABLE_NGROK_EXTENSION' in os.environ and os.environ['ENABLE_NGROK_EXTENSION
 
 trigger_mode(TRIGGER_MODE_MANUAL)
 
-load('ext://namespace', 'namespace_create')
-namespace_create('k8sta')
-k8s_resource(
-  new_name = 'common',
-  objects = [
-    'k8sta:namespace'
-  ],
-  labels = ['k8sta']
-)
-
 docker_build(
   'akuity/k8sta',
   '.',
@@ -40,8 +30,8 @@ k8s_resource(
 k8s_resource(
   workload = 'server',
   objects = [
-    'k8sta-server:clusterrole',
-    'k8sta-server:clusterrolebinding',
+    'k8sta-server:role',
+    'k8sta-server:rolebinding',
     'k8sta-server:serviceaccount',
     'k8sta-server-config:secret'
   ]
@@ -54,8 +44,8 @@ k8s_resource(
 k8s_resource(
   workload = 'controller',
   objects = [
-    'k8sta-controller:clusterrole',
-    'k8sta-controller:clusterrolebinding',
+    'k8sta-controller:role',
+    'k8sta-controller:rolebinding',
     'k8sta-controller:serviceaccount'
   ]
 )
@@ -72,7 +62,7 @@ k8s_yaml(
   helm(
     './charts/k8sta',
     name = 'k8sta',
-    namespace = 'k8sta',
+    namespace = 'argocd',
     set = [
       'controller.logLevel=DEBUG',
       'server.logLevel=DEBUG',

--- a/charts/k8sta/templates/controller/cluster-role-binding.yaml
+++ b/charts/k8sta/templates/controller/cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "k8sta.controller.fullname" . }}
   labels:
@@ -7,7 +7,7 @@ metadata:
     {{- include "k8sta.server.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "k8sta.controller.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/charts/k8sta/templates/controller/cluster-role.yaml
+++ b/charts/k8sta/templates/controller/cluster-role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.installGlobalResources }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "k8sta.controller.fullname" . }}
   labels:

--- a/charts/k8sta/templates/controller/deployment.yaml
+++ b/charts/k8sta/templates/controller/deployment.yaml
@@ -28,9 +28,7 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.controller.logLevel }}
-        - name: ARGOCD_NAMESPACE
-          value: {{ .Values.argocd.namespace }}
-        - name: K8STA_NAMESPACE
+        - name: NAMESPACE
           value: {{ .Release.Namespace }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}

--- a/charts/k8sta/templates/server/cluster-role-binding.yaml
+++ b/charts/k8sta/templates/server/cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "k8sta.server.fullname" . }}
   labels:
@@ -7,7 +7,7 @@ metadata:
     {{- include "k8sta.server.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "k8sta.server.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/charts/k8sta/templates/server/cluster-role.yaml
+++ b/charts/k8sta/templates/server/cluster-role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.installGlobalResources }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "k8sta.server.fullname" . }}
   labels:

--- a/charts/k8sta/templates/server/deployment.yaml
+++ b/charts/k8sta/templates/server/deployment.yaml
@@ -73,9 +73,7 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.server.logLevel }}
-        - name: ARGOCD_NAMESPACE
-          value: {{ .Values.argocd.namespace }}
-        - name: K8STA_NAMESPACE
+        - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: TLS_ENABLED
           value: {{ quote .Values.server.tls.enabled }}

--- a/charts/k8sta/values.yaml
+++ b/charts/k8sta/values.yaml
@@ -16,10 +16,6 @@ rbac:
   ## already exist.
   installGlobalResources: true
 
-argocd:
-  ## The namespace into which Argo CD has been installed
-  namespace: argocd
-
 ## All settings for the server component
 server:
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -45,8 +45,9 @@ func RunController(ctx context.Context, config config.Config) error {
 	mgr, err := ctrl.NewManager(
 		mgrConfig,
 		ctrl.Options{
-			Scheme: scheme,
-			Port:   9443,
+			Namespace: config.Namespace,
+			Scheme:    scheme,
+			Port:      9443,
 		},
 	)
 	if err != nil {
@@ -58,8 +59,8 @@ func RunController(ctx context.Context, config config.Config) error {
 		return errors.Wrap(err, "error obtaining Kubernetes client")
 	}
 	argoDB := db.NewDB(
-		config.ArgoCDNamespace,
-		settings.NewSettingsManager(ctx, kubeClient, config.ArgoCDNamespace),
+		config.Namespace,
+		settings.NewSettingsManager(ctx, kubeClient, config.Namespace),
 		kubeClient,
 	)
 

--- a/config.go
+++ b/config.go
@@ -13,13 +13,6 @@ func k8staConfig() (config.Config, error) {
 		log.ParseLevel(os.GetEnvVar("LOG_LEVEL", "INFO")); err != nil {
 		return config, err
 	}
-	if config.ArgoCDNamespace, err =
-		os.GetRequiredEnvVar("ARGOCD_NAMESPACE"); err != nil {
-		return config, err
-	}
-	if config.K8sTANamespace, err =
-		os.GetRequiredEnvVar("K8STA_NAMESPACE"); err != nil {
-		return config, err
-	}
-	return config, nil
+	config.Namespace, err = os.GetRequiredEnvVar("NAMESPACE")
+	return config, err
 }

--- a/config_test.go
+++ b/config_test.go
@@ -26,37 +26,25 @@ func TestK8sTAConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "ARGOCD_NAMESPACE not set",
+			name: "NAMESPACE not set",
 			setup: func() {
 				t.Setenv("LOG_LEVEL", "INFO")
 			},
 			assertions: func(_ config.Config, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
-				require.Contains(t, err.Error(), "ARGOCD_NAMESPACE")
-			},
-		},
-		{
-			name: "K8STA_NAMESPACE not set",
-			setup: func() {
-				t.Setenv("ARGOCD_NAMESPACE", "argocd")
-			},
-			assertions: func(_ config.Config, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "value not found for")
-				require.Contains(t, err.Error(), "K8STA_NAMESPACE")
+				require.Contains(t, err.Error(), "NAMESPACE")
 			},
 		},
 		{
 			name: "success",
 			setup: func() {
-				t.Setenv("K8STA_NAMESPACE", "k8sta")
+				t.Setenv("NAMESPACE", "argocd")
 			},
 			assertions: func(config config.Config, err error) {
 				require.NoError(t, err)
 				require.Equal(t, log.InfoLevel, config.LogLevel)
-				require.Equal(t, "argocd", config.ArgoCDNamespace)
-				require.Equal(t, "k8sta", config.K8sTANamespace)
+				require.Equal(t, "argocd", config.Namespace)
 			},
 		},
 	}

--- a/hack/k8sta-lines/lines.yaml
+++ b/hack/k8sta-lines/lines.yaml
@@ -2,7 +2,7 @@ apiVersion: k8sta.akuity.io/v1alpha1
 kind: Line
 metadata:
   name: guestbook
-  namespace: k8sta
+  namespace: argocd
 imageRepositories:
 - krancour/k8sta-guestbook
 environments:

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -3,7 +3,6 @@ package config
 import log "github.com/sirupsen/logrus"
 
 type Config struct {
-	LogLevel        log.Level
-	ArgoCDNamespace string
-	K8sTANamespace  string
+	LogLevel  log.Level
+	Namespace string
 }

--- a/internal/controller/tickets.go
+++ b/internal/controller/tickets.go
@@ -52,14 +52,6 @@ func NewTicketReconciler(
 	t.execCommandFn = t.execCommand
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.Ticket{}).WithEventFilter(predicate.Funcs{
-		CreateFunc: func(event event.CreateEvent) bool {
-			// We're only interested if it's in the right namespace
-			return event.Object.GetNamespace() == t.config.K8sTANamespace
-		},
-		UpdateFunc: func(event event.UpdateEvent) bool {
-			// We're only interested if it's in the right namespace
-			return event.ObjectNew.GetNamespace() == t.config.K8sTANamespace
-		},
 		DeleteFunc: func(event.DeleteEvent) bool {
 			// We're not interested in any deletes
 			return false
@@ -111,7 +103,7 @@ func (t *TicketReconciler) Reconcile(
 	if err := t.client.Get(
 		ctx,
 		client.ObjectKey{
-			Namespace: t.config.K8sTANamespace,
+			Namespace: t.config.Namespace,
 			Name:      ticket.Spec.Line,
 		},
 		&line,
@@ -169,7 +161,7 @@ func (t *TicketReconciler) Reconcile(
 	if err := t.client.Get(
 		ctx,
 		client.ObjectKey{
-			Namespace: t.config.ArgoCDNamespace,
+			Namespace: t.config.Namespace,
 			Name:      env,
 		},
 		&app,

--- a/internal/dockerhub/service.go
+++ b/internal/dockerhub/service.go
@@ -72,7 +72,7 @@ func (s *service) Handle(
 		ticket := api.Ticket{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      uuid.NewV4().String(),
-				Namespace: s.config.K8sTANamespace,
+				Namespace: s.config.Namespace,
 			},
 			Spec: api.TicketSpec{
 				Line: line.Name,
@@ -116,7 +116,7 @@ func (s *service) getLinesByImageRepo(
 	if err := s.controllerRuntimeClient.List(
 		ctx, &lines,
 		&client.ListOptions{
-			Namespace: s.config.K8sTANamespace,
+			Namespace: s.config.Namespace,
 		},
 	); err != nil {
 		return subscribedLines, errors.Wrap(err, "error retrieving Lines")


### PR DESCRIPTION
This just makes more sense given that my intention was always for a single K8sTA to complement a single Argo CD and an Argo CD instance always (currently) keeps all of its resources in a single namespace.

This also cuts down on some complexity _and_ the level of permissions that K8sTA requires.

