### PR TITLE
Cleanup directory before generating Kubernetes types proto

### DIFF
--- a/hack/generate-proto.sh
+++ b/hack/generate-proto.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 # shellcheck disable=SC2128
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE}")"/..; pwd)
 
+rm -rf "${PROJECT_ROOT}/pkg/api"
 mkdir -p "${PROJECT_ROOT}/pkg/api"
 ln -s "${PROJECT_ROOT}/api/v1alpha1" "${PROJECT_ROOT}/pkg/api/v1alpha1"
 


### PR DESCRIPTION
`make codegen` should generate `generated.proto` file from the Kubernetes type definitions. However, the current `codegen` target doesn’t update `generated.proto` file even if there are changes.

This PR fixes this issue by cleaning up directory before generating Kubernetes types proto.