### PR TITLE
simplify and improve how rest configs for kube clients are loaded

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -27,9 +27,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/kargo", "api"]
           env:
-{{- if .Values.kubeconfigSecret }}
+{{- if .Values.kubeconfigSecrets.kargo }}
             - name: KUBECONFIG
-              value: /etc/kargo/kubeconfig/kubeconfig.yaml
+              value: /etc/kargo/kubeconfigs/kubeconfig.yaml
 {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.api.logLevel }}
@@ -41,19 +41,19 @@ spec:
             exec:
               command: ["/usr/local/bin/grpc_health_probe", "-addr=:8080"]
             initialDelaySeconds: 5
-{{- if .Values.kubeconfigSecret }}
+{{- if .Values.kubeconfigSecrets.kargo }}
           volumeMounts:
-            - mountPath: /etc/kargo/kubeconfig
-              name: kubeconfig
+            - mountPath: /etc/kargo/kubeconfigs
+              name: kubeconfigs
               readOnly: true
 {{- end }}
           resources: {{ toYaml .Values.api.resources }}
-{{- if .Values.kubeconfigSecret }}
+{{- if .Values.kubeconfigSecrets.kargo }}
       volumes:
-        - name: kubeconfig
+        - name: kubeconfigs
           secret:
             defaultMode: 0644
