### PR TITLE
ci: remove scanning job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,31 +85,8 @@ jobs:
         registry: ghcr.io
         username: ${{ secrets.GH_USERNAME }}
         password: ${{ secrets.GH_TOKEN }}
-    - name: Multiarch build
+    - name: Build
       uses: docker/build-push-action@v3
       with:
         platforms: linux/amd64,linux/arm64
         push: false
-
-  scan:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
-    - name: Single arch build
-      id: build
-      uses: docker/build-push-action@v3
-      with:
-        push: false
-        load: true
-    - name: Scan image
-      uses: anchore/scan-action@v3
-      with:
-        image: ${{ steps.build.outputs.imageid }}
-        output-format: table
-      continue-on-error: true


### PR DESCRIPTION
Generating and publishing SBOMs during release is useful, but scanning images during CI is less so.

1. A good registry can scan images for us
2. We were treating the results as informational only anyway-- i.e. they were configured to not fail CI