### PR TITLE
add bookkeeper server

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -32,6 +32,7 @@ docker_build(
 k8s_resource(
   workload = 'k8sta-bookkeeper-server',
   new_name = 'bookkeeper-server',
+  port_forwards = '30083:8080',
   labels = ['k8sta']
 )
 k8s_resource(
@@ -88,6 +89,9 @@ k8s_yaml(
     name = 'k8sta',
     namespace = 'k8sta',
     set = [
+      'bookkeeper.server.logLevel=DEBUG',
+      'bookkeeper.server.service.type=NodePort',
+      'bookkeeper.server.service.nodePort=30083',
       'bookkeeper.server.tls.enabled=false',
       'controller.logLevel=DEBUG',
       'server.logLevel=DEBUG',

--- a/charts/k8sta/values.yaml
+++ b/charts/k8sta/values.yaml
@@ -17,10 +17,10 @@ rbac:
   installGlobalResources: true
 
 
-## All settings for BookKeeper
+## All settings for Bookkeeper
 bookkeeper:
 
-  ## All settings for the BookKeeper server component
+  ## All settings for the Bookkeeper server component
   server:
 
     replicas: 1

--- a/cmd/bookkeeper/server.go
+++ b/cmd/bookkeeper/server.go
@@ -32,13 +32,14 @@ func RunServer(ctx context.Context, config config.Config) error {
 		"commit":  version.GitCommit,
 		"port":    serverConfig.Port,
 		"tls":     tlsStatus,
-	}).Info("Starting BookKeeper Server")
+	}).Info("Starting Bookkeeper Server")
 
 	router := mux.NewRouter()
 	router.StrictSlash(true)
 	router.Handle(
-		"/",
+		"/v1alpha1",
 		bookkeeper.NewHandler(
+			config,
 			bookkeeper.NewService(config),
 		),
 	).Methods(http.MethodPost)

--- a/hack/kind/cluster.yaml
+++ b/hack/kind/cluster.yaml
@@ -6,11 +6,11 @@ registry: k8sta-dev-registry
 kindV1Alpha4Cluster:
   nodes:
   - extraPortMappings:
-    - containerPort: 30080
+    - containerPort: 30080 # Istio HTTP
       hostPort: 30080
-    - containerPort: 30081
+    - containerPort: 30081 # Argo CD
       hostPort: 30081
-    - containerPort: 30082
+    - containerPort: 30082 # K8sTA Server
       hostPort: 30082
-    - containerPort: 30443
-      hostPort: 30443
+    - containerPort: 30083 # Bookkeeper Server
+      hostPort: 30083

--- a/internal/bookkeeper/handler.go
+++ b/internal/bookkeeper/handler.go
@@ -1,7 +1,12 @@
 package bookkeeper
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+
+	"github.com/akuityio/k8sta/internal/common/config"
+	log "github.com/sirupsen/logrus"
 )
 
 // handler is an implementation of the http.Handler interface that can handle
