### PR TITLE
feat: bootstrap CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
       -o bin/kargo \
-      ./cmd \
+      ./cmd/controlplane \
     && bin/kargo version
 
 WORKDIR /kargo/bin

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/akuity/kargo/internal/cmd/cli"
+	"github.com/akuity/kargo/internal/logging"
+)
+
+func main() {
+	ctx := signals.SetupSignalHandler()
+	if err := cli.Execute(ctx); err != nil {
+		logging.LoggerFromContext(ctx).Error(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -5,13 +5,13 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/akuity/kargo/internal/cmd"
+	"github.com/akuity/kargo/internal/cmd/controlplane"
 	"github.com/akuity/kargo/internal/logging"
 )
 
 func main() {
 	ctx := signals.SetupSignalHandler()
-	if err := cmd.Execute(ctx); err != nil {
+	if err := controlplane.Execute(ctx); err != nil {
 		logging.LoggerFromContext(ctx).Error(err)
 		os.Exit(1)
 	}

--- a/internal/cmd/cli/root.go
+++ b/internal/cmd/cli/root.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"context"
@@ -19,9 +19,5 @@ var (
 )
 
 func Execute(ctx context.Context) error {
-	rootCmd.AddCommand(newAPICommand())
-	rootCmd.AddCommand(newAPIProxyCommand())
-	rootCmd.AddCommand(newControllerCommand())
-	rootCmd.AddCommand(newVersionCommand())
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/internal/cmd/controlplane/api.go
+++ b/internal/cmd/controlplane/api.go
@@ -1,26 +1,26 @@
-package cmd
+package controlplane
 
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/akuity/kargo/internal/api/proxy"
+	"github.com/akuity/kargo/internal/api/server"
 	"github.com/akuity/kargo/internal/config"
 	"github.com/akuity/kargo/internal/logging"
 )
 
-func newAPIProxyCommand() *cobra.Command {
+func newAPICommand() *cobra.Command {
 	return &cobra.Command{
-		Use:               "api-proxy",
+		Use:               "api",
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := config.NewAPIProxyConfig()
+			cfg := config.NewAPIConfig()
 			logger := log.New()
 			logger.SetLevel(cfg.LogLevel)
 			ctx := logging.ContextWithLogger(cmd.Context(), logger.WithFields(nil))
-			srv := proxy.NewServer(cfg)
+			srv := server.NewServer(cfg)
 			return srv.Serve(ctx)
 		},
 	}

--- a/internal/cmd/controlplane/api_proxy.go
+++ b/internal/cmd/controlplane/api_proxy.go
@@ -1,26 +1,26 @@
-package cmd
+package controlplane
 
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/akuity/kargo/internal/api/server"
+	"github.com/akuity/kargo/internal/api/proxy"
 	"github.com/akuity/kargo/internal/config"
 	"github.com/akuity/kargo/internal/logging"
 )
 
-func newAPICommand() *cobra.Command {
+func newAPIProxyCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:               "api",
+		Use:               "api-proxy",
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := config.NewAPIConfig()
+			cfg := config.NewAPIProxyConfig()
 			logger := log.New()
 			logger.SetLevel(cfg.LogLevel)
 			ctx := logging.ContextWithLogger(cmd.Context(), logger.WithFields(nil))
-			srv := server.NewServer(cfg)
+			srv := proxy.NewServer(cfg)
 			return srv.Serve(ctx)
 		},
 	}

--- a/internal/cmd/controlplane/controller.go
+++ b/internal/cmd/controlplane/controller.go
@@ -1,4 +1,4 @@
-package cmd
+package controlplane
 
 import (
 	argocd "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/internal/cmd/controlplane/root.go
+++ b/internal/cmd/controlplane/root.go
@@ -1,0 +1,27 @@
+package controlplane
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:               "kargo",
+		DisableAutoGenTag: true,
+		SilenceErrors:     true,
+		SilenceUsage:      true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.HelpFunc()(cmd, args)
+		},
+	}
+)
+
+func Execute(ctx context.Context) error {
+	rootCmd.AddCommand(newAPICommand())
+	rootCmd.AddCommand(newAPIProxyCommand())
+	rootCmd.AddCommand(newControllerCommand())
+	rootCmd.AddCommand(newVersionCommand())
+	return rootCmd.ExecuteContext(ctx)
+}

--- a/internal/cmd/controlplane/version.go
+++ b/internal/cmd/controlplane/version.go
@@ -1,4 +1,4 @@
-package cmd
+package controlplane
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Part of #262

This commit splits existing cmd into `cli` and `controlplane` to let users communicate with controlplane (API) by CLI.