### PR TITLE
index Tickets by associated Argo CD Applications

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -64,8 +64,13 @@ func RunController(ctx context.Context, config config.Config) error {
 		kubeClient,
 	)
 
-	if err := controller.SetupWithManager(config, mgr, argoDB); err != nil {
-		return errors.Wrap(err, "error creating Ticket reconciler")
+	if err := controller.SetupTicketReconcilerWithManager(
+		ctx,
+		config,
+		mgr,
+		argoDB,
+	); err != nil {
+		return errors.Wrap(err, "error setting up Ticket reconciler")
 	}
 
 	return errors.Wrap(


### PR DESCRIPTION
This allows us to trigger Ticket reconciliation every time the state of an associated Argo CD Application changes.

Eventually, this is how we'll come to know that the changes represented by a Ticket have progressed farther down the line.

There's an open question of how to keep the index up to date.