### PR TITLE
cli: account for jwts that don't expire

### DIFF
--- a/internal/api/option/auth.go
+++ b/internal/api/option/auth.go
@@ -260,6 +260,7 @@ func (a *authInterceptor) authenticate(
 	//   1. Directly by the Kargo API server (in the case of admin)
 	//   2. By Kargo's OpenID Connect identity provider
 	//   3. By the Kubernetes cluster's identity provider
+	//   4. By Kubernetes itself (a service account token, perhaps)
 
 	if untrustedClaims.Issuer == kargoIssuer {
 		// Case 1: This token was allegedly issued directly by the Kargo API server.
@@ -294,7 +295,7 @@ func (a *authInterceptor) authenticate(
 	// TODO: krancour: This isn't safe to do until we start actually using this
 	// unidentified bearer token for accessing Kubernetes.
 	//
-	// // Case 3: We don't know how to verify this token. It's probably a token
+	// // Case 3 or 4: We don't know how to verify this token. It's probably a token
 	// // issued by the Kubernetes cluster's identity provider. Just run with it.
 	// // If we're wrong, Kubernetes API calls will simply have auth errors that
 	// // will bubble back to the client.


### PR DESCRIPTION
I've just discovered that service account tokens can be JWTs that don't expire, so we need to account for that when checking if a token the CLI is holding in its configuration is expired or not.