### PR TITLE
kustomize/helm promos -- fix undesired diff between commit id and health check commit id

### DIFF
--- a/internal/controller/promotions.go
+++ b/internal/controller/promotions.go
@@ -217,10 +217,9 @@ func (e *environmentReconciler) promoteWithKustomize(
 		//
 		// TODO: This seems correct for zero environment, but it might not hold up
 		// for non-zero environments.
-		if env.Spec.Subscriptions != nil &&
-			env.Spec.Subscriptions.Repos != nil &&
-			env.Spec.Subscriptions.Repos.Git {
-			newState.HealthCheckCommit, err = repo.LastCommitID()
+		if newState.GitCommit != nil {
+			newState.GitCommit.ID, err = repo.LastCommitID()
+			newState.HealthCheckCommit = newState.GitCommit.ID
 		}
 		return newState, errors.Wrap(err, "error getting last commit ID")
 	}
@@ -246,10 +245,9 @@ func (e *environmentReconciler) promoteWithKustomize(
 	//
 	// TODO: This seems correct for zero environment, but it might not hold up
 	// for non-zero environments.
-	if env.Spec.Subscriptions != nil &&
-		env.Spec.Subscriptions.Repos != nil &&
-		env.Spec.Subscriptions.Repos.Git {
-		newState.HealthCheckCommit, err = repo.LastCommitID()
+	if newState.GitCommit != nil {
+		newState.GitCommit.ID, err = repo.LastCommitID()
+		newState.HealthCheckCommit = newState.GitCommit.ID
 	}
 	return newState, errors.Wrap(err, "error getting last commit ID")
 }
@@ -351,10 +349,9 @@ func (e *environmentReconciler) promoteWithHelm(
 		//
 		// TODO: This seems correct for zero environment, but it might not hold up
 		// for non-zero environments.
-		if env.Spec.Subscriptions != nil &&
-			env.Spec.Subscriptions.Repos != nil &&
-			env.Spec.Subscriptions.Repos.Git {
-			newState.HealthCheckCommit, err = repo.LastCommitID()
+		if newState.GitCommit != nil {
+			newState.GitCommit.ID, err = repo.LastCommitID()
+			newState.HealthCheckCommit = newState.GitCommit.ID
 		}
 		return newState, errors.Wrap(err, "error getting last commit ID")
 	}
@@ -380,10 +377,9 @@ func (e *environmentReconciler) promoteWithHelm(
 	//
 	// TODO: This seems correct for zero environment, but it might not hold up
 	// for non-zero environments.
-	if env.Spec.Subscriptions != nil &&
-		env.Spec.Subscriptions.Repos != nil &&
-		env.Spec.Subscriptions.Repos.Git {
-		newState.HealthCheckCommit, err = repo.LastCommitID()
+	if newState.GitCommit != nil {
+		newState.GitCommit.ID, err = repo.LastCommitID()
+		newState.HealthCheckCommit = newState.GitCommit.ID
 	}
 	return newState, errors.Wrap(err, "error getting last commit ID")
 }


### PR DESCRIPTION
The commit ID in a state's bill of materials and the commit ID we look for during health checks can sometimes, legitimately differ -- which is why they are separate fields in the first place. A good example of when this can happen is when Bookkeeper is in play.

This PR fixes some Kustomize and Helm-related cases where the opportunity existed for these to differ when they should _not_ have.