### PR TITLE
image pull secret no longer needed

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -27,7 +27,6 @@ k8s_resource(
   objects = [
     'kargo-admin:clusterrole',
     'kargo-developer:clusterrole',
-    'kargo-image-pull-secret:secret',
     'kargo-promoter:clusterrole',
     'kargo-selfsigned-cert-issuer:issuer'
   ]

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         {{- include "kargo.api.labels" . | nindent 8 }}
     spec:
       serviceAccount: {{ include "kargo.api.fullname" . }}
-      imagePullSecrets:
-        - name: {{ include "kargo.fullname" . }}-image-pull-secret
       containers:
 {{- if .Values.api.enableProxy }}
         - name: api-proxy

--- a/charts/kargo/templates/common/image-pull-secret.yaml
+++ b/charts/kargo/templates/common/image-pull-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "kargo.fullname" . }}-image-pull-secret
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7InVzZXJuYW1lIjoia3JhbmNvdXIiLCJwYXNzd29yZCI6ImdocF90TklzMEFJTDQwTEVQOVk4U2p2R051VXZJRXhoQjgxUnd6cGgiLCJhdXRoIjoiYTNKaGJtTnZkWEk2WjJod1gzUk9TWE13UVVsTU5EQk1SVkE1V1RoVGFuWkhUblZWZGtsRmVHaENPREZTZDNwd2FBPT0ifX19

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         {{- include "kargo.controller.labels" . | nindent 8 }}
     spec:
       serviceAccount: {{ include "kargo.controller.fullname" . }}
-      imagePullSecrets:
-      - name: {{ include "kargo.fullname" . }}-image-pull-secret
       containers:
       - name: controller
         image: {{ include "kargo.image" . }}


### PR DESCRIPTION
We will very shortly make kargo public and this image pull secret will no longer be needed to access the kargo images.

This PAT has been revoked already.