### PR TITLE
add suspended status for tickets

### DIFF
--- a/api/v1alpha1/ticket_types.go
+++ b/api/v1alpha1/ticket_types.go
@@ -20,6 +20,11 @@ const (
 	// TicketStateProgressing is a constant representing a Ticket whose change
 	// is already being progressed through a series of Stations.
 	TicketStateProgressing TicketState = "Progressing"
+	// TicketStateSuspended is a constant representing a Ticket whose change was
+	// being progressed through a series of Stations, but has stalled, probably
+	// temporarily, because all Argo CD applications that the change is currently
+	// being applied to are themselves in a Suspended state..
+	TicketStateSuspended TicketState = "Suspended"
 )
 
 // TicketStatus defines the observed state of Ticket


### PR DESCRIPTION
Fixes #44 

This PR makes it so that a `Ticket` transitions to a `Suspended` state if progress is blocked by one or more Argo CD `Application`s that are, themselves, in a `Suspended` state.