### PR TITLE
chart: fix api server permissions to work on openshift

### DIFF
--- a/charts/kargo/templates/api/cluster-role.yaml
+++ b/charts/kargo/templates/api/cluster-role.yaml
@@ -35,4 +35,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - kargo.akuity.io
+    resources:
+      # Needed for OpenShift
+      - stages/finalizers
+    verbs:
+      - patch
+      - update
 {{- end }}


### PR DESCRIPTION
Fixes #811

OpenShift enables certain, more restrictive admission controllers that are not enabled by default on other k8s distros.

This change should make promotions work on OpenShift and shouldn't have any adverse impact if you're _not_ running on OpenShift.

Many thanks to @tal-hason for finding this issue.