### PR TITLE
Add linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,51 @@
 run:
+  go: "1.20"
   deadline: 10m
   skip-files:
-    - api/.*/groupversion_info.go
-  go: "1.20"
+  - api/.*/*_types.go
+  - api/.*/groupversion_info.go
 
 linters:
+  disable-all: true
   enable:
-    - errcheck
-    - gci
-    - gofmt
-    - govet
-    - revive
-    - staticcheck
+  - bodyclose
+  - depguard
+  - errcheck
+  - exportloopref
+  - forcetypeassert
+  - gci
+  - goconst
+  - gofmt
+  - goimports
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - lll
+  - misspell
+  - nakedret
+  - revive
+  - staticcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
 
+# all available settings for linters we enable
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    packages:
+    - github.com/davecgh/go-spew/spew
+  errcheck:
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
   gci:
     sections:
       - standard
@@ -23,3 +55,51 @@ linters-settings:
       - blank
     skip-generated: true
     custom-order: true
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/org/project
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 80
+    # tab width in spaces. Default to 1.
+    tab-width: 2
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 30
+  unparam:
+    # call graph construction algorithm (cha, rta). In general, use cha for libraries,
+    # and rta for programs with main packages. Default is cha.
+    algo: cha
+
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -64,10 +64,10 @@ func newControllerCommand() *cobra.Command {
 				return errors.Wrap(err, "create manager")
 			}
 
