### PR TITLE
evaluate whether an App is synced only on basis of revision

### DIFF
--- a/internal/controller/stages/argocd.go
+++ b/internal/controller/stages/argocd.go
@@ -124,8 +124,7 @@ func stageHealthForAppHealth(app *argocd.Application) kargoapi.Health {
 }
 
 func stageHealthForAppSync(app *argocd.Application, revision string) kargoapi.Health {
-	if app.Status.Sync.Status != argocd.SyncStatusCodeSynced ||
-		(revision != "" && app.Status.Sync.Revision != revision) {
+	if revision != "" && app.Status.Sync.Revision != revision {
 
 		if app.Operation != nil && app.Operation.Sync != nil {
 			return kargoapi.Health{

--- a/internal/controller/stages/argocd_test.go
+++ b/internal/controller/stages/argocd_test.go
@@ -160,15 +160,22 @@ func TestCheckHealth(t *testing.T) {
 			},
 			assertions: func(health kargoapi.Health) {
 				require.Equal(t, kargoapi.HealthStateUnhealthy, health.Status)
-				require.Len(t, health.Issues, 2)
+				require.Len(t, health.Issues, 1)
 				require.Contains(t, health.Issues[0], "has health state")
 				require.Contains(t, health.Issues[0], argoHealth.HealthStatusDegraded)
-				require.Contains(t, health.Issues[1], "not synced")
 			},
 		},
 
 		{
 			name: "Argo CD App not synced",
+			freight: kargoapi.Freight{
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL: "fake-url",
+						ID:      "fake-commit",
+					},
+				},
+			},
 			argoCDAppUpdates: []kargoapi.ArgoCDAppUpdate{
 				{
 					AppName:      "fake-app",
@@ -183,14 +190,17 @@ func TestCheckHealth(t *testing.T) {
 			) (*argocd.Application, error) {
 				return &argocd.Application{
 					Spec: argocd.ApplicationSpec{
-						Source: &argocd.ApplicationSource{},
+						Source: &argocd.ApplicationSource{
+							RepoURL: "fake-url",
+						},
 					},
 					Status: argocd.ApplicationStatus{
 						Health: argocd.HealthStatus{
 							Status: argoHealth.HealthStatusHealthy,
 						},
 						Sync: argocd.SyncStatus{
-							Status: argocd.SyncStatusCodeOutOfSync,
+							Status:   argocd.SyncStatusCodeSynced,
+							Revision: "not-the-right-commit",
 						},
 					},
 				}, nil


### PR DESCRIPTION
Fixes #670 

If applicable, this still checks whether an App is "synced," but it's based solely on revision and not on sync state.