### PR TITLE
fix(api): allow hyphens in image name and domain

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -289,7 +289,7 @@ message HelmImageUpdate {
   // Image specifies a container image (without tag). This is a required field.
   //
   // +kubebuilder:validation:MinLength=1
-  // +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+  // +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
   optional string image = 1 [(gogoproto.customname) = "Image", (gogoproto.nullable) = false];
 
   // ValuesFilePath specifies a path to the Helm values file that is to be
@@ -340,7 +340,7 @@ message ImageSubscription {
   // value in this field MUST NOT include an image tag. This field is required.
   //
   // +kubebuilder:validation:MinLength=1
-  // +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+  // +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
   optional string repoURL = 1 [(gogoproto.customname) = "RepoURL", (gogoproto.nullable) = false];
 
   // UpdateStrategy specifies the rules for how to identify the newest version

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -112,7 +112,7 @@ type ImageSubscription struct {
 	// value in this field MUST NOT include an image tag. This field is required.
 	//
 	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+	//+kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
 	RepoURL string `json:"repoURL"`
 	// UpdateStrategy specifies the rules for how to identify the newest version
 	// of the image specified by the RepoURL field. This field is optional. When
@@ -302,7 +302,7 @@ type HelmImageUpdate struct {
 	// Image specifies a container image (without tag). This is a required field.
 	//
 	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+	//+kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
 	Image string `json:"image"`
 	// ValuesFilePath specifies a path to the Helm values file that is to be
 	// updated. This is a required field.

--- a/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
@@ -250,7 +250,7 @@ spec:
                                     description: Image specifies a container image
                                       (without tag). This is a required field.
                                     minLength: 1
-                                    pattern: ^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$
+                                    pattern: ^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$
                                     type: string
                                   key:
                                     description: Key specifies a key within the Helm
@@ -452,7 +452,7 @@ spec:
                                 repository to subscribe to. The value in this field
                                 MUST NOT include an image tag. This field is required.
                               minLength: 1
-                              pattern: ^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$
+                              pattern: ^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$
                               type: string
                             semverConstraint:
                               description: SemverConstraint specifies constraints

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -250,7 +250,7 @@ spec:
                                     description: Image specifies a container image
                                       (without tag). This is a required field.
                                     minLength: 1
-                                    pattern: ^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$
+                                    pattern: ^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$
                                     type: string
                                   key:
                                     description: Key specifies a key within the Helm
@@ -452,7 +452,7 @@ spec:
                                 repository to subscribe to. The value in this field
                                 MUST NOT include an image tag. This field is required.
                               minLength: 1
-                              pattern: ^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$
+                              pattern: ^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$
                               type: string
                             semverConstraint:
                               description: SemverConstraint specifies constraints

--- a/pkg/api/v1alpha1/generated.pb.go
+++ b/pkg/api/v1alpha1/generated.pb.go
@@ -992,7 +992,7 @@ type HelmImageUpdate struct {
 	// Image specifies a container image (without tag). This is a required field.
 	//
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+	// +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
 	Image *string `protobuf:"bytes,1,opt,name=image" json:"image,omitempty"`
 	// ValuesFilePath specifies a path to the Helm values file that is to be
 	// updated. This is a required field.
@@ -1202,7 +1202,7 @@ type ImageSubscription struct {
 	// value in this field MUST NOT include an image tag. This field is required.
 	//
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+	// +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
 	RepoURL *string `protobuf:"bytes,1,opt,name=repoURL" json:"repoURL,omitempty"`
 	// UpdateStrategy specifies the rules for how to identify the newest version
 	// of the image specified by the RepoURL field. This field is optional. When

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -850,7 +850,7 @@ export class HelmImageUpdate extends Message<HelmImageUpdate> {
    * Image specifies a container image (without tag). This is a required field.
    *
    * +kubebuilder:validation:MinLength=1
-   * +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+   * +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
    *
    * @generated from field: optional string image = 1;
    */
@@ -1031,7 +1031,7 @@ export class ImageSubscription extends Message<ImageSubscription> {
    * value in this field MUST NOT include an image tag. This field is required.
    *
    * +kubebuilder:validation:MinLength=1
-   * +kubebuilder:validation:Pattern=`^(([\w\d\.]+)(:[\d]+)?/)?[a-z0-9]+(/[a-z0-9]+)*$`
+   * +kubebuilder:validation:Pattern=`^(([\w\d\.-]+)(:[\d]+)?/)?[a-z0-9-]+(/[a-z0-9-]+)*$`
    *
    * @generated from field: optional string repoURL = 1;
    */


### PR DESCRIPTION
Image registry domains, paths, and names may contain a hyphen. Fixes #451 

Regex tests here: https://regexr.com/7gra7