@@ -9,26 +14,75 @@ import (
 // interface.
 type handler struct {
 	service Service
+	logger  *log.Logger
 }
 
 // NewHandler returns an implementation of the http.Handler interface that can
 // handle HTTP-based bookkeeping requests by delegating to a transport-agnostic
 // Service interface.
-func NewHandler(service Service) http.Handler {
-	return &handler{
+func NewHandler(config config.Config, service Service) http.Handler {
+	h := &handler{
 		service: service,
+		logger:  log.New(),
 	}
+	h.logger.SetLevel(config.LogLevel)
+	return h
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
+
 	w.Header().Set("Content-Type", "application/json")
-	// TODO: Get some payload and send it to the service
-	if err := h.service.Handle(r.Context()); err != nil {
+
+	var logger = h.logger.WithFields(log.Fields{})
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		// We're going to assume this is because the request body is missing and
+		// treat it as a bad request.
+		logger.Infof("Error reading request body: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		// nolint: errcheck
+		w.Write([]byte(`{"status": "error reading request body"}`))
+		return
+	}
+
+	req := Request{}
+	if err = json.Unmarshal(bodyBytes, &req); err != nil {
+		// The request body must be malformed.
+		logger.Infof("Error unmarshaling request body: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		// nolint: errcheck
+		w.Write([]byte(`{"status": "error unmarshaling request body"}`))
+		return
+	}
+
+	// TODO: We should apply some kind of request body validation
+
+	// Now that we have details from the request body, we can attach some more
+	// context to the logger.
+	logger = logger.WithFields(log.Fields{
+		"repo":         req.RepoURL,
+		"path":         req.Path,
+		"targetBranch": req.TargetBranch,
+	})
+
+	res, err := h.service.Handle(r.Context(), req)
+	if err != nil {
+		logger.Errorf("Error handling request: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(`{"status": "internal server error"}`)) // nolint: errcheck
 		return
 	}
+
+	resBytes, err := json.Marshal(res)
+	if err != nil {
+		logger.Errorf("Error marshaling response: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"status": "internal server error"}`)) // nolint: errcheck
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status": "success"}`)) // nolint: errcheck
+	w.Write(resBytes) // nolint: errcheck
 }

--- a/internal/bookkeeper/service.go
+++ b/internal/bookkeeper/service.go
@@ -2,17 +2,80 @@ package bookkeeper
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/akuityio/k8sta/internal/common/config"
+	"github.com/akuityio/k8sta/internal/git"
+	"github.com/akuityio/k8sta/internal/helm"
+	"github.com/akuityio/k8sta/internal/kustomize"
+	"github.com/akuityio/k8sta/internal/ytt"
 )
+
+// Request is a request for Bookkeeper to render some environment-specific
+// configuration from the repository specified by RepoURL into plain YAML in an
+// environment-specific branch.
+type Request struct {
+	// RepoURL is the URL of a remote GitOps repository.
+	RepoURL string `json:"repoURL,omitempty"`
+	// RepoCreds encapsulates read/write credentials for the remote GitOps
+	// repository referenced by the RepoURL field.
+	RepoCreds git.RepoCredentials `json:"repoCreds,omitempty"`
+	// Path is the path to a directory in the GitOps repository referenced by the
+	// RepoURL field which contains environment-specific configuration.
+	Path string `json:"path,omitempty"`
+	// TargetBranch is the name of an environment-specific branch in the GitOps
+	// repository referenced by the RepoURL field into which plain YAML should be
+	// rendered.
+	TargetBranch string `json:"targetBranch,omitempty"`
+	// ConfigManagement encapsulates details of which configuration management
+	// tool is to be used and, if applicable, configuration options for the
+	// selected tool.
+	ConfigManagement ConfigManagementConfig `json:"configManagement,omitempty"`
+}
+
+type ConfigManagementConfig struct {
+	// Helm encapsulates optional Helm configuration options.
+	Helm *HelmConfig `json:"helm,omitempty"`
+	// Kustomize encapsulates optional Kustomize configuration options.
+	Kustomize *KustomizeConfig `json:"kustomize,omitempty"`
+	// Ytt encapsulates optional ytt configuration options.
+	Ytt *YttConfig `json:"ytt,omitempty"`
+}
+
+// HelmConfig encapsulates optional Helm configuration options.
+type HelmConfig struct {
+	// ReleaseName specified the release name that will be used when running
+	// `helm template <release name> <chart> --values <values>`
+	ReleaseName string `json:"releaseName,omitempty"`
+}
+
+// KustomizeConfig encapsulates optional Kustomize configuration options.
+type KustomizeConfig struct {
+}
+
+// YttConfig encapsulates optional ytt configuration options.
+type YttConfig struct {
+}
+
+// Response encapsulates details of a successful rendering of some some
+// environment-specific configuration into plain YAML in an environment-specific
+// branch.
+type Response struct {
+	// CommitID is the ID (sha) of the commit to the environment-specific branch
+	// containing the rendered configuration.
+	CommitID string `json:"commitID,omitempty"`
+}
 
 // Service is an interface for components that can handle bookkeeping requests.
 // Implementations of this interface are transport-agnostic.
 type Service interface {
 	// Handle handles a bookkeeping request.
-	Handle(context.Context) error
+	Handle(context.Context, Request) (Response, error)
 }
 
 type service struct {
@@ -29,7 +92,245 @@ func NewService(config config.Config) Service {
 	return s
 }
 
-// TODO: Implement this
-func (s *service) Handle(ctx context.Context) error {
+func (s *service) Handle(ctx context.Context, req Request) (Response, error) {
+	logger := s.logger.WithFields(
+		log.Fields{
+			"repo":         req.RepoURL,
+			"path":         req.Path,
+			"targetBranch": req.TargetBranch,
+		},
+	)
+
+	res := Response{}
+
+	repo, err := git.Clone(ctx, req.RepoURL, req.RepoCreds)
+	if err != err {
+		return res, errors.Wrap(err, "error cloning remote repository")
+	}
+	defer repo.Close()
+
+	baseDir := filepath.Join(repo.WorkingDir(), "base")
+	envDir := filepath.Join(repo.WorkingDir(), req.Path)
+
+	// Use the caller's preferred config management tool for pre-rendering. Each
+	// strategy needs different args, so we use closures here to provide a
+	// pre-rendering function that takes no args and, instead, closes over
+	// whatever other information it needs.
+	var preRenderFn func() ([]byte, error)
+	if req.ConfigManagement.Helm != nil {
+		preRenderFn = func() ([]byte, error) {
+			return helm.Render(
+				req.ConfigManagement.Helm.ReleaseName,
+				baseDir,
+				envDir,
+			)
+		}
+	} else if req.ConfigManagement.Kustomize != nil {
+		preRenderFn = func() ([]byte, error) {
+			return kustomize.Render(envDir)
+		}
+	} else if req.ConfigManagement.Ytt != nil {
+		preRenderFn = func() ([]byte, error) {
+			return ytt.Render(baseDir, envDir)
+		}
+	} else {
+		return res, errors.New(
+			"no configuration management strategy was specified by the request",
+		)
+	}
+
+	// Ensure the existence of the directory into which we will pre-render
+	// intermediate state
+	bkEnvDir := filepath.Join(repo.WorkingDir(), ".bookkeeper", req.Path)
+	if err = kustomize.EnsurePrerenderDir(bkEnvDir); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error setting up pre-render directory %q",
+			bkEnvDir,
+		)
+	}
+
+	// This is the last commit on the default branch
+	lastCommit, err := repo.LastCommitID()
+	if err != nil {
+		return res, errors.Wrap(
+			err,
+			"error obtaining ID of the last commit to the default branch",
+		)
+	}
+
+	// Pre-render
+	preRenderedBytes, err := preRenderFn()
+	if err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error pre-rendering configuration from %q",
+			envDir,
+		)
+	}
+	logger.Debug("pre-rendered configuration")
+
+	// Write/overwrite the pre-rendered config
+	allPath := filepath.Join(bkEnvDir, "all.yaml")
+	// nolint: gosec
+	if err = os.WriteFile(allPath, preRenderedBytes, 0644); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error writing pre-rendered configuration to %q in the default branch",
+			allPath,
+		)
+	}
+	logger.Debug("wrote pre-rendered configuration to the default branch")
+
+	// Commit pre-rendered config to the local default branch
+	if err = repo.AddAllAndCommit(
+		fmt.Sprintf(
+			"bookkeeper: pre-rendering configuration from %s",
+			lastCommit,
+		),
+	); err != nil {
+		return res, errors.Wrap(
+			err,
+			"error committing pre-rendered configuration to the default branch",
+		)
+	}
+	logger.Debug("committed pre-rendered configuration to the default branch")
+
+	// Push the pre-rendered configuration to the default branch
+	if err = repo.Push(); err != nil {
+		return res, errors.Wrap(
+			err,
+			"error pushing pre-rendered configuration to the default branch",
+		)
+	}
+	logger.Debug("pushed pre-rendered configuration to the default branch")
+
+	// Now take everything the last mile with kustomize and write the
+	// fully-rendered config to a target branch...
+
+	// This is the NEW last commit on the default branch
+	if lastCommit, err = repo.LastCommitID(); err != nil {
+		return res, errors.Wrap(
+			err,
+			"error obtaining ID of the last commit to the default branch",
+		)
+	}
+
+	// Last mile rendering
+	renderedBytes, err := kustomize.Render(bkEnvDir)
+	if err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error rendering configuration from %q",
+			bkEnvDir,
+		)
+	}
+
+	// Switch to the target branch. This means checking out from a remote branch
+	// if it exists or else creating a new orphaned branch.
+	if err = s.switchToTargetBranch(repo, req.TargetBranch); err != nil {
+		return res, errors.Wrap(err, "error switching to target branch")
+	}
+
+	// Remove existing fully-rendered config (or files from the default branch
+	// that were left behind from the default branch when the orphaned target
+	// branch was created)
+	if err = s.deleteAll(repo); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error deleting existing files from %q",
+			repo.WorkingDir(),
+		)
+	}
+	logger.Debug("removed existing fully-rendered configuration")
+
+	// Write the new fully-rendered config to the root of the repo
+	allPath = filepath.Join(repo.WorkingDir(), "all.yaml")
+	// nolint: gosec
+	if err = os.WriteFile(allPath, renderedBytes, 0644); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error writing fully-rendered configuration to %q",
+			allPath,
+		)
+	}
+	logger.Debug("wrote fully-rendered configuration to the target branch")
+
+	// Commit the fully-rendered configuration to the target branch
+	if err = repo.AddAllAndCommit(
+		fmt.Sprintf(
+			"bookkeeper: rendering configuration from %s",
+			lastCommit,
+		),
+	); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error committing fully-rendered configuration to the target branch",
+		)
+	}
+	logger.Debug("committed fully-rendered configuration to the target branch")
+
+	// Push the fully-rendered configuration to the remote target branch
+	if err = repo.Push(); err != nil {
+		return res, errors.Wrap(
+			err,
+			"error pushing fully-rendered configuration to the target branch",
+		)
+	}
+	logger.Debug("pushed fully-rendered configuration to the target branch")
+
+	// Get the ID of the last commit on the target branch
+	if res.CommitID, err = repo.LastCommitID(); err != nil {
+		return res, err
+	}
+	logger.Debug("obtained sha of commit to the target branch")
+	return res, nil
+}
+
+func (s *service) switchToTargetBranch(
+	repo git.Repo,
+	targetBranch string,
+) error {
+	logger := s.logger.WithFields(
+		log.Fields{
+			"repo":         repo.URL(),
+			"targetBranch": targetBranch,
+		},
+	)
+	// Check if the target branch exists on the remote
+	if envBranchExists,
+		err := repo.RemoteBranchExists(targetBranch); err != nil {
+		return errors.Wrap(err, "error checking for existence of target branch")
+	} else if envBranchExists {
+		logger.Debug("target branch exists on remote")
+		if err = repo.Checkout(targetBranch); err != nil {
+			return errors.Wrap(err, "error checking out target branch")
+		}
+		logger.Debug("checked out target branch")
+	} else {
+		logger.Debug("target branch does not exist on remote")
+		if err = repo.CreateOrphanedBranch(targetBranch); err != nil {
+			return errors.Wrap(err, "error creating orphaned target branch")
+		}
+		logger.Debug("created orphaned target branch")
+	}
+	return nil
+}
+
+// deleteAll deletes everything from the working copy of the specified repo
+// EXCEPT the .git directory.
+func (s *service) deleteAll(repo git.Repo) error {
+	files, err := filepath.Glob(filepath.Join(repo.WorkingDir(), "*"))
+	if err != nil {
+		return errors.Wrapf(err, "error listing files in %q", repo.WorkingDir())
+	}
+	for _, file := range files {
+		if _, fileName := filepath.Split(file); fileName == ".git" {
+			continue
+		}
+		if err = os.RemoveAll(file); err != nil {
+			return errors.Wrapf(err, "error deleting %q", file)
+		}
+	}
 	return nil
 }

