### PR TITLE
chart: make api service configurable

### DIFF
--- a/charts/kargo/templates/api/service.yaml
+++ b/charts/kargo/templates/api/service.yaml
@@ -7,11 +7,14 @@ metadata:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.api.service.type }}
   ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
+  - protocol: TCP
+    port: 80
+    {{- if and (or (eq .Values.api.service.type "NodePort") (eq .Values.api.service.type "LoadBalancer")) .Values.api.service.nodePort}}
+    nodePort: {{ .Values.api.service.nodePort }}
+    {{- end }}
+    targetPort: 8080
   selector:
     {{- include "kargo.selectorLabels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -55,6 +55,17 @@ api:
 
   logLevel: INFO
 
+  service:
+    ## If you're not going to use an ingress controller, you may want to change
+    ## this value to LoadBalancer for production deployments. If running
+    ## locally, you may want to change it to NodePort OR leave it as ClusterIP
+    ## and use `kubectl port-forward` to map a port on the local network
+    ## interface to the service.
+    type: ClusterIP
+    ## Host port the service will be mapped to when service type is either
+    ## NodePort or LoadBalancer. If not specified, Kubernetes chooses.
+    # nodePort:
+
   adminAccount:
 
     ## Whether to enable the admin account.


### PR DESCRIPTION
Lacking this feature has presented a barrier to a meaningful installation in a real cluster.