### PR TITLE
feat: add commit message to Freight metadata

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -618,6 +618,10 @@ type GitCommit struct {
 	// mechanism) wherein the value of this field may differ from the commit ID
 	// found in the ID field.
 	HealthCheckCommit string `json:"healthCheckCommit,omitempty"`
+	// Message is the git commit message
+	Message string `json:"message,omitempty"`
+	// Author is the git commit author
+	Author string `json:"author,omitempty"`
 }
 
 // Equals returns a bool indicating whether two GitCommits are equivalent.

--- a/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo-kit/crds/kargo.akuity.io_stages.yaml
@@ -558,6 +558,9 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          author:
+                            description: Author is the git commit author
+                            type: string
                           branch:
                             description: Branch denotes the branch of the repository
                               where this commit was found.
@@ -576,6 +579,9 @@ spec:
                           id:
                             description: ID is the ID of a specific commit in the
                               Git repository specified by RepoURL.
+                            type: string
+                          message:
+                            description: Message is the git commit message
                             type: string
                           repoURL:
                             description: RepoURL is the URL of a Git repository.
@@ -675,6 +681,9 @@ spec:
                       description: GitCommit describes a specific commit from a specific
                         Git repository.
                       properties:
+                        author:
+                          description: Author is the git commit author
+                          type: string
                         branch:
                           description: Branch denotes the branch of the repository
                             where this commit was found.
@@ -692,6 +701,9 @@ spec:
                         id:
                           description: ID is the ID of a specific commit in the Git
                             repository specified by RepoURL.
+                          type: string
+                        message:
+                          description: Message is the git commit message
                           type: string
                         repoURL:
                           description: RepoURL is the URL of a Git repository.
@@ -798,6 +810,9 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          author:
+                            description: Author is the git commit author
+                            type: string
                           branch:
                             description: Branch denotes the branch of the repository
                               where this commit was found.
@@ -816,6 +831,9 @@ spec:
                           id:
                             description: ID is the ID of a specific commit in the
                               Git repository specified by RepoURL.
+                            type: string
+                          message:
+                            description: Message is the git commit message
                             type: string
                           repoURL:
                             description: RepoURL is the URL of a Git repository.

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -558,6 +558,9 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          author:
+                            description: Author is the git commit author
+                            type: string
                           branch:
                             description: Branch denotes the branch of the repository
                               where this commit was found.
@@ -576,6 +579,9 @@ spec:
                           id:
                             description: ID is the ID of a specific commit in the
                               Git repository specified by RepoURL.
+                            type: string
+                          message:
+                            description: Message is the git commit message
                             type: string
                           repoURL:
                             description: RepoURL is the URL of a Git repository.
@@ -675,6 +681,9 @@ spec:
                       description: GitCommit describes a specific commit from a specific
                         Git repository.
                       properties:
+                        author:
+                          description: Author is the git commit author
+                          type: string
                         branch:
                           description: Branch denotes the branch of the repository
                             where this commit was found.
@@ -692,6 +701,9 @@ spec:
                         id:
                           description: ID is the ID of a specific commit in the Git
                             repository specified by RepoURL.
+                          type: string
+                        message:
+                          description: Message is the git commit message
                           type: string
                         repoURL:
                           description: RepoURL is the URL of a Git repository.
@@ -798,6 +810,9 @@ spec:
                         description: GitCommit describes a specific commit from a
                           specific Git repository.
                         properties:
+                          author:
+                            description: Author is the git commit author
+                            type: string
                           branch:
                             description: Branch denotes the branch of the repository
                               where this commit was found.
@@ -816,6 +831,9 @@ spec:
                           id:
                             description: ID is the ID of a specific commit in the
                               Git repository specified by RepoURL.
+                            type: string
+                          message:
+                            description: Message is the git commit message
                             type: string
                           repoURL:
                             description: RepoURL is the URL of a Git repository.

--- a/internal/controller/stages/git.go
+++ b/internal/controller/stages/git.go
@@ -41,7 +41,7 @@ func (r *reconciler) getLatestCommits(
 			logger.Debug("found no credentials for git repo")
 		}
 
