### PR TITLE
feat: argocd app namespace is optional and not defaulted

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"crypto/sha1"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -358,9 +359,7 @@ type ArgoCDAppUpdate struct {
 	AppName string `json:"appName"`
 	// AppNamespace specifies the namespace of an Argo CD Application resource to
 	// be updated. If left unspecified, the namespace of this Application resource
-	// is defaulted to that of the Stage.
-	//
-	// TODO: This should default to Argo CD's namespace instead.
+	// will use the value of ARGOCD_NAMESPACE or "argocd"
 	//
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -368,6 +367,16 @@ type ArgoCDAppUpdate struct {
 	// SourceUpdates describes updates to be applied to various sources of the
 	// specified Argo CD Application resource.
 	SourceUpdates []ArgoCDSourceUpdate `json:"sourceUpdates,omitempty"`
+}
+
+func (a *ArgoCDAppUpdate) AppNamespaceOrDefault() string {
+	if a.AppNamespace != "" {
+		return a.AppNamespace
+	}
+	if envArgocdNs := os.Getenv("ARGOCD_NAMESPACE"); envArgocdNs != "" {
+		return envArgocdNs
+	}
+	return "argocd"
 }
 
 // ArgoCDSourceUpdate describes updates that should be applied to one of an Argo

--- a/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
@@ -73,11 +73,10 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         appNamespace:
-                          description: "AppNamespace specifies the namespace of an
+                          description: AppNamespace specifies the namespace of an
                             Argo CD Application resource to be updated. If left unspecified,
-                            the namespace of this Application resource is defaulted
-                            to that of the Stage. \n TODO: This should default to
-                            Argo CD's namespace instead."
+                            the namespace of this Application resource will use the
+                            value of ARGOCD_NAMESPACE or "argocd"
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         sourceUpdates:

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -73,11 +73,10 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         appNamespace:
-                          description: "AppNamespace specifies the namespace of an
+                          description: AppNamespace specifies the namespace of an
                             Argo CD Application resource to be updated. If left unspecified,
-                            the namespace of this Application resource is defaulted
-                            to that of the Stage. \n TODO: This should default to
-                            Argo CD's namespace instead."
+                            the namespace of this Application resource will use the
+                            value of ARGOCD_NAMESPACE or "argocd"
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         sourceUpdates:

--- a/internal/controller/applications/applications.go
+++ b/internal/controller/applications/applications.go
@@ -63,7 +63,7 @@ func indexStagesByApp(shardName string) func(client.Object) []string {
 		apps := make([]string, len(stage.Spec.PromotionMechanisms.ArgoCDAppUpdates))
 		for i, appCheck := range stage.Spec.PromotionMechanisms.ArgoCDAppUpdates {
 			apps[i] =
-				fmt.Sprintf("%s:%s", appCheck.AppNamespace, appCheck.AppName)
+				fmt.Sprintf("%s:%s", appCheck.AppNamespaceOrDefault(), appCheck.AppName)
 		}
 		return apps
 	}

--- a/internal/controller/promotion/argocd.go
+++ b/internal/controller/promotion/argocd.go
@@ -102,20 +102,20 @@ func (a *argoCDMechanism) doSingleUpdate(
 	newFreight kargoapi.Freight,
 ) error {
 	app, err :=
-		a.getArgoCDAppFn(ctx, update.AppNamespace, update.AppName)
+		a.getArgoCDAppFn(ctx, update.AppNamespaceOrDefault(), update.AppName)
 	if err != nil {
 		return errors.Wrapf(
 			err,
 			"error finding Argo CD Application %q in namespace %q",
 			update.AppName,
-			update.AppNamespace,
+			update.AppNamespaceOrDefault(),
 		)
 	}
 	if app == nil {
 		return errors.Errorf(
 			"unable to find Argo CD Application %q in namespace %q",
 			update.AppName,
-			update.AppNamespace,
+			update.AppNamespaceOrDefault(),
 		)
 	}
 	// Make sure this is allowed!
@@ -135,7 +135,7 @@ func (a *argoCDMechanism) doSingleUpdate(
 					err,
 					"error updating source of Argo CD Application %q in namespace %q",
 					update.AppName,
-					update.AppNamespace,
+					update.AppNamespaceOrDefault(),
 				)
 			}
 			app.Spec.Source = &source
@@ -150,7 +150,7 @@ func (a *argoCDMechanism) doSingleUpdate(
 					err,
 					"error updating source(s) of Argo CD Application %q in namespace %q",
 					update.AppName,
-					update.AppNamespace,
+					update.AppNamespaceOrDefault(),
 				)
 			}
 			app.Spec.Sources[i] = source

