### PR TITLE
feat: reduce unnecessary stage reconciles with app predicate

### DIFF
--- a/internal/controller/stages/argocd.go
+++ b/internal/controller/stages/argocd.go
@@ -88,6 +88,12 @@ func (r *reconciler) checkHealth(
 					}
 				}
 			}
+			// TODO: currently an stage relies on the Argo CD app being both Healthy and Synced in
+			// order for the freight to be healthy. But many users run in a mode where apps are in
+			// a perpetual state of drift, and it is unreasonable to expect Sync status will be
+			// Synced. We need to switch to perhaps only considering health, and perhaps
+			// consdiering whether or not an operation is in flight.
+			// See: https://github.com/akuity/kargo/issues/670
 			if healthy, reason := libArgoCD.IsApplicationHealthyAndSynced(
 				app,
 				desiredRevision,


### PR DESCRIPTION
I noticed that stages were inexplicably being modified/reconciled. Digging deeper, I found that we refreshed stages whenever there was a change to Applications.

Since apps are very churny, we should only refresh a stage if the app changes sync or health status. This PR adds a predicate to prevent unnecessary stage reconciliations, by only processing apps if health or sync status changes.

NOTE: it's incorrect to rely on sync status for Freight health. I filed a separate issue https://github.com/akuity/kargo/issues/670 for this.