### PR TITLE
make it so promotion logic isn't a critical section

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,17 +41,12 @@ FROM alpine:3.15.4 as final
 RUN apk update \
     && apk add git openssh-client \
     && addgroup -S -g 65532 nonroot \
-    && adduser -S -D -u 65532 -g nonroot -G nonroot nonroot
+    && adduser -S -D -H -u 65532 -g nonroot -G nonroot nonroot
 
-COPY --chown=nonroot:nonroot cmd/controller/ssh_config /home/nonroot/.ssh/config
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/
 COPY --from=builder /usr/local/bin/ytt /usr/local/bin/
 COPY --from=builder /k8sta/bin/ /usr/local/bin/
 
 USER nonroot
-
-RUN git config --global credential.helper store \
-    && git config --global user.name k8sta \
-    && git config --global user.email k8sta@akuity.io
 
 CMD ["/usr/local/bin/k8sta"]

--- a/cmd/controller/ssh_config
+++ b/cmd/controller/ssh_config
@@ -1,3 +1,0 @@
-Host *
-   StrictHostKeyChecking no
-   UserKnownHostsFile=/dev/null

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect

--- a/internal/controller/tickets.go
+++ b/internal/controller/tickets.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	argocd "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/db"
@@ -35,8 +34,6 @@ type ticketReconciler struct {
 	client client.Client
 	argoDB db.ArgoDB
 	logger *log.Logger
-	// Promotions are a critical section of the code
-	promoMutex sync.Mutex
 }
 
 // SetupTicketReconcilerWithManager initializes a reconciler for Ticket


### PR DESCRIPTION
Promotion logic was a critical section of code because we had to mess with files in the home directory in order to make authentication options work with the git CLI. No good.

This PR improves all that by making a temporary home directory for every promotion.