-            secretName: {{ .Values.kubeconfigSecret }}
+            secretName: {{ .Values.kubeconfigSecrets.kargo }}
 {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -27,11 +27,13 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/kargo", "controller"]
         env:
-        {{- if .Values.kubeconfigSecret }}
+        {{- if .Values.kubeconfigSecrets.kargo }}
         - name: KUBECONFIG
-          value: /etc/kargo/kubeconfig/kubeconfig.yaml
-        - name: ARGOCD_PREFER_IN_CLUSTER_REST_CONFIG
-          value: {{ quote .Values.controller.argocd.preferInClusterRestConfig }}
+          value: /etc/kargo/kubeconfigs/kubeconfig.yaml
+        {{- end }}
+        {{- if .Values.kubeconfigSecrets.argocd }}
+        - name: ARGOCD_KUBECONFIG
+          value: /etc/kargo/kubeconfigs/argocd-kubeconfig.yaml
         {{- end }}
         - name: ARGOCD_NAMESPACE
           value: {{ .Values.controller.argocd.namespace }}
@@ -39,20 +41,35 @@ spec:
           value: {{ quote .Values.controller.argocd.enableCredentialBorrowing }}
         - name: LOG_LEVEL
           value: {{ .Values.controller.logLevel }}
-        {{- if .Values.kubeconfigSecret }}
+        {{- if or .Values.kubeconfigSecrets.kargo .Values.kubeconfigSecrets.argocd }}
         volumeMounts:
-        - mountPath: /etc/kargo/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/kargo/kubeconfigs
+          name: kubeconfigs
           readOnly: true
         {{- end }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
-      {{- if .Values.kubeconfigSecret }}
+      {{- if or .Values.kubeconfigSecrets.kargo .Values.kubeconfigSecrets.argocd }}
       volumes:
-      - name: kubeconfig
-        secret:
-          defaultMode: 0644
-          secretName: {{ .Values.kubeconfigSecret }}
+      - name: kubeconfigs
+        projected:
+          sources:
+          {{- if or .Values.kubeconfigSecrets.kargo }}
+          - secret:
+              name: {{ .Values.kubeconfigSecrets.kargo }}
+              items:
+              - key: kubeconfig.yaml
+                path: kubeconfig.yaml
+                mode: 0644
+          {{- end }}
+          {{- if or .Values.kubeconfigSecrets.argocd }}
+          - secret:
+              name: {{ .Values.kubeconfigSecrets.argocd }}
+              items:
+              - key: kubeconfig.yaml
+                path: argocd-kubeconfig.yaml
+                mode: 0644
+          {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -27,9 +27,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/kargo", "webhooks-server"]
         env:
-        {{- if .Values.kubeconfigSecret }}
+        {{- if .Values.kubeconfigSecrets.kargo }}
         - name: KUBECONFIG
-          value: /etc/kargo/kubeconfig/kubeconfig.yaml
+          value: /etc/kargo/kubeconfigs/kubeconfig.yaml
         {{- end }}
         - name: KARGO_CONTROLLER_SERVICE_ACCOUNT
           value: {{ .Values.webhooksServer.controllerServiceAccount.name | default (include "kargo.controller.fullname" .) }}
@@ -45,9 +45,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        {{- if .Values.kubeconfigSecret }}
-        - mountPath: /etc/kargo/kubeconfig
-          name: kubeconfig
+        {{- if .Values.kubeconfigSecrets.kargo }}
+        - mountPath: /etc/kargo/kubeconfigs
+          name: kubeconfigs
           readOnly: true
         {{- end }}
         resources:
@@ -57,11 +57,11 @@ spec:
         secret:
           defaultMode: 0644
           secretName: {{ include "kargo.webhooksServer.fullname" . }}-cert
-      {{- if .Values.kubeconfigSecret }}
-      - name: kubeconfig
+      {{- if .Values.kubeconfigSecrets.kargo }}
+      - name: kubeconfigs
         secret:
           defaultMode: 0644
-          secretName: {{ .Values.kubeconfigSecret }}
+          secretName: {{ .Values.kubeconfigSecrets.kargo }}
       {{- end }}
       {{- with .Values.webhooksServer.nodeSelector }}
       nodeSelector:

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -25,15 +25,16 @@ rbac:
   ## in the Kargo-managed cluster.
   installClusterRoleBindings: true
 
-## Optionally point to a Kubernetes Secret in the same namespace as Kargo that
-## contains the full content of a kubeconfig under the key "kubeconfig.yaml".
-## This is a useful method of hosting Kargo in one cluster, but having it manage
-## Environments, Promotions, Argo CD Applications, etc. that live in a second
-## cluster. Note that CRDs, ValidatingWebhookConfigurations, and
-## MutatingWebhookConfigurations will need to be installed manually into the
-## cluster Kargo will be managing. This can be accomplished using the kargo-kit
-## chart.
-# kubeconfigSecret:
+## Optionally point to Kubernetes Secrets containing kubeconfig for a remote
+## Kubernetes cluster hosting Kargo resources and/or a remote Kubernetes cluster
+## hosting Argo CD resources. This is useful for cases where the Kargo
+## controller is running somewhere other than the cluster(s) it is managing. The
+## config for Kargo and Argo CD can be the same, different, or omitted entirely.
+## When omitted, the controller will fall back on in-cluster configuration.
+## In the average case, these settings should be left alone.
+kubeconfigSecrets: {}
+  # kargo:
+  # argocd:
 
 ## All settings for the api component
 api:
@@ -74,15 +75,6 @@ controller:
   argocd:
     ## The namespace into which Argo CD is installed.
     namespace: argocd
-    ## Override for an override -- prefer in-cluster REST configuration for the
-    ## client that will communicate with the Kubernetes API server that hosts
-    ## Argo CD Application resources. This is useful for rare scenarios where
-    ## kubeconfigSecret has been specified for the sake of providing client
-    ## configuration for a REMOTE Kubernetes API server that hosts Kargo
-    ## resources, BUT Argo CD Application resources are hosted on the same
-    ## cluster on which the Kargo controller will run. This setting can
-    ## typically be left alone.
-    preferInClusterRestConfig: false
     ## Specifies whether Kargo may borrow repository credentials (specially
     ## formatted and specially annotated Secrets) from Argo CD.
     enableCredentialBorrowing: true

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	kargoAPI "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api"
@@ -25,9 +24,11 @@ func newAPICommand() *cobra.Command {
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
 			var kubeClient client.Client
 			{
-				restCfg, err := config.GetConfig()
+				restCfg, err := getRestConfig(ctx, os.GetEnv("KUBECONFIG", ""))
 				if err != nil {
 					return errors.Wrap(err, "error loading REST config")
 				}
@@ -67,7 +68,7 @@ func newAPICommand() *cobra.Command {
 				return errors.Wrap(err, "error creating listener")
 			}
 			defer l.Close()
-			return srv.Serve(cmd.Context(), l, false)
+			return srv.Serve(ctx, l, false)
 		},
 	}
 }

--- a/cmd/controlplane/common.go
+++ b/cmd/controlplane/common.go
@@ -1,34 +1,27 @@
 package main
 
 import (
-	"strings"
+	"context"
 
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-func getRestConfig(
-	cfgCtx string,
-	preferInClusterCfg bool,
-) (*rest.Config, error) {
-	var cfg *rest.Config
-	var err error
-	if preferInClusterCfg {
-		if cfg, err = rest.InClusterConfig(); err != nil {
-			return nil, errors.Wrapf(err, "error loading in-cluster rest config")
-		}
-		return cfg, nil
+func getRestConfig(ctx context.Context, path string) (*rest.Config, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	// clientcmd.BuildConfigFromFlags will fall back on in-cluster config if path
+	// is empty, but will issue a warning that we can suppress by checking for
+	// that condition ourselves and calling rest.InClusterConfig() directly.
+	if path == "" {
+		logger.Debug("loading in-cluster REST config")
+		cfg, err := rest.InClusterConfig()
+		return cfg, errors.Wrap(err, "error loading in-cluster REST config")
 	}
-	if cfg, err = config.GetConfigWithContext(cfgCtx); err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			if cfg, err = config.GetConfig(); err != nil {
-				return nil, errors.Wrapf(err, "error loading default rest config")
-			}
-			return cfg, nil
-		}
-		return nil,
-			errors.Wrapf(err, "error loading rest config for context %q", cfgCtx)
-	}
-	return cfg, nil
+
+	logger.WithField("path", path).Debug("loading REST config from path")
+	cfg, err := clientcmd.BuildConfigFromFlags("", path)
+	return cfg, errors.Wrapf(err, "error loading REST config from %q", path)
 }

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -43,7 +43,7 @@ func newControllerCommand() *cobra.Command {
 
 			var kargoMgr manager.Manager
 			{
-				restCfg, err := getRestConfig("kargo", false)
+				restCfg, err := getRestConfig(ctx, os.GetEnv("KUBECONFIG", ""))
 				if err != nil {
 					return errors.Wrap(
 						err,
@@ -84,12 +84,7 @@ func newControllerCommand() *cobra.Command {
 
 			var appMgr manager.Manager
 			{
-				restCfg, err := getRestConfig(
-					"argo",
-					types.MustParseBool(
-						os.GetEnv("ARGOCD_PREFER_IN_CLUSTER_REST_CONFIG", "false"),
-					),
-				)
+				restCfg, err := getRestConfig(ctx, os.GetEnv("ARGOCD_KUBECONFIG", ""))
 				if err != nil {
 					return errors.Wrap(
 						err,

--- a/cmd/controlplane/webhooks.go
+++ b/cmd/controlplane/webhooks.go
@@ -9,6 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	api "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 	"github.com/akuity/kargo/internal/webhooks/environments"
 	"github.com/akuity/kargo/internal/webhooks/promotions"
@@ -29,7 +30,7 @@ func newWebhooksServerCommand() *cobra.Command {
 				"commit":  version.GitCommit,
 			}).Info("Starting Kargo Webhooks Server")
 
-			restCfg, err := getRestConfig("kargo", false)
+			restCfg, err := getRestConfig(ctx, os.GetEnv("KUBECONFIG", ""))
 			if err != nil {
 				return errors.Wrap(err, "error getting REST config")
 			}


### PR DESCRIPTION
This PR simplifies how kubeconfigs are loaded. This is especially relevant for the controller, which sometimes may need to load two separate configs -- one for a remote cluster hosting Kargo resourced and another for a remote cluster hosting Argo CD resources.

Prior to this PR, this could only be achieved by creating a kubeconfig containing two separate contexts and embedding it in a secret.

Now you can use two secretes to provide two separate kubeconfigs.

We always fall back in in-cluster config.

cc @gdsoumya 