### PR TITLE
cli: persist --insecure-skip-tls-verify option in config if specified during login

### DIFF
--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -28,11 +28,12 @@ func GetClientFromConfig(ctx context.Context, opt *option.Option) (
 	if err != nil {
 		return nil, err
 	}
+	skipTLSVerify := opt.InsecureTLS || cfg.InsecureSkipTLSVerify
 	if cfg, err =
-		newTokenRefresher().refreshToken(ctx, cfg, opt.InsecureTLS); err != nil {
+		newTokenRefresher().refreshToken(ctx, cfg, skipTLSVerify); err != nil {
 		return nil, errors.Wrap(err, "error refreshing token")
 	}
-	return GetClient(cfg.APIAddress, cfg.BearerToken, opt.InsecureTLS), nil
+	return GetClient(cfg.APIAddress, cfg.BearerToken, skipTLSVerify), nil
 }
 
 // GetClient returns a new client for the Kargo API server located at the

--- a/internal/cli/client/token_refresher.go
+++ b/internal/cli/client/token_refresher.go
@@ -40,10 +40,10 @@ func newTokenRefresher() *tokenRefresher {
 // the token is not parsable as a JWT, it will assume the token is not something
 // refreshable and return the provided config unmodified. If the token is
 // parsable as a JWT and is not expired, it will return the provided config
-// unmodified. If the token is expired and no refresh token is available, an
-// error is returned indicating that the user must re-authenticate. If a refresh
-// token is available, it will attempt to redeem that token and return updated
-// config.
+// unmodified. If the token is expired and no refresh token is available OR TLS
+// cert verification is disabled, an error is returned indicating that the user
+// must re-authenticate. If a refresh token is available, it will attempt to
+// redeem that token and return updated config.
 func (t *tokenRefresher) refreshToken(
 	ctx context.Context,
 	cfg config.CLIConfig,
@@ -73,9 +73,9 @@ func (t *tokenRefresher) refreshToken(
 
 	// If we get to here, the token is expired.
 
-	if cfg.RefreshToken == "" {
-		// We don't have a refresh token. So all we can do is prompt the user to
-		// re-authenticate.
+	if cfg.InsecureSkipTLSVerify || cfg.RefreshToken == "" {
+		// We don't have a refresh token OR TLS cert verification is disabled. We'll
+		// prompt the user to re-authenticate.
 		return cfg, errors.New(
 			"your token is expired; please use `kargo login` to re-authenticate",
 		)

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -53,6 +53,12 @@ type CLIConfig struct {
 	// RefreshToken, if set, is used to refresh the Token, which must, in such a
 	// case, have been issued by an OIDC identity provider.
 	RefreshToken string `json:"refreshToken,omitempty"`
+	// InsecureSkipTLSVerify indicates whether the user indicated during login
+	// that certificate warnings should be ignored. When true, this option will be
+	// applied to all subsequent Kargo commands until the user logs out or
+	// re-authenticates. When true, refresh tokens will not be used, thereby
+	// forcing users to periodically re-assess this choice.
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 // LoadCLIConfig loads Kargo CLI configuration from a file in the Kargo home

--- a/internal/cli/login/login.go
+++ b/internal/cli/login/login.go
@@ -125,11 +125,21 @@ func NewCommand(opt *option.Option) *cobra.Command {
 				}
 			}
 
+			if opt.InsecureTLS {
+				// When the user specifies during login that they want to ignore cert
+				// warnings, we will force them to periodically re-assess that choice
+				// by NOT using refresh tokens and requiring them to re-authenticate
+				// instead. Since we plan not to use the refresh token for such a case,
+				// it's more secure to throw it away immediately.
+				refreshToken = ""
+			}
+
 			err = libConfig.SaveCLIConfig(
 				libConfig.CLIConfig{
-					APIAddress:   serverAddress,
-					BearerToken:  bearerToken,
-					RefreshToken: refreshToken,
+					APIAddress:            serverAddress,
+					BearerToken:           bearerToken,
+					RefreshToken:          refreshToken,
+					InsecureSkipTLSVerify: opt.InsecureTLS,
 				},
 			)
 			return errors.Wrap(err, "error persisting configuration")


### PR DESCRIPTION
Fixes #633