### PR TITLE
Add promote command to CLI

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,17 +1,16 @@
 package main
 
 import (
+	"context"
 	"os"
 
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-
-	"github.com/akuity/kargo/internal/logging"
+	"github.com/akuity/kargo/internal/cli/option"
 )
 
 func main() {
-	ctx := signals.SetupSignalHandler()
-	if err := Execute(ctx); err != nil {
-		logging.LoggerFromContext(ctx).Error(err)
+	var opt option.Option
+	ctx := context.Background()
+	if err := NewRootCommand(&opt).ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -2,22 +2,85 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/akuity/kargo/internal/api"
+	apioption "github.com/akuity/kargo/internal/api/option"
+	"github.com/akuity/kargo/internal/cli/env"
+	"github.com/akuity/kargo/internal/cli/option"
+	"github.com/akuity/kargo/internal/config"
+	"github.com/akuity/kargo/internal/kubeclient"
 )
 
-var (
-	rootCmd = &cobra.Command{
+type localServerListenerKey struct {
+	// explicitly empty
+}
+
+func NewRootCommand(opt *option.Option) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:               "kargo",
 		DisableAutoGenTag: true,
-		SilenceErrors:     true,
 		SilenceUsage:      true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ctx := buildRootContext(cmd.Context())
+			cfg := config.NewCLIConfig()
+			rc, err := cfg.RESTConfig()
+			if err != nil {
+				return errors.Wrap(err, "load kubeconfig")
+			}
+
+			opt.ClientOption = apioption.NewClientOption(opt.UseLocalServer)
+			if opt.UseLocalServer {
+				l, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					return errors.Wrap(err, "start local server")
+				}
+				ctx = context.WithValue(ctx, localServerListenerKey{}, l)
+				srv, err := api.NewServer(config.APIConfig{
+					BaseConfig: cfg.BaseConfig,
+					LocalMode:  true,
+				}, rc)
+				if err != nil {
+					return errors.Wrap(err, "new api server")
+				}
+				go func() {
+					_ = srv.Serve(ctx, l)
+				}()
+				opt.ServerURL = fmt.Sprintf("http://%s", l.Addr())
+			} else {
+				cred, err := kubeclient.GetCredential(ctx, rc)
+				if err != nil {
+					return errors.Wrap(err, "get credential")
+				}
+				ctx = kubeclient.SetCredentialToContext(ctx, cred)
+			}
+			cmd.SetContext(ctx)
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if l, ok := cmd.Context().Value(localServerListenerKey{}).(net.Listener); ok {
+				return l.Close()
+			}
+			return nil
+		},
 	}
-)
 
-func Execute(ctx context.Context) error {
-	return rootCmd.ExecuteContext(ctx)
+	option.ServerURL(&opt.ServerURL)(cmd.PersistentFlags())
+	option.LocalServer(&opt.UseLocalServer)(cmd.PersistentFlags())
+
+	cmd.AddCommand(env.NewCommand(opt))
+	cmd.AddCommand(newVersionCommand())
+	return cmd
+}
+
+func buildRootContext(ctx context.Context) context.Context {
+	// TODO: Inject console printer or logger
+	return ctx
 }

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	versionpkg "github.com/akuity/kargo/internal/version"
+)
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := json.Marshal(versionpkg.GetVersion())
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(data))
+			return nil
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/r3labs/diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/net v0.9.0

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -12,6 +12,16 @@ import (
 	"github.com/akuity/kargo/internal/logging"
 )
 
+func NewClientOption(skipAuth bool) connect.ClientOption {
+	var interceptors []connect.Interceptor
+	if !skipAuth {
+		interceptors = append(interceptors, newAuthInterceptor())
+	}
+	return connect.WithClientOptions(
+		connect.WithInterceptors(interceptors...),
+	)
+}
+
 func NewHandlerOption(cfg config.APIConfig, logger *log.Entry) connect.HandlerOption {
 	interceptors := []connect.Interceptor{
 		newLogInterceptor(logger, loggingIgnorableMethods),

--- a/internal/cli/env/env.go
+++ b/internal/cli/env/env.go
@@ -1,0 +1,17 @@
+package env
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/akuity/kargo/internal/cli/option"
+)
+
+func NewCommand(opt *option.Option) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "environment",
+		Aliases: []string{"env"},
+		Short:   "Manage environments",
+	}
+	cmd.AddCommand(newPromoteCommand(opt))
+	return cmd
+}

