### PR TITLE
cli: persist bearer and/or refresh tokens in ~/.kargo/config on login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-redis/cache/v8 v8.4.2 // indirect
@@ -66,6 +66,7 @@ require k8s.io/apiserver v0.24.2 // indirect
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver v1.5.0
+	github.com/adrg/xdg v0.4.0
 	github.com/akuity/bookkeeper v0.1.0-rc.19
 	github.com/argoproj-labs/argocd-image-updater v0.12.1
 	github.com/argoproj/argo-cd/v2 v2.6.7

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d/go.mod h1:WML6KO
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akuity/bookkeeper v0.1.0-rc.19 h1:fkKJLFN1cgLGtktzyeMPDgvkIDmXrz+Ye9F2QdJULAY=
@@ -1480,6 +1482,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -12,6 +12,21 @@ import (
 var xdgConfigPath string
 
 func init() {
+	// If the XDG_CONFIG_HOME env var isn't set, we want to set it ourselves
+	// because we disagree with both Go and the xdg package's interpretation of
+	// what the default config home directory should be on non-*nix systems.
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			panic(errors.Wrap(err, "error determining user home directory"))
+		}
+		// This is what the spec says the default should be.
+		//
+		// See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+		os.Setenv("XDG_CONFIG_HOME", filepath.Join(userHome, ".config"))
+		xdg.Reload()
+	}
 	var err error
 	if xdgConfigPath, err =
 		xdg.ConfigFile(filepath.Join("kargo", "config")); err != nil {

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCLIConfig(t *testing.T) {
+	testConfig := CLIConfig{
+		APIAddress:  "http://localhost:8080",
+		BearerToken: "thisisafaketoken",
+	}
+	testCases := []struct {
+		name       string
+		setup      func() string
+		assertions func(cfg CLIConfig, ok bool, err error)
+	}{
+		{
+			name: "file does not exist",
+			setup: func() string {
+				return getTestConfigPath()
+			},
+			assertions: func(_ CLIConfig, ok bool, err error) {
+				require.NoError(t, err)
+				require.False(t, ok)
+			},
+		},
+		{
+			name: "file exists but is invalid",
+			setup: func() string {
+				configPath := getTestConfigPath()
+				err := os.WriteFile(configPath, []byte("this is not yaml"), 0600)
+				require.NoError(t, err)
+				return configPath
+			},
+			assertions: func(_ CLIConfig, ok bool, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "error parsing configuration file")
+				require.False(t, ok)
+			},
+		},
+		{
+			name: "file exists and is valid",
+			setup: func() string {
+				configPath := getTestConfigPath()
+				configBytes, err := yaml.Marshal(testConfig)
+				require.NoError(t, err)
+				err = os.WriteFile(configPath, configBytes, 0600)
+				require.NoError(t, err)
+				return configPath
+			},
+			assertions: func(cfg CLIConfig, ok bool, err error) {
+				require.NoError(t, err)
+				require.True(t, ok)
+				require.Equal(t, testConfig, cfg)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			configPath := testCase.setup()
+			testCase.assertions(loadCLIConfig(configPath))
+		})
+	}
+}
+
+func TestSaveCLIConfig(t *testing.T) {
+	testConfig := CLIConfig{
+		APIAddress:  "http://localhost:8080",
+		BearerToken: "thisisafaketoken",
+	}
+
+	configPath := getTestConfigPath()
+
+	err := saveCLIConfig(testConfig, configPath)
+	require.NoError(t, err)
+
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	cfg := CLIConfig{}
+	err = yaml.Unmarshal(configBytes, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, testConfig, cfg)
+}
+
+func TestDeleteCLIConfig(t *testing.T) {
+	testCases := []struct {
+		name  string
+		setup func() string
+	}{
+		{
+			name: "file does not exist",
+			setup: func() string {
+				return getTestConfigPath()
+			},
+		},
+		{
+			name: "file exists",
+			setup: func() string {
+				configPath := getTestConfigPath()
+				err := os.WriteFile(configPath, []byte("nonsense"), 0600)
+				require.NoError(t, err)
+				return configPath
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.NoError(t, deleteCLIConfig(testCase.setup()))
+		})
+	}
+}
+
+func getTestConfigPath() string {
+	return filepath.Join(os.TempDir(), "config")
+}


### PR DESCRIPTION
Part of #482 

No matter how you log in, this saves server address, a token, and, if applicable, a refresh token in a local configuration file.

The token could be any of:

* An ID token issued by an OIDC provider
* An ID token issued by the Kargo API server itself
* A bearer token gleaned from local kubeconfig

In all cases, we treat the token the same. i.e. Even ID tokens will (in a future PR) be _used_ as bearer tokens when interacting with the Kargo API server. This is not technically a correct thing to do, but there is widespread precedent for it.