### PR TITLE
fix: use patch to make stage/promotion status changes to avoid conflict errors

### DIFF
--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -36,6 +36,10 @@ type Promotion struct {
 	Status PromotionStatus `json:"status,omitempty"`
 }
 
+func (p *Promotion) GetStatus() *PromotionStatus {
+	return &p.Status
+}
+
 // PromotionSpec describes the desired transition of a specific Stage into a
 // specific StageState.
 type PromotionSpec struct {

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -55,6 +55,10 @@ type Stage struct {
 	Status StageStatus `json:"status,omitempty"`
 }
 
+func (s *Stage) GetStatus() *StageStatus {
+	return &s.Status
+}
+
 // StageSpec describes the sources of material used by a Stage and how to
 // incorporate newly observed materials into the Stage.
 type StageSpec struct {

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -23,6 +23,7 @@ import (
 	"github.com/akuity/kargo/internal/controller/runtime"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/helm"
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/kustomize"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/yaml"
@@ -237,9 +238,11 @@ func (r *reconciler) Reconcile(
 		return result, nil
 	}
 
-	promo.Status = r.sync(ctx, promo)
+	newStatus := r.sync(ctx, promo)
 
-	updateErr := r.kargoClient.Status().Update(ctx, promo)
+	updateErr := kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *api.PromotionStatus) {
+		*status = newStatus
+	})
 	if updateErr != nil {
 		logger.Errorf("error updating Promotion status: %s", updateErr)
 	}
@@ -272,8 +275,9 @@ func (r *reconciler) initializeQueues(ctx context.Context) error {
 		case api.PromotionPhaseComplete, api.PromotionPhaseFailed:
 			continue
 		case "":
-			promo.Status.Phase = api.PromotionPhasePending
-			if err := r.kargoClient.Status().Update(ctx, &promo); err != nil {
+			if err := kubeclient.PatchStatus(ctx, r.kargoClient, &promo, func(status *api.PromotionStatus) {
+				status.Phase = api.PromotionPhasePending
+			}); err != nil {
 				return errors.Wrapf(
 					err,
 					"error updating status of Promotion %q in namespace %q",
@@ -400,21 +404,23 @@ func (r *reconciler) serializedSync(
 
 				promoCtx := logging.ContextWithLogger(ctx, logger)
 
+				phase := api.PromotionPhaseComplete
+				phaseError := ""
 				if err = r.promoteFn(
 					promoCtx,
 					promo.Spec.Stage,
 					promo.Namespace,
 					promo.Spec.State,
 				); err != nil {
-					promo.Status.Phase = api.PromotionPhaseFailed
-					promo.Status.Error = err.Error()
+					phase = api.PromotionPhaseFailed
+					phaseError = err.Error()
 					logger.Errorf("error executing Promotion: %s", err)
-				} else {
-					promo.Status.Phase = api.PromotionPhaseComplete
-					promo.Status.Error = ""
 				}
 
-				if err = r.kargoClient.Status().Update(ctx, promo); err != nil {
+				if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *api.PromotionStatus) {
+					status.Phase = phase
+					status.Error = phaseError
+				}); err != nil {
 					logger.Errorf("error updating Promotion status: %s", err)
 				}
 
@@ -493,11 +499,15 @@ func (r *reconciler) promote(
 	if err != nil {
 		return err
 	}
-	stage.Status.CurrentState = &nextState
-	stage.Status.AvailableStates[targetStateIndex] = nextState
-	stage.Status.History.Push(nextState)
 
-	err = r.kargoClient.Status().Update(ctx, stage)
+	// The assumption is that controller does not process multiple promotions in one stage
+	// so we are safe from race conditions and can just update the status
+	err = kubeclient.PatchStatus(ctx, r.kargoClient, stage, func(status *api.StageStatus) {
+		status.CurrentState = &nextState
+		status.AvailableStates[targetStateIndex] = nextState
+		status.History.Push(nextState)
+	})
+
 	return errors.Wrapf(
 		err,
 		"error updating status of Stage %q in namespace %q",

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -237,17 +237,20 @@ func (r *reconciler) Reconcile(
 	}
 	logger.Debug("found Stage")
 
-	stage.Status, err = r.sync(ctx, stage)
+	var newStatus api.StageStatus
+	newStatus, err = r.sync(ctx, stage)
 	if err != nil {
-		stage.Status.Error = err.Error()
+		newStatus.Error = err.Error()
 		logger.Errorf("error syncing Stage: %s", stage.Status.Error)
 	} else {
 		// Be sure to blank this out in case there's an error in this field from
 		// the previous reconciliation
-		stage.Status.Error = ""
+		newStatus.Error = ""
 	}
 
-	updateErr := r.kargoClient.Status().Update(ctx, stage)
+	updateErr := kubeclient.PatchStatus(ctx, r.kargoClient, stage, func(status *api.StageStatus) {
+		*status = newStatus
+	})
 	if updateErr != nil {
 		logger.Errorf("error updating Stage status: %s", updateErr)
 	}

--- a/internal/kubeclient/patch.go
+++ b/internal/kubeclient/patch.go
@@ -1,0 +1,58 @@
+package kubeclient
+
+import (
+	"context"
+	"encoding/json"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HasStatus[S any] interface {
+	client.Object
+	GetStatus() S
+}
+
+// PatchStatus patches evaluate changes applied by the callback to the status of a resource
+// and patches resource status if there are any changes.
+func PatchStatus[T HasStatus[S], S any](
+	ctx context.Context, kubeClient client.Client, resource T, update func(status S)) error {
+
+	originalJSON, err := json.Marshal(resource.GetStatus())
+	if err != nil {
+		return err
+	}
+
+	var updated S
+	if err = json.Unmarshal(originalJSON, &updated); err != nil {
+		return err
+	}
+	update(updated)
+
+	modifiedJSON, err := json.Marshal(updated)
+	if err != nil {
+		return err
+	}
+
+	statusPatch, err := jsonpatch.CreateMergePatch(originalJSON, modifiedJSON)
+	if err != nil {
+		return err
+	}
+
+	patchMap := map[string]interface{}{}
+	if err = json.Unmarshal(statusPatch, &patchMap); err != nil {
+		return err
+	}
+	if len(patchMap) == 0 {
+		return nil
+	}
+
+	patch, err := json.Marshal(map[string]interface{}{
+		"status": patchMap,
+	})
+	if err != nil {
+		return err
+	}
+	return kubeClient.Status().Patch(ctx, resource, client.RawPatch(types.MergePatchType, patch))
+}


### PR DESCRIPTION
Closes https://github.com/akuity/kargo/issues/564

Conflict modification errors are happening because reconcilers are using stale objects from the informer to make updates. There are several ways to deal with it. Initially, I attempted to use non-cached clients that read promotions directly from the informer, however, it would require a big refactoring. Unfortunately, I could not find any easy way to conditionally disable the cache .

I've realized that conflict errors are happening due to frequent status updates. So it is safe to "force" update status using patch. 