### PR TITLE
add component labels to governance bot

### DIFF
--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -42,6 +42,8 @@ issue:
         - charts
         - cli
         - controller
+        - crds
+        - garbage-collector
         - ui
         - webhooks
       multiple: true


### PR DESCRIPTION
We were conspicuously missing labels for area/garbage-collector and, more importantly, area/crds -- since we should pay very close attention to PRs that update CRDs.