### PR TITLE
chart: bounce api server when secret changes

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.api.labels" . | nindent 8 }}
+      annotations:
+        {{- if .Values.api.adminAccount.enabled }}
+        secret-checksum/kargo-api: {{ include (print $.Template.BasePath "/api/secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       serviceAccount: kargo-api
       containers:


### PR DESCRIPTION
This is the only case where we inject secrets into env vars.

This is the common approach to replace pods with new ones having updated env vars any time the underlying secret changes.