### PR TITLE
first commit aimed at adding ytt support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN curl -L -o /tmp/kustomize.tar.gz \
       https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz \
     && tar xvfz /tmp/kustomize.tar.gz -C /usr/local/bin
 
+ARG YQ_VERSION=v4.27.3
+RUN curl -L -o /usr/local/bin/yq \
+    https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} \
+    && chmod 755 /usr/local/bin/yq
+
 ARG YTT_VERSION=v0.41.1
 RUN curl -L -o /usr/local/bin/ytt \
       https://github.com/vmware-tanzu/carvel-ytt/releases/download/${YTT_VERSION}/ytt-linux-${TARGETARCH} \
@@ -44,6 +49,7 @@ RUN apk update \
     && adduser -S -D -H -u 65532 -g nonroot -G nonroot nonroot
 
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/
+COPY --from=builder /usr/local/bin/yq /usr/local/bin/
 COPY --from=builder /usr/local/bin/ytt /usr/local/bin/
 COPY --from=builder /k8sta/bin/ /usr/local/bin/
 

--- a/internal/controller/promotion.go
+++ b/internal/controller/promotion.go
@@ -122,18 +122,19 @@ func (t *ticketReconciler) promoteViaRenderedYAMLBranch(
 			if err := renderStrategy.SetImage(appDir, image); err != nil {
 				return "", err
 			}
-			logger.Debug("ran kustomize edit set image")
+			logger.Debug("set image")
 		}
 	}
 
 	// Render Application-specific YAML
+	baseDir := filepath.Join(repo.WorkingDir(), "base")
 	// TODO: We may need to buffer this or use a file instead because the rendered
 	// YAML could be quite large.
-	yamlBytes, err := renderStrategy.Build(appDir)
+	yamlBytes, err := renderStrategy.Build(baseDir, appDir)
 	if err != nil {
 		return "", err
 	}
-	logger.Debug("ran kustomize build")
+	logger.Debug("built configuration")
 
 	// Only do this for image changes
 	if ticket.Change.NewImages != nil {

--- a/internal/controller/render.go
+++ b/internal/controller/render.go
@@ -7,5 +7,5 @@ type RenderStrategy interface {
 	// TODO: Document this
 	SetImage(dir string, image api.Image) error
 	// TODO: Document this
-	Build(dir string) ([]byte, error)
+	Build(baseDir, envDir string) ([]byte, error)
 }

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -35,13 +35,13 @@ func (r *RenderStrategy) SetImage(dir string, image api.Image) error {
 
 // Build runs `kustomize build` in the specified directory and returns an array
 // of bytes containing the fully rendered YAML.
-func (r *RenderStrategy) Build(dir string) ([]byte, error) {
+func (r *RenderStrategy) Build(_, envDir string) ([]byte, error) {
 	cmd := exec.Command("kustomize", "build")
-	cmd.Dir = dir
+	cmd.Dir = envDir
 	yamlBytes, err := cmd.Output()
 	return yamlBytes, errors.Wrapf(
 		err,
 		"error running kustomize build in directory %q",
-		dir,
+		envDir,
 	)
 }

--- a/internal/ytt/ytt.go
+++ b/internal/ytt/ytt.go
@@ -1,0 +1,47 @@
+package ytt
+
+import (
+	"fmt"
+	"os/exec"
+
+	api "github.com/akuityio/k8sta/api/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// TODO: Document this
+type RenderStrategy struct{}
+
+// SetImage runs `yq eval --inplace ...` in the specified directory.
+func (r *RenderStrategy) SetImage(dir string, image api.Image) error {
+	cmd := exec.Command( // nolint: gosec
+		"yq",
+		"eval",
+		"--inplace",
+		fmt.Sprintf(
+			`.images["%s"]="%s:%s"`,
+			image.Repo,
+			image.Repo,
+			image.Tag,
+		),
+		"values.yaml",
+	)
+	cmd.Dir = dir
+	return errors.Wrapf(
+		cmd.Run(),
+		"error running `yq eval ...` in directory %q",
+		dir,
+	)
+}
+
+// Build runs `ytt` to combine templated base configuration from baseDir with
+// values from the overlay in envDir and returns an array of bytes containing
+// the fully rendered YAML.
+func (r *RenderStrategy) Build(baseDir, envDir string) ([]byte, error) {
+	cmd := exec.Command("ytt", "--file", baseDir, "--file", envDir)
+	yamlBytes, err := cmd.Output()
+	return yamlBytes, errors.Wrapf(
+		err,
+		"error running `%s`",
+		cmd.String(),
+	)
+}


### PR DESCRIPTION
This PR adds a working ytt-based implementation of the `RenderStrategy` interface used by the controller.

What is still missing is a way to actually tell K8sTA which config management tool you use. That will come in a follow-up PR. It might even be reasonable to intelligently _infer_ which of kustomize or ytt should be used.