### PR TITLE
feat: support supplying bcrypt hash of admin password

### DIFF
--- a/charts/kargo/templates/api/secret.yaml
+++ b/charts/kargo/templates/api/secret.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "kargo.api.labels" . | nindent 4 }}
 {{- if .Values.api.adminAccount.enabled }}
 stringData:
-  ADMIN_ACCOUNT_PASSWORD_HASH: {{ bcrypt .Values.api.adminAccount.password }}
+  ADMIN_ACCOUNT_PASSWORD_HASH: {{ or .Values.api.adminAccount.passwordHash (bcrypt .Values.api.adminAccount.password) }}
   ADMIN_ACCOUNT_TOKEN_SIGNING_KEY: {{ quote .Values.api.adminAccount.tokenSigningKey }}
 {{- else }}
 stringData: {}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -109,8 +109,13 @@ api:
     ## false.
     enabled: true
 
-    ## A password for the admin account. It is suggested that you generate this
-    ## using a password manager or a command like
+    ## Bcrypt password hash for the admin account. If specified, will ignore
+    ## password setting
+    passwordHash:
+
+    ## A password for the admin account. Ignored if passwordHash is set.
+    ## It is suggested that you generate this using a password manager or a 
+    # command like
     ## `openssl rand -base64 29 | tr -d "=+/" | cut -c1-25`
     password: <admin password>
 


### PR DESCRIPTION
We should allow users to supply the bcrypt hash of the password instead of the plaintext password in the values.yaml. Since the hash is safe to store in plaintext/git but a password is not.

Additionally, the `bcrypt` function is not hermetic/stable/gitops-friendly and so if user uses password, every time user applies the helm chart, they will get a different hash. But supplying a hash **_is_** hermetic and wouldn't change between applies.