### PR TITLE
fix(docs): update commands for mac x86

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -95,7 +95,9 @@ At the end of this process:
 To download the Kargo CLI:
 
 ```shell
-curl -sSL -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)
+arch=$(uname -m)
+[ "$arch" = "x86_64" ] && arch=amd64
+curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}
 chmod +x kargo
 ```
 


### PR DESCRIPTION
closes #892