### PR TITLE
do not log in to ghcr.io during ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,12 +109,6 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
     - name: Build
       uses: docker/build-push-action@v3
       with:


### PR DESCRIPTION
Now that Bookkeeper is public, we don't need to be logged into ghcr anymore to pull the Bookkeeper image during the Kargo image build.

This step has actually been failing the last two days anyway, but rather than fix it, I am removing since there's no reason for it anymore.