### PR TITLE
feat: support wildcards in kargo.akuity.io/authorized-stage annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.1
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -102,7 +103,6 @@ require (
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-redis/cache/v8 v8.4.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/internal/controller/promotions/argocd.go
+++ b/internal/controller/promotions/argocd.go
@@ -148,11 +148,21 @@ func (r *reconciler) authorizeArgoCDAppUpdate(
 	}
 	allowedNamespaceGlob, err := glob.Compile(tokens[0])
 	if err != nil {
-		return permErr
+		return errors.Errorf(
+			"Argo CD Application %q in namespace %q has invalid glob expression: %q",
+			app.Name,
+			app.Namespace,
+			tokens[0],
+		)
 	}
 	allowedNameGlob, err := glob.Compile(tokens[1])
 	if err != nil {
-		return permErr
+		return errors.Errorf(
+			"Argo CD Application %q in namespace %q has invalid glob expression: %q",
+			app.Name,
+			app.Namespace,
+			tokens[1],
+		)
 	}
 	if !allowedNamespaceGlob.Match(stageMeta.Namespace) || !allowedNameGlob.Match(stageMeta.Name) {
 		return permErr

--- a/internal/controller/promotions/argocd_test.go
+++ b/internal/controller/promotions/argocd_test.go
@@ -275,6 +275,50 @@ func TestAuthorizeArgoCDAppUpdate(t *testing.T) {
 			},
 			allowed: true,
 		},
+		{
+			name: "wildcard-full-ns",
+			app: &argocd.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "*:name-yep",
+					},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name: "wildcard-full-namespace",
+			app: &argocd.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "ns-yep:*",
+					},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name: "wildcard-partial",
+			app: &argocd.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "*-ye*:*-y*",
+					},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name: "wildcard-reject",
+			app: &argocd.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "*-nope:*-nope",
+					},
+				},
+			},
+			allowed: false,
+		},
 	}
 	r := reconciler{}
 	for _, testCase := range testCases {


### PR DESCRIPTION
I found it a bit tedious to exactly match the authorized stage by the exact name. I would like to make the UX easier so that users can allow all stages in a project using a glob wildcard. e.g.:

```yaml
metadata:
  annotations:
    kargo.akuity.io/authorized-stage: kargo-demo:*
```

Or even:
```yaml
metadata:
  annotations:
    kargo.akuity.io/authorized-stage: '*:*'
```
