### PR TITLE
fix: simplify helm chart with hardwired names. add explicit namespaces

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -7,40 +7,6 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "kargo.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "kargo.api.fullname" -}}
-{{ include "kargo.fullname" . | printf "%s-api" }}
-{{- end -}}
-
-{{- define "kargo.controller.fullname" -}}
-{{ include "kargo.fullname" . | printf "%s-controller" }}
-{{- end -}}
-
-{{- define "kargo.dexServer.fullname" -}}
-{{ include "kargo.fullname" . | printf "%s-dex-server" }}
-{{- end -}}
-
-{{- define "kargo.garbageCollector.fullname" -}}
-{{ include "kargo.fullname" . | printf "%s-garbage-collector" }}
-{{- end -}}
-
-{{- define "kargo.webhooksServer.fullname" -}}
-{{ include "kargo.fullname" . | printf "%s-webhooks-server" }}
-{{- end -}}
-
-{{/*
 Create image reference as used by resources.
 */}}
 
@@ -102,22 +68,3 @@ app.kubernetes.io/component: webhooks-server
 {{- $template := index . 2 }}
 {{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
 {{- end }}
-
-{{/*
-Return the appropriate apiVersion for a networking object.
-*/}}
-{{- define "networking.apiVersion" -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "networking.apiVersion.isStable" -}}
-  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
-{{- end -}}
-
-{{- define "networking.apiVersion.supportIngressClassName" -}}
-  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- end -}}

--- a/charts/kargo/templates/api/cluster-role-binding.yaml
+++ b/charts/kargo/templates/api/cluster-role-binding.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
 {{- end }}

--- a/charts/kargo/templates/api/cluster-role.yaml
+++ b/charts/kargo/templates/api/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}
@@ -20,7 +21,7 @@ spec:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.api.labels" . | nindent 8 }}
     spec:
-      serviceAccount: {{ include "kargo.api.fullname" . }}
+      serviceAccount: kargo-api
       containers:
         - name: api
           image: {{ include "kargo.image" . }}
@@ -39,12 +40,12 @@ spec:
             - name: ADMIN_ACCOUNT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kargo.api.fullname" . }}
+                  name: kargo-api
                   key: adminPassword
             - name: TOKEN_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kargo.api.fullname" . }}
+                  name: kargo-api
                   key: tokenSigningKey
 {{- end }}
 {{- if .Values.api.oidc.enabled }}
@@ -58,7 +59,7 @@ spec:
             - name: DEX_ENABLED
               value: "true"
             - name: DEX_SERVER_ADDRESS
-              value: https://{{ include "kargo.dexServer.fullname" . }}.{{ .Release.Namespace }}.svc
+              value: https://kargo-dex-server.{{ .Release.Namespace }}.svc
             - name: DEX_CA_CERT_PATH
               value: /etc/kargo/idp-ca.crt
 {{- else }}
@@ -98,7 +99,7 @@ spec:
 {{- end }}
 {{- if and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled }}
               - secret:
-                  name: {{ include "kargo.dexServer.fullname" . }}-cert
+                  name: kargo-dex-server-cert
                   items:
                     - key: ca.crt
                       path: idp-ca.crt

--- a/charts/kargo/templates/api/ingress.yaml
+++ b/charts/kargo/templates/api/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
@@ -12,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.api.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.api.host }}
     http:
@@ -20,13 +23,13 @@ spec:
         path: /
         backend:
           service:
-            name: {{ include "kargo.api.fullname" . }}
+            name: kargo-api
             port:
               number: 80
   {{- if .Values.api.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.api.host }}
-    secretName: {{ include "kargo.api.fullname" . }}-ingress-cert
+    secretName: kargo-api-ingress-cert
   {{- end }}
 {{- end }}

--- a/charts/kargo/templates/api/secret.yaml
+++ b/charts/kargo/templates/api/secret.yaml
@@ -3,7 +3,8 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/service-account.yaml
+++ b/charts/kargo/templates/api/service-account.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/api/service.yaml
+++ b/charts/kargo/templates/api/service.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kargo.api.fullname" . }}
+  name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.api.labels" . | nindent 4 }}

