### PR TITLE
control flow stages

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -68,10 +68,12 @@ type StageSpec struct {
 	//+kubebuilder:validation:Required
 	Subscriptions *Subscriptions `json:"subscriptions"`
 	// PromotionMechanisms describes how to incorporate newly observed materials
-	// into the Stage. This is a required field.
-	//
-	//+kubebuilder:validation:Required
-	PromotionMechanisms *PromotionMechanisms `json:"promotionMechanisms"`
+	// into the Stage. This is an optional field as it is sometimes useful to
+	// aggregates available states from multiple upstream Stages without
+	// performing any actions. The utility of this is to allow multiple downstream
+	// Stages to be able to subscribe to a single upstream Stage where they may
+	// otherwise have subscribed to multiple upstream Stages.
+	PromotionMechanisms *PromotionMechanisms `json:"promotionMechanisms,omitempty"`
 }
 
 // Subscriptions describes a Stage's sources of material.

--- a/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
@@ -47,7 +47,12 @@ spec:
             properties:
               promotionMechanisms:
                 description: PromotionMechanisms describes how to incorporate newly
-                  observed materials into the Stage. This is a required field.
+                  observed materials into the Stage. This is an optional field as
+                  it is sometimes useful to aggregates available states from multiple
+                  upstream Stages without performing any actions. The utility of this
+                  is to allow multiple downstream Stages to be able to subscribe to
+                  a single upstream Stage where they may otherwise have subscribed
+                  to multiple upstream Stages.
                 properties:
                   argoCDAppUpdates:
                     description: ArgoCDAppUpdates describes updates that should be
@@ -513,7 +518,6 @@ spec:
                     type: array
                 type: object
             required:
-            - promotionMechanisms
             - subscriptions
             type: object
           status:

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -47,7 +47,12 @@ spec:
             properties:
               promotionMechanisms:
                 description: PromotionMechanisms describes how to incorporate newly
-                  observed materials into the Stage. This is a required field.
+                  observed materials into the Stage. This is an optional field as
+                  it is sometimes useful to aggregates available states from multiple
+                  upstream Stages without performing any actions. The utility of this
+                  is to allow multiple downstream Stages to be able to subscribe to
+                  a single upstream Stage where they may otherwise have subscribed
+                  to multiple upstream Stages.
                 properties:
                   argoCDAppUpdates:
                     description: ArgoCDAppUpdates describes updates that should be
@@ -513,7 +518,6 @@ spec:
                     type: array
                 type: object
             required:
-            - promotionMechanisms
             - subscriptions
             type: object
           status:

--- a/internal/api/types/v1alpha1/types.go
+++ b/internal/api/types/v1alpha1/types.go
@@ -493,11 +493,15 @@ func ToStageProto(e kubev1alpha1.Stage) *v1alpha1.Stage {
 	metadata := e.ObjectMeta.DeepCopy()
 	metadata.SetManagedFields(nil)
 
+	var promotionMechanisms *v1alpha1.PromotionMechanisms
+	if e.Spec.PromotionMechanisms != nil {
+		promotionMechanisms = ToPromotionMechanismsProto(*e.Spec.PromotionMechanisms)
+	}
 	return &v1alpha1.Stage{
 		Metadata: typesmetav1.ToObjectMetaProto(*metadata),
 		Spec: &v1alpha1.StageSpec{
 			Subscriptions:       ToSubscriptionsProto(*e.Spec.Subscriptions),
-			PromotionMechanisms: ToPromotionMechanismsProto(*e.Spec.PromotionMechanisms),
+			PromotionMechanisms: promotionMechanisms,
 		},
 		Status: &v1alpha1.StageStatus{
 			AvailableStates: availableStates,

--- a/internal/controller/promotion/composite.go
+++ b/internal/controller/promotion/composite.go
@@ -43,6 +43,10 @@ func (c *compositeMechanism) Promote(
 	stage *api.Stage,
 	newState api.StageState,
 ) (api.StageState, error) {
+	if stage.Spec.PromotionMechanisms == nil {
+		return newState, nil
+	}
+
 	newState = *newState.DeepCopy()
 
 	logger := logging.LoggerFromContext(ctx)

--- a/internal/controller/promotion/composite_test.go
+++ b/internal/controller/promotion/composite_test.go
@@ -105,7 +105,11 @@ func TestCompositePromote(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			newStateOut, err := testCase.promoMech.Promote(
 				context.Background(),
-				&api.Stage{},
+				&api.Stage{
+					Spec: &api.StageSpec{
+						PromotionMechanisms: &api.PromotionMechanisms{},
+					},
+				},
 				testCase.newState,
 			)
 			testCase.assertions(testCase.newState, newStateOut, err)

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -305,12 +305,20 @@ func (r *reconciler) syncStage(
 
 	status.ObservedGeneration = stage.Generation
 	// Only perform health checks if we have a current state
-	if status.CurrentState != nil && stage.Spec.PromotionMechanisms != nil {
-		health := r.checkHealthFn(
-			ctx,
-			*status.CurrentState,
-			stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
-		)
+	if status.CurrentState != nil {
+		var health api.Health
+		if stage.Spec.PromotionMechanisms != nil {
+			health = r.checkHealthFn(
+				ctx,
+				*status.CurrentState,
+				stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
+			)
+		} else {
+			// Healthy by default if there are no promotion mechanisms.
+			health = api.Health{
+				Status: api.HealthStateHealthy,
+			}
+		}
 		status.CurrentState.Health = &health
 		status.History.Pop()
 		status.History.Push(*status.CurrentState)

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -17,7 +17,7 @@
       "description": "Spec describes the sources of material used by the Stage and how to incorporate newly observed materials into the Stage.",
       "properties": {
         "promotionMechanisms": {
-          "description": "PromotionMechanisms describes how to incorporate newly observed materials into the Stage. This is a required field.",
+          "description": "PromotionMechanisms describes how to incorporate newly observed materials into the Stage. This is an optional field as it is sometimes useful to aggregates available states from multiple upstream Stages without performing any actions. The utility of this is to allow multiple downstream Stages to be able to subscribe to a single upstream Stage where they may otherwise have subscribed to multiple upstream Stages.",
           "properties": {
             "argoCDAppUpdates": {
               "description": "ArgoCDAppUpdates describes updates that should be applied to Argo CD Application resources to incorporate newly observed materials into the Stage. This field is optional, as such actions are not required in all cases. Note that all updates specified by the GitRepoUpdates field, if any, are applied BEFORE these.",
@@ -423,7 +423,6 @@
         }
       },
       "required": [
-        "promotionMechanisms",
         "subscriptions"
       ],
       "type": "object"


### PR DESCRIPTION
Fixes #622

Built on top of #628

Merge after #628 and only review commits starting with df73a4ed4e7e7c96435cabb9d0023021308c7603

This works by removing the constraint that all Stages must have one or more promotion mechanisms defined.

It makes this possible:

![Screenshot 2023-09-01 at 1 30 26 PM](https://github.com/akuity/kargo/assets/1821014/c9727756-4867-403c-b156-2ebf2ad7bd7c)