### PR TITLE
do not require at least one source update for each argo cd app update

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -349,9 +349,7 @@ type ArgoCDAppUpdate struct {
 	AppNamespace string `json:"appNamespace,omitempty"`
 	// SourceUpdates describes updates to be applied to various sources of the
 	// specified Argo CD Application resource.
-	//
-	//+kubebuilder:validation:MinItems=1
-	SourceUpdates []ArgoCDSourceUpdate `json:"sourceUpdates"`
+	SourceUpdates []ArgoCDSourceUpdate `json:"sourceUpdates,omitempty"`
 }
 
 // ArgoCDSourceUpdate describes updates that should be applied to one of an Argo

--- a/charts/kargo-kit/crds/kargo.akuity.io_environments.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_environments.yaml
@@ -208,11 +208,9 @@ spec:
                             required:
                             - repoURL
                             type: object
-                          minItems: 1
                           type: array
                       required:
                       - appName
-                      - sourceUpdates
                       type: object
                     type: array
                   gitRepoUpdates:

--- a/charts/kargo/crds/kargo.akuity.io_environments.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_environments.yaml
@@ -208,11 +208,9 @@ spec:
                             required:
                             - repoURL
                             type: object
-                          minItems: 1
                           type: array
                       required:
                       - appName
-                      - sourceUpdates
                       type: object
                     type: array
                   gitRepoUpdates:


### PR DESCRIPTION
This PR relaxes validation of promotion mechanisms involving Argo CD App updates.

We previously required that for any App update, at least one source update was specified. This should not have been done, because any App update unconditionally triggers a sync/refresh of the App in question, so there are certainly valid scenarios (common ones even) wherein you may wish to trigger sync/refresh without describing any other changes to apply to the Application.