--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
   namespace: {{ .Values.controller.argocd.namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
@@ -10,9 +10,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
 {{- end }}

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
   namespace: {{ .Values.controller.argocd.namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}

--- a/charts/kargo/templates/common/cert-issuer.yaml
+++ b/charts/kargo/templates/common/cert-issuer.yaml
@@ -3,7 +3,8 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kargo.fullname" . }}-selfsigned-cert-issuer
+  name: kargo-selfsigned-cert-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/charts/kargo/templates/controller/cluster-role-bindings.yaml
+++ b/charts/kargo/templates/controller/cluster-role-bindings.yaml
@@ -2,34 +2,34 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
 ---
 {{- if not .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}-argocd
+  name: kargo-controller-argocd
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.controller.fullname" . }}-argocd
+  name: kargo-controller-argocd
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
 {{- end }}
 {{- end }}

--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
@@ -54,7 +54,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}-argocd
+  name: kargo-controller-argocd
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
@@ -20,7 +21,7 @@ spec:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.controller.labels" . | nindent 8 }}
     spec:
-      serviceAccount: {{ include "kargo.controller.fullname" . }}
+      serviceAccount: kargo-controller
       containers:
       - name: controller
         image: {{ include "kargo.image" . }}

--- a/charts/kargo/templates/controller/service-account.yaml
+++ b/charts/kargo/templates/controller/service-account.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kargo.controller.fullname" . }}
+  name: kargo-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/cert.yaml
+++ b/charts/kargo/templates/dex-server/cert.yaml
@@ -2,12 +2,13 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kargo.dexServer.fullname" . }}
+  name: kargo-dex-server
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - {{ include "kargo.dexServer.fullname" . }}.{{ .Release.Namespace }}.svc
+  - kargo-dex-server.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
-    name: {{ include "kargo.fullname" . }}-selfsigned-cert-issuer
-  secretName: {{ include "kargo.dexServer.fullname" . }}-cert
+    name: kargo-selfsigned-cert-issuer
+  secretName: kargo-dex-server-cert
 {{- end }}

--- a/charts/kargo/templates/dex-server/configmap.yaml
+++ b/charts/kargo/templates/dex-server/configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: 
-  name: {{ include "kargo.dexServer.fullname" . }}
+  name: kargo-dex-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kargo.dexServer.fullname" . }}
+  name: kargo-dex-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}
@@ -18,7 +19,7 @@ spec:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.dexServer.labels" . | nindent 8 }}
     spec:
-      serviceAccount: {{ include "kargo.dexServer.fullname" . }}
+      serviceAccount: kargo-dex-server
       containers:
       - name: dex-server
         image: {{ .Values.api.oidc.dex.image.repository }}:{{ .Values.api.oidc.dex.image.tag }}
@@ -54,14 +55,14 @@ spec:
         projected:
           sources:
           - secret:
-              name: {{ include "kargo.dexServer.fullname" . }}-cert
+              name: kargo-dex-server-cert
               items:
               - key: tls.crt
                 path: tls.crt
               - key: tls.key
                 path: tls.key
           - configMap:
-              name: {{ include "kargo.dexServer.fullname" . }}
+              name: kargo-dex-server
               items:
               - key: config.yaml
                 path: config.yaml

--- a/charts/kargo/templates/dex-server/service-account.yaml
+++ b/charts/kargo/templates/dex-server/service-account.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kargo.dexServer.fullname" . }}
+  name: kargo-dex-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/dex-server/service.yaml
+++ b/charts/kargo/templates/dex-server/service.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kargo.dexServer.fullname" . }}
+  name: kargo-dex-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/garbage-collector/cluster-role-bindings.yaml
+++ b/charts/kargo/templates/garbage-collector/cluster-role-bindings.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
 {{- end }}

--- a/charts/kargo/templates/garbage-collector/cluster-roles.yaml
+++ b/charts/kargo/templates/garbage-collector/cluster-roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -2,17 +2,19 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}
 spec:
   schedule: {{ quote .Values.garbageCollector.schedule }}
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         spec:
-          serviceAccountName: {{ include "kargo.garbageCollector.fullname" . }}
+          serviceAccountName: kargo-garbage-collector
           containers:
           - name: garbage-collector
             image: {{ include "kargo.image" . }}
@@ -28,7 +30,6 @@ spec:
             resources:
               {{- toYaml .Values.garbageCollector.resources | nindent 14 }}
           restartPolicy: Never
-          concurrencyPolicy: Forbid
           {{- with .Values.garbageCollector.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/kargo/templates/garbage-collector/service-account.yaml
+++ b/charts/kargo/templates/garbage-collector/service-account.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kargo.garbageCollector.fullname" . }}
+  name: kargo-garbage-collector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.garbageCollector.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/cert.yaml
+++ b/charts/kargo/templates/webhooks-server/cert.yaml
@@ -2,12 +2,13 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - {{ include "kargo.webhooksServer.fullname" . }}.{{ .Release.Namespace }}.svc
+  - kargo-webhooks-server.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
-    name: {{ include "kargo.fullname" . }}-selfsigned-cert-issuer
-  secretName: {{ include "kargo.webhooksServer.fullname" . }}-cert
+    name: kargo-selfsigned-cert-issuer
+  secretName: kargo-webhooks-server-cert
 {{- end }}

--- a/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
@@ -2,30 +2,30 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+  name: kargo-webhooks-server-ns-controller
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+  name: kargo-webhooks-server-ns-controller
 subjects:
 - kind: ServiceAccount
   namespace: kube-system

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
@@ -38,7 +38,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}-ns-controller
+  name: kargo-webhooks-server-ns-controller
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
@@ -20,7 +21,7 @@ spec:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.webhooksServer.labels" . | nindent 8 }}
     spec:
-      serviceAccount: {{ include "kargo.webhooksServer.fullname" . }}
+      serviceAccount: kargo-webhooks-server
       containers:
       - name: webhooks-server
         image: {{ include "kargo.image" . }}
@@ -52,7 +53,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 0644
-          secretName: {{ include "kargo.webhooksServer.fullname" . }}-cert
+          secretName: kargo-webhooks-server-cert
       {{- if .Values.kubeconfigSecrets.kargo }}
       - name: kubeconfigs
         secret:

--- a/charts/kargo/templates/webhooks-server/service-account.yaml
+++ b/charts/kargo/templates/webhooks-server/service-account.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks-server/service.yaml
+++ b/charts/kargo/templates/webhooks-server/service.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kargo.webhooksServer.fullname" . }}
+  name: kargo-webhooks-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.webhooksServer.labels" . | nindent 4 }}

--- a/charts/kargo/templates/webhooks/webhooks.yaml
+++ b/charts/kargo/templates/webhooks/webhooks.yaml
@@ -2,12 +2,12 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ include "kargo.fullname" . }}
+  name: kargo
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kargo.webhooksServer.fullname" . }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kargo-webhooks-server
 webhooks:
 - name: stage.kargo.akuity.io
   admissionReviewVersions: ["v1"]
