### PR TITLE
Tiltfile: fix api.host value set when rendering chart

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -124,7 +124,7 @@ k8s_yaml(
     set = [
       'api.logLevel=DEBUG',
       'api.protocol=http',
-      'api.host=localhost',
+      'api.host=localhost:30081',
       'api.adminAccount.password=admin',
       'api.adminAccount.tokenSigningKey=iwishtowashmyirishwristwatch',
       'api.oidc.enabled=true',


### PR DESCRIPTION
#540 split `api.address` into two fields -- `api.protocol` and `api.host` -- and the port number was mistakenly dropped from the Tiltfile at that time. This PR puts it back.