### PR TITLE
add nodejs and pnpm to Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,6 +6,7 @@ ARG BUF_VERSION=v1.15.1
 ARG CONTROLLER_GEN_VERSION=v0.11.3
 ARG GOLANGCI_LINT_VERSION=1.51.2
 ARG HELM_VERSION=v3.10.0
+ARG NODE_VERSION=18.x
 
 RUN go install github.com/bufbuild/buf/cmd/buf@${BUF_VERSION} \
     && go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} \
@@ -13,4 +14,8 @@ RUN go install github.com/bufbuild/buf/cmd/buf@${BUF_VERSION} \
     && curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz \
         | tar xvz golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}/golangci-lint --strip-components=1 \
     && curl -sSfL https://get.helm.sh/helm-$HELM_VERSION-linux-${TARGETARCH}.tar.gz \
-        | tar xvz linux-${TARGETARCH}/helm --strip-components=1
+        | tar xvz linux-${TARGETARCH}/helm --strip-components=1 \
+    && curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash \
+    && apt install nodejs \
+    && curl -fsSL https://get.pnpm.io/install.sh | bash \
+    && mv /root/.local/share/pnpm/pnpm /usr/bin


### PR DESCRIPTION
I rely on `Dockerfile.dev` to provide the correct versions of different tools we use.

The containerized analog to `make codegen` (`make hack-codegen`) has bee broken lately because it was lacking Node.js and pnpm, both of which are required for the TS/JS code generation steps.

This PR fixes this.