### PR TITLE
Update `Serve` method to take listener as an argument

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
 
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/os"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,13 @@ func NewAPIConfig() APIConfig {
 	}
 }
 
+func (c APIConfig) RESTConfig() (*rest.Config, error) {
+	if c.LocalMode {
+		return kubeclient.NewClientConfig().ClientConfig()
+	}
+	return rest.InClusterConfig()
+}
+
 type ControllerConfig struct {
 	BaseConfig
 	ArgoCDNamespace         string


### PR DESCRIPTION
This commit updates `Serve` method to take listener as an argument for letting CLI to run API server in the local (user environment) to use with Dashboard or CLI itself.