### PR TITLE
docs: move the code of conduct to the docs site [skip ci]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of conduct
+
+See https://docs-k8sta-akuity-io.netlify.app/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# K8sTA contribution guide
+# K8sTA contributor guide
 
 See https://docs-k8sta-akuity-io.netlify.app/contributor-guide/

--- a/README.md
+++ b/README.md
@@ -155,4 +155,4 @@ To report an issue, request a feature, or ask a question, please open an issue
 ## Code of Conduct
 
 Participation in the K8sTA project is governed by the
-[Contributor Covenant Code of Conduct](metadocs/CODE_OF_CONDUCT.md).
+[Contributor Covenant Code of Conduct](https://docs-k8sta-akuity-io.netlify.app/code-of-conduct/).

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -1,3 +1,8 @@
+---
+title: Code of conduct
+description: Code of conduct
+---
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge


### PR DESCRIPTION
Signed-off-by: Kent <kent.rancourt@gmail.com>