### PR TITLE
Set owner reference typemeta explicitly

### DIFF
--- a/internal/api/handler/promote_environment_v1alpha1.go
+++ b/internal/api/handler/promote_environment_v1alpha1.go
@@ -61,8 +61,8 @@ func PromoteEnvironmentV1Alpha1(
 				Namespace:    req.Msg.GetProject(),
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion:         env.APIVersion,
-						Kind:               env.Kind,
+						APIVersion:         kubev1alpha1.GroupVersion.String(),
+						Kind:               "Environment",
 						Name:               env.Name,
 						UID:                env.UID,
 						BlockOwnerDeletion: pointer.Bool(true),


### PR DESCRIPTION
Fixes promotion failure because of the empty `apiVersion` and `kind`.