### PR TITLE
fix fig step in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
         chmod 755 kargo
         kargo fig > kargo-fig-spec.ts
     - name: Create Autocomplete PR
-      uses: withfig/publish-to-fig-autocomplete@v1
+      uses: withfig/push-to-fig-autocomplete-action@v1
       with:
         autocomplete-spec-name: kargo
         spec-path: kargo-fig-spec.ts


### PR DESCRIPTION
This _should_ fix the step that opens a PR with fig completion info upon release.

The old config was copied from https://github.com/withfig/push-to-fig-autocomplete-action#usage and appears to be incorrect.

New config comes from the fig doc site:

https://fig.io/docs/guides/integrating/push-to-autocomplete-action