### PR TITLE
chart: put dex config in a secret

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -73,9 +73,9 @@ k8s_resource(
   new_name = 'dex-server',
   labels = ['kargo'],
   objects = [
-    'kargo-dex-server:serviceaccount',
-    'kargo-dex-server:configmap',
-    'kargo-dex-server:certificate'
+    'kargo-dex-server:certificate',
+    'kargo-dex-server:secret',
+    'kargo-dex-server:serviceaccount'
   ]
 )
 

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -61,7 +61,7 @@ spec:
                 path: tls.crt
               - key: tls.key
                 path: tls.key
-          - configMap:
+          - secret:
               name: kargo-dex-server
               items:
               - key: config.yaml

--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -1,13 +1,14 @@
 {{- if and .Values.api.enabled .Values.api.oidc.enabled .Values.api.oidc.dex.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
+type: Opaque
 metadata:
   name: kargo-dex-server
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.dexServer.labels" . | nindent 4 }}
-data:
+stringData:
   config.yaml: |-
     issuer: {{ .Values.api.protocol }}://{{ .Values.api.address }}/dex
 


### PR DESCRIPTION
Dex connector config is extremely likely to contain OIDC client secrets.

We're better off storing this fragment of configuration in a `Secret` than a `ConfigMap`.