### PR TITLE
ci(stale): add scheduled workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: 'Close Stale PRs'
+on:
+  schedule:
+    - cron: '32 11 * * 1-5'  # 11:32 UTC / 07:32 EDT / 06:32 EST from Mon-Fri.
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30  # Don't wait 6 hours to cancel workflow if it hangs.
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-pr-label: 'stale'
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had any recent activity.
+            This issue will be closed if no further activity occurs but can be reopened if it becomes relevant again.
+          stale-pr-label: 'stale'
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has not had any recent activity.
+
+            - If this PR is not ready for review or implementation please [mark it as a draft](https://github.blog/changelog/2020-04-08-convert-pull-request-to-draft/).
+            - If this PR is ready for implementation but is intentionally on hold, please comment with a clear indication of why and add the `on hold` label to avoid it being marked as stale.
+
+            This PR will be closed if no further activity occurs but can be reopened if it becomes relevant again.
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-draft-pr: true
+          exempt-pr-labels: 'on hold'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs but can be reopened if it becomes relevant again.
+            This issue has been automatically marked as stale because it had no activity for 90 days. It will be closed if no activity occurs in the next 30 days but can be reopened if it becomes relevant again.
           days-before-stale: -1  # Don't stale PRs.
           days-before-issue-stale: 90
           days-before-issue-close: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,11 +1,10 @@
-name: 'Close Stale PRs'
+name: 'Close Stale Issues'
 on:
   schedule:
     - cron: '32 11 * * 1-5'  # 11:32 UTC / 07:32 EDT / 06:32 EST from Mon-Fri.
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
@@ -16,18 +15,8 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had any recent activity.
-            This issue will be closed if no further activity occurs but can be reopened if it becomes relevant again.
-          stale-pr-label: 'stale'
-          stale-pr-message: |
-            This PR has been automatically marked as stale because it has not had any recent activity.
-
-            - If this PR is not ready for review or implementation please [mark it as a draft](https://github.blog/changelog/2020-04-08-convert-pull-request-to-draft/).
-            - If this PR is ready for implementation but is intentionally on hold, please comment with a clear indication of why and add the `on hold` label to avoid it being marked as stale.
-
-            This PR will be closed if no further activity occurs but can be reopened if it becomes relevant again.
-          days-before-stale: 30
-          days-before-close: 7
-          exempt-issue-labels: 'priority/low,priority/normal,priority/high,priority/urgent'
-          exempt-draft-pr: true
-          exempt-pr-labels: 'on hold'
+            This issue has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs but can be reopened if it becomes relevant again.
+          days-before-stale: -1  # Don't stale PRs.
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          exempt-issue-labels: 'priority/normal,priority/high,priority/urgent'  # Only stale wontfix or low priority issues.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          stale-pr-label: 'stale'
+          stale-issue-label: 'stale'
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had any recent activity.
             This issue will be closed if no further activity occurs but can be reopened if it becomes relevant again.
@@ -28,5 +28,6 @@ jobs:
             This PR will be closed if no further activity occurs but can be reopened if it becomes relevant again.
           days-before-stale: 30
           days-before-close: 7
+          exempt-issue-labels: 'priority/low,priority/normal,priority/high,priority/urgent'
           exempt-draft-pr: true
           exempt-pr-labels: 'on hold'


### PR DESCRIPTION
On weekdays, this workflow will run once in the morning*. If an issue of `priority/low` or `priority/wontfix` has been inactive for 90 days, it will be marked as stale (by adding the `stale` label), and a comment will be left. If it remains inactive for another 30 days, it will be closed (but can be re-opened if needed, i.e. not locked).