### PR TITLE
fix: UI should use standard Connect routes

### DIFF
--- a/ui/src/config/transport.ts
+++ b/ui/src/config/transport.ts
@@ -15,6 +15,6 @@ const errorHandler: Interceptor = (next) => async (req) => {
 };
 
 export const transport = createConnectTransport({
-  baseUrl: '/api',
+  baseUrl: '',
   interceptors: [errorHandler]
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      '': {
+      '/akuity.io.kargo.service.v1alpha1.KargoService': {
         target: 'http://localhost:30081',
         changeOrigin: true
       }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -42,10 +42,9 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      '/api': {
+      '': {
         target: 'http://localhost:30081',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+        changeOrigin: true
       }
     },
     port: 3333


### PR DESCRIPTION
We're deciding **_not_** to prefix the Connect routes with `/api` due to the consequences described [here](https://connectrpc.com/docs/go/routing/#prefixing-routes):

> Unfortunately, grpc-go clients don't support prefixes: if you need to support gRPC clients, don't prefix your routes!

(basically with prefixing we would no longer be a gRPC server). This PR updates UI behavior to use standard/unprefixed gRPC/Connect route locations.

The UI seems to be working now in a real env:

<img width="1383" alt="image" src="https://github.com/akuity/kargo/assets/12677113/8097d966-c366-4090-a8b1-068e462e4ea6">

@rbreeze @rpelczar - I blindly made the vite.config.ts changes, so they are untested.