### PR TITLE
remove redundant permissions

### DIFF
--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -58,14 +58,6 @@ metadata:
     {{- include "kargo.controller.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - argoproj.io
   resources:
   - applications


### PR DESCRIPTION
This PR removes redundant permissions.

1. Secret read/list/watch on all namespaces is already granted starting on line 10 of this same file. (#250 will eventually offer the option to dial this back to certain namespaces.)

1. Secret read/list/watch on all namespaces is certainly _not_ associated with Argo CD in any way, as at most, we only ever need to read/list/watch Secrets from Argo CD's own namespace.

Bottom line... this deleted snippet is already redundant and it's doubly redundant when you consider other changes coming down the pike.