### PR TITLE
fix codegen process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.pnpm-store/
 .vscode/
 bin/
 charts/kargo/*.tgz

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ codegen:
 	controller-gen \
 		object:headerFile=hack/boilerplate.go.txt \
 		paths=./...
+	pnpm --dir=ui install --dev
 	pnpm --dir=ui run generate:schema
 
 ################################################################################


### PR DESCRIPTION
codegen fails if `zx` (and other dev-time dependencies?) isn't already installed in `ui/node_modules`.

This PR fixes that.