### PR TITLE
webhooks: remove special authz logic for namespace controller 

### DIFF
--- a/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
@@ -14,4 +14,20 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ include "kargo.webhooksServer.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: namespace-controller
 {{- end }}

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -13,4 +13,25 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+# This cluster role is custom for the namespace controller. The namespace
+# controller will not actually be able to carry our promotions because it lacks
+# permission to create Promotion resources, but having the custom promote verb
+# on Environments allows it to delete Promotion resources associated with any
+# Environment when a namespace is deleted. Without this, the webhook would
+# prevent that.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - kargo.akuity.io
+  resources:
+  - environments
+  verbs:
+  - promote
 {{- end }}

--- a/internal/webhooks/promotions/webhooks.go
+++ b/internal/webhooks/promotions/webhooks.go
@@ -93,33 +93,8 @@ func (w *webhook) ValidateDelete(
 	ctx context.Context,
 	obj runtime.Object,
 ) error {
-	logger := logging.LoggerFromContext(ctx)
-
-	promo := obj.(*api.Promotion) // nolint: forcetypeassert
-
-	// Special logic for delete only. Allow any delete by the Kubernetes namespace
-	// controller. This prevents the webhook from stopping a namespace from being
-	// cleaned up.
-	req, err := w.admissionRequestFromContextFn(ctx)
-	if err != nil {
-		logger.Error(err)
-		return apierrors.NewForbidden(
-			schema.GroupResource{
-				Group:    api.GroupVersion.Group,
-				Resource: "Promotion",
-			},
-			promo.Name,
-			errors.New(
-				"error retrieving admission request from context; refusing to "+
-					"delete Promotion",
-			),
-		)
-	}
-	if req.UserInfo.Username == "system:serviceaccount:kube-system:namespace-controller" {
-		return nil
-	}
-
-	return w.authorizeFn(ctx, promo, "delete")
+	// nolint: forcetypeassert
+	return w.authorizeFn(ctx, obj.(*api.Promotion), "delete")
 }
 
 func (w *webhook) authorize(

--- a/internal/webhooks/promotions/webhooks_test.go
+++ b/internal/webhooks/promotions/webhooks_test.go
@@ -6,10 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	admissionv1 "k8s.io/api/admission/v1"
-	authenticationv1 "k8s.io/api/authentication/v1"
 	authzv1 "k8s.io/api/authorization/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -116,93 +113,12 @@ func TestValidateUpdate(t *testing.T) {
 }
 
 func TestValidateDelete(t *testing.T) {
-	testCases := []struct {
-		name                          string
-		admissionRequestFromContextFn func(
-			context.Context,
-		) (admission.Request, error)
-		authorizeFn func(
-			context.Context,
-			*api.Promotion,
-			string,
-		) error
-		assertions func(error)
-	}{
-		{
-			name: "error getting admission request bound to context",
-			admissionRequestFromContextFn: func(
-				context.Context,
-			) (admission.Request, error) {
-				return admission.Request{}, errors.New("something went wrong")
-			},
-			assertions: func(err error) {
-				require.Error(t, err)
-				require.True(t, apierrors.IsForbidden(err))
-				require.Contains(
-					t,
-					err.Error(),
-					"error retrieving admission request from context",
-				)
-			},
-		},
-		{
-			name: "user is namespace controller service account",
-			admissionRequestFromContextFn: func(
-				context.Context,
-			) (admission.Request, error) {
-				return admission.Request{
-					AdmissionRequest: admissionv1.AdmissionRequest{
-						UserInfo: authenticationv1.UserInfo{
-							Username: "system:serviceaccount:kube-system:namespace-controller", // nolint: lll
-						},
-					},
-				}, nil
-			},
-			assertions: func(err error) {
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "user is not authorized",
-			admissionRequestFromContextFn: func(
-				context.Context,
-			) (admission.Request, error) {
-				return admission.Request{}, nil
-			},
-			authorizeFn: func(context.Context, *api.Promotion, string) error {
-				return errors.Errorf("not authorized")
-			},
-			assertions: func(err error) {
-				require.Error(t, err)
-				require.Equal(t, "not authorized", err.Error())
-			},
-		},
-		{
-			name: "user is authorized",
-			admissionRequestFromContextFn: func(
-				context.Context,
-			) (admission.Request, error) {
-				return admission.Request{}, nil
-			},
-			authorizeFn: func(context.Context, *api.Promotion, string) error {
-				return nil
-			},
-			assertions: func(err error) {
-				require.NoError(t, err)
-			},
+	w := &webhook{
+		authorizeFn: func(context.Context, *api.Promotion, string) error {
+			return nil // Always authorize
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			w := &webhook{
-				admissionRequestFromContextFn: testCase.admissionRequestFromContextFn,
-				authorizeFn:                   testCase.authorizeFn,
-			}
-			testCase.assertions(
-				w.ValidateDelete(context.Background(), &api.Promotion{}),
-			)
-		})
-	}
+	require.NoError(t, w.ValidateDelete(context.Background(), &api.Promotion{}))
 }
 
 func TestAuthorize(t *testing.T) {


### PR DESCRIPTION
With this change, we no longer need special logic in the webhooks to accommodate cases where the namespace controller is cleaning up a deleted namespace.

cc @gdsoumya. I believe we had previously discussed this.