### PR TITLE
chore: separate analytics for kargo docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ const config = {
     [
       path.join(__dirname, "plugins", "gtag", "lib"),
       {
-        trackingID: 'G-9FQ417P33N',
+        trackingID: 'G-0LYKG06H98',
         anonymizeIP: true,
       },
     ],


### PR DESCRIPTION
- current tag referred to docs.akuity.io