### PR TITLE
ci and release: use docker layer cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,3 +90,5 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64
         push: false
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,8 @@ jobs:
           VERSION=${{ github.ref_name }}
         tags: ${{ steps.meta.outputs.tags }}
         push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Sign image
       env:
         TAGS: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Signed-off-by: Kent <kent.rancourt@gmail.com>