--- a/internal/cli/env/promote.go
+++ b/internal/cli/env/promote.go
@@ -1,0 +1,61 @@
+package env
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/akuity/kargo/internal/cli/option"
+	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
+	"github.com/akuity/kargo/pkg/api/service/v1alpha1/svcv1alpha1connect"
+)
+
+type PromoteFlags struct {
+	Project string
+	State   string
+}
+
+func newPromoteCommand(opt *option.Option) *cobra.Command {
+	var flag PromoteFlags
+	cmd := &cobra.Command{
+		Use:     "promote",
+		Args:    cobra.ExactArgs(2),
+		Example: "kargo environment promote (PROJECT) (NAME) [(--state=)state-id]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			project := strings.TrimSpace(args[0])
+			if project == "" {
+				return errors.New("project is required")
+			}
+			name := strings.TrimSpace(args[1])
+			if name == "" {
+				return errors.New("name is required")
+			}
+			state := strings.TrimSpace(flag.State)
+			if state == "" {
+				// TODO: Get latest available state if empty
+				return errors.New("state is required")
+			}
+
+			client := svcv1alpha1connect.NewKargoServiceClient(http.DefaultClient, opt.ServerURL, opt.ClientOption)
+			res, err := client.PromoteEnvironment(ctx, connect.NewRequest(&v1alpha1.PromoteEnvironmentRequest{
+				Project: project,
+				Name:    name,
+				State:   state,
+			}))
+			if err != nil {
+				return errors.Wrap(err, "promote environment")
+			}
+			// TODO: Replace with console writer
+			fmt.Printf("Promotion Created: %q", res.Msg.GetPromotion().GetMetadata().GetName())
+			return nil
+		},
+	}
+	option.State(&flag.State)(cmd.Flags())
+	return cmd
+}

--- a/internal/cli/option/flag.go
+++ b/internal/cli/option/flag.go
@@ -1,0 +1,23 @@
+package option
+
+import "github.com/spf13/pflag"
+
+type FlagFn func(*pflag.FlagSet)
+
+func ServerURL(v *string) FlagFn {
+	return func(fs *pflag.FlagSet) {
+		fs.StringVar(v, "server", "", "Server URL")
+	}
+}
+
+func LocalServer(v *bool) FlagFn {
+	return func(fs *pflag.FlagSet) {
+		fs.BoolVar(v, "local-server", false, "Use local server")
+	}
+}
+
+func State(v *string) FlagFn {
+	return func(fs *pflag.FlagSet) {
+		fs.StringVar(v, "state", "", "State ID")
+	}
+}

--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -1,0 +1,12 @@
+package option
+
+import (
+	"github.com/bufbuild/connect-go"
+)
+
+type Option struct {
+	ServerURL      string
+	UseLocalServer bool
+
+	ClientOption connect.ClientOption
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,20 @@ func (c APIConfig) RESTConfig() (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
+type CLIConfig struct {
+	BaseConfig
+}
+
+func NewCLIConfig() CLIConfig {
+	return CLIConfig{
+		BaseConfig: newBaseConfig(),
+	}
+}
+
+func (c CLIConfig) RESTConfig() (*rest.Config, error) {
+	return kubeclient.NewClientConfig().ClientConfig()
+}
+
 type ControllerConfig struct {
 	BaseConfig
 	ArgoCDNamespace         string


### PR DESCRIPTION
Resolves https://github.com/akuity/kargo/issues/263

This commit adds environment promotion command to CLI. Since we discussed about launching dashboard in local environment (to utilize user's `KUBECONFIG`), this commit runs API server in local if the `local-server` flag is passed to the command.

Signed-off-by: Sunghoon Kang <hoon@akuity.io>
