### PR TITLE
improve devx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -31,17 +28,12 @@ jobs:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: git config --global url."https://krancour:${GH_TOKEN}@github.com".insteadOf https://github.com
     - name: Run unit tests
-      env:
-        SKIP_DOCKER: 'true'
       run: make test-unit
 
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -55,18 +47,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: git config --global url."https://krancour:${GH_TOKEN}@github.com".insteadOf https://github.com
+    - name: Install linter
+      run: |
+        cd /usr/local/bin
+        curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v1.49.0/golangci-lint-1.49.0-linux-amd64.tar.gz \
+          | tar xvz golangci-lint-1.49.0-linux-amd64/golangci-lint --strip-components=1
     - name: Run linter
-      env:
-        SKIP_DOCKER: 'true'
       run: make lint
 
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -80,9 +72,9 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: git config --global url."https://krancour:${GH_TOKEN}@github.com".insteadOf https://github.com
+    - name: Install controller-gen
+      run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0
     - name: Run Codegen
-      env:
-        SKIP_DOCKER: 'true'
       run: make codegen
     - name: Check nothing has changed
       run: git diff --exit-code -- .
@@ -90,16 +82,16 @@ jobs:
   lint-chart:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Install linter
+      run: |
+        cd /usr/local/bin
+        curl -sSfL https://get.helm.sh/helm-v3.10.0-linux-amd64.tar.gz \
+        | tar xvz linux-amd64/helm --strip-components=1
     - name: Run linter
-      env:
-        SKIP_DOCKER: 'true'
       run: make lint-chart
 
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/akuityio/k8sta-tools:v0.3.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.3-bullseye as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM golang:1.19.3-bullseye
+
+ARG TARGETARCH
+
+ARG CONTROLLER_GEN_VERSION=v0.10.0
+ARG GOLANGCI_LINT_VERSION=1.49.0
+ARG HELM_VERSION=v3.10.0
+
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} \
+    && cd /usr/local/bin \
+    && curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz \
+        | tar xvz golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}/golangci-lint --strip-components=1 \
+    && curl -sSfL https://get.helm.sh/helm-$HELM_VERSION-linux-${TARGETARCH}.tar.gz \
+        | tar xvz linux-${TARGETARCH}/helm --strip-components=1

--- a/docs/docs/40-contributor-guide/10-hacking-on-k8sta.md
+++ b/docs/docs/40-contributor-guide/10-hacking-on-k8sta.md
@@ -14,36 +14,47 @@ successful.
 In order to minimize the setup required to successfully apply small changes and
 in order to reduce the incidence of “it worked on my machine,” wherein changes
 that pass tests locally do not pass the same tests in CI due to environmental
