### PR TITLE
work around non-deterministic sorts in Masterminds/semver

### DIFF
--- a/internal/images/image_updater.go
+++ b/internal/images/image_updater.go
@@ -1,0 +1,146 @@
+package images
+
+import (
+	"sort"
+
+	"github.com/Masterminds/semver"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/image"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+)
+
+// Everything in this file is a workaround for non-deterministic sorting in the
+// Masterminds/semver package. More specifically, everything in this file is a
+// replacement for particular Argo CD Image Updater functionality that relies on
+// the non-deterministic sort from Masterminds/semver.
+//
+// These workarounds can be removed after
+// https://github.com/argoproj-labs/argocd-image-updater/pull/559
+// is merged AND that change makes it into an Image Updater release.
+
+// getNewestVersionFromTags is cribbed from Argo CD Image Updater and minimally
+// modified to fix the non-deterministic semver sorts.
+func getNewestVersionFromTags(
+	img *image.ContainerImage,
+	vc *image.VersionConstraint,
+	tagList *tag.ImageTagList,
+) (string, error) {
+	var availableTags []string
+	switch vc.Strategy {
+	case image.StrategySemVer:
+		availableTags = sortBySemVer(tagList)
+	case image.StrategyName:
+		availableTags = sortByName(tagList)
+	case image.StrategyLatest:
+		availableTags = sortByDate(tagList)
+	case image.StrategyDigest:
+		availableTags = sortByName(tagList)
+	}
+
+	considerTags := []string{}
+
+	// It makes no sense to proceed if we have no available tags
+	if len(availableTags) == 0 {
+		return "", nil
+	}
+
+	// The given constraint MUST match a semver constraint
+	var semverConstraint *semver.Constraints
+	var err error
+	if vc.Strategy == image.StrategySemVer {
+		// TODO: Shall we really ensure a valid semver on the current tag?
+		// This prevents updating from a non-semver tag currently.
+		if img.ImageTag != nil && img.ImageTag.TagName != "" {
+			_, err := semver.NewVersion(img.ImageTag.TagName)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if vc.Constraint != "" {
+			if vc.Strategy == image.StrategySemVer {
+				semverConstraint, err = semver.NewConstraint(vc.Constraint)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+	}
+
+	// Loop through all tags to check whether it's an update candidate.
+	for _, tag := range availableTags {
+		if vc.Strategy == image.StrategySemVer {
+			// Non-parseable tag does not mean error - just skip it
+			ver, err := semver.NewVersion(tag)
+			if err != nil {
+				continue
+			}
+
+			// If we have a version constraint, check image tag against it. If the
+			// constraint is not satisfied, skip tag.
+			if semverConstraint != nil {
+				if !semverConstraint.Check(ver) {
+					continue
+				}
+			}
+		} else if vc.Strategy == image.StrategyDigest {
+			if tag != vc.Constraint {
+				continue
+			}
+		}
+
+		// Append tag as update candidate
+		considerTags = append(considerTags, tag)
+	}
+
+	// If we found tags to consider, return the most recent tag found according
+	// to the update strategy.
+	if len(considerTags) > 0 {
+		return considerTags[len(considerTags)-1], nil
+	}
+
+	return "", nil
+}
+
+// sortBySemVer is a replacement for similar functionality in Argo CD Image
+// Updater. It relies on a workaround for Masterminds/semver package's
+// non-deterministic sorts.
+func sortBySemVer(tags *tag.ImageTagList) []string {
+	semvers := []*semver.Version{}
+	for _, tagName := range tags.Tags() {
+		semver, err := semver.NewVersion(tagName)
+		if err != nil {
+			continue
+		}
+		semvers = append(semvers, semver)
+	}
+	sort.Sort(semverCollection(semvers))
+	sortedTagNames := make([]string, len(semvers))
+	for i, semver := range semvers {
+		sortedTagNames[i] = semver.Original()
+	}
+	return sortedTagNames
+}
+
+// sortByName is a replacement for similar functionality in Argo CD Image
+// Updater. It relies on Argo CD Image Updater to do most of its work. The main
+// difference is that it returns just tag names instead of tag.ImageTag objects.
+func sortByName(tags *tag.ImageTagList) []string {
+	sortedTags := tags.SortByName()
+	sortedTagNames := make([]string, len(sortedTags))
+	for i, tag := range sortedTags {
+		sortedTagNames[i] = tag.TagName
+	}
+	return sortedTagNames
+}
+
+// sortByDate is a replacement for similar functionality in Argo CD Image
+// Updater. It relies on Argo CD Image Updater to do most of its work. The main
+// difference is that it returns just tag names instead of tag.ImageTag objects.
+func sortByDate(tags *tag.ImageTagList) []string {
+	sortedTags := tags.SortByDate()
+	sortedTagNames := make([]string, len(sortedTags))
+	for i, tag := range sortedTags {
+		sortedTagNames[i] = tag.TagName
+	}
+	return sortedTagNames
+}

--- a/internal/images/image_updater_test.go
+++ b/internal/images/image_updater_test.go
@@ -1,0 +1,105 @@
+package images
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/image"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are cribbed from Argo CD Image Updater and minimally altered to
+// test our workarounds.
+
+func TestGetNewestVersionFromTags(t *testing.T) {
+	t.Run("Find the latest version without any constraint", func(t *testing.T) {
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.3", newTag)
+	})
+
+	t.Run("Find the latest version with a semver constraint on major", func(t *testing.T) {
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{Constraint: "^1.0"}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Equal(t, "1.1.2", newTag)
+	})
+
+	t.Run("Find the latest version with a semver constraint on patch", func(t *testing.T) {
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{Constraint: "~1.0"}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.1", newTag)
+	})
+
+	t.Run("Find the latest version with a semver constraint that has no match", func(t *testing.T) {
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{Constraint: "~1.0"}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		require.Empty(t, newTag)
+	})
+
+	t.Run("Find the latest version with a semver constraint that is invalid", func(t *testing.T) {
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{Constraint: "latest"}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		assert.Error(t, err)
+		assert.Empty(t, newTag)
+	})
+
+	t.Run("Find the latest version with no tags", func(t *testing.T) {
+		tagList := newImageTagList([]string{})
+		img := image.NewFromIdentifier("jannfis/test:1.0")
+		vc := image.VersionConstraint{Constraint: "~1.0"}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Empty(t, newTag)
+	})
+
+	t.Run("Find the latest version using latest sortmode", func(t *testing.T) {
+		tagList := newImageTagListWithDate([]string{"zz", "bb", "yy", "cc", "yy", "aa", "ll"})
+		img := image.NewFromIdentifier("jannfis/test:bb")
+		vc := image.VersionConstraint{Strategy: image.StrategyLatest}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Equal(t, "ll", newTag)
+	})
+
+	t.Run("Find the latest version using latest sortmode, invalid tags", func(t *testing.T) {
+		tagList := newImageTagListWithDate([]string{"zz", "bb", "yy", "cc", "yy", "aa", "ll"})
+		img := image.NewFromIdentifier("jannfis/test:bb")
+		vc := image.VersionConstraint{Strategy: image.StrategySemVer}
+		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
+		require.NoError(t, err)
+		assert.Empty(t, newTag)
+	})
+
+}
+
+func newImageTagList(tagNames []string) *tag.ImageTagList {
+	tagList := tag.NewImageTagList()
+	for _, tagName := range tagNames {
+		tagList.Add(tag.NewImageTag(tagName, time.Unix(0, 0), ""))
+	}
+	return tagList
+}
+
+func newImageTagListWithDate(tagNames []string) *tag.ImageTagList {
+	tagList := tag.NewImageTagList()
+	for i, t := range tagNames {
+		tagList.Add(tag.NewImageTag(t, time.Unix(int64(i*5), 0), ""))
+	}
+	return tagList
+}

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -91,7 +91,7 @@ func GetLatestTag(
 		)
 	}
 
-	upImg, err := img.GetNewestVersionFromTags(vc, tags)
+	tag, err := getNewestVersionFromTags(img, vc, tags)
 	if err != nil {
 		return "", errors.Wrapf(
 			err,
@@ -99,12 +99,12 @@ func GetLatestTag(
 			repoURL,
 		)
 	}
-	if upImg == nil {
+	if tag == "" {
 		return "", errors.Errorf(
 			"found no suitable version of image %q",
 			repoURL,
 		)
 	}
 
-	return upImg.TagName, nil
+	return tag, nil
 }

--- a/internal/images/semver.go
+++ b/internal/images/semver.go
@@ -1,0 +1,38 @@
+package images
+
+import "github.com/Masterminds/semver"
+
+// Everything in this file is a workaround for non-deterministic sorting in the
+// Masterminds/semver package.
+//
+// These workarounds can be removed after
+// https://github.com/argoproj-labs/argocd-image-updater/pull/559
+// is merged AND that change makes it into an Image Updater release.
+
+// semverCollection is a replacement for semver.Collection that breaks version
+// comparison ties through a lexical comparison of the original version strings.
+// Using this, instead of semver.Collection, when sorting will yield
+// deterministic results that semver.Collection will not yield.
+type semverCollection []*semver.Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (s semverCollection) Len() int {
+	return len(s)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (s semverCollection) Less(i, j int) bool {
+	comp := s[i].Compare(s[j])
+	if comp != 0 {
+		return comp < 0
+	}
+	return s[i].Original() < s[j].Original()
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (s semverCollection) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}


### PR DESCRIPTION
Fixes #313

There are upstream fixes opened related to this as well, but it's unclear how long it will be before we can take advantage of those fixes here.

This PR cribs code from Argo CD Image Updater and Masterminds/semver and makes minimal modifications to correct the root issue.