### PR TITLE
add docs/ to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 bin/
+docs/


### PR DESCRIPTION
This speeds up the execution of `make hack-build` by quite a bit if you're like me and have a `docs/` directory chock full of `node_modules`.