### PR TITLE
add efficient priority queue implementation for all client.Object types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/argoproj-labs/argocd-image-updater v0.12.1
 	github.com/argoproj/argo-cd/v2 v2.6.2
 	github.com/satori/go.uuid v1.2.0
+	github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b
 	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1072,6 +1072,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b h1:fo0GUa0B+vxSZ8bgnL3fpCPHReM/QPlALdak9T/Zw5Y=
+github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/controller/runtime/queues.go
+++ b/internal/controller/runtime/queues.go
@@ -1,0 +1,137 @@
+package runtime
+
+import (
+	"container/heap"
+	"sync"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PriorityQueue is an interface for any priority queue containing
+// runtime.Objects.
+type PriorityQueue interface {
+	// Push adds a copy of the provided client.Object to the priority queue.
+	// Implementations MUST disallow pushing nil objects.
+	Push(client.Object) error
+	// Pop removes the highest priority client.Object from the priority queue and
+	// returns it. Implementations MUST return nil if the priority queue is empty.
+	Pop() client.Object
+	// Depth returns the depth of the PriorityQueue.
+	Depth() int
+}
+
+// ObjectCompareFn is the signature for any function that can compare the
+// relative priorities of two client.Objects. Implementations MUST return true
+// when the first argument is of higher priority than the second and MUST return
+// false otherwise. Implementors of such functions may safely assume that
+// neither argument can ever be nil.
+type ObjectPriorityFn func(client.Object, client.Object) bool
+
+// priorityQueue is an implementation of the PriorityQueue interface. This
+// encapsulates the low-level details of the priority queue implementation found
+// at https://pkg.go.dev/container/heap and is also safe for concurrent use by
+// multiple goroutines.
+type priorityQueue struct {
+	// internalQueue is priorityQueue's underlying data structure. It implements
+	// heap.Interface.
+	internalQueue *internalPriorityQueue
+	// mu is a mutex used to ensure only a single goroutine is executing critical
+	// sections of code at any time.
+	mu sync.Mutex
+}
+
+// NewPriorityQueue takes a function for comparing the relative priority of two
+// client.Objects (which MUST return true when the first argument is of higher
+// priority than the second and MUST return false otherwise) and, optionally,
+// any number of client.Objects (which do NOT needs to be pre-ordered) and
+// returns an implementation of the PriorityQueue interface that is safe for
+// concurrent use by multiple goroutines. This function will also return an
+// error if initialized with a nil comparison function or any nil
+// runtime.Objects.
+func NewPriorityQueue(
+	higherFn ObjectPriorityFn,
+	objects ...client.Object,
+) (PriorityQueue, error) {
+	if higherFn == nil {
+		return nil, errors.New(
+			"the priority queue was initialized with a nil client.Object " +
+				"comparison function",
+		)
+	}
+	if objects == nil {
+		objects = []client.Object{}
+	}
+	for i, object := range objects {
+		if object == nil {
+			return nil, errors.Errorf(
+				"the priority queue was initialized with at least one nil "+
+					"client.Object at position %d",
+				i,
+			)
+		}
+	}
+	internalQueue := &internalPriorityQueue{
+		objects:  objects,
+		higherFn: higherFn,
+	}
+	heap.Init(internalQueue)
+	return &priorityQueue{
+		internalQueue: internalQueue,
+	}, nil
+}
+
+func (p *priorityQueue) Push(item client.Object) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item == nil {
+		return errors.New("a nil client.Object was pushed onto the priority queue")
+	}
+	heap.Push(p.internalQueue, item.DeepCopyObject())
+	return nil
+}
+
+func (p *priorityQueue) Pop() client.Object {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.internalQueue.Len() == 0 {
+		return nil
+	}
+	return heap.Pop(p.internalQueue).(client.Object)
+}
+
+func (p *priorityQueue) Depth() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.internalQueue.Len()
+}
+
+// internalPriorityQueue is the underlying data structure for priorityQueue. It
+// implements heap.Interface, which allows priorityQueue to offload ordering of
+// its client.Objects by priority to the heap package.
+type internalPriorityQueue struct {
+	objects  []client.Object
+	higherFn ObjectPriorityFn
+}
+
+func (i *internalPriorityQueue) Len() int { return len(i.objects) }
+
+func (i *internalPriorityQueue) Less(n, m int) bool {
+	return i.higherFn(i.objects[n], i.objects[m])
+}
+
+func (i *internalPriorityQueue) Swap(n, m int) {
+	i.objects[n], i.objects[m] = i.objects[m], i.objects[n]
+}
+
+func (i *internalPriorityQueue) Push(item any) {
+	i.objects = append(i.objects, item.(client.Object))
+}
+
+func (i *internalPriorityQueue) Pop() any {
+	n := len(i.objects)
+	item := i.objects[n-1]
+	i.objects[n-1] = nil // avoid memory leak
+	i.objects = i.objects[:n-1]
+	return item
+}

--- a/internal/controller/runtime/queues_test.go
+++ b/internal/controller/runtime/queues_test.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/technosophos/moniker"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/akuityio/kargo/api/v1alpha1"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	_, err := NewPriorityQueue(nil)
+	require.Error(t, err)
+	require.Equal(
+		t,
+		"the priority queue was initialized with a nil client.Object "+
+			"comparison function",
+		err.Error(),
+	)
+
+	randomNamer := moniker.New()
+	objects := make([]client.Object, 50)
+	for i := range objects {
+		objects[i] = &api.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomNamer.NameSep("-"),
+			},
+		}
+	}
+	objects[0] = nil // This should be invalid
+
+	_, err = NewPriorityQueue(
+		func(client.Object, client.Object) bool {
+			return true // Implementation doesn't matter for this test
+		},
+		objects...,
+	)
+	require.Error(t, err)
+	require.Equal(
+		t,
+		"the priority queue was initialized with at least one nil client.Object "+
+			"at position 0",
+		err.Error(),
+	)
+
+	objects = objects[1:] // Remove the problematic 0 element
+
+	pq, err := NewPriorityQueue(
+		func(lhs client.Object, rhs client.Object) bool {
+			// lhs has higher priority than rhs if lexically less than rhs
+			return lhs.GetName() < rhs.GetName()
+		},
+		objects...,
+	)
+	require.NoError(t, err)
+
+	// Now push a bunch...
+	for i := 0; i < 50; i++ {
+		err = pq.Push(
+			&api.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomNamer.NameSep("-"),
+				},
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	// Now pop until we get a nil
+	objects = nil
+	for {
+		object := pq.Pop()
+		if object == nil {
+			break
+		}
+		objects = append(objects, object)
+	}
+
+	// Verify objects are ordered lexically by object name
+	var lastName string
+	for _, object := range objects {
+		if lastName != "" {
+			require.GreaterOrEqual(t, object.GetName(), lastName)
+		}
+		lastName = object.GetName()
+	}
+}


### PR DESCRIPTION
This is how we will later get the Promotions reconciler to serialize Promotion handling for any given Environment.

Note, this was written to be generic enough to be used for any implementation of `client.Object` and any definition of "priority."

cc @jessesuen 