### PR TITLE
remove very stale quickstart video

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,10 @@ application's lifecycle.
 
 Read more about Kargo in our [docs](https://kargo.akuity.io) or get hands-on
 right away by following our 
-[Quickstart documentation](https://kargo.akuity.io/quickstart) or its video
-adaptation!
+[Quickstart documentation](https://kargo.akuity.io/quickstart)!
 
 This documentation is very new, so please open issues against this repository if
 you encounter any difficulties.
-
-[![Kargo Video Quickstart](https://img.youtube.com/vi/NHXBV40GFHs/0.jpg)](https://youtu.be/NHXBV40GFHs)
 
 ## Contributing
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -20,16 +20,6 @@ This guide presents a basic introduction to Kargo. Together, we will:
 
 1. Clean up.
 
-:::info
-If you prefer learning through video, check out the video adaptation of this
-guide! (Note: This video is already somewhat outdated and will be refreshed
-soon.)
-
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/NHXBV40GFHs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
-:::
-
 ## Prerequisites
 
 * [Docker](https://www.docker.com/)


### PR DESCRIPTION
This video was recorded pre-s/environment/stage/ and pre-s/state/freight/. It's so stale that it does more harm than good.

I want to remove this now to avoid confusing readers/viewers and we can replace it in the near future with a recording of @jessesuen's webinar.

More or less fixes #754 