### PR TITLE
fix AUD claim on IDP-issued tokens

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: OIDC_ISSUER_URL
               value: {{ .Values.api.protocol }}://{{ .Values.api.host }}/dex
             - name: OIDC_CLIENT_ID
-              value: kargo
+              value: {{ .Values.api.host }}
             - name: DEX_ENABLED
               value: "true"
             - name: DEX_SERVER_ADDRESS

--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -23,7 +23,7 @@ stringData:
       http: 0.0.0.0:5558
 
     staticClients:
-    - id: kargo
+    - id: {{ .Values.api.host }}
       name: Kargo
       public: true
 


### PR DESCRIPTION
Up until now, when Dex is in play, we've used a hard-coded client ID `kargo` for public clients (Kargo CLI or SPA).

Since the OIDC spec says the client ID _must_ appear in the `AUD` claim of an ID token, Dex is  putting `kargo` in that claim. This isn't right in our case because the OIDC spec also says _access tokens_ must use the `AUD` claim to indicate the resource server(s) the token gives access to. Like Kubernetes, Kargo uses ID tokens _as_ access tokens. Resource servers _must_ verify that they are the intended audience of the token they receive.

We can satisfy both conditions by setting client ID to the Kargo API server's configured hostname. By doing so, Dex uses that as the value of the `AUD` claim and the token then contains correct information about its intended use:

e.g. As an ID token, it's intended for use by _clients of_  `kargo.example.com`. As an access token, it's intended for accessing resources _from_ `kargo.example.com`.