--- a/internal/controller/promotion.go
+++ b/internal/controller/promotion.go
@@ -79,17 +79,17 @@ func (t *ticketReconciler) promote(
 			baseDir := filepath.Join(repo.WorkingDir(), "base")
 			appDir := filepath.Join(repo.WorkingDir(), app.Spec.Source.TargetRevision)
 			if track.Spec.ConfigManagement.Helm != nil {
-				return helm.PreRender(
+				return helm.Render(
 					track.Spec.ConfigManagement.Helm.ReleaseName,
 					baseDir,
 					appDir,
 				)
 			}
 			if track.Spec.ConfigManagement.Kustomize != nil {
-				return kustomize.PreRender(appDir)
+				return kustomize.Render(appDir)
 			}
 			if track.Spec.ConfigManagement.Ytt != nil {
-				return ytt.PreRender(baseDir, appDir)
+				return ytt.Render(baseDir, appDir)
 			}
 			return nil, errors.Errorf(
 				"no configuration management strategy was specified by Track %q",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -15,13 +15,23 @@ import (
 // RepoCredentials represents the credentials for connecting to a private git
 // repository.
 type RepoCredentials struct {
-	SSHPrivateKey string
-	Username      string
-	Password      string
+	// SSHPrivateKey is a private key that can be used for both reading from and
+	// writing to some remote repository.
+	SSHPrivateKey string `json:"sshPrivateKey,omitempty"`
+	// Username identifies a principal, which combined with the value of the
+	// Password field, can be used for both reading from and writing to some
+	// remote repository.
+	Username string `json:"username,omitempty"`
+	// Password, when combined with the principal identified by the Username
+	// field, can be used for both reading from and writing to some remote
+	// repository.
+	Password string `json:"password,omitempty"`
 }
 
 // Repo is an interface for interacting with a git repository.
 type Repo interface {
+	// URL returns the remote URL of the repository.
+	URL() string
 	// WorkingDir returns an absolute path to the repository's working tree.
 	WorkingDir() string
 	// Checkout checks out the specified branch.
@@ -186,6 +196,10 @@ func (r *repo) clone() error {
 	}
 	r.currentBranch = "HEAD"
 	return nil
+}
+
+func (r *repo) URL() string {
+	return r.url
 }
 
 func (r *repo) WorkingDir() string {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO: Document this
-func PreRender(releaseName, baseDir, envDir string) ([]byte, error) {
+func Render(releaseName, baseDir, envDir string) ([]byte, error) {
 	cmd := exec.Command( // nolint: gosec
 		"helm",
 		"template",

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -74,9 +74,9 @@ func SetImage(dir string, image api.Image) error {
 }
 
 // TODO: Document this
-func PreRender(envDir string) ([]byte, error) {
+func Render(dir string) ([]byte, error) {
 	cmd := exec.Command("kustomize", "build")
-	cmd.Dir = envDir
+	cmd.Dir = dir
 	yamlBytes, err := cmd.Output()
 	return yamlBytes, errors.Wrapf(
 		err,

--- a/internal/ytt/ytt.go
+++ b/internal/ytt/ytt.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TODO: Document this
-func PreRender(baseDir, envDir string) ([]byte, error) {
+func Render(baseDir, envDir string) ([]byte, error) {
 	cmd := exec.Command("ytt", "--file", baseDir, "--file", envDir)
 	yamlBytes, err := cmd.Output()
 	return yamlBytes, errors.Wrapf(


### PR DESCRIPTION
Fixes #111 

Follow-up to #123 

This PR is a _first pass_ at the logic for a very simple "bookkeeper server." It's a stateless server with one endpoint. You POST JSON that looks something like the following and it either gives you back a commit ID or an error.

```json
{
  "repoURL": "https://github.com/krancour/k8sta-demo-deploy",
  "repoCreds": {
    "username": "krancour",
    "password": "<redacted PAT>"
  },
  "path": "env/dev",
  "targetBranch": "env/dev",
  "configManagement": {
    "kustomize": {}
  }
}
```

**_This is not perfect!!!_**

Most of this is lifted-n-shifted from existing K8sTA logic, cleaned up to _not_ know anything about K8sTA `Track`s, Argo CD `Application`s, etc., (i.e. this is purely about git and config management) and then exposed as its own server component. If K8sTA was doing it wrong before, this is still doing it wrong... for example, so far this _only_ commits directly to your GitOps repos and is not yet capable of opening PRs.

I still think this is a massive improvement because it's a big step toward using this sort of functionality internally sooner rather than later.

I will open PRs for follow-ups on a few things:

* Add a client
* Make the rest of K8sTA use the above client (as of right now, the rest of K8sTA isn't using the bookeeper server)
* Create a CLI that uses the above client (this will be a bit more convenient than using `curl`)
* Add ability to open PRs instead of pushing commits directly (GitHub only for now)