### PR TITLE
feat(docs): Add Discord link to header

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,6 +79,11 @@ const config = {
             label: 'GitHub',
             position: 'right',
           },
+          {
+            href: 'https://discord.gg/dHJBZw6ewT',
+            label: 'Discord Community',
+            position: 'right',
+          },
         ],
       },
       footer: {


### PR DESCRIPTION
resolves #923 

Not terribly familiar with how to generate these docs but this request seemed trivial enough.
I wasn't able to find instructions in the repo for how to build/generate the docs, so any pointers are very welcome.