### PR TITLE
Update webhook.go (#415)

### DIFF
--- a/internal/controller/promotions/webhook.go
+++ b/internal/controller/promotions/webhook.go
@@ -75,7 +75,7 @@ func SetupWebhookWithManager(
 			return []string{policy.Environment}
 		},
 	); err != nil {
-		return errors.Wrap(err, "error indexing Secrets by repo")
+		return errors.Wrap(err, "error indexing Promotion Policies by Environment")
 	}
 	w := &webhook{
 		client: mgr.GetClient(),


### PR DESCRIPTION
Changed the error message in webhook.go

From
```error indexing Secrets by repo```

To
```error indexing PromotionPolicies by Environment```