### PR TITLE
warehouse bug fix

### DIFF
--- a/internal/controller/warehouses/git.go
+++ b/internal/controller/warehouses/git.go
@@ -23,8 +23,8 @@ func (r *reconciler) getLatestCommits(
 	namespace string,
 	subs []kargoapi.RepoSubscription,
 ) ([]kargoapi.GitCommit, error) {
-	latestCommits := make([]kargoapi.GitCommit, len(subs))
-	for i, s := range subs {
+	latestCommits := make([]kargoapi.GitCommit, 0, len(subs))
+	for _, s := range subs {
 		if s.Git == nil {
 			continue
 		}
@@ -61,12 +61,15 @@ func (r *reconciler) getLatestCommits(
 		}
 		logger.WithField("commit", gm.Commit).
 			Debug("found latest commit from repo")
-		latestCommits[i] = kargoapi.GitCommit{
-			RepoURL: sub.RepoURL,
-			ID:      gm.Commit,
-			Branch:  sub.Branch,
-			Message: gm.Message,
-		}
+		latestCommits = append(
+			latestCommits,
+			kargoapi.GitCommit{
+				RepoURL: sub.RepoURL,
+				ID:      gm.Commit,
+				Branch:  sub.Branch,
+				Message: gm.Message,
+			},
+		)
 	}
 	return latestCommits, nil
 }

--- a/internal/controller/warehouses/helm.go
+++ b/internal/controller/warehouses/helm.go
@@ -17,9 +17,9 @@ func (r *reconciler) getLatestCharts(
 	namespace string,
 	subs []kargoapi.RepoSubscription,
 ) ([]kargoapi.Chart, error) {
-	charts := make([]kargoapi.Chart, len(subs))
+	charts := make([]kargoapi.Chart, 0, len(subs))
 
-	for i, s := range subs {
+	for _, s := range subs {
 		if s.Chart == nil {
 			continue
 		}
@@ -79,11 +79,14 @@ func (r *reconciler) getLatestCharts(
 		logger.WithField("version", vers).
 			Debug("found latest suitable chart version")
 
-		charts[i] = kargoapi.Chart{
-			RegistryURL: sub.RegistryURL,
-			Name:        sub.Name,
-			Version:     vers,
-		}
+		charts = append(
+			charts,
+			kargoapi.Chart{
+				RegistryURL: sub.RegistryURL,
+				Name:        sub.Name,
+				Version:     vers,
+			},
+		)
 	}
 
 	return charts, nil

--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -19,8 +19,8 @@ func (r *reconciler) getLatestImages(
 	namespace string,
 	subs []kargoapi.RepoSubscription,
 ) ([]kargoapi.Image, error) {
-	imgs := make([]kargoapi.Image, len(subs))
-	for i, s := range subs {
+	imgs := make([]kargoapi.Image, 0, len(subs))
+	for _, s := range subs {
 		if s.Image == nil {
 			continue
 		}
@@ -65,11 +65,14 @@ func (r *reconciler) getLatestImages(
 				sub.RepoURL,
 			)
 		}
-		imgs[i] = kargoapi.Image{
-			RepoURL:    sub.RepoURL,
-			GitRepoURL: r.getImageSourceURL(sub.GitRepoURL, tag),
-			Tag:        tag,
-		}
+		imgs = append(
+			imgs,
+			kargoapi.Image{
+				RepoURL:    sub.RepoURL,
+				GitRepoURL: r.getImageSourceURL(sub.GitRepoURL, tag),
+				Tag:        tag,
+			},
+		)
 		logger.WithField("tag", tag).
 			Debug("found latest suitable image tag")
 	}


### PR DESCRIPTION
This fixes a bug in the Warehouse reconciler that was creating freight that _always_ has a number of images, a number of git commits, and a number of charts, _each_ equal to the total number of subscriptions -- and most of those will be zero values. This is both confusing to look at and also causes problems at promotion time.