### PR TITLE
add utility for calculating exponential backoff intervals

### DIFF
--- a/internal/backoff/exponential.go
+++ b/internal/backoff/exponential.go
@@ -1,0 +1,30 @@
+package backoff
+
+import (
+	"math"
+	"time"
+
+	"github.com/akuityio/kargo/internal/rand"
+)
+
+var seededRand = rand.NewSeeded()
+
+// JitteredExponential returns a time.Duration to wait before the next retry
+// when employing a "jittered" exponential backoff. The value returned is based,
+// in-part on the number of failures to date and the maximum desired retry
+// interval. This value is "jittered" before it is returned. The importance of
+// this is that if many failures of any sort occur in rapid succession, the
+// retries will not only be staggered, but will become increasingly so as the
+// failure count increases. This strategy helps to mitigate further
+// complications in the event that the initial error was due to resource
+// contention or rate limiting.
+func JitteredExponential(
+	failureCount int,
+	maxDelay time.Duration,
+) time.Duration {
+	base := math.Pow(2, float64(failureCount))
+	capped := math.Min(base, maxDelay.Seconds())
+	jittered := (1 + seededRand.Float64()) * (capped / 2)
+	scaled := jittered * float64(time.Second)
+	return time.Duration(scaled)
+}

--- a/internal/backoff/exponential_test.go
+++ b/internal/backoff/exponential_test.go
@@ -1,0 +1,79 @@
+package backoff
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJitteredExponential(t *testing.T) {
+	testCases := []struct {
+		failureCount int
+		cap          time.Duration
+		expectedMin  time.Duration
+		expectedMax  time.Duration
+	}{
+		{
+			failureCount: 1,
+			cap:          time.Minute,
+			expectedMin:  time.Second,
+			expectedMax:  2 * time.Second,
+		},
+		{
+			failureCount: 2,
+			cap:          time.Minute,
+			expectedMin:  2 * time.Second,
+			expectedMax:  4 * time.Second,
+		},
+		{
+			failureCount: 3,
+			cap:          time.Minute,
+			expectedMin:  4 * time.Second,
+			expectedMax:  8 * time.Second,
+		},
+		{
+			failureCount: 4,
+			cap:          time.Minute,
+			expectedMin:  8 * time.Second,
+			expectedMax:  16 * time.Second,
+		},
+		{
+			failureCount: 5,
+			cap:          time.Minute,
+			expectedMin:  16 * time.Second,
+			expectedMax:  32 * time.Second,
+		},
+		{
+			failureCount: 6,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+		{
+			failureCount: 7,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+		{
+			failureCount: 8,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(strconv.Itoa(testCase.failureCount), func(t *testing.T) {
+			delay1 := JitteredExponential(testCase.failureCount, testCase.cap)
+
+			require.Less(t, testCase.expectedMin.Seconds(), delay1.Seconds())
+			require.Less(t, delay1.Seconds(), testCase.expectedMax.Seconds())
+
+			// Make sure the jitter works
+			delay2 := JitteredExponential(testCase.failureCount, testCase.cap)
+			require.NotEqual(t, delay1, delay2)
+		})
+	}
+}

--- a/internal/rand/seeded.go
+++ b/internal/rand/seeded.go
@@ -1,0 +1,43 @@
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Seeded is an interface for seeded, concurrency-safe random number generators.
+type Seeded interface {
+	// Intn returns, as an int, a non-negative pseudo-random number in [0,max). It
+	// panics if max <= 0.
+	Intn(max int) int
+	// Float64 returns, as a float64, a pseudo-random number in [0.0,1.0).
+	Float64() float64
+}
+
+type seeded struct {
+	rand *rand.Rand
+	mut  *sync.Mutex
+}
+
+// NewSeeded returns a seeded, concurrency-safe random number generator.
+func NewSeeded() Seeded {
+	// nolint: gosec
+	rnd := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	return &seeded{
+		rand: rnd,
+		mut:  &sync.Mutex{},
+	}
+}
+
+func (s *seeded) Intn(max int) int {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	return s.rand.Intn(max)
+}
+
+func (s *seeded) Float64() float64 {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	return s.rand.Float64()
+}

--- a/internal/rand/seeded_test.go
+++ b/internal/rand/seeded_test.go
@@ -1,0 +1,32 @@
+package rand
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSeeded(t *testing.T) {
+	rand, ok := NewSeeded().(*seeded)
+	require.True(t, ok)
+	require.NotNil(t, rand)
+	require.NotNil(t, rand.rand)
+	require.NotNil(t, rand.mut)
+}
+
+func TestIntn(t *testing.T) {
+	// We have no visibility into the underlying *mathrand.Rand, so we'll test
+	// that it is indeed seeded by comparing the results of Intn to results from
+	// the unseeded random number generator in the math/rand package. We use a
+	// very large n to reduce the likelihood of a coincidental match.
+	const n = 2147483647
+	require.NotEqual(t, rand.Intn(n), NewSeeded().Intn(n)) // nolint: gosec
+}
+
+func TestFloat64(t *testing.T) {
+	// We have no visibility into the underlying *mathrand.Rand, so we'll test
+	// that it is indeed seeded by comparing the results of Float64 to results
+	// from the unseeded random number generator in the math/rand package.
+	require.NotEqual(t, rand.Float64(), NewSeeded().Float64()) // nolint: gosec
+}


### PR DESCRIPTION
Related to #216 

This PR adds a utility package for calculating exponential backoff intervals. This, in turn, relies on a new package that includes a concurrency-safe pseudo-random number generator. ([Why we need this.](https://krancour.medium.com/go-pointers-random-is-gonna-to-getcha-13cba74661e7))

Actual application of the computed intervals to solve #216 will be in a follow-up.