### PR TITLE
linting: adjust revive rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -121,9 +121,6 @@ linters-settings:
       - name: error-strings
       - name: errorf
       - name: exported
-      # Allow maximum 3 results in function
-      - name: function-result-limit
-        arguments: [ 3 ]
       - name: if-return
       - name: import-shadowing
       - name: indent-error-flow


### PR DESCRIPTION
This rule is giving me trouble in some other branches and doesn't seem sensible.

Early returns make code _more_ readable by eliminating conditionals.

Limiting the number of early returns from a function is not a good idea.