### PR TITLE
feat: CLI unstable nightly builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,6 +200,46 @@ jobs:
       run: |
         echo "hash-${{ matrix.os }}-${{ matrix.arch }}=$(sha256sum bin/kargo* | awk -F 'bin/' '{print $1 $2}'| base64 -w0)" >> "$GITHUB_OUTPUT"
 
+  publish-unstable-cli:
+    needs: publish-image
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.21.3-bookworm
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: /go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build CLI
+      env:
+        GOFLAGS: -buildvcs=false
+        VERSION: ${{ needs.publish-image.outputs.unstable-version }}
+        GIT_COMMIT: ${{ github.sha }}
+        GIT_TREE_STATE: clean
+      run: make nightly-cli
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE }}
+        aws-region: us-west-2
+    - name: Push binaries
+      env:
+        CF_DISTRIBUTION_ID: ${{ secrets.CF_DISTRIBUTION_ID }}
+        VERSION: ${{ needs.publish-image.outputs.unstable-version }}
+      run: |
+        aws s3 sync "./bin/kargo-cli/${VERSION}" "s3://kargo-release/kargo-cli/${VERSION}" --acl public-read
+
+        printf "${VERSION}" > ./bin/kargo-cli/unstable.txt
+        aws s3 cp ./bin/kargo-cli/unstable.txt s3://kargo-release/kargo-cli/unstable.txt --acl public-read
+        aws cloudfront create-invalidation \
+          --distribution-id="${CF_DISTRIBUTION_ID}" \
+          --paths "/kargo-cli/unstable.txt"
+
   push-fig-autocomplete-spec:
     needs: [publish-cli]
     if: github.event_name == 'release'

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,25 @@ build-cli:
 		./cmd/cli
 
 ################################################################################
+# Used for Nighty/Unstable builds                                              #
+################################################################################
+
+.PHONY: kargo-all
+kargo-all:
+	CGO_ENABLED=0 go build \
+		-ldflags "-w -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).buildDate=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT) -X $(VERSION_PACKAGE).gitTreeState=$(GIT_TREE_STATE)" \
+		-o bin/kargo-cli/${VERSION}/${GOOS}/${GOARCH}/${BIN_NAME} ./cmd/cli
+
+.PHONY: nightly-cli
+nightly-cli:
+	make BIN_NAME=kargo GOOS=darwin GOARCH=amd64 kargo-all
+	make BIN_NAME=kargo GOOS=darwin GOARCH=arm64 kargo-all
+	make BIN_NAME=kargo GOOS=linux GOARCH=amd64 kargo-all
+	make BIN_NAME=kargo GOOS=linux GOARCH=arm64 kargo-all
+	make BIN_NAME=kargo.exe GOOS=windows GOARCH=amd64 kargo-all
+	make BIN_NAME=kargo.exe GOOS=windows GOARCH=arm64 kargo-all
+
+################################################################################
 # Code generation: To be run after modifications to API types                  #
 ################################################################################
 


### PR DESCRIPTION
PR introduces nightly unstable builds for the CLI binaries.  Downloads will be similar to the Akuity CLI.  

```bash
curl -sSL -o kargo "https://dl.akuity.io/kargo-cli/$(curl -sL https://dl.akuity.io/kargo-cli/unstable.txt)/darwin/$(uname -m)/kargo"
````
Once implemented I'm more than happy to create a separate workflow for nightly builds if desired.  The two GitHub Secrets in this PR have already been added to the repo.  Documentation will follow after testing.