### PR TITLE
categorize promotions CRD in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -38,7 +38,8 @@ k8s_resource(
 k8s_resource(
   new_name = 'crds',
   objects = [
-    'environments.kargo.akuity.io:customresourcedefinition'
+    'environments.kargo.akuity.io:customresourcedefinition',
+    'promotions.kargo.akuity.io:customresourcedefinition'
   ],
   labels = ['kargo']
 )


### PR DESCRIPTION
Missed this in #227

This fix keeps the new CRD neatly within the `crds` category in Tilt so that it's easy to refresh all CR definitions with a single click.

Without this fix, it shows up under "uncategorized."