### PR TITLE
fix where we publish charts to

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,15 +71,14 @@ jobs:
     - name: Publish chart
       env:
         HELM_EXPERIMENTAL_OCI: '1'
-        KARGO_CHART_REPO: ghcr.io/akuityio/kargo-chart
-        KARGO_KIT_CHART_REPO: ghcr.io/akuityio/kargo-kit
+        KARGO_CHARTS_REPO: ghcr.io/akuityio/kargo-charts
         VERSION: ${{ github.ref_name }}
       run: |
         cd charts/kargo
         helm dep up
         helm package . --version ${VERSION} --app-version ${VERSION}
-        helm push kargo-${VERSION}.tgz oci://${KARGO_CHART_REPO}
+        helm push kargo-${VERSION}.tgz oci://${KARGO_CHARTS_REPO}
         cd ../kargo-kit
         helm dep up
         helm package . --version ${VERSION}
-        helm push kargo-kit-${VERSION}.tgz oci://${KARGO_KIT_CHART_REPO}
+        helm push kargo-kit-${VERSION}.tgz oci://${KARGO_CHARTS_REPO}


### PR DESCRIPTION
After doing a test release (v0.1.0-rc.1), I've determined that things will be cleaner with these changes.

Currently we have this:

![Screenshot 2023-03-30 at 2 09 30 PM](https://user-images.githubusercontent.com/1821014/228926948-c7d63957-42fd-49a3-b51f-32a8d7ccc3a5.png)

With this change, we'll get:

* kargo (image)
* kargo-charts/kargo
* kargo-charts/kargo-kit

This seems like a more sensible layout for our artifacts.

I'm purposefully aborting CI on this PR because the changes only affect the release process.

I'll run another test release after this is merged.
