### PR TITLE
low-level sharding support in the controller

### DIFF
--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/kargo", "controller"]
         env:
+        {{- if .Values.controller.shardName }}
+        - name: SHARD_NAME
+          value: {{ .Values.controller.shardName }}
+        {{- end }}
         {{- if .Values.kubeconfigSecrets.kargo }}
         - name: KUBECONFIG
           value: /etc/kargo/kubeconfigs/kubeconfig.yaml

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -70,6 +70,11 @@ controller:
   ## Whether the controller is enabled.
   enabled: true
 
+  ## Set a shard name if, and only if, you are running multiple controllers
+  ## backed by a single underlying control plane. This is advanced configuration
+  ## and in nearly all cases should be left undefined.
+  # shardName:
+
   ## All settings relating to the Argo CD control plane this controller will
   ## integrate with.
   argocd:

--- a/internal/controller/applications/applications_test.go
+++ b/internal/controller/applications/applications_test.go
@@ -1,0 +1,90 @@
+package applications
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller"
+)
+
+func TestIndexStagesByApp(t *testing.T) {
+	testCases := []struct {
+		name            string
+		controllerShard string
+		stage           *api.Stage
+		assertions      func([]string)
+	}{
+		{
+			name: "stage has no health checks",
+			stage: &api.Stage{
+				Spec: &api.StageSpec{},
+			},
+			assertions: func(res []string) {
+				require.Nil(t, res)
+			},
+		},
+
+		{
+			name:            "stage has health checks, but belongs to another shard",
+			controllerShard: "foo",
+			stage: &api.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						controller.ShardLabelKey: "bar",
+					},
+				},
+				Spec: &api.StageSpec{
+					PromotionMechanisms: &api.PromotionMechanisms{
+						ArgoCDAppUpdates: []api.ArgoCDAppUpdate{
+							{
+								AppNamespace: "fake-namespace",
+								AppName:      "fake-app",
+							},
+						},
+					},
+				},
+			},
+			assertions: func(res []string) {
+				require.Nil(t, res)
+			},
+		},
+
+		{
+			name: "stage has health checks",
+			stage: &api.Stage{
+				Spec: &api.StageSpec{
+					PromotionMechanisms: &api.PromotionMechanisms{
+						ArgoCDAppUpdates: []api.ArgoCDAppUpdate{
+							{
+								AppNamespace: "fake-namespace",
+								AppName:      "fake-app",
+							},
+							{
+								AppNamespace: "another-fake-namespace",
+								AppName:      "another-fake-app",
+							},
+						},
+					},
+				},
+			},
+			assertions: func(res []string) {
+				require.Equal(
+					t,
+					[]string{
+						"fake-namespace:fake-app",
+						"another-fake-namespace:another-fake-app",
+					},
+					res,
+				)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			indexStagesByApp(testCase.controllerShard)(testCase.stage)
+		})
+	}
+}

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -1,0 +1,3 @@
+package controller
+
+const ShardLabelKey = "kargo.akuity.io/shard"

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -48,58 +48,6 @@ func TestNewStageReconciler(t *testing.T) {
 	require.NotNil(t, e.getLatestCommitIDFn)
 }
 
-func TestIndexStagesByApp(t *testing.T) {
-	testCases := []struct {
-		name       string
-		stage      *api.Stage
-		assertions func([]string)
-	}{
-		{
-			name: "stage has no health checks",
-			stage: &api.Stage{
-				Spec: &api.StageSpec{},
-			},
-			assertions: func(res []string) {
-				require.Nil(t, res)
-			},
-		},
-		{
-			name: "stage has health checks",
-			stage: &api.Stage{
-				Spec: &api.StageSpec{
-					PromotionMechanisms: &api.PromotionMechanisms{
-						ArgoCDAppUpdates: []api.ArgoCDAppUpdate{
-							{
-								AppNamespace: "fake-namespace",
-								AppName:      "fake-app",
-							},
-							{
-								AppNamespace: "another-fake-namespace",
-								AppName:      "another-fake-app",
-							},
-						},
-					},
-				},
-			},
-			assertions: func(res []string) {
-				require.Equal(
-					t,
-					[]string{
-						"fake-namespace:fake-app",
-						"another-fake-namespace:another-fake-app",
-					},
-					res,
-				)
-			},
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			indexStagesByApp(testCase.stage)
-		})
-	}
-}
-
 func TestIndexOutstandingPromotionsByStage(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -121,7 +69,7 @@ func TestIndexOutstandingPromotionsByStage(t *testing.T) {
 			},
 		},
 		{
-			name: "promotion is in terminal phase",
+			name: "promotion is in non-terminal phase",
 			promotion: &api.Promotion{
 				Spec: &api.PromotionSpec{
 					Stage: "fake-stage",


### PR DESCRIPTION
I anticipate some follow-ups to this, but this works.

cc @gdsoumya: I think this PR is of particular interest to you.

__Edit:__ More details...

This PR mainly involves updates to each of the three reconcilers.

1. Stages: The reconciler only watches Stages labeled as this controller's responsibility

1. Promotions: The reconciler only watches Promotions labeled as this controller's responsibility

1. Argo CD Applications: The reconciler still watches all Applications that it can see, but the index of "Stages by Application" is now "Stages labeled as this controller's responsibility by Application." (There are reasons this is possibly unnecessary, but it seemed like a quick, easy, and reasonable safeguard.)

Additionally, if and when the Stages reconciler creates a Promotion (auto-promotion), the new Promotion will automatically receive the same label as the Stage.

I anticipate some follow-up PRs to make this a better overall UX:

I want to promote "shard" to be a spec field. Labels are still more useful for filtering watches, so none of what's in this PR goes away, but I will amend the webhooks to guarantee shard labels always match the spec.shard field.

I've tested this by deploying two Kargo controllers in the same cluster.