### PR TITLE
chore: use teams instead of individuals in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # This file is described here: https://help.github.com/en/articles/about-code-owners
 
-* @alexmt @devholic @gdsoumya @jessesuen @kencochrane @krancour @rbreeze
+* @akuity/maintainers
 
 # Doc owners
-/docs/ @dhpup @morey-tech
+/docs/ @akuity/maintainers @akuity/doc-maintainers


### PR DESCRIPTION
Swapping individuals with teams in CODEOWNERS to avoid spamming everyone with emails on each PR.

Also closes #959