### PR TITLE
fix(docs): UI is now https & new error with expired ghcr.io auth

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -134,12 +134,14 @@ helm install kargo \
 ```
 
 The Kargo dashboard will be accessible at
-[localhost:8084](http://localhost:8084).
+[localhost:8084](https://localhost:8084).
 
 The Admin password is `admin`.
 
 :::tip
 ```
+Error: GET "https://ghcr.io/v2/akuity/kargo-charts/kargo/tags/list": GET "https://ghcr.io/token?scope=repository%3Aakuity%2Fkargo-charts%2Fkargo%3Apull&service=ghcr.io": unexpected status code 403: denied: denied
+# or
 Error: INSTALLATION FAILED: failed to authorize: failed to fetch oauth token: unexpected status: 403 Forbidden
 ```
 


### PR DESCRIPTION
In the move to v0.1.0, the UI is now https default so the link is updated. Also, a new error is shown when the user has expired ghcr.io auth for `docker`, so the tip is updated.