-differences, K8sTA has adopted a “container-first” approach to testing. This
-is to say we have made it the default that unit tests, linters, and a variety of
-other validations, when executed locally, automatically execute in a Docker
-container that is maximally similar to the container in which those same tasks
-will run during the continuous integration process.
+differences, K8sTA has made it trivial to execute tests within a container
+that is maximally similar to the containers that tests execute in during the
+continuous integration process.
 
 To take advantage of this, you only need to have
 [Docker](https://docs.docker.com/engine/install/) and `make` installed.
 
-If you wish to opt-out of tasks automatically running inside a container, you
-can set the environment variable `SKIP_DOCKER` to the value `true`. Doing so
-will require that any tools involved in tasks you execute have been installed
-locally. 
-
-## Working with Go code
-
-If you make modifications to Go code, it is recommended that you run
-corresponding unit tests and linters before opening a PR.
-
 To run all unit tests:
+
+```shell
+make hack-test-unit
+```
+
+:::info
+If you wish to opt-out of executing the tests within a container, use the
+following instead:
 
 ```shell
 make test-unit
 ```
 
+This will require Go to be installed locally.
+:::
+
 To run lint checks:
+
+```shell
+make hack-lint
+```
+
+:::info
+If you wish to opt-out of executing the linter within a container, use the
+following instead:
 
 ```shell
 make lint
 ```
+
+This will require Go and [golangci-lint](https://golangci-lint.run/) to be
+installed locally.
+:::
 
 ## Iterating quickly
 
@@ -51,12 +62,12 @@ This section focuses on the best approaches for gaining rapid feedback on
 changes you make to K8sTA's code base.
 
 By far, the fastest path to learning whether changes you have applied work as
-desired is to execute unit tests as described in previous sections. If, however,
-the changes you are applying are not well-covered by unit tests, it can become
-advantageous to build K8sTA from source, including your changes, and deploy it
-to a live Kubernetes cluster. After doing so, you can test changes manually.
-Under these circumstances, a pressing question is one of how K8sTA can be
-built/re-built and deployed as quickly as possible.
+desired is to execute unit tests as described in the previous section. If,
+however, the changes you are applying are not well-covered by unit tests, it can
+become advantageous to build K8sTA from source, including your changes, and
+deploy it to a live Kubernetes cluster. After doing so, you can test changes
+manually. Under these circumstances, a pressing question is one of how K8sTA can
+be built/re-built and deployed as quickly as possible.
 
 Building and deploying K8sTA as quickly as possible requires minimizing the
 process' dependency on remote systems – including Docker registries and
@@ -66,17 +77,14 @@ cluster is configured such that it can pull images from that local registry. To
 achieve this with minimal effort, you will need to install the latest stable
 versions of:
 
-* [kind](https://kind.sigs.k8s.io/#installation-and-usage): Runs
-  development-grade Kubernetes clusters in Docker.
-
-  :::note
-  If you strongly prefer [k3d](https://k3d.io), please consider opening a PR to
-  add support.
-  :::
+* [kind](https://kind.sigs.k8s.io/#installation-and-usage) OR
+  [k3d](https://k3d.io): Either runs development-grade Kubernetes clusters in
+  Docker.
 
 * [ctlptl](https://github.com/tilt-dev/ctlptl#how-do-i-install-it): Launches
-  development-grade Kubernetes clusters (in kind, for instance) that are
-  pre-connected to a local image registry.
+  development-grade Kubernetes clusters (in kind or k3d) that are pre-connected
+  to a local image registry. (This setup requires greater effort if attempted
+  without `ctlptl`'s help.)
 
 * [Tilt](https://docs.tilt.dev/#macoslinux): Builds components from source and
   deploys them to a development-grade Kubernetes cluster. More importantly, it
@@ -97,6 +105,12 @@ To launch a brand new Kind cluster pre-connected to a local image registry:
 
 ```shell
 make hack-kind-up
+```
+
+Alternatively, use k3d:
+
+```shell
+make hack-k3d-up
 ```
 
 Because K8sTA integrates directly with Argo CD, the above command will _also_
@@ -155,12 +169,12 @@ already-running components.
 
 If you wish to undeploy everything Tilt has deployed for you, use `tilt down`.
 
-To destroy your kind cluster, use `make hack-kind-down`.
+To destroy your kind cluster, use `make hack-kind-down` or `make hack-k3d-down`.
 
 :::info
-`make hack-kind-down` deliberately leaves your local registry
-running so that if you resume work later, you are doing so with a local
-registry that’s already primed with most layers of K8sTA’s image.
+Both `make hack-kind-down` and `make hack-k3d-down` deliberately leave your
+local registry running so that if you resume work later, you are doing so with a
+local registry that’s already primed with most layers of K8sTA’s image.
 
 If you wish to destroy the registry, use:
 
@@ -192,7 +206,7 @@ has built-in support for exposing your local K8sTA server using
 1. Configure any Docker Hub repository you own to deliver webhooks to
    `<ngrok URL>/dockerhub?access_token=insecure-dev-token`.
 
-:::cation
+:::caution
 We cannot guarantee that ngrok will work in all environments, especially if you
 are behind a corporate firewall.
 :::

--- a/hack/k3d/cluster.yaml
+++ b/hack/k3d/cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: k3d-k8sta-dev-cluster
+product: k3d
+registry: k8sta-dev-registry
+k3d:
+  v1alpha4Simple:
+    ports:
+    - port: 30080:30080
+      nodeFilters:
+      - loadbalancer
+    - port: 30081:30081
+      nodeFilters:
+      - loadbalancer
+    - port: 30082:30082
+      nodeFilters:
+      - loadbalancer


### PR DESCRIPTION
This is a bundle of changes that substantially improves devx in a few ways:

1. Recent versions of `ctlptl` work as nicely with k3d as they do with kind, so I've added make targets that launch k3d (via `ctlptl`) with optimal configuration to support local development.

1. Eliminated dependency on private k8sta-tools image. This repo now contains a secondary Dockerfile (`Dockerfile.dev`) for building containerized development tools on-demand.

1. General `Makefile` cleanup

1. Updated contributing docs to accurately reflect above improvements.