### PR TITLE
refactor: make localMode part of server config

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -78,11 +78,17 @@ func NewRootCommand(opt *option.Option, rs *rootState) (*cobra.Command, error) {
 					return errors.Wrap(err, "start local server")
 				}
 				rs.localServerListener = l
-				srv, err := api.NewServer(apiconfig.ServerConfig{}, kubeCli, dynamicCli)
+				srv, err := api.NewServer(
+					apiconfig.ServerConfig{
+						LocalMode: true,
+					},
+					kubeCli,
+					dynamicCli,
+				)
 				if err != nil {
 					return errors.Wrap(err, "new api server")
 				}
-				go srv.Serve(ctx, l, true) // nolint: errcheck
+				go srv.Serve(ctx, l) // nolint: errcheck
 				opt.LocalServerAddress = fmt.Sprintf("http://%s", l.Addr())
 			}
 			return nil

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -115,7 +115,7 @@ func newAPICommand() *cobra.Command {
 			}()
 			wg.Add(1)
 			go func() {
-				srvErr := srv.Serve(ctx, l, false)
+				srvErr := srv.Serve(ctx, l)
 				errCh <- pkgerrors.Wrap(srvErr, "serve")
 				wg.Done()
 			}()

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -29,6 +29,7 @@ func AdminConfigFromEnv() AdminConfig {
 
 type ServerConfig struct {
 	StandardConfig
+	LocalMode      bool
 	OIDCConfig     *oidc.Config
 	AdminConfig    *AdminConfig
 	DexProxyConfig *dex.ProxyConfig

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -8,14 +8,15 @@ import (
 	"connectrpc.com/connect"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/logging"
 )
 
-func NewHandlerOption(ctx context.Context, localMode bool) connect.HandlerOption {
+func NewHandlerOption(ctx context.Context, cfg config.ServerConfig) connect.HandlerOption {
 	interceptors := []connect.Interceptor{
 		newLogInterceptor(logging.LoggerFromContext(ctx), loggingIgnorableMethods),
 	}
-	if !localMode {
+	if !cfg.LocalMode {
 		interceptors = append(interceptors, &authInterceptor{})
 	}
 	return connect.WithHandlerOptions(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -37,7 +37,7 @@ type server struct {
 }
 
 type Server interface {
-	Serve(ctx context.Context, l net.Listener, localMode bool) error
+	Serve(ctx context.Context, l net.Listener) error
 }
 
 func NewServer(
@@ -52,15 +52,11 @@ func NewServer(
 	}, nil
 }
 
-func (s *server) Serve(
-	ctx context.Context,
-	l net.Listener,
-	localMode bool,
-) error {
+func (s *server) Serve(ctx context.Context, l net.Listener) error {
 	log := logging.LoggerFromContext(ctx)
 	mux := http.NewServeMux()
 
-	opts := option.NewHandlerOption(ctx, localMode)
+	opts := option.NewHandlerOption(ctx, s.cfg)
 	mux.Handle(grpchealth.NewHandler(NewHealthChecker(), opts))
 	path, svcHandler := svcv1alpha1connect.NewKargoServiceHandler(s, opts)
 	mux.Handle(path, svcHandler)


### PR DESCRIPTION
This is a tiny bit of refactoring to include the `LocalMode` field in the server config object instead of passing around a loose boolean.

I have an upcoming PR that will start passing config objects to funcs that are already receiving the loose `localMode` boolean. The two feel redundant and function signatures end up much tidier this way.

There are no functional changes in this PR.