### PR TITLE
fix: freighs are flapping during promotion

### DIFF
--- a/ui/src/features/project/project-details/project-details.tsx
+++ b/ui/src/features/project/project-details/project-details.tsx
@@ -59,9 +59,9 @@ export const ProjectDetails = () => {
     const watchStages = async () => {
       const promiseClient = createPromiseClient(KargoService, transport);
       const stream = promiseClient.watchStages({ project: name }, { signal: cancel.signal });
+      let stages = data.stages.slice();
 
       for await (const e of stream) {
-        let stages = data.stages.slice();
         const index = stages.findIndex((item) => item.metadata?.name === e.stage?.metadata?.name);
         if (e.type === 'DELETED') {
           if (index !== -1) {


### PR DESCRIPTION
Closes https://github.com/akuity/kargo/issues/716

The second attempt to fix flapping freight ids. The bug was happening because the code assumed that  `client.setQueryData` happens instantaneously. In reality, is takes a few milliseconds so data is calculated wrong when events are received too quickly. 