### PR TITLE
add option to opt-out of cred borrowing entirely

### DIFF
--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -32,7 +32,9 @@ spec:
           value: /etc/kargo/kubeconfig/kubeconfig.yaml
         {{- end }}
         - name: ARGOCD_NAMESPACE
-          value: {{ .Values.controller.argocdNamespace }}
+          value: {{ .Values.controller.argocd.namespace }}
+        - name: ARGOCD_ENABLE_CREDENTIAL_BORROWING
+          value: {{ quote .Values.controller.argocd.enableCredentialBorrowing }}
         - name: LOG_LEVEL
           value: {{ .Values.controller.logLevel }}
         {{- if .Values.kubeconfigSecret }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -69,8 +69,14 @@ controller:
   ## Whether the controller is enabled.
   enabled: true
 
-  ## The namespace into which Argo CD is installed.
-  argocdNamespace: argocd
+  ## All settings relating to the Argo CD control plane this controller will
+  ## integrate with.
+  argocd:
+    ## The namespace into which Argo CD is installed.
+    namespace: argocd
+    ## Specifies whether Kargo may borrow repository credentials (specially
+    ## formatted and specially annotated Secrets) from Argo CD.
+    enableCredentialBorrowing: true
 
   logLevel: INFO
 

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -48,11 +48,15 @@ func newControllerCommand() *cobra.Command {
 				return errors.Wrap(err, "error getting controller manager")
 			}
 
+			argoMgrForCreds := argoMgr
+			if !cfg.ArgoCDCredentialBorrowingEnabled {
+				argoMgrForCreds = nil
+			}
 			credentialsDB, err := credentials.NewKubernetesDatabase(
 				ctx,
 				cfg.ArgoCDNamespace,
 				kargoMgr,
-				argoMgr,
+				argoMgrForCreds,
 			)
 			if err != nil {
 				return errors.Wrap(err, "error initializing credentials DB")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,13 +67,18 @@ func (c CLIConfig) RESTConfig() (*rest.Config, error) {
 
 type ControllerConfig struct {
 	BaseConfig
-	ArgoCDNamespace string
+	ArgoCDNamespace                  string
+	ArgoCDCredentialBorrowingEnabled bool
 }
 
 func NewControllerConfig() ControllerConfig {
 	return ControllerConfig{
 		BaseConfig:      newBaseConfig(),
 		ArgoCDNamespace: os.MustGetEnv("ARGOCD_NAMESPACE", "argocd"),
+		ArgoCDCredentialBorrowingEnabled: os.MustGetEnvAsBool(
+			"ARGOCD_ENABLE_CREDENTIAL_BORROWING",
+			false,
+		),
 	}
 }
 

--- a/internal/os/env.go
+++ b/internal/os/env.go
@@ -3,6 +3,7 @@ package os
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 // GetEnv retrieves the value of an environment variable having the specified
@@ -28,4 +29,26 @@ func MustGetEnv(key, defaultValue string) string {
 		}
 	}
 	return value
+}
+
+// MustGetEnvAsBool attempts to parse a bool from a string value retrieved from
+// the specified environment variable. If the environment variable is undefined,
+// the specified default value is returned instead. If the environment variable
+// is defined and its value cannot successfully be parsed as a bool, the
+// function panics.
+func MustGetEnvAsBool(name string, defaultValue bool) bool {
+	valStr := os.Getenv(name)
+	if valStr == "" {
+		return defaultValue
+	}
+	if val, err := strconv.ParseBool(valStr); err == nil {
+		return val
+	}
+	panic(
+		fmt.Sprintf(
+			"value %q for environment variable %s was not parsable as a bool",
+			valStr,
+			name,
+		),
+	)
 }

--- a/internal/os/env_test.go
+++ b/internal/os/env_test.go
@@ -46,3 +46,47 @@ func TestMustGetEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBoolFromEnvVar(t *testing.T) {
+	const testEnvVarName = "ENABLED"
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func()
+	}{
+		{
+			name: "env var does not exist",
+			assertions: func() {
+				require.True(t, MustGetEnvAsBool(testEnvVarName, true))
+			},
+		},
+		{
+			name: "env var value not parsable as bool",
+			setup: func() {
+				t.Setenv(testEnvVarName, "not really")
+			},
+			assertions: func() {
+				require.Panics(t, func() {
+					MustGetEnvAsBool(testEnvVarName, false)
+				})
+			},
+		},
+		{
+			name: "env var exists",
+			setup: func() {
+				t.Setenv(testEnvVarName, "true")
+			},
+			assertions: func() {
+				require.True(t, MustGetEnvAsBool(testEnvVarName, false))
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.setup != nil {
+				testCase.setup()
+			}
+			testCase.assertions()
+		})
+	}
+}


### PR DESCRIPTION
Repository credentials (specially formatted Secrets) in Argo CD's namespace already require a special annotation to opt _in_ to being borrowed by the Kargo controller on behalf of a particular project or projects.

This feature takes things a step further and permits the operator who installs Kargo to opt out of credential borrowing behavior entirely.