### PR TITLE
fix git reset --hard command

### DIFF
--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -278,7 +278,7 @@ func (r *repo) RemoteBranchExists(branch string) (bool, error) {
 
 func (r *repo) ResetHard() error {
 	_, err :=
-		libExec.Exec(r.buildCommand("git", "reset", "--hard"))
+		libExec.Exec(r.buildCommand("reset", "--hard"))
 	return errors.Wrap(err, "error resetting branch working tree")
 }
 


### PR DESCRIPTION
This fixes a bug that resulted from incompatible changes in #353 and #355 that went unnoticed because they didn't actually manifest as a merge conflict.