### PR TITLE
chart: fix missing cert resource for ingress

### DIFF
--- a/charts/kargo/templates/api/ingress-cert.yaml
+++ b/charts/kargo/templates/api/ingress-cert.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled .Values.api.ingress.tls.enabled .Values.api.ingress.tls.selfSignedCert }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kargo-api-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.api.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - {{ .Values.api.host }}
+  issuerRef:
+    kind: Issuer
+    name: kargo-selfsigned-cert-issuer
+  secretName: kargo-api-ingress-cert
+{{- end }}

--- a/charts/kargo/templates/common/cert-issuer.yaml
+++ b/charts/kargo/templates/common/cert-issuer.yaml
@@ -1,5 +1,5 @@
 
-{{- if or (and .Values.webhooksServer.enabled .Values.webhooksServer.tls.selfSignedCert) (and .Values.api.enabled .Values.api.oidc.enabled .Values.api.oidc.dex.enabled .Values.api.oidc.dex.tls.selfSignedCert) }}
+{{- if or (and .Values.api.enabled .Values.api.ingress.enabled .Values.api.ingress.tls.enabled .Values.api.ingress.tls.selfSignedCert) (and .Values.webhooksServer.enabled .Values.webhooksServer.tls.selfSignedCert) (and .Values.api.enabled .Values.api.oidc.enabled .Values.api.oidc.dex.enabled .Values.api.oidc.dex.tls.selfSignedCert) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:


### PR DESCRIPTION
#540 was missing some templates that are needed when API ingress with a self-signed cert is enabled.