### PR TITLE
throw error if trying to sync to non-existent upstream environment

### DIFF
--- a/internal/controller/environments/environments.go
+++ b/internal/controller/environments/environments.go
@@ -546,6 +546,13 @@ func (r *reconciler) getAvailableStatesFromUpstreamEnvs(
 				sub.Namespace,
 			)
 		}
+		if upstreamEnv == nil {
+			return nil, errors.Errorf(
+				"found no upstream environment %q in namespace %q",
+				sub.Name,
+				sub.Namespace,
+			)
+		}
 		for _, state := range upstreamEnv.Status.History {
 			if _, ok := stateSet[state.ID]; !ok &&
 				state.Health != nil && state.Health.Status == api.HealthStateHealthy {


### PR DESCRIPTION
Without this, you get a nil pointer dereference under these circumstances.

With this, the errors surfaces within the Environment's status.