### PR TITLE
update docs for v0.2.0

### DIFF
--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -5,59 +5,76 @@ description: Concepts
 
 This section covers important Kargo concepts.
 
-## What is a `stage`?
+## The Basics
 
-When you hear the term “environment”, what you envision will depend significantly
-on your perspective. To eliminate confusion, Kargo avoids the term "environment"
-altogether in favor of something more precise: _stage_. The important feature of
-a _stage_ is that its name ("test" or "prod," for instance) denotes an application
-instance's _purpose_ and not its _location_. [This blog post](https://akuity.io/blog/kargo-stage-not-environment/) discusses the rationale behind this.
+### What is a Stage?
 
-The progression of new materials from stage-to-stage can be fully automated or
-manually triggered, as called for by your use cases or preferences.
+When you hear the term “environment”, what you envision will depend
+significantly on your perspective. To eliminate confusion, Kargo avoids the term
+"environment" altogether in favor of **stage**. The important feature of a stage
+is that its name ("test" or "prod," for instance) denotes an application
+instance's _purpose_ and not necessarily its _location_.
+[This blog post](https://akuity.io/blog/kargo-stage-not-environment/) discusses
+the rationale behind this choice.
+
+_Stages are Kargo's most important concept._ They can be linked together in a
+directed asyclic graph to describe a delivery pipeline. Typically, such a
+pipeline may feature a "test" or "dev" stage as its starting point, with one or
+more "prod" stages at the end.
+
+### What is Freight?
+
+**Freight** is Kargo's second most important concept. A single "piece of
+freight" is a set of references to one or more versioned artifacts, which may
+include one or more:
+
+* Container images (from image repositories)
+
+* Kubernetes manifests (from Git repositories)
+
+* Helm charts (from chart repositories)
+
+Freight can therefore be thought of as a sort of meta-artifact. Freight is what
+Kargo seeks to progress from one stage to another.
+
+### What is a Warehouse?
+
+A **warehouse** is a _source_ of freight. A warehouse subscribes to one or more:
+
+* Container image repositories
+
+* Git repositories
+
+* Helm charts repositories
+
+Anytime something new is discovered in any repository to which a warehouse
+subscribes, the warehouse produces a new piece of freight.
+
+### What is a Promotion?
+
+A **promotion** is a request to move a piece of freight into a specified stage.
+
+### What is a Promotion Policy?
+
+A **promotion policy**, at present, determines only whether a specific stage is
+eligible to for new freight to be automatically promoted into it.
+
+## Corresponding Resource Types
+
+Each of Kargo's fundamental concepts maps directly onto a custom Kubernetes
+resource type.
 
 :::info
-As a matter of convention, throughout this documentation, we are careful to use
-`Stage` (capitalized and monospaced) when we're referring specifically to that
-custom resource type and "stage" in standard typeface when referring to the
-concept.
+Related resources must be grouped together in a single project, which is a
+specially labeled Kubernetes `Namespace`. In our examples, we group all of our
+resources together in a `kargo-demo` namespace.
 :::
 
-## `Stage` Resources
+### `Stage` Resources
 
-Like many Kubernetes resource types, the `Stage` resource type is decomposed
-into three main sections:
+Each Kargo stage is represented by a Kubernetes resource of type `Stage`.
 
-* `metadata` that describes the resource's identifying information, such as
-  name, namespace, labels, etc.
-
-  :::info
-  Related `Stage` resources should be grouped together in a single, dedicated
-  namespace. In our examples, we group all of our `Stage` resources together in
-  a `kargo-demo` namespace.
-  :::
-
-* `spec` that encapsulates the user-defined particulars of each resource.
-
-* `status` that encapsulates resource state.
-
-At this highest level, a manifest describing a `Stage` resource may appear as
-follows:
-
-```yaml
-apiVersion: kargo.akuity.io/v1alpha1
-kind: Stage
-metadata:
-  name: test
-  namespace: kargo-demo
-spec:
-  # ...
-status:
-  # ...
-```
-
-A `Stage` resource's `spec` field further decomposes into two main areas of
-concern:
+A `Stage` resource's `spec` field decomposes into two main areas of concern:
 
 * Subscriptions
 
@@ -65,35 +82,23 @@ concern:
 
 The following sections will explore each of these in greater detail.
 
-### Subscriptions
+#### Subscriptions
 
 The `spec.subscriptions` field is used to describe the sources from which a
-`Stage` obtains *materials*. Materials include any combination of the following:
+`Stage` obtains `Freight`. These subscriptions can be to a single `Warehouse` or
+to one or more "upstream" `Stage` resources.
 
-* Manifests from a Git repository. These can be plain YAML or rendered with the
-  assistance of configuration management tools like
-  [Kustomize](https://kustomize.io/) or [Helm](https://helm.sh/).
+For each `Stage`, the Kargo controller will periodically check its subscriptions
+for new _qualified_ `Freight`.
 
-* Docker images from an image repository.
+For a `Stage` subscribed directly to a `Warehouse`, _any_ new `Freight` resource
+from that `Warehouse` is considered qualified.
 
-* Helm charts from a chart repository.
+For a `Stage` subscribed to one or more "upstream" `Stage`s, `Freight` is
+qualified only after those "upstream" `Stage` resources have reached a healthy
+state while hosting that `Freight`.
 
-Alternatively, instead of subscribing directly to repositories, a `Stage` may
-subscribe to another, "upstream" `Stage`.
-
-For each `Stage`, the Kargo controller will periodically check all subscriptions
-for the latest available materials. A single set of materials is known as a
-*freight* (or _piece_ of freight). The controller produces a canonical
-representation of each piece of freight and uses that to calculate a SHA1 hash
-which becomes its ID. Because freight IDs are calculated deterministically from
-the underlying materials, each ID is intrinsically a _fingerprint_. Two pieces
-of freight having the same materials have the same ID. (This enables cheap
-comparisons.) This ID is compared to those in a stack of known, *available
-freight* stored in the `Stage` resource's `status` field. If a piece of freight
-is new, it is pushed onto the stack and becomes *available.*
-
-In the following example, the `test` `Stage` subscribes to manifests from a Git
-repository _and_ images from an image repository:
+In the following example, the `test` `Stage` subscribes to a single `Warehouse`:
 
 ```yaml
 apiVersion: kargo.akuity.io/v1alpha1
@@ -103,36 +108,29 @@ metadata:
   namespace: kargo-demo
 spec:
   subscriptions:
-    repos:
-      git:
-      - repoURL: https://github.com/example/kargo-demo.git
-        branch: main
-      images:
-      - repoURL: nginx
-        semverConstraint: ^1.24.0
+    warehouse: my-warehouse
   # ...
 ```
 
-This is how the `test` `Stage` resource's `status` field may appear after
-polling the two repositories to which it subscribes:
+In this example, the `uat` `Stage` subscribes to the `test` `Stage`:
 
 ```yaml
-status:
-  availableFreight:
-  - id: 51636b9332d5938b9f2d382e9713b54ceb62a323
-    firstSeen: "2023-04-21T18:34:56Z"
-    commits:
-    - id: dd8dc6a021d9d6c42e937f8b8f221a838342ec2a
-      repoURL: https://github.com/example/kargo-demo.git
-    images:
-    - repoURL: nginx
-      tag: 1.24.0
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: uat
+  namespace: kargo-demo
+spec:
+  subscriptions:
+    stages:
+    - test
+  # ...
 ```
 
-### Promotion Mechanisms
+#### Promotion Mechanisms
 
-The `spec.promotionMechanisms` field is used to describe _how_ to move freight
-into the `Stage`.
+The `spec.promotionMechanisms` field is used to describe _how_ to transition
+`Freight` into the `Stage`.
 
 There are two general methods of accomplishing this:
 
@@ -179,10 +177,8 @@ aggregating the results of sync/health state for all such `Application`
 resources(s).
 :::
 
-In the following example, the `test` `Stage` subscribes to manifests from a Git
-repository _and_ images from an image repository, as in the previous section.
-The example has now been amended to also show that transitioning freight into
-the `test` `Stage` requires:
+The following example, shows that transitioning `Freight` into the `test`
+`Stage` requires:
 
 1. Updating the `https://github.com/example/kargo-demo.git` repository by
    running `kustomize edit set image` in the `stages/test` directory and
@@ -198,14 +194,7 @@ metadata:
   name: test
   namespace: kargo-demo
 spec:
-  subscriptions:
-    repos:
-      git:
-      - repoURL: https://github.com/example/kargo-demo.git
-        branch: main
-      images:
-      - repoURL: nginx
-        semverConstraint: ^1.24.0
+  # ...
   promotionMechanisms:
     gitRepoUpdates:
     - repoURL: https://github.com/example/kargo-demo.git
@@ -219,103 +208,147 @@ spec:
       appNamespace: argocd
 ```
 
-If you commit changes to the Git repository's `main` branch _or_ if a new
-version of the `nginx` image were published to Docker Hub, these mechanisms
-provide the recipe for applying those changes to our `test` `Stage`.
+#### Status
 
-:::note
-Promotion mechanisms describe _how_ to move freight into a `Stage`, but they say
-nothing of _which_ piece of freight or _when_ to do this. Keep reading. These
-will be covered in the next section.
-:::
+A `Stage` resource's `status` field records:
 
-:::info
-In the example above, you may have noticed the use of a stage-specific
-branch in the Git repository. Since we _subscribe_ to the Git repository's
-`main` branch, we could create an undesired loop in our automation if it also
-_writes_ to that same branch. Combining manifests from `main` with the desired
-images and then writing those changes to the `stages/test` branch (which the
-corresponding Argo CD `Application` would reference as its `targetRevision`) is
-a strategy to prevent such a loop from ever forming.
-:::
+* The `Freight` currently deployed to the `Stage`.
 
-The application of any `Stage` resource's promotion mechanisms transitions a
-piece of freight into the `Stage` and updates the `Stage`'s `status` field
-accordingly.
+* History of `Freight` that has been deployed to the `Stage`. (From most to
+  least recent.)
 
-Continuing with our example, our `test` `Stage`'s `status` may appear as follows
-after its first promotion:
+* The health status any any associated Argo CD `Application` resources.
+
+For example:
 
 ```yaml
 status:
-  availableFreight:
-  - id: 404df86560cab5d515e7aa74653e665c1dc96e1c
-    firstSeen: "2023-04-21T19:05:36Z"
-    commits:
-    - id: 02d153f75e5c042d576c713be52b57e1db8ddc97
-      repoURL: https://github.com/example/kargo-demo.git
-    images:
-    - repoURL: nginx
-      tag: 1.24.0
   currentFreight:
-    id: 404df86560cab5d515e7aa74653e665c1dc96e1c
-    firstSeen: "2023-04-21T19:05:36Z"
-    commits:
-    - id: 02d153f75e5c042d576c713be52b57e1db8ddc97
-      repoURL: https://github.com/example/kargo-demo.git
+    id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
     images:
     - repoURL: nginx
-      tag: 1.24.0
-    health:
-      status: Healthy
+      tag: 1.25.3
+    commits:
+    - repoURL: https://github.com/example/kargo-demo.git
+      id: 1234abc
+  health:
+    argoCDApps:
+    - healthStatus:
+        status: Healthy
+      name: kargo-demo-test
+      namespace: argocd
+      syncStatus:
+        revision: 4b1bd08ffbaecf0961e1877d7f2cc8bde7090575
+        status: Synced
+    status: Healthy
   history:
-  - id: 404df86560cab5d515e7aa74653e665c1dc96e1c
-    firstSeen: "2023-04-21T19:05:36Z"
-    commits:
-    - id: 02d153f75e5c042d576c713be52b57e1db8ddc97
-      repoURL: https://github.com/example/kargo-demo.git
+  - id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
     images:
     - repoURL: nginx
-      tag: 1.24.0
-    health:
-      status: Healthy
+      tag: 1.25.3
+    commits:
+    - repoURL: https://github.com/example/kargo-demo.git
+      id: 1234abc
 ```
 
-Above, we can see that the piece of freight currently deployed to the `Stage` is
-recorded in the `currentFreight` field. The `history` field duplicates this
-information, but as the freight in a stage continues to change over time, each
-new piece of freight will be _pushed_ onto the `history` collection, making that
-field a historic record of of the freight that has moved through the `Stage`.
+### `Freight` Resources
 
-## `Promotion` resources
+Each piece of Kargo freight is represented by a Kubernetes resource of type
+`Freight`. `Freight` resources are immutable except for their `status` field.
 
-In the previous section, we discussed _how_ promotion mechanisms move freight
-from one `Stage` to another, but we have not yet discussed what actually
-triggers that process.
+A single `Freight` resource references one or more versioned artifacts, such as:
 
-Kargo `Promotion` resources are used as _requests_ to progress a piece of
-freight from one `Stage`to another.
+* Container images (from image repositories)
 
-`Promotion` resources may be created either automatically or manually, depending
-on policies (covered in the next section).
+* Kubernetes manifests (from Git repositories)
 
-Regardless of whether it is created manually or automatically, a `Promotion`
-looks like this:
+* Helm charts (from chart repositories)
+
+A `Freight` resource's `id` field _and_ `metadata.name` field are both (for now)
+set to the same value, which is a SHA1 hash of a canonical representation of the
+artifacts referenced by the `Freight` resource. (This is enforced by an
+admission webhook.) The `id` and `metadata.name` fields, therefore, are both
+"fingerprints," deterministically derived from the `Freight`'s contents.
+
+A `Freight` resource's `status` field records a list of `Stage` resources in
+which the `Freight` has been _qualified_. A `Freight` resource is qualified in
+any `Stage` that reached a healthy state while hosting it.
+
+`Freight` resources look similar to the following:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Freight
+metadata:
+  name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
+  namespace: kargo-demo
+id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
+images:
+- repoURL: nginx
+  tag: 1.25.3
+commits:
+- repoURL: https://github.com/example/kargo-demo.git
+  id: 1234abc
+status:
+  qualifications:
+    test: {}
+```
+
+### `Warehouse` Resources
+
+Each Kargo warehouse is represented by a Kubernetes resource of type
+`Warehouse`.
+
+A `Warehouse` resource's most important field is its `spec.subscriptions` field,
+which is used to subscribe to one or more:
+
+* Container image repositories
+
+* Git repositories
+
+* Helm charts repositories
+
+The following example shows a `Warehouse` resource that subscribes to a
+container image repository and a Git repository:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: my-warehouse
+  namespace: kargo-demo
+spec:
+  subscriptions:
+  - image:
+      repoURL: nginx
+      semverConstraint: ^1.24.0
+  - git:
+      repoURL: https://github.com/example/kargo-demo.git
+```
+
+### `Promotion` Resources
+
+Each Kargo promotion is represented by a Kubernetes resource of type
+`Promotion`.
+
+A `Promotion` resource's two most important fields are its `spec.freight` and
+`spec.stage` fields, which respectively identify a piece of `Freight` and a
+target `Stage` to which that `Freight` should be promoted.
+
+`Promotions` are, in some cases, created automatically by Kargo. In other cases,
+they are created manually by users. In either case, a `Promotion` resource
+resembles the following:
 
 ```yaml
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Promotion
 metadata:
-  name: test-to-404df86560cab5d515e7aa74653e665c1dc96e1c
+  name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390-to-test
   namespace: kargo-demo
 spec:
   stage: test
-  freight: 404df86560cab5d515e7aa74653e665c1dc96e1c
+  freight: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
 ```
-
-`Promotion` resources are simple. Their `spec.stage` and `spec.freight`
-fields specify a `Stage` by name and one of its available pieces of freight,
-which should be moved into that `Stage`.
 
 :::info
 The name in a `Promotion`'s `metadata.name` field is inconsequential. Only
@@ -323,84 +356,70 @@ the `spec` matters.
 :::
 
 When a `Promotion` has concluded -- whether successfully or unsuccessfully --
-the `Promotion`'s `status` field is updated to reflect the outcome.
+the `Promotion`'s `status` field is updated to reflect the outcome. For example:
 
-_So, who can create `Promotion` resources? And when does Kargo create them
-automatically?_
+```yaml
+status:
+  phase: Succeeded
+```
 
-## Creating `Promotion`s Manually
+### `PromotionPolicy` Resources
+
+Each Kargo promotion policy is represented by a Kubernetes resource of type
+`PromotionPolicy`.
+
+A `PromotionPolicy` resource's two most important fields are its `stage` and
+`enableAutoPromotion` fields, which, respectively, identify a `Stage` and
+indicate whether that `Stage` should be eligible to automatically receive new
+`Freight`.
+
+The following example shows a `PromotionPolicy` resource that enables automatic
+promotions to the `test` `Stage`:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionPolicy
+metadata:
+  name: test
+  namespace: kargo-demo
+stage: test
+enableAutoPromotion: true
+```
+
+Kargo considers auto-promotion disabled by default for any `Stage` that does not
+have a corresponding `PromotionPolicy` resource. If a `Stage` has multiple
+corresponding `PromotionPolicy` resources, then the policy is considered
+ambiguous and auto-promotion will be considered disabled by default.
+
+:::note
+Promotion policies are represented by a separate resource type (instead of being
+a field on a `Stage` resource) because the users with authority to decide what
+`Stage` resources should be eligible for auto-promotion may not be the same
+users with authority to define the `Stage` resources themselves.
+:::
+
+## Role-Based Access Control
 
 As with all resource types in Kubernetes, permissions to perform various actions
-on `Promotion` resources, including creating new ones, are governed by
+on resources of different types are governed by
 [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
-Kubernetes RBAC, alone, cannot address one particular concern, however. Often,
-it is necessary to grant a user permission to create `Promotion` resources for
-some particular `Stage`s but not for others. To address this, Kargo utilizes an
-admission control webhook that conducts access reviews to determine if a user
-creating a `Promotion` resource has the virtual `promote` verb for the `Stage`
-referenced by the `Promotion` resource.
+For all Kargo resource types, Kubernetes RBAC functions exactly as one would
+expect, with one notable exception.
+
+Often, it is necessary to grant a user permission to create `Promotion`
+resources that reference certain `Stage`s, but not others. To address this,
+Kargo utilizes an admission control webhook that conducts access reviews to
+determine if a user creating a `Promotion` resource has the virtual `promote`
+verb for the `Stage` referenced by the `Promotion` resource.
 
 :::info
 [This blog post](https://blog.aquasec.com/kubernetes-verbs) is an excellent
 primer on virtual verbs in Kubernetes RBAC.
 :::
 
-The pre-defined `kargo-promoter` `ClusterRole` grants the ability to create,
-read, update, delete, and list `Promotion` resources and also grants the virtual
-`promote` ability for all `Stages`:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kargo-promoter
-  labels:
-    # ...
-rules:
-- apiGroups:
-  - kargo.akuity.io
-  resources:
-  - promotions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- # ...
-- apiGroups:
-  - kargo.akuity.io
-  resources:
-  - stages
-  verbs:
-  - promote
-```
-
-To grant a fictional user `alice` the ability to create `Promotion`s for all
-`Stage`s in a given namespace, such as `kargo-demo`, a `RoleBinding` (_not_ a
-`ClusterRoleBinding`) such as the following may be created:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: alice-promoter
-  namespace: kargo-demo
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kargo-promoter
-subjects:
-- kind: User
-  name: alice
-```
-
-Suppose, however, that a fictional user `bob` should be permitted to create
-`Promotion` resources that reference the `UAT` `Stage`, but not any other.
-The following `Role` and `RoleBinding` would address that need:
+The following `Role` resource describes permissions to create `Promotion`
+references that reference the `uat` `Stage` only:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -429,11 +448,16 @@ rules:
   - uat
   verbs:
   - promote
----
+```
+
+To grant a fictional user `alice`, in the QA department, the ability to promote
+to `uat` only, create a corresponding `RoleBinding`:
+
+```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: bob-uat-promoter
+  name: alice-uat-promoter
   namespace: kargo-demo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -441,37 +465,5 @@ roleRef:
   name: uat-promoter
 subjects:
 - kind: User
-  name: bob
+  name: alice
 ```
-
-## Auto-promotions
-
-At times, it may be desirable for Kargo itself to create a new `Promotion`
-resource to _automatically_ transition new freight into a certain `Stage`.
-
-Enabling this requires the creation of a `PromotionPolicy` resource. The
-following example demonstrates how a `test` `Stage` can take advantage of
-auto-promotions:
-
-```yaml
-apiVersion: kargo.akuity.io/v1alpha1
-kind: PromotionPolicy
-metadata:
-  name: test
-  namespace: kargo-demo
-stage: test
-enableAutoPromotion: true
-```
-
-:::info
-Why isn't `enableAutoPromotion` a field on the `Stage` resource type itself?
-
-It is entirely plausible that the users with permission to define a `Stage`
-aren't intended to have the authority to execute promotions _to_ that `Stage`.
-If `enableAutoPromotion` were a field on the `Stage` resource type, then users
-with permission to create and update `Stage`s could enable auto-promotion to
-effect a promotion they themselves could not otherwise have performed manually.
-
-By utilizing a separate `PromotionPolicy` resource to enable auto-promotion for
-a given `Stage`, this would-be method of privilege escalation is eliminated.
-:::

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -131,136 +131,109 @@ Let's begin by creating a repository on GitHub to house variations of our
 application manifests for three different stages of a sample application: test,
 UAT, and production.
 
-Visit https://github.com/akuity/kargo-demo and fork the repository into your own
-GitHub account.
+1. Visit https://github.com/akuity/kargo-demo and fork the repository into your
+   own GitHub account.
 
-You can explore the repository and see that the `main` branch contains common
-configuration in a `base/` directory as well as stage-specific overlays in
-paths of the form `stages/<stage name>/`. [Kustomize](https://kustomize.io/)
-is used as a configuration management tool that combines base configuration with
-stage-specific configuration.
+1. You can explore the repository and see that the `main` branch contains common
+   configuration in a `base/` directory as well as stage-specific overlays in
+   paths of the form `stages/<stage name>/`.
 
-:::note
-This layout is typical of a GitOps repository using Kustomize and is not at all
-Kargo-specific.
+    :::note
+    This layout is typical of a GitOps repository using
+    [Kustomize](https://kustomize.io/) for configuration management and is not
+    at all Kargo-specific.
 
-Kargo also works just as well with Helm and with plain YAML.
-:::
+    Kargo also works just as well with [Helm](https://helm.sh).
+    :::
+
+1. We'll be using it later, so save the location of your GitOps repository in an
+   environment variable:
+
+   ```shell
+   export GITOPS_REPO_URL=<your repo URL, starting with https://>
+   ```
 
 ### Create Argo CD `Application` Resources
 
 In this step, we will create three Argo CD `Application` resources that deploy
 the sample application at three different stages of its lifecycle, with three
 slightly different configurations, to three different namespaces in our local
-cluster.
+cluster:
 
-To get started, you will need a GitHub
-[personal access token](https://github.com/settings/tokens)
-with adequate permissions to read from and write to the repository you forked in
-the previous section.
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo-demo-test
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: kargo-demo:test
+spec:
+  project: default
+  source:
+    repoURL: ${GITOPS_REPO_URL}
+    targetRevision: stage/test
+    path: stages/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kargo-demo-test
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo-demo-uat
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: kargo-demo:uat
+spec:
+  project: default
+  source:
+    repoURL: ${GITOPS_REPO_URL}
+    targetRevision: stage/uat
+    path: stages/uat
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kargo-demo-uat
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo-demo-prod
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: kargo-demo:prod
+spec:
+  project: default
+  source:
+    repoURL: ${GITOPS_REPO_URL}
+    targetRevision: stage/prod
+    path: stages/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kargo-demo-prod
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+EOF
+```
 
-1. Save the location of your GitOps repository, your GitHub handle, and your
-   personal access token in environment variables:
+If you visit [your Argo CD dashboard](https://localhost:8443), you will notice
+all three Argo CD `Application`s have not yet synced because they're not
+configured to do so automatically, and in fact, the branches referenced by their
+`targetRevision` fields do not even exist yet.
 
-   ```shell
-   export GITOPS_REPO_URL=<your repo URL, starting with https://>
-   export GITHUB_USERNAME=<your github handle>
-   export GITHUB_PAT=<your personal access token>
-   ```
-
-1. Create a `Secret` containing repository credentials, and Argo CD
-   `Application` resources for each stage:
-
-   ```shell
-   apiVersion: v1
-   kind: Secret
-   type: Opaque
-   metadata:
-     name: kargo-demo-repo
-     namespace: argocd
-     labels:
-       argocd.argoproj.io/secret-type: repository
-     annotations:
-       kargo.akuity.io/authorized-projects: kargo-demo
-   stringData:
-     type: git
-     project: default
-     url: ${GITOPS_REPO_URL}
-     username: ${GITHUB_USERNAME}
-     password: ${GITHUB_PAT}
-   ---
-   apiVersion: argoproj.io/v1alpha1
-   kind: Application
-   metadata:
-     name: kargo-demo-test
-     namespace: argocd
-     annotations:
-       kargo.akuity.io/authorized-stage: kargo-demo:test
-   spec:
-     project: default
-     source:
-       repoURL: ${GITOPS_REPO_URL}
-       targetRevision: stage/test
-       path: stages/test
-     destination:
-       server: https://kubernetes.default.svc
-       namespace: kargo-demo-test
-     syncPolicy:
-       syncOptions:
-       - CreateNamespace=true
-   ---
-   apiVersion: argoproj.io/v1alpha1
-   kind: Application
-   metadata:
-     name: kargo-demo-uat
-     namespace: argocd
-     annotations:
-       kargo.akuity.io/authorized-stage: kargo-demo:uat
-   spec:
-     project: default
-     source:
-       repoURL: ${GITOPS_REPO_URL}
-       targetRevision: stage/uat
-       path: stages/uat
-     destination:
-       server: https://kubernetes.default.svc
-       namespace: kargo-demo-uat
-     syncPolicy:
-       syncOptions:
-       - CreateNamespace=true
-   ---
-   apiVersion: argoproj.io/v1alpha1
-   kind: Application
-   metadata:
-     name: kargo-demo-prod
-     namespace: argocd
-     annotations:
-       kargo.akuity.io/authorized-stage: kargo-demo:prod
-   spec:
-     project: default
-     source:
-       repoURL: ${GITOPS_REPO_URL}
-       targetRevision: stage/prod
-       path: stages/prod
-     destination:
-       server: https://kubernetes.default.svc
-       namespace: kargo-demo-prod
-     syncPolicy:
-       syncOptions:
-       - CreateNamespace=true
-   EOF
-   ```
-
-  If you visit [your Argo CD dashboard](https://localhost:8443), you will notice
-  all three Argo CD `Application`s have not yet synced because they're not
-  configured to do so automatically, and in fact, the branches referenced by their
-  `targetRevision` fields do not even exist yet.
-
-  :::info
-  Our three stages all existing in a single cluster is for the sake of
-  expediency. A single Argo CD control plane can manage multiple clusters, so
-  these could also have been spread across multiple clusters.
-  :::
+:::info
+Our three stages all existing in a single cluster is for the sake of expediency.
+A single Argo CD control plane can manage multiple clusters, so these could just
+as easily have been spread across multiple clusters.
+:::
 
 ### Hands on with the Kargo CLI
 
@@ -268,266 +241,312 @@ Up to this point, we haven't done anything with Kargo -- in fact everything
 we've done thus far should be familiar to anyone who's already using Argo CD and
 Kustomize. Now it's time to see what Kargo can do!
 
-1. Begin by logging into Kargo:
+To get started, you will need a GitHub
+[personal access token](https://github.com/settings/tokens)
+with adequate permissions to read from and write to the repository you forked in
+the previous section.
 
-  ```shell
-  kargo login https://localhost:8444 \
-    --admin \
-    --password admin \
-    --insecure-skip-tls-verify
-  ```
+1. Save your GitHub handle and your personal access token in environment
+   variables:
 
-1. Next, we'll create a Kargo project (a specially labeled namespace) and three
-   Kargo `Stage` resources. This can be thought of as an orchestration layer for
-   our GitOps repository and Argo CD `Application` resources.
+   ```shell
+   export GITHUB_USERNAME=<your github handle>
+   export GITHUB_PAT=<your personal access token>
+   ```
 
-  ```shell
-  cat <<EOF | kargo apply -f -
-  apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: kargo-demo
-    labels:
-      kargo.akuity.io/project: "true"
-  ---
-  apiVersion: kargo.akuity.io/v1alpha1
-  kind: Stage
-  metadata:
-    name: test
-    namespace: kargo-demo
-  spec:
-    subscriptions:
-      repos:
-        images:
-        - repoURL: nginx
+1. Then, log into Kargo:
+
+    ```shell
+    kargo login https://localhost:8444 \
+      --admin \
+      --password admin \
+      --insecure-skip-tls-verify
+    ```
+
+1. Next, we'll create a Kargo project, which is really a specially labeled
+   Kubernetes `Namespace`:
+
+    ```shell
+    kargo create project kargo-demo
+    ```
+
+1. To create some credentials (a Kubernetes `Secret`) for writing to our GitOps
+   repository, we will fall back on `kubectl`:
+
+    ```shell
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: Secret
+    type: Opaque
+    metadata:
+      name: kargo-demo-repo
+      namespace: kargo-demo
+      labels:
+        kargo.akuity.io/secret-type: repository
+    stringData:
+      type: git
+      project: default
+      url: ${GITOPS_REPO_URL}
+      username: ${GITHUB_USERNAME}
+      password: ${GITHUB_PAT}
+    EOF
+    ```
+
+    :::info
+    Falling back on `kubectl` for credential management is necessary at this
+    time because the Kargo API server lacks sufficient permissions to manage
+    Kubernetes `Secret` resources.
+
+    This will be addressed in future versions.
+    :::
+
+1. Next, returning to the `kargo` CLI, we create a `Warehouse` and three Kargo
+   `Stage` resources. All of this his can be thought of as an orchestration
+   layer for our GitOps repository and Argo CD `Application` resources.
+
+    ```shell
+    cat <<EOF | kargo apply -f -
+    apiVersion: kargo.akuity.io/v1alpha1
+    kind: Warehouse
+    metadata:
+      name: kargo-demo
+      namespace: kargo-demo
+    spec:
+      subscriptions:
+      - image:
+          repoURL: nginx
           semverConstraint: ^1.24.0
-    promotionMechanisms:
-      gitRepoUpdates:
-      - repoURL: ${GITOPS_REPO_URL}
-        writeBranch: stage/test
-        kustomize:
-          images:
-          - image: nginx
-            path: stages/test
-      argoCDAppUpdates:
-      - appName: kargo-demo-test
-        appNamespace: argocd
-  ---
-  apiVersion: kargo.akuity.io/v1alpha1
-  kind: Stage
-  metadata:
-    name: uat
-    namespace: kargo-demo
-  spec:
-    subscriptions:
-      upstreamStages:
-      - name: test
-    promotionMechanisms:
-      gitRepoUpdates:
-      - repoURL: ${GITOPS_REPO_URL}
-        writeBranch: stage/uat
-        kustomize:
-          images:
-          - image: nginx
-            path: stages/uat
-      argoCDAppUpdates:
-      - appName: kargo-demo-uat
-        appNamespace: argocd
-  ---
-  apiVersion: kargo.akuity.io/v1alpha1
-  kind: Stage
-  metadata:
-    name: prod
-    namespace: kargo-demo
-  spec:
-    subscriptions:
-      upstreamStages:
-      - name: uat
-    promotionMechanisms:
-      gitRepoUpdates:
-      - repoURL: ${GITOPS_REPO_URL}
-        writeBranch: stage/prod
-        kustomize:
-          images:
-          - image: nginx
-            path: stages/prod
-      argoCDAppUpdates:
-      - appName: kargo-demo-prod
-        appNamespace: argocd
-  EOF
-  ```
+    ---
+    apiVersion: kargo.akuity.io/v1alpha1
+    kind: Stage
+    metadata:
+      name: test
+      namespace: kargo-demo
+    spec:
+      subscriptions:
+        warehouse: kargo-demo
+      promotionMechanisms:
+        gitRepoUpdates:
+        - repoURL: ${GITOPS_REPO_URL}
+          writeBranch: stage/test
+          kustomize:
+            images:
+            - image: nginx
+              path: stages/test
+        argoCDAppUpdates:
+        - appName: kargo-demo-test
+          appNamespace: argocd
+    ---
+    apiVersion: kargo.akuity.io/v1alpha1
+    kind: Stage
+    metadata:
+      name: uat
+      namespace: kargo-demo
+    spec:
+      subscriptions:
+        upstreamStages:
+        - name: test
+      promotionMechanisms:
+        gitRepoUpdates:
+        - repoURL: ${GITOPS_REPO_URL}
+          writeBranch: stage/uat
+          kustomize:
+            images:
+            - image: nginx
+              path: stages/uat
+        argoCDAppUpdates:
+        - appName: kargo-demo-uat
+          appNamespace: argocd
+    ---
+    apiVersion: kargo.akuity.io/v1alpha1
+    kind: Stage
+    metadata:
+      name: prod
+      namespace: kargo-demo
+    spec:
+      subscriptions:
+        upstreamStages:
+        - name: uat
+      promotionMechanisms:
+        gitRepoUpdates:
+        - repoURL: ${GITOPS_REPO_URL}
+          writeBranch: stage/prod
+          kustomize:
+            images:
+            - image: nginx
+              path: stages/prod
+        argoCDAppUpdates:
+        - appName: kargo-demo-prod
+          appNamespace: argocd
+    EOF
+    ```
 
-  Use the CLI to view the three `Stage` resources in our new project:
+1. Use the CLI to view our `Warehouse` resource:
 
-  ```shell
-  kargo get stages --project kargo-demo
-  ```
+    ```shell
+    kargo get warehouses --project kargo-demo
+    ```
 
-  Sample output:
+    Sample output:
 
-  ```shell
-  NAME   CURRENT FREIGHT   HEALTH    AGE
-  prod                     Healthy   20s
-  test                     Healthy   20s
-  uat                      Healthy   20s
-  ```
+    ```shell
+    NAME         AGE
+    kargo-demo   13s
+    ```
 
-1. Dissecting the manifest from the previous step, we see the `test` `Stage`
-   subscribes directly to the `nginx` image repository. When a new version of
-   the `nginx` container image matching the specified constraints is discovered,
-   Kargo has discovered new `Freight`.
+1. Use the CLI to view our three `Stage` resources:
 
-  :::info
-  `Freight` is a set of references to one or more versioned artifacts, which and
-  may include:
+    ```shell
+    kargo get stages --project kargo-demo
+    ```
 
-    * Container images (from image repositories)
+    Sample output:
 
-    * Kubernetes manifests (from Git repositories)
+    ```shell
+    NAME   CURRENT FREIGHT   HEALTH    AGE
+    prod                     Healthy   20s
+    test                     Healthy   20s
+    uat                      Healthy   20s
+    ```
 
-    * Helm charts (from chart repositories)
+1. Our `Warehouse`, which subscribes to the `nginx` image repository, also
+   should have already produced `Freight`:
 
-  This introductory example has `Freight` that references only a specific
-  version of the `nginx` container image.
-  :::
+    ```shell
+    kargo get freight --project kargo-demo
+    ```
 
-  We can query the status of the `test` `Stage` to see the latest `Freight`
-  available to it:
+    Sample output:
 
-  ```shell
-  kargo get stage test --project kargo-demo --output jsonpath-as-json={.status}
-  ```
+    ```shell
+    NAME                                       AGE
+    47b33c0c92b54439e5eb7fb80ecc83f8626fe390   5m49s
+    ```
+    :::info
+    `Freight` is a set of references to one or more versioned artifacts, which
+    may include:
 
-  Truncated sample output:
+      * Container images (from image repositories)
 
-  ```shell
-  [
-      {
-          "availableFreight": [
-              {
-                  "firstSeen": "2023-09-20T18:09:05Z",
-                  "id": "b73f9d1afaca87254b64e64e5439557e86dcba79",
-                  "images": [
-                      {
-                          "repoURL": "nginx",
-                          "tag": "1.25.2"
-                      }
-                  ],
-                  "qualified": true
-              }
-          ],
-          ...
-      }
-  ]
-  ```
+      * Kubernetes manifests (from Git repositories)
 
-   Save the ID of the available `Freight` to an environment variable for
-   convenience:
+      * Helm charts (from chart repositories)
 
-  ```shell
-  export FREIGHT_ID=$(kargo get stage test --project kargo-demo --output jsonpath={.status.availableFreight\[0\].id})
-  ```
+    This introductory example has `Freight` that references only a specific
+    version of the `nginx` container image.
+    :::
 
-  _Promote_ the `Freight` into the `test` `Stage`:
+1. We'll use it later, so save the ID of the `Freight` to an environment
+   variable:
 
-  ```shell
-  kargo stage promote kargo-demo test --freight $FREIGHT_ID
-  ```
+    ```shell
+    export FREIGHT_ID=$(kargo get freight --project kargo-demo --output jsonpath={.id})
+    ```
 
-  Sample output:
+1. Now, let's _promote_ the `Freight` into the `test` `Stage`:
 
-  ```shell
-  Promotion Created: "test.01haswttm2p4qwcenpnn5s1m96.b73f9d1"
-  ```
+    ```shell
+    kargo stage promote kargo-demo test --freight $FREIGHT_ID
+    ```
 
-   Query for `Promotion` resources within our project to see one has been
-   created and is currently pending:
+    Sample output:
 
-  ```shell
-  kargo get promotions --project kargo-demo
-  ```
+    ```shell
+    Promotion Created: "test.01haswttm2p4qwcenpnn5s1m96.b73f9d1"
+    ```
 
-  Sample output:
+    Query for `Promotion` resources within our project to see one has been
+    created:
 
-  ```shell
-  NAME                                      STAGE   FREIGHT                                    PHASE     AGE
-  test.01haswttm2p4qwcenpnn5s1m96.b73f9d1   test    b73f9d1afaca87254b64e64e5439557e86dcba79   Pending   7s
-  ```
+    ```shell
+    kargo get promotions --project kargo-demo
+    ```
 
-  We can repeat the command above until our `Promotion` has succeeded.
+    Our `Promotion` may briefly appear to be in a `Pending` phase, but more than
+    likely, it will almost immediately be `Running`, or even `Succeeded`:
 
-  Once the `Promotion` has succeeded, we can, again view all `Stage` resources in
-  our project, and at a glance, see that the `test` `Stage` is now either in a
-  `Progressing` or `Healthy` state.
+    ```shell
+    NAME                                      STAGE   FREIGHT                                    PHASE     AGE
+    test.01haswttm2p4qwcenpnn5s1m96.b73f9d1   test    b73f9d1afaca87254b64e64e5439557e86dcba79   Running   7s
+    ```
 
-  ```shell
-  kargo get stages --project kargo-demo
-  ```
+    Once the `Promotion` has succeeded, we can again view all `Stage` resources
+    in our project, and at a glance, see that the `test` `Stage` is now either
+    in a `Progressing` or `Healthy` state.
 
-  Sample output:
+    ```shell
+    kargo get stages --project kargo-demo
+    ```
 
-  ```shell
-  NAME   CURRENT FREIGHT                            HEALTH        AGE
-  prod                                              Healthy       6m55s
-  test   b73f9d1afaca87254b64e64e5439557e86dcba79   Progressing   6m55s
-  uat                                               Healthy       6m55s
-  ```
+    Sample output:
 
-  We can repeat the command above until our `Promotion` is in a `Healthy` state.
+    ```shell
+    NAME   CURRENT FREIGHT                            HEALTH        AGE
+    prod                                              Healthy       6m55s
+    test   b73f9d1afaca87254b64e64e5439557e86dcba79   Progressing   6m55s
+    uat                                               Healthy       6m55s
+    ```
 
-  We can further validate the success of this entire process by visiting the
-  test instance of our site at [localhost:8081](http://localhost:8081).
+    We can repeat the command above until our `Promotion` is in a `Healthy`
+    state and we can further validate the success of this entire process by
+    visiting the test instance of our site at
+    [localhost:8081](http://localhost:8081).
 
-  If we once again view the `status` of our `test` `Stage` in more detail, we
-  will see that it now reflects not only `Freight` available to the `Stage`, but
-  also its current `Freight`, and the history of all `Freight` that have passed
-  through this stage. (The collection is ordered most to least recent.)
+    If we once again view the `status` of our `test` `Stage` in more detail, we
+    will see that it now reflects its current `Freight`, and the history of all
+    `Freight` that have passed through this stage. (The collection is ordered
+    most to least recent.)
 
-  ```shell
-  kargo get stage test --project kargo-demo --output jsonpath-as-json={.status}
-  ```
+    ```shell
+    kargo get stage test --project kargo-demo --output jsonpath-as-json={.status}
+    ```
 
-  Truncated sample output:
+    Truncated sample output:
 
-  ```shell
-  [
-      {
-          "availableFreight": [
-              ...
-          ],
-          "currentFreight": {
-              "firstSeen": "2023-09-20T18:52:12Z",
-              "id": "b73f9d1afaca87254b64e64e5439557e86dcba79",
-              "images": [
-                  {
-                      "repoURL": "nginx",
-                      "tag": "1.25.2"
-                  }
-              ],
-              "qualified": true
-          },
-          ...
-          "history": [
-              {
-                  "firstSeen": "2023-09-20T18:52:12Z",
-                  "id": "b73f9d1afaca87254b64e64e5439557e86dcba79",
-                  "images": [
-                      {
-                          "repoURL": "nginx",
-                          "tag": "1.25.2"
-                      }
-                  ],
-                  "qualified": true
-              }
-          ]
-      }
-  ]
-  ```
+    ```shell
+    {
+        "currentFreight": {
+            "id": "b73f9d1afaca87254b64e64e5439557e86dcba79",
+            "images": [
+                {
+                    "repoURL": "nginx",
+                    "tag": "1.25.3"
+                }
+            ],
+        },
+        ...
+        "history": [
+            {
+                "id": "b73f9d1afaca87254b64e64e5439557e86dcba79",
+                "images": [
+                    {
+                        "repoURL": "nginx",
+                        "tag": "1.25.3"
+                    }
+                ],
+            }
+        ]
+    }
+    ```
 
-  Importantly, by virtue of the `test` `Stage` having achieved a `Healthy` state
-  with its current `Freight`, the sample output above shows the current
-  `Freight` is now _qualified_, which designates it as eligible for promotion to
-  the next `Stage` -- `uat`.
+1. If we look at our `Freight` in greater detail, we'll see that by virtue of
+   the `test` `Stage` having achieved a `Healthy` state, the `Freight` is now
+   _qualified_ in `test`, which designates it as eligible for promotion to the
+   next `Stage` -- in our case, `uat`.
+
+    ```shell
+    kargo get freight $FREIGHT_ID --project kargo-demo --output jsonpath-as-json={.status}
+    ```
+
+    Sample output:
+
+    ```shell
+    {
+        "qualifications": {
+            "test": {}
+        }
+    }
+    ```
 
 ### Behind the Scenes
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -168,26 +168,10 @@ the previous section.
    export GITHUB_PAT=<your personal access token>
    ```
 
-1. Create namespaces for each of our three stages, a `Secret` containing
-   repository credentials, and Argo CD `Application` resources for each stage:
+1. Create a `Secret` containing repository credentials, and Argo CD
+   `Application` resources for each stage:
 
    ```shell
-   cat <<EOF | kubectl apply -f -
-   apiVersion: v1
-   kind: Namespace
-   metadata:
-     name: kargo-demo-test
-   ---
-   apiVersion: v1
-   kind: Namespace
-   metadata:
-     name: kargo-demo-uat
-   ---
-   apiVersion: v1
-   kind: Namespace
-   metadata:
-     name: kargo-demo-prod
-   ---
    apiVersion: v1
    kind: Secret
    type: Opaque
@@ -221,6 +205,9 @@ the previous section.
      destination:
        server: https://kubernetes.default.svc
        namespace: kargo-demo-test
+     syncPolicy:
+       syncOptions:
+       - CreateNamespace=true
    ---
    apiVersion: argoproj.io/v1alpha1
    kind: Application
@@ -238,6 +225,9 @@ the previous section.
      destination:
        server: https://kubernetes.default.svc
        namespace: kargo-demo-uat
+     syncPolicy:
+       syncOptions:
+       - CreateNamespace=true
    ---
    apiVersion: argoproj.io/v1alpha1
    kind: Application
@@ -255,6 +245,9 @@ the previous section.
      destination:
        server: https://kubernetes.default.svc
        namespace: kargo-demo-prod
+     syncPolicy:
+       syncOptions:
+       - CreateNamespace=true
    EOF
    ```
 


### PR DESCRIPTION
Fixes #988

This PR reworks the quickstart and concepts documentation for v0.2.0.

__This should not be merged until after v0.2.0 is released or else this change will break the quickstart.__