### PR TITLE
Use `pkg/errors` by default

### DIFF
--- a/internal/api/promote_subscribers_v1alpha1.go
+++ b/internal/api/promote_subscribers_v1alpha1.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"context"
-	"errors"
+	goerrors "errors"
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -73,7 +74,7 @@ func (s *server) PromoteSubscribers(
 
 	return connect.NewResponse(&svcv1alpha1.PromoteSubscribersResponse{
 		Promotions: createdPromos,
-	}), errors.Join(promoteErrs...)
+	}), goerrors.Join(promoteErrs...)
 }
 
 // findStageSubscribers returns a list of Stages that are subscribed to the given Stage

--- a/internal/cli/apply/apply.go
+++ b/internal/cli/apply/apply.go
@@ -1,11 +1,11 @@
 package apply
 
 import (
-	"errors"
+	goerrors "errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,25 +34,25 @@ kargo apply -f stage.yaml
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			if len(flag.Filenames) == 0 {
-				return pkgerrors.New("filename is required")
+				return errors.New("filename is required")
 			}
 
 			rawManifest, err := option.ReadManifests(flag.Filenames...)
 			if err != nil {
-				return pkgerrors.Wrap(err, "read manifests")
+				return errors.Wrap(err, "read manifests")
 			}
 
 			var printer printers.ResourcePrinter
 			if pointer.StringDeref(opt.PrintFlags.OutputFormat, "") != "" {
 				printer, err = opt.PrintFlags.ToPrinter()
 				if err != nil {
-					return pkgerrors.Wrap(err, "new printer")
+					return errors.Wrap(err, "new printer")
 				}
 			}
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.Wrap(err, "get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			// TODO: Current implementation of apply is not the same as `kubectl` does.
@@ -63,7 +63,7 @@ kargo apply -f stage.yaml
 					Manifest: rawManifest,
 				}))
 			if err != nil {
-				return pkgerrors.Wrap(err, "apply resource")
+				return errors.Wrap(err, "apply resource")
 			}
 
 			resCap := len(resp.Msg.GetResults())
@@ -84,7 +84,7 @@ kargo apply -f stage.yaml
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.CreatedResourceManifest, &obj); err != nil {
 					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
-						pkgerrors.Wrap(err, "Error: unmarshal created manifest"))
+						errors.Wrap(err, "Error: unmarshal created manifest"))
 					continue
 				}
 				if printer == nil {
@@ -101,7 +101,7 @@ kargo apply -f stage.yaml
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.UpdatedResourceManifest, &obj); err != nil {
 					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
-						pkgerrors.Wrap(err, "Error: unmarshal updated manifest"))
+						errors.Wrap(err, "Error: unmarshal updated manifest"))
 					continue
 				}
 				if printer == nil {
@@ -114,7 +114,7 @@ kargo apply -f stage.yaml
 				}
 				_ = printer.PrintObj(&obj, opt.IOStreams.Out)
 			}
-			return errors.Join(errs...)
+			return goerrors.Join(errs...)
 		},
 	}
 	opt.PrintFlags.AddFlags(cmd)

--- a/internal/cli/create/create.go
+++ b/internal/cli/create/create.go
@@ -1,11 +1,11 @@
 package create
 
 import (
-	"errors"
+	goerrors "errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,31 +37,31 @@ kargo create project my-project
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			if len(flag.Filenames) == 0 {
-				return pkgerrors.New("filename is required")
+				return errors.New("filename is required")
 			}
 
 			manifest, err := option.ReadManifests(flag.Filenames...)
 			if err != nil {
-				return pkgerrors.Wrap(err, "read manifests")
+				return errors.Wrap(err, "read manifests")
 			}
 
 			var printer printers.ResourcePrinter
 			if pointer.StringDeref(opt.PrintFlags.OutputFormat, "") != "" {
 				printer, err = opt.PrintFlags.ToPrinter()
 				if err != nil {
-					return pkgerrors.Wrap(err, "new printer")
+					return errors.Wrap(err, "new printer")
 				}
 			}
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.Wrap(err, "get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.CreateResource(ctx, connect.NewRequest(&kargosvcapi.CreateResourceRequest{
 				Manifest: manifest,
 			}))
 			if err != nil {
-				return pkgerrors.Wrap(err, "create resource")
+				return errors.Wrap(err, "create resource")
 			}
 
 			resCap := len(resp.Msg.GetResults())
