### PR TITLE
enable API server to use TLS natively (without ingress)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -47,6 +47,7 @@ k8s_resource(
   ],
   labels = ['kargo'],
   objects = [
+    'kargo-api:certificate',
     'kargo-api:clusterrole',
     'kargo-api:clusterrolebinding',
     'kargo-api:configmap',
@@ -128,7 +129,6 @@ k8s_yaml(
     namespace = 'kargo',
     set = [
       'api.logLevel=DEBUG',
-      'api.protocol=http',
       'api.host=localhost:30081',
       'api.adminAccount.password=admin',
       'api.adminAccount.tokenSigningKey=iwishtowashmyirishwristwatch',

--- a/charts/kargo/templates/api/cert.yaml
+++ b/charts/kargo/templates/api/cert.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.api.enabled .Values.api.tls.enabled .Values.api.tls.selfSignedCert }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kargo-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.api.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - {{ .Values.api.host }}
+  issuerRef:
+    kind: Issuer
+    name: kargo-selfsigned-cert-issuer
+  secretName: kargo-api-cert
+{{- end }}

--- a/charts/kargo/templates/api/configmap.yaml
+++ b/charts/kargo/templates/api/configmap.yaml
@@ -12,16 +12,29 @@ data:
   {{- if .Values.kubeconfigSecrets.kargo }}
   KUBECONFIG: /etc/kargo/kubeconfig.yaml
   {{- end }}
+  {{- if .Values.api.tls.enabled }}
+  TLS_ENABLED: "true"
+  TLS_CERT_PATH: /etc/kargo/tls.crt
+  TLS_KEY_PATH: /etc/kargo/tls.key
+  {{- end }}
   {{- if .Values.api.adminAccount.enabled }}
   ADMIN_ACCOUNT_ENABLED: "true"
-  ADMIN_ACCOUNT_TOKEN_ISSUER: {{ .Values.api.protocol }}://{{ .Values.api.host }}
+  {{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled .Values.api.ingress.tls.enabled) }}
+  ADMIN_ACCOUNT_TOKEN_ISSUER: https://{{ .Values.api.host }}
+  {{- else }}
+  ADMIN_ACCOUNT_TOKEN_ISSUER: http://{{ .Values.api.host }}
+  {{- end }}
   ADMIN_ACCOUNT_TOKEN_AUDIENCE: {{ .Values.api.host }}
   ADMIN_ACCOUNT_TOKEN_TTL: {{ .Values.api.adminAccount.tokenTTL }}
   {{- end }}
   {{- if .Values.api.oidc.enabled }}
   OIDC_ENABLED: "true"
   {{- if .Values.api.oidc.dex.enabled }}
-  OIDC_ISSUER_URL: {{ .Values.api.protocol }}://{{ .Values.api.host }}/dex
+  {{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled .Values.api.ingress.tls.enabled) }}
+  OIDC_ISSUER_URL: https://{{ .Values.api.host }}/dex
+  {{- else }}
+  OIDC_ISSUER_URL: http://{{ .Values.api.host }}/dex
+  {{- end }}
   OIDC_CLIENT_ID: {{ .Values.api.host }}
   OIDC_CLI_CLIENT_ID: {{ .Values.api.host }}-cli
   DEX_ENABLED: "true"

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -41,11 +41,23 @@ spec:
               protocol: TCP
           livenessProbe:
             exec:
-              command: ["/usr/local/bin/grpc_health_probe", "-addr=:8080"]
+              command:
+                - /usr/local/bin/grpc_health_probe
+                - -addr=:8080
+{{- if .Values.api.tls.enabled }}
+                - -tls
+                - -tls-no-verify
+{{- end }}                
             initialDelaySeconds: 10
           readinessProbe:
             exec:
-              command: ["/usr/local/bin/grpc_health_probe", "-addr=:8080"]
+              command:
+                - /usr/local/bin/grpc_health_probe
+                - -addr=:8080
+{{- if .Values.api.tls.enabled }}
+                - -tls
+                - -tls-no-verify
+{{- end }}
             initialDelaySeconds: 5
 {{- if or .Values.kubeconfigSecrets.kargo (and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled) }}
           volumeMounts:
@@ -54,7 +66,7 @@ spec:
               readOnly: true
 {{- end }}
           resources: {{ toYaml .Values.api.resources }}
-{{- if or .Values.kubeconfigSecrets.kargo (and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled) }}
+{{- if or .Values.kubeconfigSecrets.kargo (and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled) .Values.api.tls.enabled }}
       volumes:
         - name: config
           projected:
@@ -66,6 +78,15 @@ spec:
                     - key: kubeconfig.yaml
                       path: kubeconfig.yaml
                       mode: 0644
+{{- end }}
+{{- if .Values.api.tls.enabled }}
+              - secret:
+                  name: kargo-api-cert
+                  items:
+                    - key: tls.crt
+                      path: tls.crt
+                    - key: tls.key
+                      path: tls.key
 {{- end }}
 {{- if and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled }}
               - secret:

--- a/charts/kargo/templates/api/ingress.yaml
+++ b/charts/kargo/templates/api/ingress.yaml
@@ -25,7 +25,11 @@ spec:
           service:
             name: kargo-api
             port:
