### PR TITLE
fix: correct incorrect naming in promotions live update implementation

### DIFF
--- a/ui/src/features/stage/promotions.tsx
+++ b/ui/src/features/stage/promotions.tsx
@@ -33,7 +33,7 @@ export const Promotions = () => {
     }
     const cancel = new AbortController();
 
-    const watchStages = async () => {
+    const watchPromotions = async () => {
       const promiseClient = createPromiseClient(KargoService, transport);
       const stream = promiseClient.watchPromotions(
         { project: projectName, stage: stageName },
@@ -62,15 +62,15 @@ export const Promotions = () => {
           }
         }
 
-        // Update Stages list
-        const listStagesQueryKey = listPromotions.getQueryKey({
+        // Update Promotions list
+        const listPromotionsQueryKey = listPromotions.getQueryKey({
           project: projectName,
           stage: stageName
         });
-        client.setQueryData(listStagesQueryKey, { promotions });
+        client.setQueryData(listPromotionsQueryKey, { promotions });
       }
     };
-    watchStages();
+    watchPromotions();
 
     return () => cancel.abort();
   }, [isLoading]);


### PR DESCRIPTION
Fixes wrong variable names in promotions live update implementation.

The `isLoading` check is required because react effect depends on it . I still need to have `promotionsResponse` check to make sure data was loaded and did not crash due to error

https://github.com/akuity/kargo/blob/e3c340e51f1f9aabd5989917272f9b58d6429653/ui/src/features/stage/promotions.tsx#L31