--- a/internal/controller/stages/argocd.go
+++ b/internal/controller/stages/argocd.go
@@ -30,7 +30,7 @@ func (r *reconciler) checkHealth(
 
 	for _, check := range argoCDAppUpdates {
 		app, err :=
-			r.getArgoCDAppFn(ctx, r.argoClient, check.AppNamespace, check.AppName)
+			r.getArgoCDAppFn(ctx, r.argoClient, check.AppNamespaceOrDefault(), check.AppName)
 		if err != nil {
 			if health.Status != kargoapi.HealthStateUnhealthy {
 				health.Status = kargoapi.HealthStateUnknown
@@ -40,7 +40,7 @@ func (r *reconciler) checkHealth(
 				fmt.Sprintf(
 					"error finding Argo CD Application %q in namespace %q: %s",
 					check.AppName,
-					check.AppNamespace,
+					check.AppNamespaceOrDefault(),
 					err,
 				),
 			)
@@ -53,7 +53,7 @@ func (r *reconciler) checkHealth(
 				fmt.Sprintf(
 					"unable to find Argo CD Application %q in namespace %q",
 					check.AppName,
-					check.AppNamespace,
+					check.AppNamespaceOrDefault(),
 				),
 			)
 		} else if len(app.Spec.Sources) > 0 {
@@ -66,7 +66,7 @@ func (r *reconciler) checkHealth(
 					"bugs in Argo CD currently prevent a comprehensive assessment of "+
 						"the health of multi-source Application %q in namespace %q",
 					check.AppName,
-					check.AppNamespace,
+					check.AppNamespaceOrDefault(),
 				),
 			)
 		} else {

--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -57,7 +57,7 @@ func indexStagesByArgoCDApplications(shardName string) client.IndexerFunc {
 		apps := make([]string, len(stage.Spec.PromotionMechanisms.ArgoCDAppUpdates))
 		for i, appCheck := range stage.Spec.PromotionMechanisms.ArgoCDAppUpdates {
 			apps[i] =
-				fmt.Sprintf("%s:%s", appCheck.AppNamespace, appCheck.AppName)
+				fmt.Sprintf("%s:%s", appCheck.AppNamespaceOrDefault(), appCheck.AppName)
 		}
 		return apps
 	}

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -41,24 +41,9 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
-	stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
+func (w *webhook) Default(_ context.Context, _ runtime.Object) error {
 	// Note that defaults are applied BEFORE validation, so we do not have the
 	// luxury of assuming certain required fields must be non-nil.
-	if stage.Spec != nil {
-
-		if stage.Spec.PromotionMechanisms != nil {
-			// Default namespace for Argo CD Applications we update
-			for i := range stage.Spec.PromotionMechanisms.ArgoCDAppUpdates {
-				if stage.Spec.PromotionMechanisms.ArgoCDAppUpdates[i].AppNamespace == "" {
-					stage.Spec.PromotionMechanisms.ArgoCDAppUpdates[i].AppNamespace =
-						stage.Namespace
-				}
-			}
-		}
-
-	}
-
 	return nil
 }
 

--- a/internal/webhook/stage/webhook_test.go
+++ b/internal/webhook/stage/webhook_test.go
@@ -39,11 +39,6 @@ func TestDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, e.Spec.Subscriptions.UpstreamStages, 1)
 	require.Len(t, e.Spec.PromotionMechanisms.ArgoCDAppUpdates, 1)
-	require.Equal(
-		t,
-		testNamespace,
-		e.Spec.PromotionMechanisms.ArgoCDAppUpdates[0].AppNamespace,
-	)
 }
 
 func TestValidateSpec(t *testing.T) {

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -31,7 +31,7 @@
                     "type": "string"
                   },
                   "appNamespace": {
-                    "description": "AppNamespace specifies the namespace of an Argo CD Application resource to be updated. If left unspecified, the namespace of this Application resource is defaulted to that of the Stage. \n TODO: This should default to Argo CD's namespace instead.",
+                    "description": "AppNamespace specifies the namespace of an Argo CD Application resource to be updated. If left unspecified, the namespace of this Application resource will use the value of ARGOCD_NAMESPACE or \"argocd\"",
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                     "type": "string"
                   },


### PR DESCRIPTION
The Stage's argocd application namespace (typically `argocd`) currently:

1. is required that it be specified
2. and if left unspecified, we will default the value to that of the Stage namespace

The issue I have with this is:
1. application namespace is generally not a concern for end users (in the default and most common operation mode of Argo CD).
2. the correct namespace will be more commonly `argocd` instead of the Stage's namespace
3. an admin should be able to change this centrally, without touching everyone's stages
4. the defaulting behavior done by our webhook, will cause problems with GitOps (because this is a list field)

This PR makes it such that:
1. we don't default the namespace in the webhook
2. we will choose to use ARGOCD_NAMESPACE if unspecified
3. and if ARGOCD_NAMESPACE is unspecified, we will use `argocd`
