### PR TITLE
add AUD claim to admin tokens

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -41,6 +41,8 @@ spec:
 {{- if .Values.api.adminAccount.enabled }}
             - name: ADMIN_ACCOUNT_ENABLED
               value: "true"
+            - name: ADMIN_ACCOUNT_TOKEN_AUDIENCE
+              value: {{ .Values.api.host }}
             - name: ADMIN_ACCOUNT_PASSWORD_HASH
               valueFrom:
                 secretKeyRef:

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -15,6 +15,9 @@ import (
 type AdminConfig struct {
 	// HashedPassword is a bcrypt hash of the password for the admin account.
 	HashedPassword string `envconfig:"ADMIN_ACCOUNT_PASSWORD_HASH" required:"true"`
+	// TokenAudience is the value to be used in the AUD claim of ID tokens issued
+	// for the admin account.
+	TokenAudience string `envconfig:"ADMIN_ACCOUNT_TOKEN_AUDIENCE" required:"true"`
 	// TokenSigningKey is the key used to sign ID tokens for the admin account.
 	TokenSigningKey []byte `envconfig:"TOKEN_SIGNING_KEY" required:"true"`
 }

--- a/internal/api/handler/admin_login_v1alpha1.go
+++ b/internal/api/handler/admin_login_v1alpha1.go
@@ -14,6 +14,10 @@ import (
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+func init() {
+	jwt.MarshalSingleStringAsArray = false
+}
+
 type AdminLoginV1Alpha1Func func(
 	context.Context,
 	*connect.Request[svcv1alpha1.AdminLoginRequest],
@@ -47,6 +51,7 @@ func AdminLoginV1Alpha1(cfg *config.AdminConfig) AdminLoginV1Alpha1Func {
 			jwt.RegisteredClaims{
 				IssuedAt:  jwt.NewNumericDate(now),
 				Issuer:    "kargo",
+				Audience:  []string{cfg.TokenAudience},
 				NotBefore: jwt.NewNumericDate(now),
 				Subject:   "admin",
 				ID:        uuid.NewV4().String(),


### PR DESCRIPTION
This PR adds the `AUD` (audience) claim to the JWTs issued as admin account ID tokens.

Outside of OIDC, `AUD` is optional, but this claim adds useful information about the token's intended use, so it's good to set it.