### PR TITLE
fix missing version info in official images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
         build-args: |
           VERSION=${{ github.ref_name }}
+          GIT_COMMIT=${{ github.sha }}
+          GIT_TREE_STATE=clean
         tags: ${{ steps.meta.outputs.tags }}
         push: true
         cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ARG VERSION_PACKAGE=github.com/akuity/kargo/internal/version
-ARG VERSION
+
 ARG CGO_ENABLED=0
 
 WORKDIR /kargo
@@ -13,8 +13,12 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG GIT_TREE_STATE
+
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-      -ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+      -ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PACKAGE}.gitCommit=${GIT_COMMIT} -X ${VERSION_PACKAGE}.gitTreeState=${GIT_TREE_STATE}" \
       -o bin/kargo \
       ./cmd \
     && bin/kargo version

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,11 @@ hack-codegen: hack-build-dev-tools
 
 .PHONY: hack-build
 hack-build:
-	docker build . -t kargo:dev
+	docker build \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		--build-arg GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi) \
+		--tag kargo:dev \
+		.
 
 .PHONY: hack-kind-up
 hack-kind-up:

--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,11 @@ docker_build(
     'go.mod',
     'go.sum'
   ],
-  ignore = ['**/*_test.go']
+  ignore = ['**/*_test.go'],
+  build_args = {
+    'GIT_COMMIT': local('git rev-parse HEAD'),
+    'GIT_TREE_STATE': local('if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi')
+  }
 )
 
 k8s_resource(

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-	"runtime/debug"
-	"strconv"
 	"time"
 )
 
 var (
-	version   = ""                     // Injected with a linker flag
-	buildDate = "1970-01-01T00:00:00Z" // Injected with a linker flag
+	version      = ""                     // Injected with a linker flag
+	buildDate    = "1970-01-01T00:00:00Z" // Injected with a linker flag
+	gitCommit    = ""                     // Injected with a linker flag
+	gitTreeState = ""                     // Injected with a linker flag
 )
 
 // Version encapsulates all available information about the source code and the
@@ -21,9 +21,6 @@ type Version struct {
 	Version string
 	// BuildDate is the date/time on which the application was built.
 	BuildDate time.Time
-	// GitCommitDate is the date of the last commit to the application's source
-	// code that is included in this build.
-	GitCommitDate time.Time
 	// GitCommit is the ID (sha) of the last commit to the application's source
 	// code that is included in this build.
 	GitCommit string
@@ -42,56 +39,37 @@ type Version struct {
 var ver Version
 
 func init() {
-	ver = Version{
-		GoVersion: runtime.Version(),
-		Compiler:  runtime.Compiler,
-		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-	}
-
-	var err error
-	if ver.BuildDate, err =
-		time.Parse(time.RFC3339, buildDate); err != nil {
+	buildDate, err := time.Parse(time.RFC3339, buildDate)
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		log.Fatal("Build info not found")
-	}
-	for _, setting := range buildInfo.Settings {
-		switch setting.Key {
-		case "vcs.modified":
-			if ver.GitTreeDirty, err = strconv.ParseBool(setting.Value); err != nil {
-				log.Fatal(err)
-			}
-		case "vcs.revision":
-			ver.GitCommit = setting.Value
-		case "vcs.time":
-			if ver.GitCommitDate, err =
-				time.Parse(time.RFC3339, setting.Value); err != nil {
-				log.Fatal(err)
-			}
-		}
+	ver = Version{
+		Version:      version,
+		BuildDate:    buildDate,
+		GitCommit:    gitCommit,
+		GitTreeDirty: gitTreeState != "clean",
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
 	// If we're missing the version string or commit info, or if the tree is
 	// dirty, dynamically formulate a version string from available info...
-	if version == "" || ver.GitCommit == "" || ver.GitTreeDirty {
+	if ver.Version == "" || ver.GitCommit == "" || ver.GitTreeDirty {
 		// Override whatever version string we started with
-		version = "devel"
+		ver.Version = "devel"
 		// Tack on commit info
 		if len(ver.GitCommit) >= 7 {
-			version = fmt.Sprintf("%s+%s", version, ver.GitCommit[0:7])
+			ver.Version = fmt.Sprintf("%s+%s", ver.Version, gitCommit[0:7])
 		} else {
-			version = fmt.Sprintf("%s+unknown", version)
+			ver.Version = fmt.Sprintf("%s+unknown", ver.Version)
 		}
 		// Indicate if the tree was dirty
 		if ver.GitTreeDirty {
-			version = fmt.Sprintf("%s.dirty", version)
+			ver.Version = fmt.Sprintf("%s.dirty", ver.Version)
 		}
 	}
-
-	ver.Version = version
 }
 
 func GetVersion() Version {


### PR DESCRIPTION
Fixes #345

The root cause of the issue is that many build details were previously determined at runtime using `debug.ReadBuildInfo()` and because the `.git/` dir is (rightfully) not present in the container when the `kargo` binary is built, git related details are absent from that `BuildInfo` object.

The resolution is to inject commit ID and tree state using linker flags instead.