### PR TITLE
fix use of context.TODO() in tests

### DIFF
--- a/internal/api/handler/get_stage_v1alpha1_test.go
+++ b/internal/api/handler/get_stage_v1alpha1_test.go
@@ -71,8 +71,8 @@ func TestGetStageV1Alpha1(t *testing.T) {
 				).
 				Build()
 
-			ctx := context.TODO()
-			res, err := GetStageV1Alpha1(kc)(ctx, connect.NewRequest(ts.req))
+			res, err :=
+				GetStageV1Alpha1(kc)(context.Background(), connect.NewRequest(ts.req))
 			if ts.errExpected {
 				require.Error(t, err)
 				require.Equal(t, ts.expectedCode, connect.CodeOf(err))

--- a/internal/api/handler/list_stages_v1alpha1_test.go
+++ b/internal/api/handler/list_stages_v1alpha1_test.go
@@ -56,8 +56,8 @@ func TestListStagesV1Alpha1(t *testing.T) {
 				}).
 				Build()
 
-			ctx := context.TODO()
-			res, err := ListStagesV1Alpha1(kc)(ctx, connect.NewRequest(ts.req))
+			res, err :=
+				ListStagesV1Alpha1(kc)(context.Background(), connect.NewRequest(ts.req))
 			if ts.errExpected {
 				require.Error(t, err)
 				require.Equal(t, ts.expectedCode, connect.CodeOf(err))

--- a/internal/api/handler/promote_stage_v1alpha1_test.go
+++ b/internal/api/handler/promote_stage_v1alpha1_test.go
@@ -72,7 +72,7 @@ func TestPromoteStageV1Alpha1(t *testing.T) {
 				}).
 				Build()
 
-			ctx := context.TODO()
+			ctx := context.Background()
 			res, err := PromoteStageV1Alpha1(kc)(ctx, connect.NewRequest(ts.req))
 			if ts.errExpected {
 				require.Error(t, err)

--- a/internal/kubeclient/transport_test.go
+++ b/internal/kubeclient/transport_test.go
@@ -41,7 +41,7 @@ func Test_credentialHook(t *testing.T) {
 			if ts.credential != "" {
 				req.Header.Set("Authorization", ts.credential)
 			}
-			res, err := hc.Do(req.WithContext(context.TODO()))
+			res, err := hc.Do(req.WithContext(context.Background()))
 			defer func() {
 				_ = res.Body.Close()
 			}()


### PR DESCRIPTION
Let's prefer using `context.Background()` over `context.TODO()` in test code. The latter creates the impression there is something in need of fixing when there really isn't anything to fix.