### PR TITLE
improved CLI installation instructions in quickstart

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -32,7 +32,7 @@ This guide presents a basic introduction to Kargo. Together, we will:
     3. Extract the contents of the downloaded package to a directory of your choice.
     4. Add the directory containing the `kargo` executable to your system's `PATH` environment variable.
 
-    After completing these steps, you should be able to run the kargo command in your terminal to interact with Kargo.
+    After completing these steps, you should be able to run the `kargo` command in your terminal to interact with Kargo.
 
 ### Starting a Local Cluster
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -25,7 +25,14 @@ This guide presents a basic introduction to Kargo. Together, we will:
     * kind: v0.17.0
     * k3d: v5.4.9
 * [Helm](https://helm.sh/docs/): These instructions were tested with v3.11.2.
-* The `kargo` CLI: Download it from [the releases page](https://github.com/akuity/kargo/releases/latest).
+* The `kargo` CLI: To install the kargo CLI, follow these steps.
+
+    1. Visit [the releases page](https://github.com/akuity/kargo/releases/latest) of the Kargo GitHub repository
+    2. Download the appropriate release package for your operating system (e.g., `kargo-linux-amd64` for Linux).
+    3. Extract the contents of the downloaded package to a directory of your choice.
+    4. Add the directory containing the `kargo` executable to your system's `PATH` environment variable.
+
+    After completing these steps, you should be able to run the kargo command in your terminal to interact with Kargo.
 
 ### Starting a Local Cluster
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -25,7 +25,7 @@ This guide presents a basic introduction to Kargo. Together, we will:
     * kind: v0.17.0
     * k3d: v5.4.9
 * [Helm](https://helm.sh/docs/): These instructions were tested with v3.11.2.
-* The `kargo` CLI: To install the kargo CLI, follow these steps.
+* The `kargo` CLI: To install it, follow these steps.
 
     1. Visit [the releases page](https://github.com/akuity/kargo/releases/latest) of the Kargo GitHub repository.
     2. Download the appropriate release package for your operating system (e.g., `kargo-linux-amd64` for Linux).

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -27,7 +27,7 @@ This guide presents a basic introduction to Kargo. Together, we will:
 * [Helm](https://helm.sh/docs/): These instructions were tested with v3.11.2.
 * The `kargo` CLI: To install the kargo CLI, follow these steps.
 
-    1. Visit [the releases page](https://github.com/akuity/kargo/releases/latest) of the Kargo GitHub repository
+    1. Visit [the releases page](https://github.com/akuity/kargo/releases/latest) of the Kargo GitHub repository.
     2. Download the appropriate release package for your operating system (e.g., `kargo-linux-amd64` for Linux).
     3. Extract the contents of the downloaded package to a directory of your choice.
     4. Add the directory containing the `kargo` executable to your system's `PATH` environment variable.


### PR DESCRIPTION
Fixes #837         

Added more instructions for the CLI installation involving download of release package and adding system's `PATH` environment variable. 