### PR TITLE
use sha1 sums for state ids

### DIFF
--- a/internal/controller/environments/environments.go
+++ b/internal/controller/environments/environments.go
@@ -2,7 +2,7 @@ package environments
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"fmt"
 	"sort"
 	"strings"
@@ -551,6 +551,6 @@ func getStateID(state api.EnvironmentState) string {
 	sort.Strings(materials)
 	return fmt.Sprintf(
 		"%x",
-		sha256.Sum256([]byte(strings.Join(materials, "|"))),
+		sha1.Sum([]byte(strings.Join(materials, "|"))),
 	)
 }


### PR DESCRIPTION
It was a mistake in #303 that I used sha256 sums for deterministic state IDs.

Sha1 is shorter and more familiar because it is what git uses.