### PR TITLE
further accounting for recent github org move

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: ghcr.io/akuityio/kargo
+        images: ghcr.io/akuity/kargo
         flavor: latest=false
         tags: type=semver,pattern={{raw}}
     - name: Build and push
@@ -71,7 +71,7 @@ jobs:
     - name: Publish chart
       env:
         HELM_EXPERIMENTAL_OCI: '1'
-        KARGO_CHARTS_REPO: ghcr.io/akuityio/kargo-charts
+        KARGO_CHARTS_REPO: ghcr.io/akuity/kargo-charts
         VERSION: ${{ github.ref_name }}
       run: |
         CHART_VERSION=$(echo $VERSION | cut -c 2-)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kargo
 
-![CI](https://github.com/akuityio/kargo/actions/workflows/ci.yaml/badge.svg)
-[![codecov](https://codecov.io/gh/akuityio/kargo/branch/main/graph/badge.svg?token=DWEYXEJCYZ)](https://codecov.io/gh/akuityio/kargo)
+![CI](https://github.com/akuity/kargo/actions/workflows/ci.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/akuity/kargo/branch/main/graph/badge.svg?token=DWEYXEJCYZ)](https://codecov.io/gh/akuity/kargo)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 Placeholder
@@ -35,7 +35,7 @@ for more info on how to get started quickly and easily.
 ## Support & Feedback
 
 To report an issue, request a feature, or ask a question, please open an issue
-[here](https://github.com/akuityio/kargo/issues).
+[here](https://github.com/akuity/kargo/issues).
 
 ## Code of Conduct
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,7 @@ k8s_resource(
 )
 
 docker_build(
-  'ghcr.io/akuityio/kargo',
+  'ghcr.io/akuity/kargo',
   '.',
   only = [
     'api/',

--- a/api/proto/buf.yaml
+++ b/api/proto/buf.yaml
@@ -1,5 +1,5 @@
 version: v1
-name: buf.build/akuityio/kargo
+name: buf.build/akuity/kargo
 deps:
   - buf.build/googleapis/googleapis
   - buf.build/grpc-ecosystem/grpc-gateway

--- a/charts/kargo-kit/Chart.yaml
+++ b/charts/kargo-kit/Chart.yaml
@@ -4,7 +4,7 @@ description: Kargo Kit installs resources required by clusters that are managed 
 type: application
 version: 0.1.0
 sources:
-- https://github.com/akuityio/kargo
+- https://github.com/akuity/kargo
 maintainers:
 - name: Kent Rancourt
   email: kent@akuity.io

--- a/charts/kargo/Chart.yaml
+++ b/charts/kargo/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.1.0
 appVersion: v0.1.0
 sources:
-- https://github.com/akuityio/kargo
+- https://github.com/akuity/kargo
 maintainers:
 - name: Kent Rancourt
   email: kent@akuity.io

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -3,7 +3,7 @@
 ## Declare variables to be passed into your templates.
 
 image:
-  repository: ghcr.io/akuityio/kargo
+  repository: ghcr.io/akuity/kargo
   ## tag should only be specified if you want to override Chart.appVersion
   ## The default tag is the value of .Chart.AppVersion
   # tag:


### PR DESCRIPTION
This cleans up the last few remaining references to the akuityio github org.

Most importantly, this changes where we publish images and charts and where the charts find images.