-			if err := environments.SetupWebhookWithManager(mgr); err != nil {
+			if err = environments.SetupWebhookWithManager(mgr); err != nil {
 				return errors.Wrap(err, "error initializing Environment webhooks")
 			}
-			if err :=
+			if err =
 				promotions.SetupWebhookWithManager(ctx, mgr, config); err != nil {
 				return errors.Wrap(err, "error initializing Environment webhooks")
 			}
@@ -86,7 +86,6 @@ func newControllerCommand() *cobra.Command {
 				return errors.Wrap(err, "setup environment reconciler")
 			}
 			if err := promotions.SetupReconcilerWithManager(
-				ctx,
 				mgr,
 				credentialsDB,
 				bookkeeper.NewService(

--- a/internal/api/proxy/server.go
+++ b/internal/api/proxy/server.go
@@ -51,6 +51,8 @@ func (s *server) Serve(ctx context.Context) error {
 		runtime.WithHealthzEndpoint(grpc_health_v1.NewHealthClient(cc)),
 	)
 	// TODO: Register services
+	// TODO: Set header timeout to avoid potential Slowloris attack
+	// nolint: gosec
 	srv := &http.Server{
 		Handler: mux,
 	}

--- a/internal/api/server/grpc_health_v1.go
+++ b/internal/api/server/grpc_health_v1.go
@@ -16,6 +16,9 @@ func newGRPCHealthV1Server() grpc_health_v1.HealthServer {
 	return &grpcHealthV1Server{}
 }
 
-func (s *grpcHealthV1Server) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+func (s *grpcHealthV1Server) Check(
+	ctx context.Context,
+	req *grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error) {
 	return handler.NewGRPCHealthCheckV1()(ctx, req)
 }

--- a/internal/api/server/handler/grpc_health_check_v1.go
+++ b/internal/api/server/handler/grpc_health_check_v1.go
@@ -6,10 +6,16 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-type GRPCHealthCheckV1Func func(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error)
+type GRPCHealthCheckV1Func func(
+	context.Context,
+	*grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error)
 
 func NewGRPCHealthCheckV1() GRPCHealthCheckV1Func {
-	return func(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return func(
+		context.Context,
+		*grpc_health_v1.HealthCheckRequest,
+	) (*grpc_health_v1.HealthCheckResponse, error) {
 		return &grpc_health_v1.HealthCheckResponse{
 			Status: grpc_health_v1.HealthCheckResponse_SERVING,
 		}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,10 +28,12 @@ type APIConfig struct {
 
 func NewAPIConfig() APIConfig {
 	return APIConfig{
-		BaseConfig:              newBaseConfig(),
-		Host:                    os.MustGetEnv("HOST", "0.0.0.0"),
-		Port:                    MustAtoi(os.MustGetEnv("PORT", "50051")),
-		GracefulShutdownTimeout: MustParseDuration(os.MustGetEnv("GRACEFUL_SHUTDOWN_TIMEOUT", "30s")),
+		BaseConfig: newBaseConfig(),
+		Host:       os.MustGetEnv("HOST", "0.0.0.0"),
+		Port:       MustAtoi(os.MustGetEnv("PORT", "50051")),
+		GracefulShutdownTimeout: MustParseDuration(
+			os.MustGetEnv("GRACEFUL_SHUTDOWN_TIMEOUT", "30s"),
+		),
 	}
 }
 
@@ -46,11 +48,13 @@ type APIProxyConfig struct {
 
 func NewAPIProxyConfig() APIProxyConfig {
 	return APIProxyConfig{
-		BaseConfig:              newBaseConfig(),
-		Host:                    os.MustGetEnv("HOST", "0.0.0.0"),
-		Port:                    MustAtoi(os.MustGetEnv("PORT", "8080")),
-		APIEndpoint:             os.MustGetEnv("API_ENDPOINT", "localhost:50051"),
-		GracefulShutdownTimeout: MustParseDuration(os.MustGetEnv("GRACEFUL_SHUTDOWN_TIMEOUT", "30s")),
+		BaseConfig:  newBaseConfig(),
+		Host:        os.MustGetEnv("HOST", "0.0.0.0"),
+		Port:        MustAtoi(os.MustGetEnv("PORT", "8080")),
+		APIEndpoint: os.MustGetEnv("API_ENDPOINT", "localhost:50051"),
+		GracefulShutdownTimeout: MustParseDuration(
+			os.MustGetEnv("GRACEFUL_SHUTDOWN_TIMEOUT", "30s"),
+		),
 	}
 }
 

--- a/internal/controller/environments/environments.go
+++ b/internal/controller/environments/environments.go
@@ -89,7 +89,6 @@ type reconciler struct {
 	) ([]api.Image, error)
 
 	getLatestTagFn func(
-		ctx context.Context,
 		repoURL string,
 		updateStrategy images.ImageUpdateStrategy,
 		semverConstraint string,
@@ -153,13 +152,7 @@ func SetupReconcilerWithManager(
 		)
 	}
 
-	e, err := newReconciler(
-		mgr.GetClient(),
-		credentialsDB,
-	)
-	if err != nil {
-		return errors.Wrap(err, "error initializing Environment reconciler")
-	}
+	e := newReconciler(mgr.GetClient(), credentialsDB)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.Environment{}).
@@ -206,7 +199,7 @@ func indexOutstandingPromotionsByEnvironment(obj client.Object) []string {
 func newReconciler(
 	client client.Client,
 	credentialsDB credentials.Database,
-) (*reconciler, error) {
+) *reconciler {
 	r := &reconciler{
 		client:        client,
 		credentialsDB: credentialsDB,
@@ -233,7 +226,7 @@ func newReconciler(
 	r.getLatestChartVersionFn = helm.GetLatestChartVersion
 	r.getLatestCommitIDFn = git.GetLatestCommitID
 
-	return r, nil
+	return r
 }
 
 // findEnvsForApp dynamically returns reconciliation requests for all

--- a/internal/controller/environments/environments_test.go
+++ b/internal/controller/environments/environments_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestNewEnvironmentReconciler(t *testing.T) {
-	e, err := newReconciler(
+	e := newReconciler(
 		fake.NewClientBuilder().Build(),
 		&credentials.FakeDB{},
 	)
-	require.NoError(t, err)
 	require.NotNil(t, e.client)
 	require.NotNil(t, e.credentialsDB)
 
@@ -175,7 +174,12 @@ func TestSync(t *testing.T) {
 			[]api.EnvironmentSubscription,
 		) ([]api.EnvironmentState, error)
 		client     client.Client
-		assertions func(initialStatus, newStatus api.EnvironmentStatus, client client.Client, err error)
+		assertions func(
+			initialStatus api.EnvironmentStatus,
+			newStatus api.EnvironmentStatus,
+			client client.Client,
+			err error,
+		)
 	}{
 		{
 			name: "error checking for outstanding promotions",

--- a/internal/controller/environments/git_test.go
+++ b/internal/controller/environments/git_test.go
@@ -114,12 +114,12 @@ func TestGetLatestCommits(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				credentialsDB:       testCase.credentialsDB,
 				getLatestCommitIDFn: testCase.getLatestCommitIDFn,
 			}
 			testCase.assertions(
-				reconciler.getLatestCommits(
+				r.getLatestCommits(
 					context.Background(),
 					"fake-namespace",
 					[]api.GitSubscription{

--- a/internal/controller/environments/helm_test.go
+++ b/internal/controller/environments/helm_test.go
@@ -152,17 +152,15 @@ func TestGetLatestCharts(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				credentialsDB:           testCase.credentialsDB,
 				getLatestChartVersionFn: testCase.getLatestChartVersionFn,
 			}
-			testCase.assertions(
-				reconciler.getLatestCharts(
-					context.Background(),
-					"fake-namespace",
-					testSubs,
-				),
-			)
+			testCase.assertions(r.getLatestCharts(
+				context.Background(),
+				"fake-namespace",
+				testSubs,
+			))
 		})
 	}
 }

--- a/internal/controller/environments/images.go
+++ b/internal/controller/environments/images.go
@@ -42,7 +42,6 @@ func (r *reconciler) getLatestImages(
 		}
 
 		tag, err := r.getLatestTagFn(
-			ctx,
 			sub.RepoURL,
 			images.ImageUpdateStrategy(sub.UpdateStrategy),
 			sub.SemverConstraint,

--- a/internal/controller/environments/images_test.go
+++ b/internal/controller/environments/images_test.go
@@ -17,7 +17,6 @@ func TestGetLatestImages(t *testing.T) {
 		name           string
 		credentialsDB  credentials.Database
 		getLatestTagFn func(
-			context.Context,
 			string,
 			images.ImageUpdateStrategy,
 			string,
@@ -41,7 +40,6 @@ func TestGetLatestImages(t *testing.T) {
 				},
 			},
 			getLatestTagFn: func(
-				ctx context.Context,
 				repoURL string,
 				updateStrategy images.ImageUpdateStrategy,
 				semverConstraint string,
@@ -76,7 +74,6 @@ func TestGetLatestImages(t *testing.T) {
 				},
 			},
 			getLatestTagFn: func(
-				ctx context.Context,
 				repoURL string,
 				updateStrategy images.ImageUpdateStrategy,
 				semverConstraint string,
@@ -108,12 +105,12 @@ func TestGetLatestImages(t *testing.T) {
 					RepoURL: "fake-url",
 				},
 			}
-			reconciler := reconciler{
+			r := reconciler{
 				credentialsDB:  testCase.credentialsDB,
 				getLatestTagFn: testCase.getLatestTagFn,
 			}
 			testCase.assertions(
-				reconciler.getLatestImages(
+				r.getLatestImages(
 					context.Background(),
 					"fake-namespace",
 					testSubs,

--- a/internal/controller/environments/webhook.go
+++ b/internal/controller/environments/webhook.go
@@ -27,7 +27,7 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
-	env := obj.(*api.Environment)
+	env := obj.(*api.Environment) // nolint: forcetypeassert
 	// Note that defaults are applied BEFORE validation, so we do not have the
 	// luxury of assuming certain required fields must be non-nil.
 	if env.Spec != nil {
@@ -65,10 +65,8 @@ func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
 	return nil
 }
 
-func (w *webhook) ValidateCreate(
-	_ context.Context,
-	obj runtime.Object,
-) error {
+func (w *webhook) ValidateCreate(_ context.Context, obj runtime.Object) error {
+	// nolint: forcetypeassert
 	return w.validateCreateOrUpdate(obj.(*api.Environment))
 }
 
@@ -77,6 +75,7 @@ func (w *webhook) ValidateUpdate(
 	_ runtime.Object,
 	newObj runtime.Object,
 ) error {
+	// nolint: forcetypeassert
 	return w.validateCreateOrUpdate(newObj.(*api.Environment))
 }
 

--- a/internal/controller/promotions/argocd_test.go
+++ b/internal/controller/promotions/argocd_test.go
@@ -276,10 +276,10 @@ func TestAuthorizeArgoCDAppUpdate(t *testing.T) {
 			allowed: true,
 		},
 	}
-	reconciler := reconciler{}
+	r := reconciler{}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := reconciler.authorizeArgoCDAppUpdate(
+			err := r.authorizeArgoCDAppUpdate(
 				v1.ObjectMeta{
 					Name:      "name-yep",
 					Namespace: "ns-yep",
@@ -511,13 +511,13 @@ func TestApplyArgoCDAppUpdate(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				getArgoCDAppFn:            testCase.getArgoCDAppFn,
 				applyArgoCDSourceUpdateFn: testCase.applyArgoCDSourceUpdateFn,
 				patchFn:                   testCase.patchFn,
 			}
 			testCase.assertions(
-				reconciler.applyArgoCDAppUpdate(
+				r.applyArgoCDAppUpdate(
 					context.Background(),
 					v1.ObjectMeta{
 						Name:      "fake-env",

--- a/internal/controller/promotions/bookkeeper_test.go
+++ b/internal/controller/promotions/bookkeeper_test.go
@@ -211,11 +211,11 @@ func TestApplyBookkeeperUpdate(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				credentialsDB:     testCase.credentialsDB,
 				bookkeeperService: testCase.bookkeeperService,
 			}
-			newState, err := reconciler.applyBookkeeperUpdate(
+			newState, err := r.applyBookkeeperUpdate(
 				context.Background(),
 				"fake-namespace",
 				testCase.newState,

--- a/internal/controller/promotions/git_test.go
+++ b/internal/controller/promotions/git_test.go
@@ -146,11 +146,11 @@ func TestApplyGitRepoUpdate(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				credentialsDB:    testCase.credentialsDB,
 				gitApplyUpdateFn: testCase.gitApplyUpdateFn,
 			}
-			outState, err := reconciler.applyGitRepoUpdate(
+			outState, err := r.applyGitRepoUpdate(
 				context.Background(),
 				"fake-namespace",
 				testCase.newState,

--- a/internal/controller/promotions/helm_test.go
+++ b/internal/controller/promotions/helm_test.go
@@ -150,13 +150,13 @@ func TestApplyHelm(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				setStringsInYAMLFileFn:        testCase.setStringsInYAMLFileFn,
 				buildChartDependencyChangesFn: testCase.buildChartDependencyChangesFn,
 				updateChartDependenciesFn:     testCase.updateChartDependenciesFn,
 			}
 			testCase.assertions(
-				reconciler.applyHelm(
+				r.applyHelm(
 					testCase.newState,
 					testCase.update,
 					"",

--- a/internal/controller/promotions/kustomize_test.go
+++ b/internal/controller/promotions/kustomize_test.go
@@ -73,11 +73,11 @@ func TestApplyKustomize(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := reconciler{
+			r := reconciler{
 				kustomizeSetImageFn: testCase.kustomizeSetImageFn,
 			}
 			testCase.assertions(
-				reconciler.applyKustomize(
+				r.applyKustomize(
 					testCase.newState,
 					testCase.update,
 					"",

--- a/internal/controller/promotions/webhook.go
+++ b/internal/controller/promotions/webhook.go
@@ -97,6 +97,7 @@ func (w *webhook) ValidateCreate(
 	ctx context.Context,
 	obj runtime.Object,
 ) error {
+	// nolint: forcetypeassert
 	return w.authorizeFn(ctx, obj.(*api.Promotion), "create")
 }
 
@@ -105,14 +106,14 @@ func (w *webhook) ValidateUpdate(
 	oldObj runtime.Object,
 	newObj runtime.Object,
 ) error {
-	promo := newObj.(*api.Promotion)
+	promo := newObj.(*api.Promotion) // nolint: forcetypeassert
 
 	if err := w.authorizeFn(ctx, promo, "update"); err != nil {
 		return err
 	}
 
 	// PromotionSpecs are meant to be immutable
-	if *promo.Spec != *(oldObj.(*api.Promotion).Spec) {
+	if *promo.Spec != *(oldObj.(*api.Promotion).Spec) { // nolint: forcetypeassert
 		return apierrors.NewInvalid(
 			schema.GroupKind{
 				Group: api.GroupVersion.Group,
@@ -137,7 +138,7 @@ func (w *webhook) ValidateDelete(
 ) error {
 	logger := logging.LoggerFromContext(ctx)
 
-	promo := obj.(*api.Promotion)
+	promo := obj.(*api.Promotion) // nolint: forcetypeassert
 
 	// Special logic for delete only. Allow any delete by the Kubernetes namespace
 	// controller. This prevents the webhook from stopping a namespace from being

--- a/internal/controller/promotions/webhooks_test.go
+++ b/internal/controller/promotions/webhooks_test.go
@@ -119,8 +119,10 @@ func TestValidateUpdate(t *testing.T) {
 func TestValidateDelete(t *testing.T) {
 	testCases := []struct {
 		name                          string
-		admissionRequestFromContextFn func(context.Context) (admission.Request, error)
-		authorizeFn                   func(
+		admissionRequestFromContextFn func(
+			context.Context,
+		) (admission.Request, error)
+		authorizeFn func(
 			context.Context,
 			*api.Promotion,
 			string,
@@ -269,7 +271,7 @@ func TestAuthorize(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
-				policies := objs.(*api.PromotionPolicyList)
+				policies := objs.(*api.PromotionPolicyList) // nolint: forcetypeassert
 				policies.Items = []api.PromotionPolicy{{}, {}}
 				return nil
 			},
@@ -290,7 +292,7 @@ func TestAuthorize(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
-				policies := objs.(*api.PromotionPolicyList)
+				policies := objs.(*api.PromotionPolicyList) // nolint: forcetypeassert
 				policies.Items = []api.PromotionPolicy{{}}
 				return nil
 			},
@@ -315,7 +317,7 @@ func TestAuthorize(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
-				policies := objs.(*api.PromotionPolicyList)
+				policies := objs.(*api.PromotionPolicyList) // nolint: forcetypeassert
 				policies.Items = []api.PromotionPolicy{{}}
 				return nil
 			},
@@ -324,7 +326,12 @@ func TestAuthorize(t *testing.T) {
 			) (admission.Request, error) {
 				return admission.Request{}, nil
 			},
-			isSubjectAuthorizedFn: func(ctx context.Context, pp *api.PromotionPolicy, p *api.Promotion, ui authenticationv1.UserInfo) (bool, error) {
+			isSubjectAuthorizedFn: func(
+				context.Context,
+				*api.PromotionPolicy,
+				*api.Promotion,
+				authenticationv1.UserInfo,
+			) (bool, error) {
 				return false, errors.New("something went wrong")
 			},
 			assertions: func(err error) {
@@ -343,7 +350,7 @@ func TestAuthorize(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
-				policies := objs.(*api.PromotionPolicyList)
+				policies := objs.(*api.PromotionPolicyList) // nolint: forcetypeassert
 				policies.Items = []api.PromotionPolicy{{}}
 				return nil
 			},
@@ -372,7 +379,7 @@ func TestAuthorize(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
-				policies := objs.(*api.PromotionPolicyList)
+				policies := objs.(*api.PromotionPolicyList) // nolint: forcetypeassert
 				policies.Items = []api.PromotionPolicy{{}}
 				return nil
 			},
@@ -650,6 +657,7 @@ func TestGetSubjectRoles(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
+				// nolint: forcetypeassert
 				roleBindings := objs.(*rbacv1.RoleBindingList)
 				roleBindings.Items = []rbacv1.RoleBinding{
 					{
@@ -675,6 +683,7 @@ func TestGetSubjectRoles(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
+				// nolint: forcetypeassert
 				roleBindings := objs.(*rbacv1.RoleBindingList)
 				roleBindings.Items = []rbacv1.RoleBinding{
 					{
@@ -709,6 +718,7 @@ func TestGetSubjectRoles(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
+				// nolint: forcetypeassert
 				roleBindings := objs.(*rbacv1.RoleBindingList)
 				roleBindings.Items = []rbacv1.RoleBinding{
 					{
@@ -742,6 +752,7 @@ func TestGetSubjectRoles(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
+				// nolint: forcetypeassert
 				roleBindings := objs.(*rbacv1.RoleBindingList)
 				roleBindings.Items = []rbacv1.RoleBinding{
 					{
@@ -777,6 +788,7 @@ func TestGetSubjectRoles(t *testing.T) {
 				objs client.ObjectList,
 				_ ...client.ListOption,
 			) error {
+				// nolint: forcetypeassert
 				roleBindings := objs.(*rbacv1.RoleBindingList)
 				roleBindings.Items = []rbacv1.RoleBinding{
 					{
@@ -869,7 +881,7 @@ func TestGetServiceAccountNamespaceAndName(t *testing.T) {
 		},
 		{
 			name:              "subject name represents a service account",
-			username:          "system:serviceaccount:fake-namespace:fake-service-account",
+			username:          "system:serviceaccount:fake-namespace:fake-service-account", // nolint: lll
 			expectedNamespace: "fake-namespace",
 			expectedName:      "fake-service-account",
 		},

--- a/internal/controller/runtime/queues.go
+++ b/internal/controller/runtime/queues.go
@@ -97,7 +97,7 @@ func (p *priorityQueue) Pop() client.Object {
 	if p.internalQueue.Len() == 0 {
 		return nil
 	}
-	return heap.Pop(p.internalQueue).(client.Object)
+	return heap.Pop(p.internalQueue).(client.Object) // nolint: forcetypeassert
 }
 
 func (p *priorityQueue) Depth() int {
@@ -125,7 +125,7 @@ func (i *internalPriorityQueue) Swap(n, m int) {
 }
 
 func (i *internalPriorityQueue) Push(item any) {
-	i.objects = append(i.objects, item.(client.Object))
+	i.objects = append(i.objects, item.(client.Object)) // nolint: forcetypeassert
 }
 
 func (i *internalPriorityQueue) Pop() any {

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -31,7 +31,7 @@ const (
 	// credentials stored in Kubernetes Secrets by repository type + URL.
 	secretsByRepo = "repo"
 
-	kargoSecretTypeLabel = "kargo.akuity.io/secret-type"
+	kargoSecretTypeLabel = "kargo.akuity.io/secret-type" // nolint: gosec
 )
 
 // Credentials generically represents any type of repository credential.

--- a/internal/git/convenience.go
+++ b/internal/git/convenience.go
@@ -74,7 +74,8 @@ func ApplyUpdate(
 
 	// Sometimes we don't write to the same branch we read from...
 	if readRef != writeBranch {
-		tempDir, err := os.MkdirTemp("", "")
+		var tempDir string
+		tempDir, err = os.MkdirTemp("", "")
 		if err != nil {
 			return "", errors.Wrap(
 				err,
@@ -94,7 +95,8 @@ func ApplyUpdate(
 			return "", errors.Wrap(err, "error resetting repository working tree")
 		}
 
-		if branchExists, err := repo.RemoteBranchExists(writeBranch); err != nil {
+		var branchExists bool
+		if branchExists, err = repo.RemoteBranchExists(writeBranch); err != nil {
 			return "", errors.Wrapf(
 				err,
 				"error checking for existence of branch %q in remote repo %q",

--- a/internal/git/convenience_test.go
+++ b/internal/git/convenience_test.go
@@ -179,7 +179,10 @@ func createDummyRepoDir(dirCount, fileCount int) (string, error) {
 	}
 	// Add some dummy dirs
 	for i := 0; i < dirCount; i++ {
-		if err = os.Mkdir(filepath.Join(dir, fmt.Sprintf("dir-%d", i)), 0755); err != nil {
+		if err = os.Mkdir(
+			filepath.Join(dir, fmt.Sprintf("dir-%d", i)),
+			0755,
+		); err != nil {
 			return dir, err
 		}
 	}

--- a/internal/images/image_updater.go
+++ b/internal/images/image_updater.go
@@ -50,8 +50,7 @@ func getNewestVersionFromTags(
 		// TODO: Shall we really ensure a valid semver on the current tag?
 		// This prevents updating from a non-semver tag currently.
 		if img.ImageTag != nil && img.ImageTag.TagName != "" {
-			_, err := semver.NewVersion(img.ImageTag.TagName)
-			if err != nil {
+			if _, err = semver.NewVersion(img.ImageTag.TagName); err != nil {
 				return "", err
 			}
 		}

--- a/internal/images/image_updater_test.go
+++ b/internal/images/image_updater_test.go
@@ -14,8 +14,10 @@ import (
 // test our workarounds.
 
 func TestGetNewestVersionFromTags(t *testing.T) {
-	t.Run("Find the latest version without any constraint", func(t *testing.T) {
-		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+	t.Run("Find the latest version without any constraint", func(t *testing.T) { // nolint: lll
+		tagList := newImageTagList([]string{
+			"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3",
+		})
 		img := image.NewFromIdentifier("jannfis/test:1.0")
 		vc := image.VersionConstraint{}
 		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
@@ -23,17 +25,22 @@ func TestGetNewestVersionFromTags(t *testing.T) {
 		assert.Equal(t, "2.0.3", newTag)
 	})
 
-	t.Run("Find the latest version with a semver constraint on major", func(t *testing.T) {
-		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+	t.Run("Find the latest version with a semver constraint on major", func(t *testing.T) { // nolint: lll
+		tagList := newImageTagList([]string{
+			"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3",
+		})
 		img := image.NewFromIdentifier("jannfis/test:1.0")
 		vc := image.VersionConstraint{Constraint: "^1.0"}
 		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
 		require.NoError(t, err)
 		assert.Equal(t, "1.1.2", newTag)
-	})
+	},
+	)
 
-	t.Run("Find the latest version with a semver constraint on patch", func(t *testing.T) {
-		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
+	t.Run("Find the latest version with a semver constraint on patch", func(t *testing.T) { // nolint: lll
+		tagList := newImageTagList([]string{
+			"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3",
+		})
 		img := image.NewFromIdentifier("jannfis/test:1.0")
 		vc := image.VersionConstraint{Constraint: "~1.0"}
 		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
@@ -41,7 +48,7 @@ func TestGetNewestVersionFromTags(t *testing.T) {
 		assert.Equal(t, "1.0.1", newTag)
 	})
 
-	t.Run("Find the latest version with a semver constraint that has no match", func(t *testing.T) {
+	t.Run("Find the latest version with a semver constraint that has no match", func(t *testing.T) { // nolint: lll
 		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
 		img := image.NewFromIdentifier("jannfis/test:1.0")
 		vc := image.VersionConstraint{Constraint: "~1.0"}
@@ -50,7 +57,7 @@ func TestGetNewestVersionFromTags(t *testing.T) {
 		require.Empty(t, newTag)
 	})
 
-	t.Run("Find the latest version with a semver constraint that is invalid", func(t *testing.T) {
+	t.Run("Find the latest version with a semver constraint that is invalid", func(t *testing.T) { // nolint: lll
 		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
 		img := image.NewFromIdentifier("jannfis/test:1.0")
 		vc := image.VersionConstraint{Constraint: "latest"}
@@ -69,7 +76,9 @@ func TestGetNewestVersionFromTags(t *testing.T) {
 	})
 
 	t.Run("Find the latest version using latest sortmode", func(t *testing.T) {
-		tagList := newImageTagListWithDate([]string{"zz", "bb", "yy", "cc", "yy", "aa", "ll"})
+		tagList := newImageTagListWithDate([]string{
+			"zz", "bb", "yy", "cc", "yy", "aa", "ll",
+		})
 		img := image.NewFromIdentifier("jannfis/test:bb")
 		vc := image.VersionConstraint{Strategy: image.StrategyLatest}
 		newTag, err := getNewestVersionFromTags(img, &vc, tagList)
@@ -77,8 +86,10 @@ func TestGetNewestVersionFromTags(t *testing.T) {
 		assert.Equal(t, "ll", newTag)
 	})
 
-	t.Run("Find the latest version using latest sortmode, invalid tags", func(t *testing.T) {
-		tagList := newImageTagListWithDate([]string{"zz", "bb", "yy", "cc", "yy", "aa", "ll"})
+	t.Run("Find the latest version using latest sortmode, invalid tags", func(t *testing.T) { // nolint: lll
+		tagList := newImageTagListWithDate([]string{
+			"zz", "bb", "yy", "cc", "yy", "aa", "ll",
+		})
 		img := image.NewFromIdentifier("jannfis/test:bb")
 		vc := image.VersionConstraint{Strategy: image.StrategySemVer}
 		newTag, err := getNewestVersionFromTags(img, &vc, tagList)

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"context"
 	"log"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/image"
@@ -28,7 +27,6 @@ func init() {
 }
 
 func GetLatestTag(
-	ctx context.Context,
 	repoURL string,
 	updateStrategy ImageUpdateStrategy,
 	semverConstraint string,

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Masterminds/semver"
@@ -63,7 +62,6 @@ func TestGetLatestTag(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				GetLatestTag(
-					context.Background(),
 					testCase.repoURL,
 					ImageUpdateStrategySemVer,
 					testCase.semverConstraint,

--- a/internal/kubeclient/context.go
+++ b/internal/kubeclient/context.go
@@ -8,7 +8,10 @@ type authCredentialContextKey struct {
 	// explicitly empty
 }
 
-func ContextWithAuthCredential(ctx context.Context, cred string) context.Context {
+func ContextWithAuthCredential(
+	ctx context.Context,
+	cred string,
+) context.Context {
 	return context.WithValue(ctx, authCredentialContextKey{}, cred)
 }
 

--- a/internal/kubeclient/transport.go
+++ b/internal/kubeclient/transport.go
@@ -20,7 +20,9 @@ func newAuthRoundTripper(rt http.RoundTripper) http.RoundTripper {
 	}
 }
 
-func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rt *authRoundTripper) RoundTrip(
+	req *http.Request,
+) (*http.Response, error) {
 	if v, ok := AuthCredentialFromContext(req.Context()); ok {
 		req.Header.Set("Authorization", v)
 	}

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -32,7 +32,7 @@ func ContextWithLogger(ctx context.Context, logger *log.Entry) context.Context {
 // returned.
 func LoggerFromContext(ctx context.Context) *log.Entry {
 	if logger := ctx.Value(loggerContextKey{}); logger != nil {
-		return ctx.Value(loggerContextKey{}).(*log.Entry)
+		return ctx.Value(loggerContextKey{}).(*log.Entry) // nolint: forcetypeassert
 	}
 	return globalLogger
 }

--- a/internal/os/env.go
+++ b/internal/os/env.go
@@ -15,9 +15,9 @@ func GetEnv(key, defaultValue string) string {
 	return value
 }
 
-// MustGetEnv retrieves the value of an environment variable having the specified
-// key. If the value is empty string, a specified default is returned instead.
-// It will panic if the defaultValue is empty too.
+// MustGetEnv retrieves the value of an environment variable having the
+// specified key. If the value is empty string, a specified default is returned
+// instead. It will panic if the defaultValue is empty too.
 func MustGetEnv(key, defaultValue string) string {
 	value := os.Getenv(key)
 	if value == "" {


### PR DESCRIPTION
Fixes #354

I was uneasy about it when we relaxed the linters a bit sometime back. I got curious about what kind of issues were sneaking through with fewer linters and I found a variety of things I wish I'd discovered sooner.

While a minority of these linters may be enforcing cosmetic things, like maximum line length (which I think is actually important because it makes it easier to review PRs from a phone), some of these linters are actually surfacing actionable issues. Just this morning, I have found shadow declarations (which can hinder readability), unused params, ineffectual assignments, implicit memory aliasing (a frequent source of bugs), and even the potential for a Slowloris attack (which still needs to be resolved).

I'd like to have more linters rather than fewer so issues like these don't remain undetected. We can, of course, tweak these further over time.

There are no functional changes in this PR, except for the possibly that as-yet-undetected bugs were closed when I fixed implicit memory aliasing issues.