@@ -15,7 +15,7 @@ webhooks:
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
-      name: {{ include "kargo.webhooksServer.fullname" . }}
+      name: kargo-webhooks-server
       path: /mutate-kargo-akuity-io-v1alpha1-stage
   rules:
   - scope: Namespaced
@@ -28,12 +28,12 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ include "kargo.fullname" . }}
+  name: kargo
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kargo.webhooksServer.fullname" . }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kargo-webhooks-server
 webhooks:
 - name: stage.kargo.akuity.io
   admissionReviewVersions: ["v1"]
@@ -41,7 +41,7 @@ webhooks:
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
-      name: {{ include "kargo.webhooksServer.fullname" . }}
+      name: kargo-webhooks-server
       path: /validate-kargo-akuity-io-v1alpha1-stage
   rules:
   - scope: Namespaced
@@ -56,7 +56,7 @@ webhooks:
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
-      name: {{ include "kargo.webhooksServer.fullname" . }}
+      name: kargo-webhooks-server
       path: /validate-kargo-akuity-io-v1alpha1-promotion
   rules:
   - scope: Namespaced
@@ -71,7 +71,7 @@ webhooks:
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
-      name: {{ include "kargo.webhooksServer.fullname" . }}
+      name: kargo-webhooks-server
       path: /validate-kargo-akuity-io-v1alpha1-promotionpolicy
   rules:
     - scope: Namespaced


### PR DESCRIPTION
1. Use hardwired names for resources instead of dynamic names based on release name (e.g. stop doing: `{{ include "kargo.fullname" . }}-api`). Dynamic resource names really only matter when installing a chart twice in the same namespace, which I would say we draw the line and don't support. By using hardwired names, it will simplify references that we do throughout the chart (e.g. to configmaps, services). Another benefit is that when providing advice/support to our users, we can give commands that universally work. e.g.:

```
kubectl port-forward -n kargo svc/kargo-api 8080:80
```

2. Ensure all namespaced scoped resources have namespace set to be `{{ .Release.Namespace }}`

```yaml
metadata:
  namespace: {{ .Release.Namespace }}
```

The reason is: the chart installs across two namespaces (kargo and argocd). This makes it impossible to do the following unless your kubecontext is in the kargo namespace:
```
helm template kargo --namespace kargo | kubectl apply -f -
```
This also doesn't work:
```
helm template kargo --namespace kargo | kubectl apply -f - -n kargo
```
because kubectl apply doesn't want to override the namespace. I would like a valid installation method to be:
```
helm template kargo | kubectl apply -f -
```

3. The CronJob was invalid. When deployed with Argo CD, it would get this error during validation. `concurrencyPolicy` is supposed to be at the spec level.

```
error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template.spec): unknown field "concurrencyPolicy" in io.k8s.api.core.v1.PodSpec
```

4. The ingress resource introduced in https://github.com/akuity/kargo/pull/540, did not utilize the `ingressClassName` from values.