### PR TITLE
discourage and prevent subscription loops

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -103,13 +103,12 @@ type GitSubscription struct {
 	//+kubebuilder:validation:MinLength=1
 	//+kubebuilder:validation:Pattern=`^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$`
 	RepoURL string `json:"repoURL"`
-	// Branch references a particular branch of the repository. This field is
-	// optional. Leaving this unspecified is equivalent to specifying the
-	// repository's default branch, whatever that may happen to be -- typically
-	// "main" or "master".
+	// Branch references a particular branch of the repository. This is a required
+	// field.
 	//
-	//+kubebuilder:validation:Optional
-	Branch string `json:"branch,omitempty"`
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Pattern=`^\w+([-/]\w+)*$`
+	Branch string `json:"branch"`
 }
 
 // ImageSubscription defines a subscription to an image repository.
@@ -228,13 +227,24 @@ type GitRepoUpdate struct {
 	//+kubebuilder:validation:MinLength=1
 	//+kubebuilder:validation:Pattern=`^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$`
 	RepoURL string `json:"repoURL"`
-	// Branch references a particular branch of the repository to be updated. This
-	// field is optional. Leaving this unspecified is equivalent to specifying the
-	// repository's default branch, whatever that may happen to be -- typically
-	// "main" or "master".
+	// ReadBranch specifies a particular branch of the repository from which to
+	// locate contents that will be written to the branch specified by the
+	// WriteBranch field. This field is optional. In cases where an
+	// EnvironmentState includes a GitCommit, that commit's ID will supersede the
+	// value of this field. Therefore, in practice, this field is only used to
+	// clarify what branch of a repository can be treated as a source of manifests
+	// or other configuration when an Environment has no subscription to that
+	// repository.
 	//
 	//+kubebuilder:validation:Optional
-	Branch string `json:"branch,omitempty"`
+	//+kubebuilder:validation:Pattern=`^(\w+([-/]\w+)*)?$`
+	ReadBranch string `json:"readBranch"`
+	// WriteBranch specifies the particular branch of the repository to be
+	// updated. This is a required field.
+	//
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Pattern=`^\w+([-/]\w+)*$`
+	WriteBranch string `json:"writeBranch"`
 	// Bookkeeper describes how to use Bookkeeper to incorporate newly observed
 	// materials into the Environment. This is mutually exclusive with the
 	// Kustomize and Helm fields.
@@ -608,6 +618,8 @@ type GitCommit struct {
 	// ID is the ID of a specific commit in the Git repository specified by
 	// RepoURL.
 	ID string `json:"id,omitempty"`
+	// Branch denotes the branch of the repository where this commit was found.
+	Branch string `json:"branch,omitempty"`
 	// HealthCheckCommit is the ID of a specific commit. When specified,
 	// assessments of Environment health will used this value (instead of ID) when
 	// determining if applicable sources of Argo CD Application resources

--- a/charts/kargo-kit/crds/kargo.akuity.io_environments.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_environments.yaml
@@ -232,13 +232,6 @@ spec:
                             This is mutually exclusive with the Kustomize and Helm
                             fields.
                           type: object
-                        branch:
-                          description: Branch references a particular branch of the
-                            repository to be updated. This field is optional. Leaving
-                            this unspecified is equivalent to specifying the repository's
-                            default branch, whatever that may happen to be -- typically
-                            "main" or "master".
-                          type: string
                         helm:
                           description: Helm describes how to use Helm to incorporate
                             newly observed materials into the Environment. This is
@@ -359,14 +352,33 @@ spec:
                           required:
                           - images
                           type: object
+                        readBranch:
+                          description: ReadBranch specifies a particular branch of
+                            the repository from which to locate contents that will
+                            be written to the branch specified by the WriteBranch
+                            field. This field is optional. In cases where an EnvironmentState
+                            includes a GitCommit, that commit's ID will supersede
+                            the value of this field. Therefore, in practice, this
+                            field is only used to clarify what branch of a repository
+                            can be treated as a source of manifests or other configuration
+                            when an Environment has no subscription to that repository.
+                          pattern: ^(\w+([-/]\w+)*)?$
+                          type: string
                         repoURL:
                           description: RepoURL is the URL of the repository to update.
                             This is a required field.
                           minLength: 1
                           pattern: ^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$
                           type: string
+                        writeBranch:
+                          description: WriteBranch specifies the particular branch
+                            of the repository to be updated. This is a required field.
+                          minLength: 1
+                          pattern: ^\w+([-/]\w+)*$
+                          type: string
                       required:
                       - repoURL
+                      - writeBranch
                       type: object
                     type: array
                 type: object
@@ -420,10 +432,9 @@ spec:
                           properties:
                             branch:
                               description: Branch references a particular branch of
-                                the repository. This field is optional. Leaving this
-                                unspecified is equivalent to specifying the repository's
-                                default branch, whatever that may happen to be --
-                                typically "main" or "master".
+                                the repository. This is a required field.
+                              minLength: 1
+                              pattern: ^\w+([-/]\w+)*$
                               type: string
                             repoURL:
                               description: URL is the repository's URL. This is a
@@ -432,6 +443,7 @@ spec:
                               pattern: ^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$
                               type: string
                           required:
+                          - branch
                           - repoURL
                           type: object
                         type: array
@@ -575,6 +587,10 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          branch:
+                            description: Branch denotes the branch of the repository
+                              where this commit was found.
+                            type: string
                           healthCheckCommit:
                             description: HealthCheckCommit is the ID of a specific
                               commit. When specified, assessments of Environment health
@@ -682,6 +698,10 @@ spec:
                       description: GitCommit describes a specific commit from a specific
                         Git repository.
                       properties:
+                        branch:
+                          description: Branch denotes the branch of the repository
+                            where this commit was found.
+                          type: string
                         healthCheckCommit:
                           description: HealthCheckCommit is the ID of a specific commit.
                             When specified, assessments of Environment health will
@@ -798,6 +818,10 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          branch:
+                            description: Branch denotes the branch of the repository
+                              where this commit was found.
+                            type: string
                           healthCheckCommit:
                             description: HealthCheckCommit is the ID of a specific
                               commit. When specified, assessments of Environment health

--- a/charts/kargo/crds/kargo.akuity.io_environments.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_environments.yaml
@@ -232,13 +232,6 @@ spec:
                             This is mutually exclusive with the Kustomize and Helm
                             fields.
                           type: object
-                        branch:
-                          description: Branch references a particular branch of the
-                            repository to be updated. This field is optional. Leaving
-                            this unspecified is equivalent to specifying the repository's
-                            default branch, whatever that may happen to be -- typically
-                            "main" or "master".
-                          type: string
                         helm:
                           description: Helm describes how to use Helm to incorporate
                             newly observed materials into the Environment. This is
@@ -359,14 +352,33 @@ spec:
                           required:
                           - images
                           type: object
+                        readBranch:
+                          description: ReadBranch specifies a particular branch of
+                            the repository from which to locate contents that will
+                            be written to the branch specified by the WriteBranch
+                            field. This field is optional. In cases where an EnvironmentState
+                            includes a GitCommit, that commit's ID will supersede
+                            the value of this field. Therefore, in practice, this
+                            field is only used to clarify what branch of a repository
+                            can be treated as a source of manifests or other configuration
+                            when an Environment has no subscription to that repository.
+                          pattern: ^(\w+([-/]\w+)*)?$
+                          type: string
                         repoURL:
                           description: RepoURL is the URL of the repository to update.
                             This is a required field.
                           minLength: 1
                           pattern: ^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$
                           type: string
+                        writeBranch:
+                          description: WriteBranch specifies the particular branch
+                            of the repository to be updated. This is a required field.
+                          minLength: 1
+                          pattern: ^\w+([-/]\w+)*$
+                          type: string
                       required:
                       - repoURL
+                      - writeBranch
                       type: object
                     type: array
                 type: object
@@ -420,10 +432,9 @@ spec:
                           properties:
                             branch:
                               description: Branch references a particular branch of
-                                the repository. This field is optional. Leaving this
-                                unspecified is equivalent to specifying the repository's
-                                default branch, whatever that may happen to be --
-                                typically "main" or "master".
+                                the repository. This is a required field.
+                              minLength: 1
+                              pattern: ^\w+([-/]\w+)*$
                               type: string
                             repoURL:
                               description: URL is the repository's URL. This is a
@@ -432,6 +443,7 @@ spec:
                               pattern: ^((https?://)|([\w-]+@))([\w\d\.]+)(:[\d]+)?/(.*)$
                               type: string
                           required:
+                          - branch
                           - repoURL
                           type: object
                         type: array
@@ -575,6 +587,10 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          branch:
+                            description: Branch denotes the branch of the repository
+                              where this commit was found.
+                            type: string
                           healthCheckCommit:
                             description: HealthCheckCommit is the ID of a specific
                               commit. When specified, assessments of Environment health
@@ -682,6 +698,10 @@ spec:
                       description: GitCommit describes a specific commit from a specific
                         Git repository.
                       properties:
+                        branch:
+                          description: Branch denotes the branch of the repository
+                            where this commit was found.
+                          type: string
                         healthCheckCommit:
                           description: HealthCheckCommit is the ID of a specific commit.
                             When specified, assessments of Environment health will
@@ -798,6 +818,10 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          branch:
+                            description: Branch denotes the branch of the repository
+                              where this commit was found.
+                            type: string
                           healthCheckCommit:
                             description: HealthCheckCommit is the ID of a specific
                               commit. When specified, assessments of Environment health

--- a/internal/controller/environments/git.go
+++ b/internal/controller/environments/git.go
@@ -53,6 +53,7 @@ func (r *reconciler) getLatestCommits(
 		latestCommits[i] = api.GitCommit{
 			RepoURL: sub.RepoURL,
 			ID:      commit,
+			Branch:  sub.Branch,
 		}
 	}
 	return latestCommits, nil

--- a/internal/controller/environments/webhook.go
+++ b/internal/controller/environments/webhook.go
@@ -274,13 +274,13 @@ func (w *webhook) validateGitRepoUpdate(
 	if update.Helm != nil {
 		count++
 	}
-	if count != 1 {
+	if count > 1 {
 		return field.ErrorList{
 			field.Invalid(
 				f,
 				update,
 				fmt.Sprintf(
-					"exactly one of %s.bookkeeper, or %s.kustomize, or %s.helm must "+
+					"no more than one of %s.bookkeeper, or %s.kustomize, or %s.helm may "+
 						"be defined",
 					f.String(),
 					f.String(),

--- a/internal/controller/environments/webhook_test.go
+++ b/internal/controller/environments/webhook_test.go
@@ -586,27 +586,6 @@ func TestValidateGitRepoUpdates(t *testing.T) {
 		assertions func(api.GitRepoUpdate, field.ErrorList)
 	}{
 		{
-			name:   "no config management tools specified",
-			update: api.GitRepoUpdate{},
-			assertions: func(update api.GitRepoUpdate, errs field.ErrorList) {
-				require.Equal(
-					t,
-					field.ErrorList{
-						{
-							Type:     field.ErrorTypeInvalid,
-							Field:    "gitRepoUpdates[0]",
-							BadValue: update,
-							Detail: "exactly one of gitRepoUpdates[0].bookkeeper, or " +
-								"gitRepoUpdates[0].kustomize, or gitRepoUpdates[0].helm " +
-								"must be defined",
-						},
-					},
-					errs,
-				)
-			},
-		},
-
-		{
 			name: "more than one config management tool specified",
 			update: api.GitRepoUpdate{
 				Bookkeeper: &api.BookkeeperPromotionMechanism{},
@@ -621,9 +600,9 @@ func TestValidateGitRepoUpdates(t *testing.T) {
 							Type:     field.ErrorTypeInvalid,
 							Field:    "gitRepoUpdates[0]",
 							BadValue: update,
-							Detail: "exactly one of gitRepoUpdates[0].bookkeeper, or " +
+							Detail: "no more than one of gitRepoUpdates[0].bookkeeper, or " +
 								"gitRepoUpdates[0].kustomize, or gitRepoUpdates[0].helm " +
-								"must be defined",
+								"may be defined",
 						},
 					},
 					errs,
@@ -664,27 +643,6 @@ func TestValidateGitRepoUpdate(t *testing.T) {
 		assertions func(api.GitRepoUpdate, field.ErrorList)
 	}{
 		{
-			name:   "no config management tools specified",
-			update: api.GitRepoUpdate{},
-			assertions: func(update api.GitRepoUpdate, errs field.ErrorList) {
-				require.Equal(
-					t,
-					field.ErrorList{
-						{
-							Type:     field.ErrorTypeInvalid,
-							Field:    "gitRepoUpdate",
-							BadValue: update,
-							Detail: "exactly one of gitRepoUpdate.bookkeeper, or " +
-								"gitRepoUpdate.kustomize, or gitRepoUpdate.helm must be " +
-								"defined",
-						},
-					},
-					errs,
-				)
-			},
-		},
-
-		{
 			name: "more than one config management tool specified",
 			update: api.GitRepoUpdate{
 				Bookkeeper: &api.BookkeeperPromotionMechanism{},
@@ -699,8 +657,8 @@ func TestValidateGitRepoUpdate(t *testing.T) {
 							Type:     field.ErrorTypeInvalid,
 							Field:    "gitRepoUpdate",
 							BadValue: update,
-							Detail: "exactly one of gitRepoUpdate.bookkeeper, or " +
-								"gitRepoUpdate.kustomize, or gitRepoUpdate.helm must be " +
+							Detail: "no more than one of gitRepoUpdate.bookkeeper, or " +
+								"gitRepoUpdate.kustomize, or gitRepoUpdate.helm may be " +
 								"defined",
 						},
 					},

--- a/internal/controller/promotions/bookkeeper_test.go
+++ b/internal/controller/promotions/bookkeeper_test.go
@@ -30,28 +30,31 @@ func TestApplyBookkeeperUpdate(t *testing.T) {
 		},
 
 		{
-			name: "target branch is unspecified",
+			name: "invalid update",
+			newState: api.EnvironmentState{
+				Commits: []api.GitCommit{
+					{
+						RepoURL: "fake-url",
+						Branch:  "fake-branch",
+					},
+				},
+			},
 			update: api.GitRepoUpdate{
-				Bookkeeper: &api.BookkeeperPromotionMechanism{},
+				RepoURL:     "fake-url",
+				WriteBranch: "fake-branch",
+				Bookkeeper:  &api.BookkeeperPromotionMechanism{},
 			},
-			assertions: func(_, _ api.EnvironmentState, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "no target branch is specified")
-			},
-		},
-
-		{
-			name: "state doesn't contain any information about the repo",
-			update: api.GitRepoUpdate{
-				Branch:     "env/fake",
-				Bookkeeper: &api.BookkeeperPromotionMechanism{},
-			},
-			assertions: func(_, _ api.EnvironmentState, err error) {
+			assertions: func(inState, outState api.EnvironmentState, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
 					err.Error(),
-					"environment does not subscribe to repo",
+					"invalid update specified; cannot write to branch",
+				)
+				require.Contains(
+					t,
+					err.Error(),
+					"because it will form a subscription loop",
 				)
 			},
 		},
@@ -73,9 +76,9 @@ func TestApplyBookkeeperUpdate(t *testing.T) {
 				},
 			},
 			update: api.GitRepoUpdate{
-				RepoURL:    "fake-git-url",
-				Branch:     "env/fake",
-				Bookkeeper: &api.BookkeeperPromotionMechanism{},
+				RepoURL:     "fake-git-url",
+				WriteBranch: "env/fake",
+				Bookkeeper:  &api.BookkeeperPromotionMechanism{},
 			},
 			credentialsDB: &credentials.FakeDB{
 				GetFn: func(
@@ -117,9 +120,9 @@ func TestApplyBookkeeperUpdate(t *testing.T) {
 				},
 			},
 			update: api.GitRepoUpdate{
-				RepoURL:    "fake-git-url",
-				Branch:     "env/fake",
-				Bookkeeper: &api.BookkeeperPromotionMechanism{},
+				RepoURL:     "fake-git-url",
+				WriteBranch: "env/fake",
+				Bookkeeper:  &api.BookkeeperPromotionMechanism{},
 			},
 			credentialsDB: &credentials.FakeDB{
 				GetFn: func(
@@ -168,9 +171,9 @@ func TestApplyBookkeeperUpdate(t *testing.T) {
 				},
 			},
 			update: api.GitRepoUpdate{
-				RepoURL:    "fake-git-url",
-				Branch:     "env/fake",
-				Bookkeeper: &api.BookkeeperPromotionMechanism{},
+				RepoURL:     "fake-git-url",
+				WriteBranch: "env/fake",
+				Bookkeeper:  &api.BookkeeperPromotionMechanism{},
 			},
 			credentialsDB: &credentials.FakeDB{
 				GetFn: func(

--- a/internal/git/convenience.go
+++ b/internal/git/convenience.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/pkg/errors"
 )
 
@@ -41,7 +44,8 @@ func GetLatestCommitID(
 
 func ApplyUpdate(
 	repoURL string,
-	branch string,
+	readRef string,
+	writeBranch string,
 	creds *Credentials,
 	updateFn func(homeDir, workingDir string) (string, error),
 ) (string, error) {
@@ -51,12 +55,14 @@ func ApplyUpdate(
 	}
 	defer repo.Close()
 
-	if branch != "" {
-		if err = repo.Checkout(branch); err != nil {
+	// If readRef is non-empty, check out the specified commit or branch,
+	// otherwise just move using the repository's default branch as the source.
+	if readRef != "" {
+		if err = repo.Checkout(readRef); err != nil {
 			return "", errors.Wrapf(
 				err,
-				"error checking out branch %q from git repo",
-				repoURL,
+				"error checking out %q from git repo",
+				readRef,
 			)
 		}
 	}
@@ -66,20 +72,83 @@ func ApplyUpdate(
 		return "", err
 	}
 
-	var hasDiffs bool
-	if hasDiffs, err = repo.HasDiffs(); err != nil || !hasDiffs {
+	// Sometimes we don't write to the same branch we read from...
+	if readRef != writeBranch {
+		tempDir, err := os.MkdirTemp("", "")
+		if err != nil {
+			return "", errors.Wrap(
+				err,
+				"error creating temp directory for pending changes",
+			)
+		}
+		defer os.RemoveAll(tempDir)
+
+		if err = moveRepoContents(repo.WorkingDir(), tempDir); err != nil {
+			return "", errors.Wrap(
+				err,
+				"error moving repository working tree to temporary location",
+			)
+		}
+
+		if err = repo.ResetHard(); err != nil {
+			return "", errors.Wrap(err, "error resetting repository working tree")
+		}
+
+		if branchExists, err := repo.RemoteBranchExists(writeBranch); err != nil {
+			return "", errors.Wrapf(
+				err,
+				"error checking for existence of branch %q in remote repo %q",
+				writeBranch,
+				repoURL,
+			)
+		} else if !branchExists {
+			if err = repo.CreateOrphanedBranch(writeBranch); err != nil {
+				return "", errors.Wrapf(
+					err,
+					"error creating branch %q in repo %q",
+					writeBranch,
+					repoURL,
+				)
+			}
+		} else {
+			if err = repo.Checkout(writeBranch); err != nil {
+				return "", errors.Wrapf(
+					err,
+					"error checking out branch %q from git repo %q",
+					writeBranch,
+					repoURL,
+				)
+			}
+		}
+
+		if err = deleteRepoContents(repo.WorkingDir()); err != nil {
+			return "",
+				errors.Wrap(err, "error clearing contents from repository working tree")
+		}
+
+		if err = moveRepoContents(tempDir, repo.WorkingDir()); err != nil {
+			return "", errors.Wrap(
+				err,
+				"error restoring repository working tree from temporary location",
+			)
+		}
+	}
+
+	hasDiffs, err := repo.HasDiffs()
+	if err != nil {
 		return "",
 			errors.Wrapf(err, "error checking for diffs in git repo %q", repoURL)
 	}
 
-	if err = repo.AddAllAndCommit(commitMsg); err != nil {
-		return "",
-			errors.Wrapf(err, "error committing updates to git repo %q", repoURL)
-	}
-
-	if err = repo.Push(); err != nil {
-		return "",
-			errors.Wrapf(err, "error pushing updates to git repo %q", repoURL)
+	if hasDiffs {
+		if err = repo.AddAllAndCommit(commitMsg); err != nil {
+			return "",
+				errors.Wrapf(err, "error committing updates to git repo %q", repoURL)
+		}
+		if err = repo.Push(); err != nil {
+			return "",
+				errors.Wrapf(err, "error pushing updates to git repo %q", repoURL)
+		}
 	}
 
 	commitID, err := repo.LastCommitID()
@@ -92,4 +161,38 @@ func ApplyUpdate(
 	}
 
 	return commitID, nil
+}
+
+func moveRepoContents(srcDir, destDir string) error {
+	dirEntries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, dirEntry := range dirEntries {
+		if dirEntry.Name() == ".git" {
+			continue
+		}
+		srcPath := filepath.Join(srcDir, dirEntry.Name())
+		destPath := filepath.Join(destDir, dirEntry.Name())
+		if err = os.Rename(srcPath, destPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteRepoContents(dir string) error {
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, dirEntry := range dirEntries {
+		if dirEntry.Name() == ".git" {
+			continue
+		}
+		if err = os.RemoveAll(filepath.Join(dir, dirEntry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/git/convenience_test.go
+++ b/internal/git/convenience_test.go
@@ -2,6 +2,9 @@ package git
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -90,26 +93,105 @@ func TestApplyUpdate(t *testing.T) {
 			},
 		},
 
-		{
-			name:    "no diffs after update",
-			repoURL: "https://github.com/argoproj/argo-cd.git",
-			updateFn: func(string, string) (string, error) {
-				return "", nil
-			},
-			assertions: func(commitID string, err error) {
-				require.NoError(t, err)
-				require.Empty(t, commitID)
-			},
-		},
-
 		// TODO: Hard to test success case without actually pushing to a remote
 		// repository.
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
-				ApplyUpdate(testCase.repoURL, testCase.branch, nil, testCase.updateFn),
+				ApplyUpdate(
+					testCase.repoURL,
+					testCase.branch,
+					testCase.branch,
+					nil,
+					testCase.updateFn,
+				),
 			)
 		})
 	}
+}
+
+func TestMoveRepoContents(t *testing.T) {
+	const subdirCount = 50
+	const fileCount = 50
+	// Create dummy repo dir
+	srcDir, err := createDummyRepoDir(subdirCount, fileCount)
+	defer os.RemoveAll(srcDir)
+	require.NoError(t, err)
+	// Double-check the setup
+	dirEntries, err := os.ReadDir(srcDir)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, subdirCount+fileCount+1)
+	// Create destination dir
+	destDir, err := os.MkdirTemp("", "")
+	defer os.RemoveAll(destDir)
+	require.NoError(t, err)
+	// Move
+	err = moveRepoContents(srcDir, destDir)
+	require.NoError(t, err)
+	// .git should not have moved
+	_, err = os.Stat(filepath.Join(srcDir, ".git"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(destDir, ".git"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+	// Everything else should have moved
+	dirEntries, err = os.ReadDir(srcDir)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, 1)
+	dirEntries, err = os.ReadDir(destDir)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, subdirCount+fileCount)
+}
+
+func TestDeleteRepoContents(t *testing.T) {
+	const subdirCount = 50
+	const fileCount = 50
+	// Create dummy repo dir
+	dir, err := createDummyRepoDir(subdirCount, fileCount)
+	defer os.RemoveAll(dir)
+	require.NoError(t, err)
+	// Double-check the setup
+	dirEntries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, subdirCount+fileCount+1)
+	// Delete
+	err = deleteRepoContents(dir)
+	require.NoError(t, err)
+	// .git should not have been deleted
+	_, err = os.Stat(filepath.Join(dir, ".git"))
+	require.NoError(t, err)
+	// Everything else should be deleted
+	dirEntries, err = os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, dirEntries, 1)
+}
+
+func createDummyRepoDir(dirCount, fileCount int) (string, error) {
+	// Create a directory
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return dir, err
+	}
+	// Add a dummy .git/ subdir
+	if err = os.Mkdir(filepath.Join(dir, ".git"), 0755); err != nil {
+		return dir, err
+	}
+	// Add some dummy dirs
+	for i := 0; i < dirCount; i++ {
+		if err = os.Mkdir(filepath.Join(dir, fmt.Sprintf("dir-%d", i)), 0755); err != nil {
+			return dir, err
+		}
+	}
+	// Add some dummy files
+	for i := 0; i < fileCount; i++ {
+		file, err := os.Create(filepath.Join(dir, fmt.Sprintf("file-%d", i)))
+		if err != nil {
+			return dir, err
+		}
+		if err = file.Close(); err != nil {
+			return dir, err
+		}
+	}
+	return dir, nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -55,6 +55,8 @@ type Repo interface {
 	// RemoteBranchExists returns a bool indicating if the specified branch exists
 	// in the remote repository.
 	RemoteBranchExists(branch string) (bool, error)
+	// ResetHard performs a hard reset.
+	ResetHard() error
 	// URL returns the remote URL of the repository.
 	URL() string
 	// HomeDir returns an absolute path to the home directory of the system user
@@ -283,6 +285,12 @@ func (r *repo) RemoteBranchExists(branch string) (bool, error) {
 		branch,
 		r.url,
 	)
+}
+
+func (r *repo) ResetHard() error {
+	_, err :=
+		libExec.Exec(r.buildCommand("git", "reset", "--hard"))
+	return errors.Wrap(err, "error resetting branch working tree")
 }
 
 func (r *repo) URL() string {


### PR DESCRIPTION
After a lot of analysis and discussion, @jessesuen and I determined that scenarios wherein someone tries to write to a branch that they also subscribe to is the root of many bugs, difficulties, and odd behaviors and simply should neither be shown in our examples -- or even permitted.

This PR addresses that. It breaks down like this:

1. Subscriptions _must_ specify a branch now. It's no longer optional. Previously, when unspecified, it equated to the default branch -- whatever that happened to be. It's become prudent to be more explicit about this because...

1. When a new commit is found, we record what branch the commit was found on. This is important later during promotion because...

1. We look at any commits contained in the new state (freight) for the exact set of manifests or other configuration we intend to promote. If such a commit is found (due to a subscription), we verify that the user isn't trying to write to the same branch the commit came from -- accidental loop prevented!

    If such a commit is not found (because there was no subscription to the repo being updating), the formation of a subscription loop is not a concern, but we also don't know exactly what commit to base the update on.

    To help resolve that, the `Branch` field in the `GitRepoUpdate` type has now been separated into two fields: `WriteBranch` (required) and `ReadBranch` (optional). In cases where the commit on which to base the update cannot be determined by looking at state (freight), then `ReadBranch` clarifies by specifying a branch whose head can be the basis of the update. This is critical for one specific use case: One wherein there is no subscription to some git repo, but environment-specific branches in that repo still need to be updated as new images are discovered.

I've tried this against dozens of different use cases and am happy with the outcome in all cases.