### PR TITLE
chart improvements to require less sweeping permissions to read secrets

### DIFF
--- a/charts/argocd-kit/templates/argocd/role-binding.yaml
+++ b/charts/argocd-kit/templates/argocd/role-binding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.argocd.enableCredentialBorrowing }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argocd-kit.fullname" . }}-kargo-controller
+  namespace: {{ .Values.argocd.namespace }}
+  labels:
+    {{- include "argocd-kit.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argocd-kit.fullname" . }}-kargo-controller
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "argocd-kit.fullname" . }}-kargo-controller
+{{- end }}

--- a/charts/argocd-kit/templates/argocd/role.yaml
+++ b/charts/argocd-kit/templates/argocd/role.yaml
@@ -1,16 +1,18 @@
+{{- if .Values.argocd.enableCredentialBorrowing }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "argocd-kit.fullname" . }}-kargo-controller
+  namespace: {{ .Values.argocd.namespace }}
   labels:
     {{- include "argocd-kit.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - argoproj.io
+  - ""
   resources:
-  - applications
+  - secrets
   verbs:
   - get
   - list
-  - patch
   - watch
+{{- end }}

--- a/charts/argocd-kit/values.yaml
+++ b/charts/argocd-kit/values.yaml
@@ -1,3 +1,12 @@
 # Default values for argocd-kit.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+  ## All settings relating to the Argo CD control plane this controller will
+  ## integrate with.
+  argocd:
+    ## The namespace into which Argo CD is installed.
+    namespace: argocd
+    ## Specifies whether Kargo may borrow repository credentials (specially
+    ## formatted and specially annotated Secrets) from Argo CD.
+    enableCredentialBorrowing: true

--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.controller.argocd.enableCredentialBorrowing }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kargo.controller.fullname" . }}
+  namespace: {{ .Values.controller.argocd.namespace }}
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kargo.controller.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "kargo.controller.fullname" . }}
+{{- end }}

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.controller.argocd.enableCredentialBorrowing }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kargo.controller.fullname" . }}
+  namespace: {{ .Values.controller.argocd.namespace }}
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.controller.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}


### PR DESCRIPTION
This PR improves the full `kargo` and `argocd-kit` charts to reduce the breadth of `Secret` reading permissions required by the Kargo controller.

For `argo-kit`, this means that `Secret` reading permissions are granted _only_ for the namespace that Argo CD is installed into and, even then, only if "credential borrowing" is enabled per `argocd.enableCredentialBorrowing`.

The logic for the full `kargo` chart is quite similar, _however_, at present, the Kargo controller gets permission to read `Secret` resources from all namespaces regardless, but this is set to change once #250 is addressed.