### PR TITLE
improve commit messages for non-bookkeeper cases

### DIFF
--- a/internal/controller/promotions/helm_test.go
+++ b/internal/controller/promotions/helm_test.go
@@ -24,9 +24,9 @@ func TestApplyHelm(t *testing.T) {
 			string,
 			[]api.Chart,
 			[]api.HelmChartDependencyUpdate,
-		) (map[string]map[string]string, error)
+		) (map[string]map[string]string, []string, error)
 		updateChartDependenciesFn func(homePath, chartPath string) error
-		assertions                func(err error)
+		assertions                func(changeSummary []string, err error)
 	}{
 		{
 			name: "error modifying values.yaml",
@@ -50,7 +50,7 @@ func TestApplyHelm(t *testing.T) {
 			setStringsInYAMLFileFn: func(string, map[string]string) error {
 				return errors.New("something went wrong")
 			},
-			assertions: func(err error) {
+			assertions: func(_ []string, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error updating values in file")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -63,10 +63,10 @@ func TestApplyHelm(t *testing.T) {
 				string,
 				[]api.Chart,
 				[]api.HelmChartDependencyUpdate,
-			) (map[string]map[string]string, error) {
-				return nil, errors.New("something went wrong")
+			) (map[string]map[string]string, []string, error) {
+				return nil, nil, errors.New("something went wrong")
 			},
-			assertions: func(err error) {
+			assertions: func(_ []string, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -83,17 +83,17 @@ func TestApplyHelm(t *testing.T) {
 				string,
 				[]api.Chart,
 				[]api.HelmChartDependencyUpdate,
-			) (map[string]map[string]string, error) {
+			) (map[string]map[string]string, []string, error) {
 				// We only need to build enough of a change map to make sure we get into
 				// the loop
 				return map[string]map[string]string{
 					"/fake/path/Chart.yaml": {},
-				}, nil
+				}, nil, nil
 			},
 			setStringsInYAMLFileFn: func(string, map[string]string) error {
 				return errors.New("something went wrong")
 			},
-			assertions: func(err error) {
+			assertions: func(_ []string, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -110,12 +110,12 @@ func TestApplyHelm(t *testing.T) {
 				string,
 				[]api.Chart,
 				[]api.HelmChartDependencyUpdate,
-			) (map[string]map[string]string, error) {
+			) (map[string]map[string]string, []string, error) {
 				return map[string]map[string]string{
 					// We only need to build enough of a change map to make sure we get
 					// into the loop
 					"/fake/path/Chart.yaml": {},
-				}, nil
+				}, nil, nil
 			},
 			setStringsInYAMLFileFn: func(string, map[string]string) error {
 				return nil
@@ -123,7 +123,7 @@ func TestApplyHelm(t *testing.T) {
 			updateChartDependenciesFn: func(string, string) error {
 				return errors.New("something went wrong")
 			},
-			assertions: func(err error) {
+			assertions: func(_ []string, err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -140,10 +140,10 @@ func TestApplyHelm(t *testing.T) {
 				string,
 				[]api.Chart,
 				[]api.HelmChartDependencyUpdate,
-			) (map[string]map[string]string, error) {
-				return nil, nil
+			) (map[string]map[string]string, []string, error) {
+				return nil, nil, nil
 			},
-			assertions: func(err error) {
+			assertions: func(_ []string, err error) {
 				require.NoError(t, err)
 			},
 		},
@@ -204,7 +204,7 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 			Value:          "Tag",
 		},
 	}
-	result := buildValuesFilesChanges(images, imageUpdates)
+	result, changeSummary := buildValuesFilesChanges(images, imageUpdates)
 	require.Equal(
 		t,
 		map[string]map[string]string{
@@ -217,6 +217,15 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 			},
 		},
 		result,
+	)
+	require.Equal(
+		t,
+		[]string{
+			"updated fake-values.yaml to use image fake-url:fake-tag",
+			"updated fake-values.yaml to use image another-fake-url:another-fake-tag",
+			"updated another-fake-values.yaml to use image fake-url:fake-tag",
+		},
+		changeSummary,
 	)
 }
 
@@ -294,7 +303,8 @@ func TestBuildChartDependencyChanges(t *testing.T) {
 		// we expect it to be left alone.
 	}
 
-	result, err := buildChartDependencyChanges(testDir, charts, chartUpdates)
+	result, changeSummary, err :=
+		buildChartDependencyChanges(testDir, charts, chartUpdates)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -307,5 +317,14 @@ func TestBuildChartDependencyChanges(t *testing.T) {
 			},
 		},
 		result,
+	)
+	require.Equal(
+		t,
+		[]string{
+			"updated charts/foo/Chart.yaml to use subchart fake-chart:fake-version",
+			"updated charts/bar/Chart.yaml to use subchart " +
+				"another-fake-chart:another-fake-version",
+		},
+		changeSummary,
 	)
 }

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -71,7 +71,7 @@ type reconciler struct {
 		repoDir string,
 		charts []api.Chart,
 		chartUpdates []api.HelmChartDependencyUpdate,
-	) (map[string]map[string]string, error)
+	) (map[string]map[string]string, []string, error)
 
 	updateChartDependenciesFn func(homePath, chartPath string) error
 


### PR DESCRIPTION
Fixes #213

This PR updates functions that are involved in applying changes to a Git repo to also return a summary of those changes as a `[]string`.

A new `buildCommitMessage(changeSummary []string) string` function can convert that summary into a nicely formatted commit message.

* If the summary has no items in it, the message is very generic. This really shouldn't happen, but I'm covering my bases.
* If the summary has one item in it, that one item becomes the commit message.
* If the summary has multiple items in it, the first line is very generic and subsequent lines summarize all changes.