### PR TITLE
Manage all kubernetes runtime scheme in `kubeclient` package

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/akuity/kargo/internal/cli/login"
 	"github.com/akuity/kargo/internal/cli/option"
 	"github.com/akuity/kargo/internal/cli/stage"
+	"github.com/akuity/kargo/internal/kubeclient"
 )
 
 // rootState holds state used internally by the root command.
@@ -81,9 +82,9 @@ func NewRootCommand(opt *option.Option, rs *rootState) (*cobra.Command, error) {
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
-	scheme, err := option.NewScheme()
+	scheme, err := kubeclient.NewCLIScheme()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "new cli scheme")
 	}
 	opt.PrintFlags = genericclioptions.NewPrintFlags("").WithTypeSetter(scheme)
 	option.InsecureTLS(&opt.InsecureTLS)(cmd.PersistentFlags())

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -3,23 +3,21 @@ package main
 import (
 	"sync"
 
-	argocd "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/akuity/bookkeeper"
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/controller/applications"
 	"github.com/akuity/kargo/internal/controller/promotions"
 	"github.com/akuity/kargo/internal/controller/stages"
 	"github.com/akuity/kargo/internal/credentials"
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	"github.com/akuity/kargo/internal/types"
@@ -59,19 +57,9 @@ func newControllerCommand() *cobra.Command {
 				}
 				restCfg.ContentType = runtime.ContentTypeJSON
 
-				scheme := runtime.NewScheme()
-				if err = corev1.AddToScheme(scheme); err != nil {
-					return errors.Wrap(
-						err,
-						"error adding Kubernetes core API to Kargo controller manager "+
-							"scheme",
-					)
-				}
-				if err = kargoapi.AddToScheme(scheme); err != nil {
-					return errors.Wrap(
-						err,
-						"error adding Kargo API to Kargo controller manager scheme",
-					)
+				scheme, err := kubeclient.NewKargoManagerScheme()
+				if err != nil {
+					return errors.Wrap(err, "new kargo manager scheme")
 				}
 				if kargoMgr, err = ctrl.NewManager(
 					restCfg,
@@ -97,20 +85,9 @@ func newControllerCommand() *cobra.Command {
 				}
 				restCfg.ContentType = runtime.ContentTypeJSON
 
-				scheme := runtime.NewScheme()
-				if err = corev1.AddToScheme(scheme); err != nil {
-					return errors.Wrap(
-						err,
-						"error adding Kubernetes core API to Argo CD Application "+
-							"controller manager scheme",
-					)
-				}
-				if err = argocd.AddToScheme(scheme); err != nil {
-					return errors.Wrap(
-						err,
-						"error adding Kargo API to Argo CD Application controller manager "+
-							"scheme",
-					)
+				scheme, err := kubeclient.NewAppManagerScheme()
+				if err != nil {
+					return errors.Wrap(err, "new app manager scheme")
 				}
 
 				var watchNamespace string // Empty string means all namespaces

--- a/cmd/controlplane/garbage_collector.go
+++ b/cmd/controlplane/garbage_collector.go
@@ -4,13 +4,11 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/garbage"
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 )
@@ -39,12 +37,9 @@ func newGarbageCollectorCommand() *cobra.Command {
 				if err != nil {
 					return errors.Wrap(err, "error loading REST config")
 				}
-				scheme := runtime.NewScheme()
-				if err = corev1.AddToScheme(scheme); err != nil {
-					return errors.Wrap(err, "error adding Kubernetes core API to scheme")
-				}
-				if err = kargoapi.AddToScheme(scheme); err != nil {
-					return errors.Wrap(err, "error adding Kargo API to scheme")
+				scheme, err := kubeclient.NewGarbageCollectorScheme()
+				if err != nil {
+					return errors.Wrap(err, "new garbage collector scheme")
 				}
 				if kubeClient, err = client.New(
 					restCfg,

--- a/cmd/controlplane/webhooks.go
+++ b/cmd/controlplane/webhooks.go
@@ -4,12 +4,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	authzv1 "k8s.io/api/authorization/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/os"
@@ -39,17 +35,10 @@ func newWebhooksServerCommand() *cobra.Command {
 				return errors.Wrap(err, "error getting REST config")
 			}
 
-			scheme := runtime.NewScheme()
-			if err = corev1.AddToScheme(scheme); err != nil {
-				return errors.Wrap(err, "add corev1 to scheme")
+			scheme, err := kubeclient.NewWebhooksServerScheme()
+			if err != nil {
+				return errors.Wrap(err, "new webhooks server scheme")
 			}
-			if err = authzv1.AddToScheme(scheme); err != nil {
-				return errors.Wrap(err, "add authzv1 to scheme")
-			}
-			if err = kargoapi.AddToScheme(scheme); err != nil {
-				return errors.Wrap(err, "add kargo api to scheme")
-			}
-
 			mgr, err := ctrl.NewManager(
 				restCfg,
 				ctrl.Options{

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4,23 +4,19 @@ import (
 	"embed"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/kubeclient"
 )
 
 //go:embed testdata/*
 var testData embed.FS
 
 func mustNewScheme() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		panic(errors.Wrap(err, "add core v1 scheme"))
-	}
-	if err := kargoapi.AddToScheme(scheme); err != nil {
-		panic(errors.Wrap(err, "add kargo v1alpha1 scheme"))
+	scheme, err := kubeclient.NewAPIScheme()
+	if err != nil {
+		panic(errors.Wrap(err, "new api scheme"))
 	}
 	return scheme
 }

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -13,15 +13,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
-	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	libClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	libCluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/user"
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/logging"
 )
 
@@ -59,14 +58,11 @@ type ClientOptions struct {
 // provided ClientOptions struct.
 func setOptionsDefaults(opts ClientOptions) (ClientOptions, error) {
 	if opts.Scheme == nil {
-		opts.Scheme = runtime.NewScheme()
-		if err := kubescheme.AddToScheme(opts.Scheme); err != nil {
-			return opts,
-				errors.Wrap(err, "error adding Kubernetes API to scheme")
+		scheme, err := kubeclient.NewKubernetesScheme()
+		if err != nil {
+			return opts, errors.Wrap(err, "new kubernetes scheme")
 		}
-		if err := kargoapi.AddToScheme(opts.Scheme); err != nil {
-			return opts, errors.Wrap(err, "error adding Kargo API to scheme")
-		}
+		opts.Scheme = scheme
 	}
 	if opts.NewInternalClient == nil {
 		opts.NewInternalClient = newDefaultInternalClient

--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -1,12 +1,7 @@
 package option
 
 import (
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 type Option struct {
@@ -24,15 +19,4 @@ func NewOption() *Option {
 	return &Option{
 		Project: OptionalString(),
 	}
-}
-
-func NewScheme() (*runtime.Scheme, error) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return nil, errors.Wrap(err, "add core v1 scheme")
-	}
-	if err := kargoapi.AddToScheme(scheme); err != nil {
-		return nil, errors.Wrap(err, "add kargo v1alpha1 scheme")
-	}
-	return scheme, nil
 }

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -16,6 +15,7 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/runtime"
 	"github.com/akuity/kargo/internal/credentials"
+	"github.com/akuity/kargo/internal/kubeclient"
 )
 
 func TestNewPromotionReconciler(t *testing.T) {
@@ -32,8 +32,8 @@ func TestNewPromotionReconciler(t *testing.T) {
 }
 
 func TestInitializeQueues(t *testing.T) {
-	scheme := k8sruntime.NewScheme()
-	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
+	scheme, err := kubeclient.NewKargoScheme()
+	require.NoError(t, err)
 	r := reconciler{
 		kargoClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 			&kargoapi.Promotion{
@@ -48,7 +48,7 @@ func TestInitializeQueues(t *testing.T) {
 		).Build(),
 		promoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
 	}
-	err := r.initializeQueues(context.Background())
+	err = r.initializeQueues(context.Background())
 	require.NoError(t, err)
 }
 
@@ -216,13 +216,13 @@ func TestSerializedSync(t *testing.T) {
 		},
 	}
 
-	scheme := k8sruntime.NewScheme()
-	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
+	scheme, err := kubeclient.NewKargoScheme()
+	require.NoError(t, err)
 	kargoClient := fake.NewClientBuilder().
 		WithScheme(scheme).WithObjects(promo).Build()
 
 	pq := newPromotionsQueue()
-	err := pq.Push(promo)
+	err = pq.Push(promo)
 	require.NoError(t, err)
 
 	r := reconciler{
@@ -257,8 +257,8 @@ func TestSerializedSync(t *testing.T) {
 }
 
 func TestGetPromo(t *testing.T) {
-	scheme := k8sruntime.NewScheme()
-	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
+	scheme, err := kubeclient.NewKargoScheme()
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name       string

--- a/internal/garbage/collector_test.go
+++ b/internal/garbage/collector_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/logging"
 )
 
@@ -342,8 +342,7 @@ func TestCleanProject(t *testing.T) {
 		const numPromos = 100
 		const testProject = "fake-project"
 
-		scheme := runtime.NewScheme()
-		err := kargoapi.AddToScheme(scheme)
+		scheme, err := kubeclient.NewGarbageCollectorScheme()
 		require.NoError(t, err)
 
 		initialPromos := []client.Object{}

--- a/internal/kubeclient/manifest/manifest_test.go
+++ b/internal/kubeclient/manifest/manifest_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/kubeclient"
 )
 
 func TestParser(t *testing.T) {
@@ -131,9 +132,8 @@ metadata:
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, kargoapi.AddToScheme(scheme))
+	scheme, err := kubeclient.NewAPIScheme()
+	require.NoError(t, err)
 	parseKubernetesManifest := NewParser(scheme)
 
 	for name, tc := range testCases {

--- a/internal/kubeclient/scheme.go
+++ b/internal/kubeclient/scheme.go
@@ -1,0 +1,61 @@
+package kubeclient
+
+import (
+	argocd "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/pkg/errors"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+var kargoSchemes = runtime.SchemeBuilder{
+	corev1.AddToScheme,
+	kargoapi.AddToScheme,
+}
+
+func newScheme(extraSchemes ...func(*runtime.Scheme) error) (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range extraSchemes {
+		if err := addToScheme(scheme); err != nil {
+			return nil, errors.Wrap(err, "add api to scheme")
+		}
+	}
+	return scheme, nil
+}
+func NewAPIScheme() (*runtime.Scheme, error) {
+	return newScheme(kargoSchemes...)
+}
+
+func NewAppManagerScheme() (*runtime.Scheme, error) {
+	return newScheme(
+		corev1.AddToScheme,
+		argocd.AddToScheme,
+	)
+}
+
+func NewCLIScheme() (*runtime.Scheme, error) {
+	return newScheme(kargoSchemes...)
+}
+
+func NewKargoScheme() (*runtime.Scheme, error) {
+	return newScheme(kargoSchemes...)
+}
+
+func NewKargoManagerScheme() (*runtime.Scheme, error) {
+	return newScheme(kargoSchemes...)
+}
+
+func NewKubernetesScheme() (*runtime.Scheme, error) {
+	return newScheme(kubescheme.AddToScheme, kargoapi.AddToScheme)
+}
+
+func NewGarbageCollectorScheme() (*runtime.Scheme, error) {
+	return newScheme(kargoSchemes...)
+}
+
+func NewWebhooksServerScheme() (*runtime.Scheme, error) {
+	return newScheme(append(kargoSchemes, authzv1.AddToScheme)...)
+}


### PR DESCRIPTION
This commit allows all components to use same base runtime scheme.