### PR TITLE
Chart is using https

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -114,7 +114,7 @@ helm install argocd argo-cd \
 ```
 
 The Argo CD dashboard will be accessible at
-[localhost:8080](http://localhost:8080).
+[localhost:8080](https://localhost:8080).
 
 You can safely ignore cert errors.
 


### PR DESCRIPTION
clicking the link didnt work while going through the quick start guide - adding an `s` to http to reduce confusion.