### PR TITLE
use latest Bookkeeper release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require k8s.io/apiserver v0.24.2 // indirect
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/akuity/bookkeeper v0.1.0-alpha.2-rc.16.0.20230524205937-0fc174228025
+	github.com/akuity/bookkeeper v0.1.0-rc.18
 	github.com/argoproj-labs/argocd-image-updater v0.12.1
 	github.com/argoproj/argo-cd/v2 v2.6.7
 	github.com/bufbuild/connect-go v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/akuity/bookkeeper v0.1.0-alpha.2-rc.16.0.20230524205937-0fc174228025 h1:+PZhODyTkNXXIXQEBSZcvLxxwXv87vlDo7l8uKUHNAU=
-github.com/akuity/bookkeeper v0.1.0-alpha.2-rc.16.0.20230524205937-0fc174228025/go.mod h1:+7DpI38SdIdsDLj0dALiFIVtltZrUqZEssv4qyjnFYw=
+github.com/akuity/bookkeeper v0.1.0-rc.18 h1:T1B15L0fl0Jjk7Aoe79JUFeyfzCU1We8YRQPA3pjx4k=
+github.com/akuity/bookkeeper v0.1.0-rc.18/go.mod h1:+7DpI38SdIdsDLj0dALiFIVtltZrUqZEssv4qyjnFYw=
 github.com/akuity/gogoproto v0.0.0-20230530161421-5282e198ab74 h1:cB1ZvmFnNgfnwOruMAt1u4f/RcybS6ndABGATqBm0xA=
 github.com/akuity/gogoproto v0.0.0-20230530161421-5282e198ab74/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=


### PR DESCRIPTION
The newest Bookkeeper release has more concise commit messages, which leads to a much better signal-to-noise ratio in repo history/logs.