### PR TITLE
add CLI build to CI and release processes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
     - name: Check nothing has changed
       run: git diff --exit-code -- .
 
-  build:
+  build-image:
     needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
     runs-on: ubuntu-latest
     steps:
@@ -134,3 +134,22 @@ jobs:
         push: false
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+  build-cli:
+    needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.20.7-bookworm
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: /go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build CLI
+      env:
+        GOFLAGS: -buildvcs=false
+      run: make build-cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  push:
+  publish-image:
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU
@@ -55,7 +55,7 @@ jobs:
         image: ${{ steps.meta.outputs.tags }}
 
   publish-charts:
-    needs: push
+    needs: publish-image
     runs-on: ubuntu-latest
     steps:
     - name: Set up Helm
@@ -89,3 +89,36 @@ jobs:
         helm dep up
         helm package . --version ${CHART_VERSION}
         helm push argocd-kit-${CHART_VERSION}.tgz oci://${KARGO_CHARTS_REPO}
+
+  publish-cli:
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.20.7-bookworm
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: /go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build CLI
+      env:
+        GOFLAGS: -buildvcs=false
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
+        VERSION: ${{ github.ref_name }}
+        GIT_COMMIT: ${{ github.sha }}
+        GIT_TREE_STATE: clean
+      run: make build-cli
+    - name: Publish CLI
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: bin/*
+        file_glob: true
+        repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #501

`make build-cli` will cross-compile the CLI for any OS and CPU architecture.

`make hack-build-cli` will cross-compile the CLI for any OS and CPU architecture _inside a container_.

In either case, the OS and CPU architecture default to those of the _host_ machine.

In CI the process, we build the CLI just once to validate there are no compilation errors.

In the release process, we invoke `make build-cli` six times for six common OS/arch combinations. All of these get uploaded to the release page.


