### PR TITLE
fix: don't crash controller on reconcile panics

### DIFF
--- a/internal/controller/applications/applications.go
+++ b/internal/controller/applications/applications.go
@@ -37,6 +37,7 @@ func SetupReconcilerWithManager(
 	}
 	return ctrl.NewControllerManagedBy(argoMgr).
 		For(&argocd.Application{}).
+		WithOptions(controller.CommonOptions()).
 		Complete(newReconciler(kargoMgr.GetClient()))
 }
 

--- a/internal/controller/options.go
+++ b/internal/controller/options.go
@@ -1,0 +1,11 @@
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+func CommonOptions() controller.Options {
+	return controller.Options{
+		RecoverPanic: true,
+	}
+}

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -62,6 +62,7 @@ func SetupReconcilerWithManager(
 			For(&kargoapi.Promotion{}).
 			WithEventFilter(predicate.GenerationChangedPredicate{}).
 			WithEventFilter(shardPredicate).
+			WithOptions(controller.CommonOptions()).
 			Complete(
 				newReconciler(
 					kargoMgr.GetClient(),

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -158,6 +158,7 @@ func SetupReconcilerWithManager(
 				),
 			).
 			WithEventFilter(shardPredicate).
+			WithOptions(controller.CommonOptions()).
 			Complete(
 				newReconciler(
 					kargoMgr.GetClient(),


### PR DESCRIPTION
Partially resolves https://github.com/akuity/kargo/issues/656

Depends on https://github.com/akuity/kargo/pull/650

If a promotion function panics, we will fail the promotion rather than crash the controller, and the promotion will have a proper message and phase:

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: Promotion
metadata:
  creationTimestamp: "2023-09-06T21:11:10Z"
  generation: 1
  name: dev.01h9p5bczmwqj1z5hhf6880p8f.e9b3b60
  namespace: kargo-guestbook
  ownerReferences:
  - apiVersion: kargo.akuity.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Stage
    name: dev
    uid: 32626a1f-c00f-468a-8e76-d1a0d83e7920
  resourceVersion: "127330362"
  uid: 5482cac2-16ed-4f5f-ad55-2d3a4e5c8db7
spec:
  freight: e9b3b603e17ea2e291535b605a58c2e62f1949be
  stage: dev
status:
  error: 'runtime error: invalid memory address or nil pointer dereference'
  phase: Failed
```