### PR TITLE
slight refactoring of config.LoadCLIConfig() func

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -55,35 +55,39 @@ type CLIConfig struct {
 
 // LoadCLIConfig loads Kargo CLI configuration from a file in the Kargo home
 // directory.
-func LoadCLIConfig() (CLIConfig, bool, error) {
+func LoadCLIConfig() (CLIConfig, error) {
 	return loadCLIConfig(xdgConfigPath)
 }
 
-func loadCLIConfig(configPath string) (CLIConfig, bool, error) {
+func loadCLIConfig(configPath string) (CLIConfig, error) {
 	cfg := CLIConfig{}
 	_, err := os.Stat(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return cfg, false, nil
+			return cfg, errors.Errorf(
+				"no configuration file was found at %s; please use `kargo login` to "+
+					"continue\n",
+				configPath,
+			)
 		}
-		return cfg, false, err
+		return cfg, err
 	}
 	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
-		return cfg, false, errors.Wrapf(
+		return cfg, errors.Wrapf(
 			err,
 			"error reading configuration file at %s",
 			configPath,
 		)
 	}
 	if err := yaml.Unmarshal(configBytes, &cfg); err != nil {
-		return cfg, false, errors.Wrapf(
+		return cfg, errors.Wrapf(
 			err,
 			"error parsing configuration file at %s",
 			configPath,
 		)
 	}
-	return cfg, true, nil
+	return cfg, nil
 }
 
 // SaveCLIConfig saves Kargo CLI configuration to a file in the Kargo home

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -17,16 +17,16 @@ func TestLoadCLIConfig(t *testing.T) {
 	testCases := []struct {
 		name       string
 		setup      func() string
-		assertions func(cfg CLIConfig, ok bool, err error)
+		assertions func(cfg CLIConfig, err error)
 	}{
 		{
 			name: "file does not exist",
 			setup: func() string {
 				return getTestConfigPath()
 			},
-			assertions: func(_ CLIConfig, ok bool, err error) {
-				require.NoError(t, err)
-				require.False(t, ok)
+			assertions: func(_ CLIConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "no configuration file was found")
 			},
 		},
 		{
@@ -37,10 +37,9 @@ func TestLoadCLIConfig(t *testing.T) {
 				require.NoError(t, err)
 				return configPath
 			},
-			assertions: func(_ CLIConfig, ok bool, err error) {
+			assertions: func(_ CLIConfig, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error parsing configuration file")
-				require.False(t, ok)
 			},
 		},
 		{
@@ -53,9 +52,8 @@ func TestLoadCLIConfig(t *testing.T) {
 				require.NoError(t, err)
 				return configPath
 			},
-			assertions: func(cfg CLIConfig, ok bool, err error) {
+			assertions: func(cfg CLIConfig, err error) {
 				require.NoError(t, err)
-				require.True(t, ok)
 				require.Equal(t, testConfig, cfg)
 			},
 		},


### PR DESCRIPTION
This is a slight refactor of recent changes from #508.

I had anticipated cases where I might try to load config and find that none existed and proceed _without_ an error, but I am not finding any such case. Since that isn't required, this approach is more straightforward.