### PR TITLE
add ability to run kargo in one cluster but manage another

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -47,6 +47,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/kargo", "api"]
           env:
+{{- if .Values.kubeconfigSecret }}
+            - name: KUBECONFIG
+              value: /etc/kargo/kubeconfig
+{{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.api.logLevel }}
           ports:
@@ -57,7 +61,20 @@ spec:
             exec:
               command: ["/usr/local/bin/grpc_health_probe", "-addr=:50051"]
             initialDelaySeconds: 5
+{{- if .Values.kubeconfigSecret }}
+          volumeMounts:
+            - mountPath: /etc/kargo/kubeconfig
+              name: kubeconfig
+              readOnly: true
+{{- end }}
           resources: {{ toYaml .Values.api.resources }}
+{{- if .Values.kubeconfigSecret }}
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 0600
+            secretName: {{ .Values.kubeconfigSecret }}
+{{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -100,6 +100,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/kargo", "controller"]
         env:
+        {{- if .Values.kubeconfigSecret }}
+        - name: KUBECONFIG
+          value: /etc/kargo/kubeconfig
+        {{- end }}
         - name: ARGOCD_NAMESPACE
           value: {{ .Values.controller.argocdNamespace }}
         - name: LOG_LEVEL
@@ -112,6 +116,11 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- if .Values.kubeconfigSecret }}
+        - mountPath: /etc/kargo/kubeconfig
+          name: kubeconfig
+          readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
       volumes:
@@ -119,6 +128,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "kargo.fullname" . }}-webhook-server-cert
+      {{- if .Values.kubeconfigSecret }}
+      - name: kubeconfig
+        secret:
+          defaultMode: 0600
+          secretName: {{ .Values.kubeconfigSecret }}
+      {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -16,6 +16,15 @@ rbac:
   ## already exist.
   installGlobalResources: true
 
+## kubeconfigSecret may optionally point to a Kubernetes Secret in the same
+## namespace as Kargo that contains the full content of a kubeconfig under the
+## key "kubeconfig.yaml". This is a useful method of running Kargo in one
+## cluster, but having it manage Environments, Promotions, Argo CD Applications,
+## etc. that live in a second cluster. Note that CRDs and
+## ValidatingWebhookConfigurations will need to be installed manually into the
+## cluster Kargo will be managing.
+# kubeconfigSecret:
+
 ## All settings for the api component
 api:
 


### PR DESCRIPTION
Fixes #261

Caveats:

CRDs and ValidatingWebhookConfigurations need to be manually installed on the cluster where the Kargo data lives.

cc @jessesuen 

#283 is a logical follow-up to this.