### PR TITLE
add ui/node_modules to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 bin/
 docs/
+ui/node_modules/


### PR DESCRIPTION
This speeds up local builds of the image a lot by sparing us hundreds of MBs of context transfer.