### PR TITLE
Update webhook.go (#415)

### DIFF
--- a/internal/controller/promotions/webhook.go
+++ b/internal/controller/promotions/webhook.go
@@ -75,7 +75,7 @@ func SetupWebhookWithManager(
 			return []string{policy.Environment}
 		},
 	); err != nil {
-		return errors.Wrap(err, "error indexing Secrets by repo")
+		return errors.Wrap(err, "error indexing PromotionPolicies by Environment")
 	}
 	w := &webhook{
 		client: mgr.GetClient(),


### PR DESCRIPTION
Replaced error messge in webhook.go

From
`error indexing Secrets by repo`

To
`error indexing PromotionPolicies by Environment`

Signed-off-by: Akshay Jain <jainakshay1783@gmail.com>