### PR TITLE
keep all available freight qualified

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -401,12 +401,11 @@ func (r *reconciler) promote(
 		return nil
 	}
 
-	var targetFreightIndex int
 	var targetFreight *kargoapi.Freight
-	for i, availableFreight := range stage.Status.AvailableFreight {
+	for _, availableFreight := range stage.Status.AvailableFreight {
 		if availableFreight.ID == freightID {
-			targetFreightIndex = i
 			targetFreight = availableFreight.DeepCopy()
+			targetFreight.Qualified = false
 			break
 		}
 	}
@@ -444,7 +443,6 @@ func (r *reconciler) promote(
 		// control-flow stages in the first place)
 		if stage.Spec.PromotionMechanisms != nil {
 			status.CurrentFreight = &nextFreight
-			status.AvailableFreight[targetFreightIndex] = nextFreight
 			status.History.Push(nextFreight)
 		}
 	})

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -577,6 +577,7 @@ func (r *reconciler) getLatestFreightFromRepos(
 		Commits:   latestCommits,
 		Images:    latestImages,
 		Charts:    latestCharts,
+		Qualified: true,
 	}
 	freight.UpdateFreightID()
 	return freight, nil
@@ -624,7 +625,6 @@ func (r *reconciler) getAvailableFreightFromUpstreamStages(
 				for i := range freight.Commits {
 					freight.Commits[i].HealthCheckCommit = ""
 				}
-				freight.Qualified = false
 				availableFreight = append(availableFreight, freight)
 				freightSet[freight.ID] = struct{}{}
 			}

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -1032,6 +1032,7 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 								Version:     "fake-version",
 							},
 						},
+						Qualified: true,
 					},
 					freight,
 				)


### PR DESCRIPTION
Whether a Stage's available Freight are marked as qualified or not is not supposed to matter. (And doesn't.) Qualification in an immediately upstream Stage is a _pre-req_ for making it _into_ that collection to begin with.

It can, however, spark confusion if available Freight are marked as unqualified. Is it available or isn't it?

This PR ensures that available Freight _always_ will appear qualified. They are.

The flip-side of this is that Freight is now explicitly _disqualified_ when it is promoted to be a Stage's _current_ Freight.



