### PR TITLE
chart: add option to create ingress resource

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -122,7 +122,8 @@ k8s_yaml(
     namespace = 'kargo',
     set = [
       'api.logLevel=DEBUG',
-      'api.address=http://localhost:30081',
+      'api.protocol=http',
+      'api.host=localhost',
       'api.adminAccount.password=admin',
       'api.adminAccount.tokenSigningKey=iwishtowashmyirishwristwatch',
       'api.oidc.enabled=true',

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: "true"
 {{- if .Values.api.oidc.dex.enabled }}
             - name: OIDC_ISSUER_URL
-              value: {{ .Values.api.address }}/dex
+              value: {{ .Values.api.protocol }}://{{ .Values.api.host }}/dex
             - name: OIDC_CLIENT_ID
               value: kargo
             - name: DEX_ENABLED

--- a/charts/kargo/templates/api/ingress.yaml
+++ b/charts/kargo/templates/api/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kargo.api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.api.labels" . | nindent 4 }}
+  {{- with .Values.api.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.api.host }}
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        path: /
+        backend:
+          service:
+            name: {{ include "kargo.api.fullname" . }}
+            port:
+              number: 80
+  {{- if .Values.api.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.api.host }}
+    secretName: {{ include "kargo.api.fullname" . }}-ingress-cert
+  {{- end }}
+{{- end }}

--- a/charts/kargo/templates/api/service.yaml
+++ b/charts/kargo/templates/api/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kargo.fullname" . }}-api
+  name: {{ include "kargo.api.fullname" . }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/configmap.yaml
+++ b/charts/kargo/templates/dex-server/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kargo.dexServer.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    issuer: {{ .Values.api.address }}/dex
+    issuer: {{ .Values.api.protocol }}://{{ .Values.api.address }}/dex
 
     storage:
       type: memory

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -50,10 +50,46 @@ api:
 
   ## The protocol and domain name where Kargo's API server will be accessible.
   ## This should be set accurately for a variety of reasons, including (when
-  ## applicable) generation of correct OpenID Connect issuer and callback URLs.
-  address: http://localhost
+  ## applicable) generation of a correct Ingress resource and correct OpenID
+  ## Connect issuer and callback URLs.
+  protocol: http
+  host: localhost
 
   logLevel: INFO
+
+  ingress:
+    ## Whether to enable ingress. By default, this is disabled. Enabling ingress
+    ## is advanced usage.
+    ##
+    ## All other settings in this section will be ignored when this is set to
+    ## false.
+    enabled: false
+    ## Optionally use annotations specified by your ingress controller's
+    ## documentation to customize the behavior of the ingress resource.
+    annotations:
+      # kubernetes.io/ingress.class: nginx
+    ## From Kubernetes 1.18+ this field is supported in case your ingress
+    ## controller supports it. When set, you do not need to add the ingress
+    ## class as annotation.
+    ingressClassName:
+    tls:
+      ## Whether to enable TLS.
+      ##
+      ## All other settings in this section will be ignored when this is set to
+      ## false.
+      enabled: true
+      ## Whether to generate a self-signed certificate for use with the API
+      ## server's Ingress resource.
+      ##
+      ## If true, cert-manager CRDs MUST be pre-installed on this cluster.
+      ## Kargo will create and use its own namespaced issuer.
+      ##
+      ## If false, a cert secret named
+      ## <Helm release name>-api-ingress-server-cert MUST be provided in the
+      ## same namespace as Kargo.
+      ##
+      ## There is no provision for running Dex without TLS.
+      selfSignedCert: true
 
   service:
     ## If you're not going to use an ingress controller, you may want to change
@@ -154,7 +190,7 @@ api:
       #   config:
       #     clientID: <your client ID>
       #     clientSecret: <your client secret>
-      #     redirectURI: <Kargo API server address>/dex/callback
+      #     redirectURI: <api.protocol>://<api.host>/dex/callback
       ## GitHub Example
       # - id: github
       #   name: GitHub
@@ -162,7 +198,7 @@ api:
       #   config:
       #     clientID: <your client ID>
       #     clientSecret: <your client secret>
-      #     redirectURI: <Kargo API server address>/dex/callback
+      #     redirectURI: <api.protocol>://<api.host>/dex/callback
 
       resources: {}
         # We usually recommend not to specify default resources and to leave
@@ -279,6 +315,8 @@ webhooksServer:
     ## namespaced issuer. If false, a cert secret named
     ## <Helm release name>-webhook-servers-cert MUST be provided in the same
     ## namespace as Kargo.
+    ##
+    ## ## There is no provision for webhooks without TLS.
     selfSignedCert: true
 
   resources: {}


### PR DESCRIPTION
This adds an option to include an Ingress resource in the chart installation.

I found myself having to add an ingress manually earlier today and figured we should just square it away here.