@@ -79,7 +79,7 @@ kargo create project my-project
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.CreatedResourceManifest, &obj); err != nil {
 					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
-						pkgerrors.Wrap(err, "Error: unmarshal created manifest"))
+						errors.Wrap(err, "Error: unmarshal created manifest"))
 					continue
 				}
 				if printer == nil {
@@ -92,7 +92,7 @@ kargo create project my-project
 				}
 				_ = printer.PrintObj(&obj, opt.IOStreams.Out)
 			}
-			return errors.Join(createErrs...)
+			return goerrors.Join(createErrs...)
 		},
 	}
 	opt.PrintFlags.AddFlags(cmd)

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -1,12 +1,12 @@
 package delete
 
 import (
-	"errors"
+	goerrors "errors"
 	"fmt"
 	"strings"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,24 +39,24 @@ kargo delete -f stage.yaml
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			if len(flag.Filenames) == 0 {
-				return pkgerrors.New("filename is required")
+				return errors.New("filename is required")
 			}
 
 			manifest, err := option.ReadManifests(flag.Filenames...)
 			if err != nil {
-				return pkgerrors.Wrap(err, "read manifests")
+				return errors.Wrap(err, "read manifests")
 			}
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.Wrap(err, "get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			resp, err := kargoSvcCli.DeleteResource(ctx, connect.NewRequest(&kargosvcapi.DeleteResourceRequest{
 				Manifest: manifest,
 			}))
 			if err != nil {
-				return pkgerrors.Wrap(err, "delete resource")
+				return errors.Wrap(err, "delete resource")
 			}
 
 			resCap := len(resp.Msg.GetResults())
@@ -74,7 +74,7 @@ kargo delete -f stage.yaml
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.DeletedResourceManifest, &obj); err != nil {
 					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
-						pkgerrors.Wrap(err, "Error: unmarshal deleted manifest"))
+						errors.Wrap(err, "Error: unmarshal deleted manifest"))
 					continue
 				}
 				name := strings.TrimLeft(types.NamespacedName{
@@ -83,7 +83,7 @@ kargo delete -f stage.yaml
 				}.String(), "/")
 				fmt.Fprintf(opt.IOStreams.Out, "%s Deleted: %q\n", obj.GetKind(), name)
 			}
-			return errors.Join(deleteErrs...)
+			return goerrors.Join(deleteErrs...)
 		},
 	}
 	option.Filenames("delete", &flag.Filenames)(cmd.Flags())

--- a/internal/cli/delete/project.go
+++ b/internal/cli/delete/project.go
@@ -1,11 +1,11 @@
 package delete
 
 import (
-	"errors"
+	goerrors "errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
@@ -27,7 +27,7 @@ kargo delete project my-project
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.New("get client from config")
+				return errors.New("get client from config")
 			}
 
 			var resErr error
@@ -35,7 +35,7 @@ kargo delete project my-project
 				if _, err := kargoSvcCli.DeleteProject(ctx, connect.NewRequest(&v1alpha1.DeleteProjectRequest{
 					Name: name,
 				})); err != nil {
-					resErr = errors.Join(resErr, pkgerrors.Wrap(err, "Error"))
+					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
 					continue
 				}
 				_, _ = fmt.Fprintf(opt.IOStreams.Out, "Project Deleted: %q\n", name)

--- a/internal/cli/delete/stage.go
+++ b/internal/cli/delete/stage.go
@@ -1,11 +1,11 @@
 package delete
 
 import (
-	"errors"
+	goerrors "errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
@@ -27,7 +27,7 @@ kargo delete stage --project=my-project my-stage
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.New("get client from config")
+				return errors.New("get client from config")
 			}
 
 			project := opt.Project.OrElse("")
@@ -41,7 +41,7 @@ kargo delete stage --project=my-project my-stage
 					Project: project,
 					Name:    name,
 				})); err != nil {
-					resErr = errors.Join(resErr, pkgerrors.Wrap(err, "Error"))
+					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
 					continue
 				}
 				_, _ = fmt.Fprintf(opt.IOStreams.Out, "Stage Deleted: %q\n", name)

--- a/internal/cli/get/get.go
+++ b/internal/cli/get/get.go
@@ -1,10 +1,9 @@
 package get
 
 import (
-	"errors"
 	"strings"
 
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,12 +34,12 @@ kargo get stages my-project -o json
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return pkgerrors.New("get client from config")
+				return errors.New("get client from config")
 			}
 
 			resource := strings.ToLower(strings.TrimSpace(args[0]))
 			if resource == "" {
-				return pkgerrors.New("resource is required")
+				return errors.New("resource is required")
 			}
 
 			var resErr error
@@ -94,7 +93,7 @@ kargo get stages my-project -o json
 					return resErr
 				}
 			default:
