### PR TITLE
feat: qualify all availableFreight in control-flow stages

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -345,6 +345,19 @@ func (r *reconciler) syncStage(
 			status.CurrentFreight,
 			stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
 		)
+	} else {
+		// If a Stage has no promotion mechanisms, the stage is being used
+		// as a control-flow. For now, this just means all availableFreight
+		// is automatically & immediately qualified for downstream stages.
+		// In the future, we may have more options before qualifying them
+		// (e.g. require that they were qualified in all our upstreams)
+		status.History = status.AvailableFreight.DeepCopy()
+		for i := range status.History {
+			status.History[i].Qualified = true
+		}
+		// Also, a Stage without promotion mechanisms doesn't have
+		// a "current" freight. Make sure this is empty to avoid confusion
+		status.CurrentFreight = nil
 	}
 	if status.CurrentFreight != nil &&
 		(status.Health == nil || status.Health.Status == kargoapi.HealthStateHealthy) {


### PR DESCRIPTION
In my project, I have a control-flow Stage used to promote simultaneously to all downstream Stages. However, currently it requires I create promotion jobs to get freight into that history. It doesn't make sense for me to kick off a bunch of promotion jobs for control-flow stages that are essentially no-ops for getting freight into history. I simply want all availableFreight to be immediately become promotable to downstream.

This PR does the following:
1. A stage with no promotion mechanisms copies all availableFreight into history, and marks them all as qualified.
2. If, for some reason, a promotion job was run against a control-flow stage (which is technically something we should try and prevent in API), it will act as a no-op instead of muck around with the Stage's history.