-		gm, err := r.getLatestCommitIDFn(ctx, sub.RepoURL, sub.Branch, repoCreds)
+		gm, err := r.getLatestCommitMetaFn(ctx, sub.RepoURL, sub.Branch, repoCreds)
 		if err != nil {
 			return nil, errors.Wrapf(
 				err,
@@ -61,7 +61,7 @@ func (r *reconciler) getLatestCommits(
 	return latestCommits, nil
 }
 
-func getLatestCommitID(
+func getLatestCommitMeta(
 	ctx context.Context,
 	repoURL string,
 	branch string,

--- a/internal/controller/stages/git_test.go
+++ b/internal/controller/stages/git_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestGetLatestCommits(t *testing.T) {
 	testCases := []struct {
-		name                string
-		credentialsDB       credentials.Database
-		getLatestCommitIDFn func(
+		name                  string
+		credentialsDB         credentials.Database
+		getLatestCommitMetaFn func(
 			context.Context,
 			string,
 			string,
@@ -62,7 +62,7 @@ func TestGetLatestCommits(t *testing.T) {
 					return credentials.Credentials{}, false, nil
 				},
 			},
-			getLatestCommitIDFn: func(
+			getLatestCommitMetaFn: func(
 				context.Context,
 				string,
 				string,
@@ -94,7 +94,7 @@ func TestGetLatestCommits(t *testing.T) {
 					return credentials.Credentials{}, false, nil
 				},
 			},
-			getLatestCommitIDFn: func(
+			getLatestCommitMetaFn: func(
 				context.Context,
 				string,
 				string,
@@ -120,8 +120,8 @@ func TestGetLatestCommits(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := reconciler{
-				credentialsDB:       testCase.credentialsDB,
-				getLatestCommitIDFn: testCase.getLatestCommitIDFn,
+				credentialsDB:         testCase.credentialsDB,
+				getLatestCommitMetaFn: testCase.getLatestCommitMetaFn,
 			}
 			testCase.assertions(
 				r.getLatestCommits(
@@ -178,7 +178,7 @@ func TestGetLatestCommitID(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
-				getLatestCommitID(context.TODO(), testCase.repoURL, testCase.branch, nil),
+				getLatestCommitMeta(context.TODO(), testCase.repoURL, testCase.branch, nil),
 			)
 		})
 	}

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -110,10 +110,17 @@ type reconciler struct {
 	) (string, error)
 
 	getLatestCommitIDFn func(
+		ctx context.Context,
 		repoURL string,
 		branch string,
 		creds *git.RepoCredentials,
-	) (string, error)
+	) (*gitMeta, error)
+}
+
+type gitMeta struct {
+	Commit  string
+	Message string
+	Author  string
 }
 
 // SetupReconcilerWithManager initializes a reconciler for Stage resources and

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -109,7 +109,7 @@ type reconciler struct {
 		creds *helm.Credentials,
 	) (string, error)
 
-	getLatestCommitIDFn func(
+	getLatestCommitMetaFn func(
 		ctx context.Context,
 		repoURL string,
 		branch string,
@@ -210,7 +210,7 @@ func newReconciler(
 	r.getLatestTagFn = images.GetLatestTag
 	r.getLatestChartsFn = r.getLatestCharts
 	r.getLatestChartVersionFn = helm.GetLatestChartVersion
-	r.getLatestCommitIDFn = getLatestCommitID
+	r.getLatestCommitMetaFn = getLatestCommitMeta
 
 	return r
 }

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -45,7 +45,7 @@ func TestNewStageReconciler(t *testing.T) {
 	require.NotNil(t, e.getLatestTagFn)
 	require.NotNil(t, e.getLatestChartsFn)
 	require.NotNil(t, e.getLatestChartVersionFn)
-	require.NotNil(t, e.getLatestCommitIDFn)
+	require.NotNil(t, e.getLatestCommitMetaFn)
 }
 
 func TestSync(t *testing.T) {

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -462,6 +462,10 @@
                 "items": {
                   "description": "GitCommit describes a specific commit from a specific Git repository.",
                   "properties": {
+                    "author": {
+                      "description": "Author is the git commit author",
+                      "type": "string"
+                    },
                     "branch": {
                       "description": "Branch denotes the branch of the repository where this commit was found.",
                       "type": "string"
@@ -472,6 +476,10 @@
                     },
                     "id": {
                       "description": "ID is the ID of a specific commit in the Git repository specified by RepoURL.",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the git commit message",
                       "type": "string"
                     },
                     "repoURL": {
@@ -570,6 +578,10 @@
               "items": {
                 "description": "GitCommit describes a specific commit from a specific Git repository.",
                 "properties": {
+                  "author": {
+                    "description": "Author is the git commit author",
+                    "type": "string"
+                  },
                   "branch": {
                     "description": "Branch denotes the branch of the repository where this commit was found.",
                     "type": "string"
@@ -580,6 +592,10 @@
                   },
                   "id": {
                     "description": "ID is the ID of a specific commit in the Git repository specified by RepoURL.",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message is the git commit message",
                     "type": "string"
                   },
                   "repoURL": {
@@ -682,6 +698,10 @@
                 "items": {
                   "description": "GitCommit describes a specific commit from a specific Git repository.",
                   "properties": {
+                    "author": {
+                      "description": "Author is the git commit author",
+                      "type": "string"
+                    },
                     "branch": {
                       "description": "Branch denotes the branch of the repository where this commit was found.",
                       "type": "string"
@@ -692,6 +712,10 @@
                     },
                     "id": {
                       "description": "ID is the ID of a specific commit in the Git repository specified by RepoURL.",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the git commit message",
                       "type": "string"
                     },
                     "repoURL": {


### PR DESCRIPTION
Stores git commit message in freight so we can show it in the UI

```yaml
  availableFreight:
  - commits:
    - branch: main
      id: 5c7d29985412024a39dff4b0286bf9eb3f2a0450
      message: 'feat: remove github workflow to render manifests'
      repoURL: https://github.com/jessesuen/guestbook-deploy.git
    firstSeen: "2023-09-07T22:48:07Z"
    id: 4e1f65309798525de29191ea734ea4f980f07b43
    images:
    - gitRepoURL: https://github.com/jessesuen/guestbook/tree/v0.0.6
      repoURL: ghcr.io/jessesuen/guestbook
      tag: v0.0.6
```