### PR TITLE
improve ci and release processes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         platforms: linux/amd64,linux/arm64
         push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,11 @@ jobs:
       with:
         cosign-release: 'v2.1.1' # optional
     - name: Login to GHCR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: Docker meta
@@ -41,7 +41,7 @@ jobs:
         tags: type=semver,pattern={{raw}}
     - name: Build and push
       id: image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         platforms: linux/amd64,linux/arm64
         build-args: |
@@ -82,8 +82,8 @@ jobs:
       image: ghcr.io/akuity/kargo
       digest: ${{ needs.publish-image.outputs.image-digest }}
     secrets:
-      registry-username: ${{ secrets.GH_USERNAME }}
-      registry-password: ${{ secrets.GH_TOKEN }}
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   publish-charts:
     needs: publish-image
@@ -94,11 +94,11 @@ jobs:
       with:
         version: '3.12.3'
     - name: Login to GHCR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Publish chart


### PR DESCRIPTION
These same changes were applied to Kargo Render earlier today in the course of trying to work out permission issues that were partly caused by that repo's recent rename (from bookkeeper).

This allows us to delete some of our Action secrets in favor of a per-execution username/secret that GH Actions manages _for_ us. The updated versions of Actions we use are in order to take full advantage of that.