### PR TITLE
fix ISS claim on admin tokens

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -41,12 +41,14 @@ spec:
 {{- if .Values.api.adminAccount.enabled }}
             - name: ADMIN_ACCOUNT_ENABLED
               value: "true"
+            - name: ADMIN_ACCOUNT_TOKEN_ISSUER
+              value: {{ .Values.api.protocol }}://{{ .Values.api.host }}
             - name: ADMIN_ACCOUNT_PASSWORD_HASH
               valueFrom:
                 secretKeyRef:
                   name: kargo-api
                   key: adminPassword
-            - name: TOKEN_SIGNING_KEY
+            - name: ADMIN_ACCOUNT_TOKEN_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
                   name: kargo-api

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -15,7 +15,7 @@ import (
 type AdminConfig struct {
 	// HashedPassword is a bcrypt hash of the password for the admin account.
 	HashedPassword string `envconfig:"ADMIN_ACCOUNT_PASSWORD_HASH" required:"true"`
-	// TokenIssuer the value to be used in the ISS claim of ID tokens issued for
+	// TokenIssuer is the value to be used in the ISS claim of ID tokens issued for
 	// for the admin account.
 	TokenIssuer string `envconfig:"ADMIN_ACCOUNT_TOKEN_ISSUER" required:"true"`
 	// TokenAudience is the value to be used in the AUD claim of ID tokens issued

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -15,8 +15,11 @@ import (
 type AdminConfig struct {
 	// HashedPassword is a bcrypt hash of the password for the admin account.
 	HashedPassword string `envconfig:"ADMIN_ACCOUNT_PASSWORD_HASH" required:"true"`
+	// TokenIssuer the value to be used in the ISS claim of ID tokens issued for
+	// for the admin account.
+	TokenIssuer string `envconfig:"ADMIN_ACCOUNT_TOKEN_ISSUER" required:"true"`
 	// TokenSigningKey is the key used to sign ID tokens for the admin account.
-	TokenSigningKey []byte `envconfig:"TOKEN_SIGNING_KEY" required:"true"`
+	TokenSigningKey []byte `envconfig:"ADMIN_ACCOUNT_TOKEN_SIGNING_KEY" required:"true"`
 }
 
 // AdminConfigFromEnv returns an AdminConfig populated from environment

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -16,7 +16,7 @@ type AdminConfig struct {
 	// HashedPassword is a bcrypt hash of the password for the admin account.
 	HashedPassword string `envconfig:"ADMIN_ACCOUNT_PASSWORD_HASH" required:"true"`
 	// TokenIssuer is the value to be used in the ISS claim of ID tokens issued for
-	// for the admin account.
+	// the admin account.
 	TokenIssuer string `envconfig:"ADMIN_ACCOUNT_TOKEN_ISSUER" required:"true"`
 	// TokenAudience is the value to be used in the AUD claim of ID tokens issued
 	// for the admin account.

--- a/internal/api/handler/admin_login_v1alpha1.go
+++ b/internal/api/handler/admin_login_v1alpha1.go
@@ -46,7 +46,7 @@ func AdminLoginV1Alpha1(cfg *config.AdminConfig) AdminLoginV1Alpha1Func {
 			jwt.SigningMethodHS256,
 			jwt.RegisteredClaims{
 				IssuedAt:  jwt.NewNumericDate(now),
-				Issuer:    "kargo",
+				Issuer:    cfg.TokenIssuer,
 				NotBefore: jwt.NewNumericDate(now),
 				Subject:   "admin",
 				ID:        uuid.NewV4().String(),

--- a/internal/api/option/auth.go
+++ b/internal/api/option/auth.go
@@ -20,11 +20,7 @@ import (
 	"github.com/akuity/kargo/internal/api/user"
 )
 
-const (
-	authHeaderKey = "Authorization"
-
-	kargoIssuer = "kargo"
-)
+const authHeaderKey = "Authorization"
 
 var exemptProcedures = map[string]struct{}{
 	"/grpc.health.v1.Health/Check":                                   {},
@@ -262,7 +258,8 @@ func (a *authInterceptor) authenticate(
 	//   3. By the Kubernetes cluster's identity provider
 	//   4. By Kubernetes itself (a service account token, perhaps)
 
-	if untrustedClaims.Issuer == kargoIssuer {
+	if a.cfg.AdminConfig != nil &&
+		untrustedClaims.Issuer == a.cfg.AdminConfig.TokenIssuer {
 		// Case 1: This token was allegedly issued directly by the Kargo API server.
 		if a.verifyKargoIssuedTokenFn(rawToken) {
 			return user.ContextWithInfo(

--- a/internal/api/option/auth_test.go
+++ b/internal/api/option/auth_test.go
@@ -155,9 +155,10 @@ func TestAuthenticate(t *testing.T) {
 	// The way the tests are structured, we don't need this to be valid. It just
 	// needs to be non-empty.
 	const (
-		testProcedure = "akuity.io.kargo.service.v1alpha1.KargoService/ListProjects"
-		testIDPIssuer = "fake-issuer"
-		testToken     = "some-token"
+		testProcedure   = "akuity.io.kargo.service.v1alpha1.KargoService/ListProjects"
+		testIDPIssuer   = "fake-idp-issuer"
+		testKargoIssuer = "fake-kargo-issuer"
+		testToken       = "some-token"
 	)
 	testSets := map[string]struct {
 		procedure       string
@@ -223,10 +224,15 @@ func TestAuthenticate(t *testing.T) {
 		"failure verifying Kargo-issued token": {
 			procedure: testProcedure,
 			authInterceptor: &authInterceptor{
+				cfg: config.ServerConfig{
+					AdminConfig: &config.AdminConfig{
+						TokenIssuer: testKargoIssuer,
+					},
+				},
 				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
 					rc, ok := claims.(*jwt.RegisteredClaims)
 					require.True(t, ok)
-					rc.Issuer = kargoIssuer
+					rc.Issuer = testKargoIssuer
 					return nil, nil, nil
 				},
 				verifyKargoIssuedTokenFn: func(rawToken string) bool {
@@ -248,10 +254,15 @@ func TestAuthenticate(t *testing.T) {
 		"success verifying Kargo-issued token": {
 			procedure: testProcedure,
 			authInterceptor: &authInterceptor{
+				cfg: config.ServerConfig{
+					AdminConfig: &config.AdminConfig{
+						TokenIssuer: testKargoIssuer,
+					},
+				},
 				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
 					rc, ok := claims.(*jwt.RegisteredClaims)
 					require.True(t, ok)
-					rc.Issuer = kargoIssuer
+					rc.Issuer = testKargoIssuer
 					return nil, nil, nil
 				},
 				verifyKargoIssuedTokenFn: func(rawToken string) bool {


### PR DESCRIPTION
Up until now we've been using a hard coded value `kargo` in the `ISS` (issuer) claim of ID tokens issued for the admin account.

This is not technically a correct thing to do as it bears insufficient information about the provenance of the token and that matters when the token is presented back to the API server by the client. We use the `ISS` claim to decide which logic to apply to properly verify the token. (i.e. Verify it as an admin token, a token from an OIDC identity provider, or a SA token issued by Kubernetes.)

Making this change will prevent a Kargo API server from attempting to verify admin tokens clearly issued by _other_ Kargo API servers. (fwiw, that verification would fail anyway as long as both servers used different signing keys, but we probably should not take it for granted that 100% of all operators will use adequately unique signing keys. _Someone_ will use `key` or `password`.)

This PR updates the API server to use the configured protocol and hostname as the value of the `ISS` claim.