### PR TITLE
chart: explicitly set namespace on namespace-scoped resources

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kargo.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/secret.yaml
+++ b/charts/kargo/templates/api/secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "kargo.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/service-account.yaml
+++ b/charts/kargo/templates/api/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kargo.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/service.yaml
+++ b/charts/kargo/templates/api/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kargo.fullname" . }}-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/common/cert-issuer.yaml
+++ b/charts/kargo/templates/common/cert-issuer.yaml
@@ -4,6 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "kargo.fullname" . }}-selfsigned-cert-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kargo.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}

--- a/charts/kargo/templates/controller/service-account.yaml
+++ b/charts/kargo/templates/controller/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kargo.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/cert.yaml
+++ b/charts/kargo/templates/dex-server/cert.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "kargo.dexServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - {{ include "kargo.dexServer.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/kargo/templates/dex-server/configmap.yaml
+++ b/charts/kargo/templates/dex-server/configmap.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 metadata:
   name: 
   name: {{ include "kargo.dexServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kargo.dexServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/service-account.yaml
+++ b/charts/kargo/templates/dex-server/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kargo.dexServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/service.yaml
+++ b/charts/kargo/templates/dex-server/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kargo.dexServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "kargo.garbageCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}

--- a/charts/kargo/templates/garbage-collector/service-account.yaml
+++ b/charts/kargo/templates/garbage-collector/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kargo.garbageCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/cert.yaml
+++ b/charts/kargo/templates/webhooks-server/cert.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "kargo.webhooksServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - {{ include "kargo.webhooksServer.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kargo.webhooksServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/service-account.yaml
+++ b/charts/kargo/templates/webhooks-server/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kargo.webhooksServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/service.yaml
+++ b/charts/kargo/templates/webhooks-server/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kargo.webhooksServer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}


### PR DESCRIPTION
Requested by @jessesuen 

Long story short, this change will make `helm template kargo charts/kargo -n kargo | kubectl apply -f -` possible where it was not possible before.