### PR TITLE
chart: add image pull secret

### DIFF
--- a/charts/k8sta/templates/common/image-pull-secret.yaml
+++ b/charts/k8sta/templates/common/image-pull-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "k8sta.fullname" . }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7InVzZXJuYW1lIjoia3JhbmNvdXIiLCJwYXNzd29yZCI6ImdocF90TklzMEFJTDQwTEVQOVk4U2p2R051VXZJRXhoQjgxUnd6cGgiLCJhdXRoIjoiYTNKaGJtTnZkWEk2WjJod1gzUk9TWE13UVVsTU5EQk1SVkE1V1RoVGFuWkhUblZWZGtsRmVHaENPREZTZDNwd2FBPT0ifX19

--- a/charts/k8sta/templates/controller/deployment.yaml
+++ b/charts/k8sta/templates/controller/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         {{- include "k8sta.controller.labels" . | nindent 8 }}
     spec:
       serviceAccount: {{ include "k8sta.controller.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "k8sta.fullname" . }}-image-pull-secret
       containers:
       - name: controller
         image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}

--- a/charts/k8sta/templates/server/deployment.yaml
+++ b/charts/k8sta/templates/server/deployment.yaml
@@ -65,6 +65,8 @@ spec:
         {{- end }}
     spec:
       serviceAccount: {{ include "k8sta.server.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "k8sta.fullname" . }}-image-pull-secret
       containers:
       - name: server
         image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}


### PR DESCRIPTION
This PR temporarily adds an image pull secret to the chart.

This source code repo and the chart repo are both private, so this secret isn't being made public.

When this source code repo and/or the chart repo are made public, this secret won't be needed anymore. It can be removed and the corresponding PAT revoked.