### PR TITLE
switch to new toolset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
     - main
 
 env:
+  DEV_IMAGE_NAME: ghcr.io/akuityio/k8sta-tools:v0.2.0
   IMAGE_NAME: krancour/k8sta
 
 jobs:
@@ -16,7 +17,10 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: brigadecore/go-tools:v0.8.0
+      image: ghcr.io/akuityio/k8sta-tools:v0.2.0
+      credentials:
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
       env:
         SKIP_DOCKER: 'true'
     steps:
@@ -28,7 +32,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: brigadecore/go-tools:v0.8.0
+      image: ghcr.io/akuityio/k8sta-tools:v0.2.0
+      credentials:
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
       env:
         SKIP_DOCKER: 'true'
     steps:
@@ -40,7 +47,10 @@ jobs:
   lint-chart:
     runs-on: ubuntu-latest
     container:
-      image: brigadecore/helm-tools:v0.4.0
+      image: ghcr.io/akuityio/k8sta-tools:v0.2.0
+      credentials:
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
       env:
         SKIP_DOCKER: 'true'
     steps:
@@ -57,11 +67,12 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Login to Docker Hub
+    - name: Login to GHCR
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
     - name: Multiarch build
       uses: docker/build-push-action@v3
       with:
@@ -72,11 +83,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Login to Docker Hub
+    - name: Login to GHCR
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
     - name: Single arch build
       id: build
       uses: docker/build-push-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,12 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Login to Docker Hub
+    - name: Login to GHCR
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: Docker meta
@@ -38,15 +39,18 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         push: true
 
+  # TODO: Publish the chart
+
   publish-sbom:
     needs: push
     runs-on: ubuntu-latest
     steps:
-    - name: Login to Docker Hub
+    - name: Login to GHCR
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ secrets.GH_USERNAME }}
+        password: ${{ secrets.GH_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: Docker meta

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode/
+charts/k8sta/*.tgz
 coverage.txt
-bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
+FROM --platform=$BUILDPLATFORM ghcr.io/akuityio/k8sta-tools:v0.2.0 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/charts/k8sta/crds/k8sta.akuity.io_tickets.yaml
+++ b/charts/k8sta/crds/k8sta.akuity.io_tickets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: tickets.k8sta.akuity.io
 spec:

--- a/charts/k8sta/crds/k8sta.akuity.io_tracks.yaml
+++ b/charts/k8sta/crds/k8sta.akuity.io_tracks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: tracks.k8sta.akuity.io
 spec:

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -2,6 +2,7 @@ run:
   concurrency: 1
   deadline: 10m
   skip-files:
+  - api/.*/groupversion_info.go
 
 linters:
   disable-all: true


### PR DESCRIPTION
* Use `ghcr.io/akuityio/k8sta-tools:v0.2.0`:
    * As base image 
    * In `Makefile` (can be disabled if you don't want to run targets in a container)
    * In actions
* Fix linting issue (due to newer linter version in `ghcr.io/akuityio/k8sta-tools:v0.2.0`)
* Streamline the `Makefile`
    * Remove targets that developers have no reason to run (i.e. things that _only_ ever need to happen during CI)
    * Optimize what's left