### PR TITLE
chart: fix missing volumemount

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -59,7 +59,7 @@ spec:
                 - -tls-no-verify
 {{- end }}
             initialDelaySeconds: 5
-{{- if or .Values.kubeconfigSecrets.kargo (and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled) }}
+{{- if or .Values.kubeconfigSecrets.kargo (and .Values.api.oidc.enabled .Values.api.oidc.dex.enabled) .Values.api.tls.enabled }}
           volumeMounts:
             - mountPath: /etc/kargo
               name: config


### PR DESCRIPTION
If OIDC/Dex are disabled and no custom kubeconfig is specified, but TLS is used for the API server, you can end up with a volume containing the certs, but the corresponding `volumeMount` will be missing.

This PR uses the same conditional for both.