-				return pkgerrors.Errorf("unknown resource %q", resource)
+				return errors.Errorf("unknown resource %q", resource)
 			}
 			_ = printResult(opt, res)
 			return resErr
@@ -111,7 +110,7 @@ func printResult(opt *option.Option, res runtime.Object) error {
 	}
 	printer, err := opt.PrintFlags.ToPrinter()
 	if err != nil {
-		return pkgerrors.Wrap(err, "new printer")
+		return errors.Wrap(err, "new printer")
 	}
 	return printer.PrintObj(res, opt.IOStreams.Out)
 }

--- a/internal/cli/get/project.go
+++ b/internal/cli/get/project.go
@@ -2,10 +2,10 @@ package get
 
 import (
 	"context"
-	"errors"
+	goerrors "errors"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -24,7 +24,7 @@ func filterProjects(
 		/* explicitly empty */
 	}))
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "list projects")
+		return nil, errors.Wrap(err, "list projects")
 	}
 	return func(names ...string) ([]runtime.Object, error) {
 		res := make([]runtime.Object, 0, len(resp.Msg.GetProjects()))
@@ -44,7 +44,7 @@ func filterProjects(
 			if project, ok := projects[name]; ok {
 				res = append(res, project)
 			} else {
-				resErr = errors.Join(err, pkgerrors.Errorf("project %q not found", name))
+				resErr = goerrors.Join(err, errors.Errorf("project %q not found", name))
 			}
 		}
 		return res, resErr

--- a/internal/cli/get/stage.go
+++ b/internal/cli/get/stage.go
@@ -2,10 +2,10 @@ package get
 
 import (
 	"context"
-	"errors"
+	goerrors "errors"
 
 	"connectrpc.com/connect"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -25,7 +25,7 @@ func filterStages(
 		Project: project,
 	}))
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "list stages")
+		return nil, errors.Wrap(err, "list stages")
 	}
 	return func(names ...string) ([]runtime.Object, error) {
 		res := make([]runtime.Object, 0, len(resp.Msg.GetStages()))
@@ -45,7 +45,7 @@ func filterStages(
 			if stage, ok := stages[name]; ok {
 				res = append(res, stage)
 			} else {
-				resErr = errors.Join(err, pkgerrors.Errorf("stage %q not found", name))
+				resErr = goerrors.Join(err, errors.Errorf("stage %q not found", name))
 			}
 		}
 		return res, resErr

--- a/internal/cli/option/kubernetes.go
+++ b/internal/cli/option/kubernetes.go
@@ -3,7 +3,7 @@ package option
 import (
 	"bytes"
 
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -23,7 +23,7 @@ func ReadManifests(filenames ...string) ([]byte, error) {
 		Do().
 		Infos()
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "build resources")
+		return nil, errors.Wrap(err, "build resources")
 	}
 
 	var buf bytes.Buffer
@@ -34,10 +34,10 @@ func ReadManifests(filenames ...string) ([]byte, error) {
 	for _, info := range buildRes {
 		u, ok := info.Object.(*unstructured.Unstructured)
 		if !ok {
-			return nil, pkgerrors.Errorf("expected *unstructured.Unstructured, got %T", info.Object)
+			return nil, errors.Errorf("expected *unstructured.Unstructured, got %T", info.Object)
 		}
 		if err := enc.Encode(&u.Object); err != nil {
-			return nil, pkgerrors.Wrap(err, "encode object")
+			return nil, errors.Wrap(err, "encode object")
 		}
 	}
 	return buf.Bytes(), nil

--- a/internal/controller/promotion/argocd_test.go
+++ b/internal/controller/promotion/argocd_test.go
@@ -2,10 +2,10 @@ package promotion
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	argocd "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/promotion/bookkeeper_test.go
+++ b/internal/controller/promotion/bookkeeper_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
-	"errors"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/bookkeeper"

--- a/internal/controller/promotion/composite_test.go
+++ b/internal/controller/promotion/composite_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
-	"errors"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -2,13 +2,13 @@ package promotion
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/bookkeeper/pkg/git"

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -1,11 +1,11 @@
 package promotion
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/promotion/kustomize_test.go
+++ b/internal/controller/promotion/kustomize_test.go
@@ -1,9 +1,9 @@
 package promotion
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/stages/images_test.go
+++ b/internal/controller/stages/images_test.go
@@ -2,10 +2,10 @@ package stages
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"


### PR DESCRIPTION
`pkg/errors` provides more information than golang's standard `errors` package, since it extends `errors` package  (e.g. stacktrace). This commit updates existing code to use `pkg/errors` by default.