### PR TITLE
update PromotionPhases

### DIFF
--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -30,6 +30,11 @@ const (
 	PromotionPhaseErrored PromotionPhase = "Errored"
 )
 
+// IsTerminal returns true if the PromotionPhase is a terminal one.
+func (p *PromotionPhase) IsTerminal() bool {
+	return *p == PromotionPhaseSucceeded || *p == PromotionPhaseErrored
+}
+
 //+kubebuilder:resource:shortName={promo,promos}
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -7,10 +7,27 @@ import (
 type PromotionPhase string
 
 const (
-	PromotionPhasePending    PromotionPhase = "Pending"
-	PromotionPhaseInProgress PromotionPhase = "Promoting"
-	PromotionPhaseComplete   PromotionPhase = "Completed"
-	PromotionPhaseFailed     PromotionPhase = "Failed"
+	// PromotionPhasePending denotes a Promotion that has not been executed yet.
+	// i.e. It is currently waiting in a queue. Queues are stage-specific and
+	// prioritized by Promotion creation time.
+	PromotionPhasePending PromotionPhase = "Pending"
+	// PromotionPhaseRunning denotes a Promotion that is actively being executed.
+	//
+	// TODO: "Active" is the operative word here. We are leaving room for the
+	// possibility in the near future that an in-progress Promotion might be
+	// paused/suspended pending some user action.
+	PromotionPhaseRunning PromotionPhase = "Running"
+	// PromotionPhaseSucceeded denotes a Promotion that has been successfully
+	// executed.
+	PromotionPhaseSucceeded PromotionPhase = "Succeeded"
+	// PromotionPhaseErrored denotes a Promotion that has failed for technical
+	// reasons. Further information about the failure can be found in the
+	// Promotion's status.
+	//
+	// TODO: "For technical reasons" is the operative phrase here. We are leaving
+	// room for the possibility in the near future that a Promotion might fail
+	// as a result of some user action.
+	PromotionPhaseErrored PromotionPhase = "Errored"
 )
 
 //+kubebuilder:resource:shortName={promo,promos}

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -422,7 +422,7 @@ After creating the `test` `Stage` resource, we should almost immediately see:
 
    ```text
    NAME                                               STAGE   FREIGHT                                    PHASE       AGE
-   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   55s
+   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   55s
    ```
 
 1. Your GitOps repository has a new commit.
@@ -508,8 +508,8 @@ see:
 
    ```
    NAME                                               STAGE   FREIGHT                                    PHASE       AGE
-   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   2m40s
-   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   43s
+   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   2m40s
+   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   43s
    ```
 
 1. [Your Argo CD dashboard](http://localhost:8080) shows that `kargo-demo-uat`
@@ -590,8 +590,8 @@ After creating the `prod` `Stage` resource, we should almost immediately see:
 
    ```
    NAME                                               STAGE   FREIGHT                                    PHASE       AGE
-   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   4m4s
-   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   2m7s
+   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   4m4s
+   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   2m7s
    ```
 
 1. [Your Argo CD dashboard](http://localhost:8080) shows that `kargo-demo-prod`
@@ -634,9 +634,9 @@ After a few moments, we should be able to see:
 
    ```text
    NAME                                               STAGE   FREIGHT                                    PHASE       AGE
-   prod-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   prod    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   12s
-   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   8m11s
-   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Completed   6m14ss
+   prod-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   prod    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   12s
+   test-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686   test    d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   8m11s
+   uat-to-d9a3e3e54b11b3e4a763e7cb8b1098089b567686    uat     d9a3e3e54b11b3e4a763e7cb8b1098089b567686   Succeeded   6m14ss
    ```
 
 1. The `prod` `Stage` has now been assigned a current freight:

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -193,10 +193,10 @@ func (r *reconciler) initializeQueues(ctx context.Context) error {
 	logger := logging.LoggerFromContext(ctx)
 	for _, p := range promos.Items {
 		promo := p // This is to sidestep implicit memory aliasing in this for loop
-		switch promo.Status.Phase {
-		case kargoapi.PromotionPhaseSucceeded, kargoapi.PromotionPhaseErrored:
+		if promo.Status.Phase.IsTerminal() {
 			continue
-		case "":
+		}
+		if promo.Status.Phase == "" {
 			if err := kubeclient.PatchStatus(ctx, r.kargoClient, &promo, func(status *kargoapi.PromotionStatus) {
 				status.Phase = kargoapi.PromotionPhasePending
 			}); err != nil {
@@ -345,7 +345,7 @@ func (r *reconciler) serializedSync(
 				}
 
 				if promo.Status.Phase == kargoapi.PromotionPhaseSucceeded && err == nil {
-					logger.Debug("completed Promotion")
+					logger.Debug("Promotion succeeded")
 				}
 			}
 		}

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -253,7 +253,7 @@ func TestSerializedSync(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, promo)
-	require.Equal(t, kargoapi.PromotionPhaseComplete, promo.Status.Phase)
+	require.Equal(t, kargoapi.PromotionPhaseSucceeded, promo.Status.Phase)
 }
 
 func TestGetPromo(t *testing.T) {

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -29,7 +29,7 @@ func TestNewStageReconciler(t *testing.T) {
 	// Assert that all overridable behaviors were initialized to a default:
 
 	// Loop guard:
-	require.NotNil(t, e.hasOutstandingPromotionsFn)
+	require.NotNil(t, e.hasNonTerminalPromotionsFn)
 
 	// Common:
 	require.NotNil(t, e.getArgoCDAppFn)
@@ -52,7 +52,7 @@ func TestSync(t *testing.T) {
 	scheme := k8sruntime.NewScheme()
 	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
 
-	noOutstandingPromotionsFn := func(
+	noNonTerminalPromotionsFn := func(
 		context.Context,
 		string,
 		string,
@@ -64,7 +64,7 @@ func TestSync(t *testing.T) {
 		name                       string
 		spec                       kargoapi.StageSpec
 		initialStatus              kargoapi.StageStatus
-		hasOutstandingPromotionsFn func(
+		hasNonTerminalPromotionsFn func(
 			ctx context.Context,
 			stageNamespace string,
 			stageName string,
@@ -93,8 +93,8 @@ func TestSync(t *testing.T) {
 		)
 	}{
 		{
-			name: "error checking for outstanding promotions",
-			hasOutstandingPromotionsFn: func(
+			name: "error checking for non-terminal promotions",
+			hasNonTerminalPromotionsFn: func(
 				context.Context,
 				string,
 				string,
@@ -115,8 +115,8 @@ func TestSync(t *testing.T) {
 		},
 
 		{
-			name: "outstanding promotions found",
-			hasOutstandingPromotionsFn: func(
+			name: "non-terminal promotions found",
+			hasNonTerminalPromotionsFn: func(
 				context.Context,
 				string,
 				string,
@@ -141,7 +141,7 @@ func TestSync(t *testing.T) {
 				Subscriptions: &kargoapi.Subscriptions{},
 			},
 			initialStatus:              kargoapi.StageStatus{},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			assertions: func(
 				initialStatus kargoapi.StageStatus,
 				newStatus kargoapi.StageStatus,
@@ -161,7 +161,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -189,7 +189,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -272,7 +272,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			checkHealthFn: func(
 				context.Context,
 				kargoapi.Freight,
@@ -325,7 +325,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getAvailableFreightFromUpstreamStagesFn: func(
 				context.Context,
 				string,
@@ -357,7 +357,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getAvailableFreightFromUpstreamStagesFn: func(
 				context.Context,
 				string,
@@ -393,7 +393,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getAvailableFreightFromUpstreamStagesFn: func(
 				context.Context,
 				string,
@@ -430,7 +430,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -498,7 +498,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -581,7 +581,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -657,7 +657,7 @@ func TestSync(t *testing.T) {
 					Repos: &kargoapi.RepoSubscriptions{},
 				},
 			},
-			hasOutstandingPromotionsFn: noOutstandingPromotionsFn,
+			hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 			getLatestFreightFromReposFn: func(
 				context.Context,
 				string,
@@ -742,7 +742,7 @@ func TestSync(t *testing.T) {
 			// nolint: lll
 			reconciler := &reconciler{
 				kargoClient:                             tc.kargoClient,
-				hasOutstandingPromotionsFn:              tc.hasOutstandingPromotionsFn,
+				hasNonTerminalPromotionsFn:              tc.hasNonTerminalPromotionsFn,
 				checkHealthFn:                           tc.checkHealthFn,
 				getLatestFreightFromReposFn:             tc.getLatestFreightFromReposFn,
 				getAvailableFreightFromUpstreamStagesFn: tc.getAvailableFreightFromUpstreamStagesFn,

--- a/internal/garbage/collector.go
+++ b/internal/garbage/collector.go
@@ -227,8 +227,7 @@ func (c *collector) cleanProject(ctx context.Context, project string) error {
 	var deleteErrCount int
 	for i := c.cfg.MaxRetainedPromotions; i < len(promos.Items); i++ {
 		promo := promos.Items[i]
-		switch promo.Status.Phase {
-		case kargoapi.PromotionPhaseSucceeded, kargoapi.PromotionPhaseErrored:
+		if promo.Status.Phase.IsTerminal() {
 			promoLogger := logger.WithField("promotion", promo.Name)
 			if err := c.deletePromotionFn(ctx, &promo); err != nil {
 				promoLogger.Errorf("error deleting Promotion: %s", err)

--- a/internal/garbage/collector.go
+++ b/internal/garbage/collector.go
@@ -228,7 +228,7 @@ func (c *collector) cleanProject(ctx context.Context, project string) error {
 	for i := c.cfg.MaxRetainedPromotions; i < len(promos.Items); i++ {
 		promo := promos.Items[i]
 		switch promo.Status.Phase {
-		case kargoapi.PromotionPhaseComplete, kargoapi.PromotionPhaseFailed:
+		case kargoapi.PromotionPhaseSucceeded, kargoapi.PromotionPhaseErrored:
 			promoLogger := logger.WithField("promotion", promo.Name)
 			if err := c.deletePromotionFn(ctx, &promo); err != nil {
 				promoLogger.Errorf("error deleting Promotion: %s", err)

--- a/internal/garbage/collector_test.go
+++ b/internal/garbage/collector_test.go
@@ -301,7 +301,7 @@ func TestCleanProject(t *testing.T) {
 						promos.Items,
 						kargoapi.Promotion{
 							Status: kargoapi.PromotionStatus{
-								Phase: kargoapi.PromotionPhaseComplete,
+								Phase: kargoapi.PromotionPhaseSucceeded,
 							},
 						},
 					)
@@ -361,7 +361,7 @@ func TestCleanProject(t *testing.T) {
 						CreationTimestamp: metav1.NewTime(creationTime),
 					},
 					Status: kargoapi.PromotionStatus{
-						Phase: kargoapi.PromotionPhaseComplete,
+						Phase: kargoapi.PromotionPhaseSucceeded,
 					},
 				},
 			)

--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -21,8 +21,8 @@ const (
 
 var (
 	NonOutstandingPromotionPhases = []kargoapi.PromotionPhase{
-		kargoapi.PromotionPhaseComplete,
-		kargoapi.PromotionPhaseFailed,
+		kargoapi.PromotionPhaseSucceeded,
+		kargoapi.PromotionPhaseErrored,
 	}
 )
 

--- a/internal/kubeclient/indexer_test.go
+++ b/internal/kubeclient/indexer_test.go
@@ -155,7 +155,7 @@ func TestIndexPromotionsByStage(t *testing.T) {
 			},
 			expected: []string{"fake-stage"},
 		},
-		"filter nonOutstandingPromotionPhase/terminal phase": {
+		"isPromotionPhaseNonTerminal excludes Promotions in terminal phases": {
 			input: &kargoapi.Promotion{
 				Spec: &kargoapi.PromotionSpec{
 					Stage: "fake-stage",
@@ -165,11 +165,11 @@ func TestIndexPromotionsByStage(t *testing.T) {
 				},
 			},
 			predicates: []func(*kargoapi.Promotion) bool{
-				filterNonOutstandingPromotionPhases,
+				isPromotionPhaseNonTerminal,
 			},
 			expected: nil,
 		},
-		"filter nonOutstandingPromotionPhase/non-terminal phase": {
+		"isPromotionPhaseNonTerminal selects Promotions in non-terminal phases": {
 			input: &kargoapi.Promotion{
 				Spec: &kargoapi.PromotionSpec{
 					Stage: "fake-stage",
@@ -179,7 +179,7 @@ func TestIndexPromotionsByStage(t *testing.T) {
 				},
 			},
 			predicates: []func(*kargoapi.Promotion) bool{
-				filterNonOutstandingPromotionPhases,
+				isPromotionPhaseNonTerminal,
 			},
 			expected: []string{"fake-stage"},
 		},

--- a/internal/kubeclient/indexer_test.go
+++ b/internal/kubeclient/indexer_test.go
@@ -139,7 +139,7 @@ func TestIndexPromotionsByStage(t *testing.T) {
 					Stage: "fake-stage",
 				},
 				Status: kargoapi.PromotionStatus{
-					Phase: kargoapi.PromotionPhaseComplete,
+					Phase: kargoapi.PromotionPhaseSucceeded,
 				},
 			},
 			expected: []string{"fake-stage"},
@@ -161,7 +161,7 @@ func TestIndexPromotionsByStage(t *testing.T) {
 					Stage: "fake-stage",
 				},
 				Status: kargoapi.PromotionStatus{
-					Phase: kargoapi.PromotionPhaseComplete,
+					Phase: kargoapi.PromotionPhaseSucceeded,
 				},
 			},
 			predicates: []func(*kargoapi.Promotion) bool{


### PR DESCRIPTION
Fixes #600 

This goes a little bit beyond #600. While auditing where and how the PromotionPhases I was modifying are used, I discovered:

* A lot of references to "outstanding" or "non-outstanding" Promotions. I felt like this was a bit ambiguous. For instance, it wouldn't be crazy for someone to assume that a Promotion that is Running is _not_ outstanding (but it is).

  I updated the code to use less ambiguous terminology -- terminal or non-terminal.
  
  This also presented the opportunity to add a convenient `phase.IsTerminal()` function that makes all other code that needs to make such a determination less brittle when we add new phases.

* Places where predicates used in indexing Promotions by non-terminal (formerly "non-outstanding") used the word "filter" which can also be confusing. The purpose of a filter is to _exclude_ things, while the purpose of a predicate it to _select_ things. So I made updates to these as well to improve the clarity of the code.

I couldn't spot any UI changes that were required to complement the phase name changes, but @rbreeze or @rpelczar can correct me if I missed something.

There are no functional changes in this PR.