### PR TITLE
strip/add "Bearer " prefix when reading/setting auth header

### DIFF
--- a/internal/kubeclient/auth.go
+++ b/internal/kubeclient/auth.go
@@ -3,6 +3,7 @@ package kubeclient
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"k8s.io/client-go/rest"
 )
@@ -42,5 +43,8 @@ func GetCredential(ctx context.Context, cfg *rest.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return res.Header.Get(xKargoUserCredentialHeader), nil
+	return strings.TrimPrefix(
+		res.Header.Get(xKargoUserCredentialHeader),
+		"Bearer ",
+	), nil
 }


### PR DESCRIPTION
Related to #508

I have observed that when we use `kubeclient.GetCredential()` to glean the Kubernetes bearer token from the current Kubeconfig, the result returned includes the prefix `"Bearer "`.

This can even be seen in the config that is saved upon login in #508:

```console
cat ~/.config/kargo/config
apiAddress: http://localhost:30081
bearerToken: Bearer <redacted>
```

Since I don't want to store an _HTTP header_ and want to store _just the token_, I need to strip the "Bearer " prefix from the header value at the end of `kubeclient.GetCredential()`.

If we strip it there, we _also_ have to put it back before using it -- hence the complementary changes in the `option` package.

In the end, this is cleaner because awareness of how to format the header correctly is built into the components that set and get the header value instead of those components assuming that the token was pre-formatted for use as an auth header value.