### PR TITLE
controller: promo status patch fix

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -330,8 +330,6 @@ func (r *reconciler) syncPromo(
 		return status
 	}
 
-	promo.Status.Phase = api.PromotionPhasePending
-
 	stage := types.NamespacedName{
 		Namespace: promo.Namespace,
 		Name:      promo.Spec.Stage,


### PR DESCRIPTION
This line doesn't belong and it is often interfering with the correct operation of the status patches.

This line is setting the Promotion's phase to the same value as what the patch should be setting it to, so it looks like no change and the patch is not even attempted.