### PR TITLE
Silence `proto: tag has too few fields` warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,8 @@ require (
 )
 
 replace (
+	github.com/cosmos/gogoproto => github.com/akuity/gogoproto v0.0.0-20230530161421-5282e198ab74
+
 	// https://github.com/golang/go/issues/33546#issuecomment-519656923
 	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akuity/bookkeeper v0.1.0-alpha.2-rc.16.0.20230524205937-0fc174228025 h1:+PZhODyTkNXXIXQEBSZcvLxxwXv87vlDo7l8uKUHNAU=
 github.com/akuity/bookkeeper v0.1.0-alpha.2-rc.16.0.20230524205937-0fc174228025/go.mod h1:+7DpI38SdIdsDLj0dALiFIVtltZrUqZEssv4qyjnFYw=
+github.com/akuity/gogoproto v0.0.0-20230530161421-5282e198ab74 h1:cB1ZvmFnNgfnwOruMAt1u4f/RcybS6ndABGATqBm0xA=
+github.com/akuity/gogoproto v0.0.0-20230530161421-5282e198ab74/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -282,8 +284,6 @@ github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/gogoproto v1.4.10 h1:QH/yT8X+c0F4ZDacDv3z+xE3WU1P1Z3wQoLMBRJoKuI=
-github.com/cosmos/gogoproto v1.4.10/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
Some Kubernetes types have `protobuf:"-"` tag (same as the `json`) to be skipped from protobuf library. However, these types shows `proto: tag has too few fields` error, since `-` tag is not allowed in current implementation of `gogoproto` - current protobuf library.

This commit silences this error log by using a forked version of gogoproto ([akuity/gogoproto](https://github.com/akuity/gogoproto)), which allows `-` tag.

Related issue: https://github.com/istio/istio/issues/19735