### PR TITLE
cli: fix broken auto-completion

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -36,17 +36,16 @@ func NewRootCommand(opt *option.Option, rs *rootState) (*cobra.Command, error) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			ctx := buildRootContext(cmd.Context())
 
-			restCfg, err := config.GetConfig()
-			if err != nil {
-				return errors.Wrap(err, "get REST config")
-			}
-			client, err :=
-				kubernetes.NewClient(ctx, restCfg, kubernetes.ClientOptions{})
-			if err != nil {
-				return errors.Wrap(err, "error creating Kubernetes client")
-			}
-
 			if opt.UseLocalServer {
+				restCfg, err := config.GetConfig()
+				if err != nil {
+					return errors.Wrap(err, "get REST config")
+				}
+				client, err :=
+					kubernetes.NewClient(ctx, restCfg, kubernetes.ClientOptions{})
+				if err != nil {
+					return errors.Wrap(err, "error creating Kubernetes client")
+				}
 				l, err := net.Listen("tcp", "127.0.0.1:0")
 				if err != nil {
 					return errors.Wrap(err, "start local server")


### PR DESCRIPTION
Fixes #812

The issue is that the CLI was unconditionally creating a k8s client, but that is only needed when using the `--local` flag.

Moving instantiation of the client within the conditional solves the problem.