### PR TITLE
remove permission to access configmaps

### DIFF
--- a/charts/k8sta/templates/controller/role.yaml
+++ b/charts/k8sta/templates/controller/role.yaml
@@ -10,7 +10,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - secrets
   verbs:
   - get


### PR DESCRIPTION
This PR removes a phantom remnant of the very earliest iteration wherein `Track` configuration was stored in a `ConfigMap` instead of a CRD.