+              {{- if .Values.api.tls.enabled }}
+              number: 443
+              {{- else }}
               number: 80
+              {{- end }}
   {{- if .Values.api.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/kargo/templates/api/service.yaml
+++ b/charts/kargo/templates/api/service.yaml
@@ -11,7 +11,11 @@ spec:
   type: {{ .Values.api.service.type }}
   ports:
   - protocol: TCP
+    {{- if .Values.api.tls.enabled }}
+    port: 443
+    {{- else }}
     port: 80
+    {{- end }}
     {{- if and (or (eq .Values.api.service.type "NodePort") (eq .Values.api.service.type "LoadBalancer")) .Values.api.service.nodePort}}
     nodePort: {{ .Values.api.service.nodePort }}
     {{- end }}

--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -10,7 +10,11 @@ metadata:
     {{- include "kargo.dexServer.labels" . | nindent 4 }}
 stringData:
   config.yaml: |-
-    issuer: {{ .Values.api.protocol }}://{{ .Values.api.host }}/dex
+    {{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled .Values.api.ingress.tls.enabled) }}
+    issuer: https://{{ .Values.api.host }}/dex
+    {{- else }}
+    issuer: http://{{ .Values.api.host }}/dex
+    {{- end }}
 
     storage:
       type: memory
@@ -30,7 +34,11 @@ stringData:
       name: Kargo
       public: true
       redirectURIs:
-      - {{ .Values.api.protocol }}://{{ .Values.api.host }}/login
+      {{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled .Values.api.ingress.tls.enabled) }}
+      - https://{{ .Values.api.host }}/login
+      {{- else }}
+      - http://{{ .Values.api.host }}/login
+      {{- end }}
     - id: {{ .Values.api.host }}-cli
       name: Kargo CLI
       public: true

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -48,14 +48,32 @@ api:
   ## The number of API server pods. (Default: 1)
   # replicas: 3
 
-  ## The protocol and domain name where Kargo's API server will be accessible.
-  ## This should be set accurately for a variety of reasons, including (when
-  ## applicable) generation of a correct Ingress resource and correct OpenID
-  ## Connect issuer and callback URLs.
-  protocol: http
+  ## The domain name where Kargo's API server will be accessible. This should be
+  ## set accurately for a variety of reasons, including (when applicable)
+  ## generation of a correct Ingress resource and correct OpenID Connect issuer
+  ## and callback URLs.
+  ##
+  ## Note: The protocol (http vs https) should not be specified and is
+  ## automatically inferred by from other configuration options.
   host: localhost
 
   logLevel: INFO
+
+  tls:
+    ## Whether to enable TLS directly on the API server. This is helpful if you
+    ## do not intend to use an Ingress controller OR you require TLS end-to-end.
+    ##
+    ## All other settings in this section will be ignored when this is set to
+    ## false.
+    enabled: true
+    ## Whether to generate a self-signed certificate for use by the API server.
+    ##
+    ## If true, cert-manager CRDs MUST be pre-installed on this cluster.
+    ## Kargo will create and use its own namespaced issuer.
+    ##
+    ## If false, a cert secret named
+    ## kargo-api-cert MUST be provided in the same namespace as Kargo.
+    selfSignedCert: true
 
   ingress:
     ## Whether to enable ingress. By default, this is disabled. Enabling ingress
@@ -73,7 +91,7 @@ api:
     ## class as annotation.
     ingressClassName:
     tls:
-      ## Whether to enable TLS.
+      ## Whether to enable TLS on the Ingress.
       ##
       ## All other settings in this section will be ignored when this is set to
       ## false.
@@ -86,8 +104,6 @@ api:
       ##
       ## If false, a cert secret named
       ## kargo-api-ingress-cert MUST be provided in the same namespace as Kargo.
-      ##
-      ## There is no provision for running Dex without TLS.
       selfSignedCert: true
 
   service:
@@ -214,7 +230,7 @@ api:
       #   config:
       #     clientID: <your client ID>
       #     clientSecret: <your client secret>
-      #     redirectURI: <api.protocol>://<api.host>/dex/callback
+      #     redirectURI: <http(s)>://<api.host>/dex/callback
       ## GitHub Example
       # - id: github
       #   name: GitHub
@@ -222,7 +238,7 @@ api:
       #   config:
       #     clientID: <your client ID>
       #     clientSecret: <your client secret>
-      #     redirectURI: <api.protocol>://<api.host>/dex/callback
+      #     redirectURI: <http(s)>://<api.host>/dex/callback
 
       resources: {}
         # We usually recommend not to specify default resources and to leave

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -82,7 +82,7 @@ type AdminConfig struct {
 // AdminConfigFromEnv returns an AdminConfig populated from environment
 // variables.
 func AdminConfigFromEnv() AdminConfig {
-	cfg := AdminConfig{}
+	var cfg AdminConfig
 	envconfig.MustProcess("", &cfg)
 	return cfg
 }


### PR DESCRIPTION
This fixes #548 

As noted in the issue, this covers cases where Ingress is not used or Ingress _is_ used and company policy requires TLS end-to-end. (I guess those people should have service meshes, but you never know. 🤷 )

TLS with a self-signed cert is also enabled _by default_ so users who ignore installation options still start off on more secure footing.