### PR TITLE
make go linting in CI reuse make target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,23 +30,24 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
-  lint:
+  lint-go:
     runs-on: ubuntu-latest
     container:
       image: golang:1.20.4-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: /go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.51.2
+    - name: Install linter
+      env:
+        GOLANGCI_LINT_VERSION: 1.51.2
+      working-directory: /usr/local/bin
+      run: |
+        curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.tar.gz \
+        | tar xvz golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64/golangci-lint --strip-components=1
+    - name: Run linter
+      env:
+        GO_LINT_ERROR_FORMAT: github-actions
+      run: make lint-go
 
   lint-charts:
     runs-on: ubuntu-latest
@@ -110,7 +111,7 @@ jobs:
       run: git diff --exit-code -- .
 
   build:
-    needs: [test-unit, lint, lint-charts, lint-proto, check-codegen]
+    needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL ?= /bin/bash
 
 ARGO_CD_CHART_VERSION := 5.21.0
 BUF_LINT_ERROR_FORMAT ?= text
+GO_LINT_ERROR_FORMAT ?= colored-line-number
 CERT_MANAGER_CHART_VERSION := 1.11.0
 
 ################################################################################
@@ -20,7 +21,7 @@ lint: lint-go lint-proto lint-charts
 
 .PHONY: lint-go
 lint-go:
-	golangci-lint run
+	golangci-lint run --out-format=$(GO_LINT_ERROR_FORMAT)
 
 .PHONY: lint-proto
 lint-proto:


### PR DESCRIPTION
This ensures more consistent linting results across CI and developers running `make lint` (or `make hack-lint`) locally.