### PR TITLE
chart: fix dex server liveness/readiness probes

### DIFF
--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -31,24 +31,24 @@ spec:
           readOnly: true
         resources:
           {{- toYaml .Values.api.oidc.dex.resources | nindent 10 }}
-      livenessProbe:
-        httpGet:
-          path: /healthz/live
-          port: 5558
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 1
-        successThreshold: 1
-        failureThreshold: 300
-      readinessProbe:
-        httpGet:
-          path: /healthz/ready
-          port: 5558
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 1
-        successThreshold: 1
-        failureThreshold: 300
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 5558
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 300
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 5558
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 300
       volumes:
       - name: config
         projected:


### PR DESCRIPTION
These probes were not working because they weren't indented at the proper level.

Before this PR: We get warnings on chart install/upgrade.

After: Probes work as expected.