### PR TITLE
feat(promo): support long-lived promotions and improve reactiveness

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -157,6 +157,7 @@ func newControllerCommand() *cobra.Command {
 			}
 
 			if err := promotions.SetupReconcilerWithManager(
+				ctx,
 				kargoMgr,
 				appMgr,
 				credentialsDB,

--- a/internal/cli/stage/promote.go
+++ b/internal/cli/stage/promote.go
@@ -56,7 +56,7 @@ func newPromoteCommand(opt *option.Option) *cobra.Command {
 			}
 			if pointer.StringDeref(opt.PrintFlags.OutputFormat, "") == "" {
 				fmt.Fprintf(opt.IOStreams.Out,
-					"Promotion Created: %q", res.Msg.GetPromotion().GetMetadata().GetName())
+					"Promotion Created: %q\n", res.Msg.GetPromotion().GetMetadata().GetName())
 				return nil
 			}
 			printer, err := opt.PrintFlags.ToPrinter()

--- a/internal/controller/promotions/promoqueues.go
+++ b/internal/controller/promotions/promoqueues.go
@@ -1,0 +1,156 @@
+package promotions
+
+import (
+	"context"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/runtime"
+	"github.com/akuity/kargo/internal/logging"
+)
+
+// promoQueues is a data structure to hold priority queues of all Stages
+// as well as the "active" promotion for each stage
+type promoQueues struct {
+	// activePromoByStage holds the active promotion for a given stage (if any)
+	activePromoByStage map[types.NamespacedName]string
+	// pendingPromoQueuesByStage holds a priority queue of promotions, per Stage. We allow one
+	// promotion to run at a time, ordered by creationTimestamp.
+	pendingPromoQueuesByStage map[types.NamespacedName]runtime.PriorityQueue
+	// promoQueuesByStageMu protects access to the above maps
+	promoQueuesByStageMu sync.RWMutex
+}
+
+func newPriorityQueue() runtime.PriorityQueue {
+	// We can safely ignore errors here because the only error that can happen
+	// involves initializing the queue with a nil priority function, which we
+	// know we aren't doing.
+	pq, _ := runtime.NewPriorityQueue(func(left, right client.Object) bool {
+		if left.GetCreationTimestamp().Time.Equal(
+			right.GetCreationTimestamp().Time,
+		) {
+			return left.GetName() < right.GetName()
+		}
+		return left.GetCreationTimestamp().Time.
+			Before(right.GetCreationTimestamp().Time)
+	})
+	return pq
+}
+
+// initializeQueues adds the promotion list to relevant priority queues.
+// This is intended to be invoked ONCE and the caller MUST ensure that.
+func (pqs *promoQueues) initializeQueues(ctx context.Context, promos kargoapi.PromotionList) {
+	pqs.promoQueuesByStageMu.Lock()
+	defer pqs.promoQueuesByStageMu.Unlock()
+	logger := logging.LoggerFromContext(ctx)
+	for _, promo := range promos.Items {
+		promo := promo // This is to sidestep implicit memory aliasing in this for loop
+		if promo.Status.Phase.IsTerminal() || promo.Spec == nil {
+			continue
+		}
+		stage := types.NamespacedName{
+			Namespace: promo.Namespace,
+			Name:      promo.Spec.Stage,
+		}
+		pq, ok := pqs.pendingPromoQueuesByStage[stage]
+		if !ok {
+			pq = newPriorityQueue()
+			pqs.pendingPromoQueuesByStage[stage] = pq
+		}
+		if promo.Status.Phase == kargoapi.PromotionPhaseRunning {
+			if pqs.activePromoByStage[stage] == "" {
+				pqs.activePromoByStage[stage] = promo.Name
+			}
+			continue
+		}
+		pq.Push(&promo)
+		logger.WithFields(log.Fields{
+			"promotion": promo.Name,
+			"namespace": promo.Namespace,
+			"stage":     promo.Spec.Stage,
+			"phase":     promo.Status.Phase,
+		}).Debug("pushed Promotion onto Stage-specific Promotion queue")
+	}
+	if logger.Logger.IsLevelEnabled(log.DebugLevel) {
+		for stage, pq := range pqs.pendingPromoQueuesByStage {
+			logger.WithFields(log.Fields{
+				"stage":     stage.Name,
+				"namespace": stage.Namespace,
+				"depth":     pq.Depth(),
+			}).Debug("Stage-specific Promotion queue initialized")
+		}
+	}
+}
+
+// tryActivate tries to mark the given Pending promotion as the active one so it can reconcile.
+// Returns true if the promo is already active or became active as a result of this call.
+// Returns false if it should not reconcile (another promo is active, or next in line).
+func (pqs *promoQueues) tryActivate(ctx context.Context, promo *kargoapi.Promotion) bool {
+	if promo == nil || promo.Spec == nil {
+		return false
+	}
+	stageKey := types.NamespacedName{
+		Namespace: promo.Namespace,
+		Name:      promo.Spec.Stage,
+	}
+	logger := logging.LoggerFromContext(ctx)
+
+	pqs.promoQueuesByStageMu.Lock()
+	defer pqs.promoQueuesByStageMu.Unlock()
+
+	pq, ok := pqs.pendingPromoQueuesByStage[stageKey]
+	if !ok {
+		// PriorityQueue for the stage has not been been initialized
+		pq = newPriorityQueue()
+		pqs.pendingPromoQueuesByStage[stageKey] = pq
+	}
+
+	// Push this promo to the queue in case it doesn't exist in the queue. Note that we
+	// deduplicate pushes on the same object, so this is safe to call repeatedly
+	if pq.Push(promo) {
+		logger.Debug("promo added to priority queue")
+	}
+
+	if activePromoName := pqs.activePromoByStage[stageKey]; activePromoName != "" {
+		// There is already an active promo. It's either this promo or someone else.
+		return activePromoName == promo.Name
+	}
+
+	// If we get here, the Stage does not have any Promotions Running against it.
+	// Now check if it this promo is the one that should run next.
+	first := pq.Peek()
+	if first == nil {
+		// This promo exists but nothing exists in the PriorityQueue. This should not happen.
+		// But since there appears to be no other promos, allow this one to become the active one.
+		pqs.activePromoByStage[stageKey] = promo.Name
+		logger.Debug("activated promo (empty queue)")
+		return true
+	}
+	if first.GetNamespace() == promo.Namespace && first.GetName() == promo.Name {
+		// This promo is the first in the queue. Mark it as active and pop it off the pending queue.
+		popped := pq.Pop()
+		pqs.activePromoByStage[stageKey] = popped.GetName()
+		logger.Debug("activated promo")
+		return true
+	}
+	return false
+}
+
+// deactivate removes the active entry for the given stage key.
+// This should only be called after the active promotion has become terminal.
+func (pqs *promoQueues) deactivate(ctx context.Context, stageKey types.NamespacedName, promoName string) {
+	pqs.promoQueuesByStageMu.RLock()
+	defer pqs.promoQueuesByStageMu.RUnlock()
+	if pqs.activePromoByStage[stageKey] == promoName {
+		logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
+			"namespace": stageKey.Namespace,
+			"promotion": promoName,
+		})
+		delete(pqs.activePromoByStage, stageKey)
+		logger.Debug("deactivated promo")
+	}
+}

--- a/internal/controller/promotions/promoqueues_test.go
+++ b/internal/controller/promotions/promoqueues_test.go
@@ -1,0 +1,178 @@
+package promotions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/akuity/kargo/api/v1alpha1"
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/runtime"
+)
+
+var (
+	now    = metav1.Now()
+	before = metav1.Time{Time: now.Add(time.Second * -1)}
+	after  = metav1.Time{Time: now.Add(time.Second)}
+
+	fooStageKey = types.NamespacedName{Namespace: testNamespace, Name: "foo"}
+	barStageKey = types.NamespacedName{Namespace: testNamespace, Name: "bar"}
+
+	testNamespace = "default"
+	testPromos    = v1alpha1.PromotionList{
+		Items: []v1alpha1.Promotion{
+			// foo stage. two have same creation timestamp but different names
+			*newPromo(testNamespace, "d", "foo", "", after),
+			*newPromo(testNamespace, "b", "foo", "", now),
+			*newPromo(testNamespace, "c", "foo", "", now),
+			*newPromo(testNamespace, "a", "foo", "", before),
+			// bar stage. two are Running (possibly because of bad bookkeeping).
+			// one needs to be deduplicated. one promo is invalid
+			*newPromo(testNamespace, "x", "bar", "", before),
+			*newPromo(testNamespace, "x", "bar", "", before),
+			*newPromo(testNamespace, "y", "bar", v1alpha1.PromotionPhaseRunning, now),
+			*newPromo(testNamespace, "z", "bar", "", after),
+			kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: now,
+					Name:              "w",
+					Namespace:         testNamespace,
+				},
+			},
+		},
+	}
+)
+
+func newPromo(namespace, name, stage string,
+	phase v1alpha1.PromotionPhase,
+	creationTimestamp metav1.Time,
+) *kargoapi.Promotion {
+	return &kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: creationTimestamp,
+			Name:              name,
+			Namespace:         namespace,
+		},
+		Spec: &v1alpha1.PromotionSpec{
+			Stage: stage,
+		},
+		Status: v1alpha1.PromotionStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestInitializeQueues(t *testing.T) {
+	pqs := promoQueues{
+		activePromoByStage:        map[types.NamespacedName]string{},
+		pendingPromoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
+	}
+	pqs.initializeQueues(context.Background(), testPromos)
+
+	// foo stage checks
+	require.Equal(t, "", pqs.activePromoByStage[fooStageKey])
+	require.Equal(t, 4, pqs.pendingPromoQueuesByStage[fooStageKey].Depth())
+	require.Equal(t, "a", pqs.pendingPromoQueuesByStage[fooStageKey].Pop().GetName())
+	require.Equal(t, "b", pqs.pendingPromoQueuesByStage[fooStageKey].Pop().GetName())
+	require.Equal(t, "c", pqs.pendingPromoQueuesByStage[fooStageKey].Pop().GetName())
+	require.Equal(t, "d", pqs.pendingPromoQueuesByStage[fooStageKey].Pop().GetName())
+	require.Nil(t, pqs.pendingPromoQueuesByStage[fooStageKey].Pop())
+
+	// bar stage checks
+	require.Equal(t, "y", pqs.activePromoByStage[barStageKey])
+	// We expect 2 instead of 4 (one was deduped, one went to activePromoByStage)
+	require.Equal(t, 2, pqs.pendingPromoQueuesByStage[barStageKey].Depth())
+	require.Equal(t, "x", pqs.pendingPromoQueuesByStage[barStageKey].Pop().GetName())
+	require.Equal(t, "z", pqs.pendingPromoQueuesByStage[barStageKey].Pop().GetName())
+	require.Nil(t, pqs.pendingPromoQueuesByStage[barStageKey].Pop())
+}
+
+func TestNewPromotionsQueue(t *testing.T) {
+	// runtime.PriorityQueue is already tested pretty well, so what we mainly
+	// want to assert here is that our function for establishing relative priority
+	// is correct.
+	pq := newPriorityQueue()
+
+	// The last added should be the first out if our priority logic is correct
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		added := pq.Push(&kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%d", i),
+				CreationTimestamp: metav1.NewTime(
+					now.Add(-1 * time.Duration(i) * time.Minute),
+				),
+			},
+		})
+		require.True(t, added)
+	}
+
+	// Verify objects are prioritized by creation time
+	var lastTime *time.Time
+	for {
+		object := pq.Pop()
+		if object == nil {
+			break
+		}
+		promo := object.(*kargoapi.Promotion) // nolint: forcetypeassert
+		if lastTime != nil {
+			require.Greater(t, promo.CreationTimestamp.Time, *lastTime)
+		}
+		lastTime = &promo.CreationTimestamp.Time
+	}
+}
+
+func TestTryActivate(t *testing.T) {
+	pqs := promoQueues{
+		activePromoByStage:        map[types.NamespacedName]string{},
+		pendingPromoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
+	}
+	pqs.initializeQueues(context.Background(), testPromos)
+
+	ctx := context.TODO()
+
+	// 1. nil promotion
+	assert.False(t, pqs.tryActivate(ctx, nil))
+
+	// 2. invalid promotion
+	assert.False(t, pqs.tryActivate(ctx, &kargoapi.Promotion{}))
+
+	// 3. Try to activate promos not first in queue
+	for _, promoName := range []string{"b", "c", "d"} {
+		assert.False(t, pqs.tryActivate(ctx, newPromo(testNamespace, promoName, "foo", "", now)))
+		assert.Equal(t, "", pqs.activePromoByStage[fooStageKey])
+		assert.Equal(t, 4, pqs.pendingPromoQueuesByStage[fooStageKey].Depth())
+	}
+
+	// 4. Now try to activate highest priority. this should succeed
+	assert.True(t, pqs.tryActivate(ctx, newPromo(testNamespace, "a", "foo", "", now)))
+	assert.Equal(t, "a", pqs.activePromoByStage[fooStageKey])
+	assert.Equal(t, 3, pqs.pendingPromoQueuesByStage[fooStageKey].Depth())
+}
+
+func TestDeactivate(t *testing.T) {
+	pqs := promoQueues{
+		activePromoByStage:        map[types.NamespacedName]string{},
+		pendingPromoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
+	}
+	pqs.initializeQueues(context.Background(), testPromos)
+
+	ctx := context.TODO()
+
+	// Test setup
+	assert.True(t, pqs.tryActivate(ctx, newPromo(testNamespace, "a", "foo", "", now)))
+
+	// 1. deactivate something not even active. it should be a no-op
+	pqs.deactivate(ctx, fooStageKey, "not-active")
+	assert.Equal(t, "a", pqs.activePromoByStage[fooStageKey])
+
+	// 2. Deactivate the active one
+	pqs.deactivate(ctx, fooStageKey, "a")
+	assert.Equal(t, "", pqs.activePromoByStage[fooStageKey])
+}

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -13,13 +12,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	render "github.com/akuity/kargo-render"
+	"github.com/akuity/kargo/api/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller"
 	"github.com/akuity/kargo/internal/controller/promotion"
 	"github.com/akuity/kargo/internal/controller/runtime"
 	"github.com/akuity/kargo/internal/credentials"
+	"github.com/akuity/kargo/internal/kargo"
 	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/logging"
 )
@@ -29,9 +31,8 @@ type reconciler struct {
 	kargoClient     client.Client
 	promoMechanisms promotion.Mechanism
 
-	promoQueuesByStage   map[types.NamespacedName]runtime.PriorityQueue
-	promoQueuesByStageMu sync.Mutex
-	initializeOnce       sync.Once
+	pqs            *promoQueues
+	initializeOnce sync.Once
 
 	// The following behaviors are overridable for testing purposes:
 
@@ -41,6 +42,7 @@ type reconciler struct {
 // SetupReconcilerWithManager initializes a reconciler for Promotion resources
 // and registers it with the provided Manager.
 func SetupReconcilerWithManager(
+	ctx context.Context,
 	kargoMgr manager.Manager,
 	argoMgr manager.Manager,
 	credentialsDB credentials.Database,
@@ -53,22 +55,42 @@ func SetupReconcilerWithManager(
 		return errors.Wrap(err, "error creating shard selector predicate")
 	}
 
-	return errors.Wrap(
-		ctrl.NewControllerManagedBy(kargoMgr).
-			For(&kargoapi.Promotion{}).
-			WithEventFilter(predicate.GenerationChangedPredicate{}).
-			WithEventFilter(shardPredicate).
-			WithOptions(controller.CommonOptions()).
-			Complete(
-				newReconciler(
-					kargoMgr.GetClient(),
-					argoMgr.GetClient(),
-					credentialsDB,
-					renderService,
-				),
-			),
-		"error registering Promotion reconciler",
+	reconciler := newReconciler(
+		kargoMgr.GetClient(),
+		argoMgr.GetClient(),
+		credentialsDB,
+		renderService,
 	)
+
+	changePredicate := predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.AnnotationChangedPredicate{},
+	)
+
+	c, err := ctrl.NewControllerManagedBy(kargoMgr).
+		For(&kargoapi.Promotion{}).
+		WithEventFilter(changePredicate).
+		WithEventFilter(shardPredicate).
+		WithOptions(controller.CommonOptions()).
+		Build(reconciler)
+	if err != nil {
+		return errors.Wrap(err, "error building Promotion reconciler")
+	}
+
+	logger := logging.LoggerFromContext(ctx)
+	// Watch Promotions that complete and enqueue the next highest promotion key
+	priorityQueueHandler := &EnqueueHighestPriorityPromotionHandler{
+		ctx:         ctx,
+		logger:      logger,
+		kargoClient: reconciler.kargoClient,
+		pqs:         reconciler.pqs,
+	}
+	promoWentTerminal := kargo.NewPromoWentTerminalPredicate(logger)
+	if err := c.Watch(&source.Kind{Type: &kargoapi.Promotion{}}, priorityQueueHandler, promoWentTerminal); err != nil {
+		return errors.Wrap(err, "unable to watch Promotions")
+	}
+
+	return nil
 }
 
 func newReconciler(
@@ -77,9 +99,13 @@ func newReconciler(
 	credentialsDB credentials.Database,
 	renderService render.Service,
 ) *reconciler {
+	pqs := promoQueues{
+		activePromoByStage:        map[types.NamespacedName]string{},
+		pendingPromoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
+	}
 	r := &reconciler{
-		kargoClient:        kargoClient,
-		promoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
+		kargoClient: kargoClient,
+		pqs:         &pqs,
 		promoMechanisms: promotion.NewMechanisms(
 			argoClient,
 			credentialsDB,
@@ -90,29 +116,12 @@ func newReconciler(
 	return r
 }
 
-func newPromotionsQueue() runtime.PriorityQueue {
-	// We can safely ignore errors here because the only error that can happen
-	// involves initializing the queue with a nil priority function, which we
-	// know we aren't doing.
-	pq, _ := runtime.NewPriorityQueue(func(left, right client.Object) bool {
-		return left.GetCreationTimestamp().Time.
-			Before(right.GetCreationTimestamp().Time)
-	})
-	return pq
-}
-
 // Reconcile is part of the main Kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *reconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
-	// We count all of Reconcile() as a critical section of code to ensure we
-	// don't start reconciling a second Promotion before lazy initialization
-	// completes upon reconciliation of the FIRST promotion.
-	r.promoQueuesByStageMu.Lock()
-	defer r.promoQueuesByStageMu.Unlock()
-
 	result := ctrl.Result{
 		// Note: If there is a failure, controller runtime ignores this and uses
 		// progressive backoff instead. So this value only prevents requeueing
@@ -127,14 +136,15 @@ func (r *reconciler) Reconcile(
 	// to list Promotions prior to that point.
 	var err error
 	r.initializeOnce.Do(func() {
-		if err = r.initializeQueues(ctx); err == nil {
+		promos := kargoapi.PromotionList{}
+		if err = r.kargoClient.List(ctx, &promos); err != nil {
+			err = errors.Wrap(err, "error listing promotions")
+		} else {
+			r.pqs.initializeQueues(ctx, promos)
 			logger.Debug(
-				"initialized Stage-specific Promotion queues from list of " +
-					"existing Promotions",
+				"initialized Stage-specific Promotion queues from list of existing Promotions",
 			)
 		}
-		// TODO: Do not hardcode this interval
-		go r.serializedSync(ctx, 10*time.Second)
 	})
 	if err != nil {
 		return result, errors.Wrap(err, "error initializing Promotion queues")
@@ -158,205 +168,77 @@ func (r *reconciler) Reconcile(
 		return result, nil
 	}
 
-	newStatus := r.syncPromo(ctx, promo)
+	if promo.Status.Phase == v1alpha1.PromotionPhaseRunning {
+		// anything we've already marked Running, we allow it to continue to reconcile
+	} else if promo.Status.Phase.IsTerminal() {
+		// if promo is already finished, nothing to do
+		return result, nil
+	} else {
+		// promo is Pending. Try to activate it.
+		if !r.pqs.tryActivate(ctx, promo) {
+			// It wasn't our turn. Mark this promo as pending (if it wasn't already)
+			if promo.Status.Phase != v1alpha1.PromotionPhasePending {
+				err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+					status.Phase = v1alpha1.PromotionPhasePending
+				})
+				return result, err
+			}
+			return result, nil
+		}
+	}
 
-	updateErr := kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
-		*status = newStatus
+	logger = logger.WithFields(log.Fields{
+		"stage":   promo.Spec.Stage,
+		"freight": promo.Spec.Freight,
 	})
-	if updateErr != nil {
-		logger.Errorf("error updating Promotion status: %s", updateErr)
+	logger.Debug("executing Promotion")
+
+	// Update promo status as Running to give visibility in UI
+	if promo.Status.Phase != v1alpha1.PromotionPhaseRunning {
+		if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+			status.Phase = v1alpha1.PromotionPhaseRunning
+		}); err != nil {
+			return result, err
+		}
 	}
 
-	// If we had no error, but couldn't update, then we DO have an error. But we
-	// do it this way so that a failure to update is never counted as THE failure
-	// when something else more serious occurred first.
-	if err == nil {
-		err = updateErr
+	promoCtx := logging.ContextWithLogger(ctx, logger)
+
+	phase := kargoapi.PromotionPhaseSucceeded
+	phaseError := ""
+
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				logger.Errorf("Promotion panic: %v", err)
+				phase = kargoapi.PromotionPhaseErrored
+				phaseError = fmt.Sprintf("%v", err)
+			}
+		}()
+		if err = r.promoteFn(
+			promoCtx,
+			*promo,
+		); err != nil {
+			phase = kargoapi.PromotionPhaseErrored
+			phaseError = err.Error()
+			logger.Errorf("error executing Promotion: %s", err)
+		}
+	}()
+
+	if phase.IsTerminal() {
+		logger.Debugf("promotion %s", phase)
 	}
 
-	// Controller runtime automatically gives us a progressive backoff if err is
-	// not nil
+	err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+		status.Phase = phase
+		status.Error = phaseError
+	})
+	if err != nil {
+		logger.Errorf("error updating Promotion status: %s", err)
+	}
+
+	// Controller runtime automatically gives us a progressive backoff if err is not nil
 	return result, err
-}
-
-// initializeQueues lists all Promotions and adds them to relevant priority
-// queues. This is intended to be invoked ONCE and the caller MUST ensure that.
-// It is also assumed that the caller has already obtained a lock on
-// promoQueuesByStageMu.
-func (r *reconciler) initializeQueues(ctx context.Context) error {
-	promos := kargoapi.PromotionList{}
-	if err := r.kargoClient.List(ctx, &promos); err != nil {
-		return errors.Wrap(err, "error listing promotions")
-	}
-	logger := logging.LoggerFromContext(ctx)
-	for _, p := range promos.Items {
-		promo := p // This is to sidestep implicit memory aliasing in this for loop
-		if promo.Status.Phase.IsTerminal() {
-			continue
-		}
-		if promo.Status.Phase == "" {
-			if err := kubeclient.PatchStatus(ctx, r.kargoClient, &promo, func(status *kargoapi.PromotionStatus) {
-				status.Phase = kargoapi.PromotionPhasePending
-			}); err != nil {
-				return errors.Wrapf(
-					err,
-					"error updating status of Promotion %q in namespace %q",
-					promo.Name,
-					promo.Namespace,
-				)
-			}
-		}
-		stage := types.NamespacedName{
-			Namespace: promo.Namespace,
-			Name:      promo.Spec.Stage,
-		}
-		pq, ok := r.promoQueuesByStage[stage]
-		if !ok {
-			pq = newPromotionsQueue()
-			r.promoQueuesByStage[stage] = pq
-		}
-		// The only error that can occur here happens when you push a nil and we
-		// know we're not doing that.
-		pq.Push(&promo) // nolint: errcheck
-		logger.WithFields(log.Fields{
-			"promotion": promo.Name,
-			"namespace": promo.Namespace,
-			"stage":     promo.Spec.Stage,
-			"phase":     promo.Status.Phase,
-		}).Debug("pushed Promotion onto Stage-specific Promotion queue")
-	}
-	if logger.Logger.IsLevelEnabled(log.DebugLevel) {
-		for stage, pq := range r.promoQueuesByStage {
-			logger.WithFields(log.Fields{
-				"stage":     stage.Name,
-				"namespace": stage.Namespace,
-				"depth":     pq.Depth(),
-			}).Debug("Stage-specific Promotion queue initialized")
-		}
-	}
-	return nil
-}
-
-// syncPromo enqueues Promotion requests to a Stage-specific priority queue. This
-// functions assumes the caller has obtained a lock on promoQueuesByStageMu.
-func (r *reconciler) syncPromo(
-	ctx context.Context,
-	promo *kargoapi.Promotion,
-) kargoapi.PromotionStatus {
-	status := *promo.Status.DeepCopy()
-
-	// Only deal with brand new Promotions
-	if promo.Status.Phase != "" {
-		return status
-	}
-
-	stage := types.NamespacedName{
-		Namespace: promo.Namespace,
-		Name:      promo.Spec.Stage,
-	}
-
-	pq, ok := r.promoQueuesByStage[stage]
-	if !ok {
-		pq = newPromotionsQueue()
-		r.promoQueuesByStage[stage] = pq
-	}
-
-	status.Phase = kargoapi.PromotionPhasePending
-
-	// Ignore any errors from this operation. Errors can only occur when you
-	// try to push a nil onto the queue and we know we're not doing that.
-	pq.Push(promo) // nolint: errcheck
-
-	logging.LoggerFromContext(ctx).WithField("depth", pq.Depth()).
-		Infof("pushed Promotion %q to Queue for Stage %q in namespace %q ",
-			promo.Name,
-			promo.Spec.Stage,
-			promo.Namespace,
-		)
-
-	return status
-}
-
-func (r *reconciler) serializedSync(
-	ctx context.Context,
-	interval time.Duration,
-) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return
-		}
-		for _, pq := range r.promoQueuesByStage {
-			if popped := pq.Pop(); popped != nil {
-				promo := popped.(*kargoapi.Promotion) // nolint: forcetypeassert
-
-				logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
-					"promotion": promo.Name,
-					"namespace": promo.Namespace,
-				})
-
-				// Refresh promo instead of working with something stale
-				var err error
-				if promo, err = kargoapi.GetPromotion(
-					ctx,
-					r.kargoClient,
-					types.NamespacedName{
-						Namespace: promo.Namespace,
-						Name:      promo.Name,
-					},
-				); err != nil {
-					logger.Error("error finding Promotion")
-					continue
-				}
-				if promo == nil || promo.Status.Phase != kargoapi.PromotionPhasePending {
-					continue
-				}
-
-				logger = logger.WithFields(log.Fields{
-					"stage":   promo.Spec.Stage,
-					"freight": promo.Spec.Freight,
-				})
-				logger.Debug("executing Promotion")
-
-				promoCtx := logging.ContextWithLogger(ctx, logger)
-
-				phase := kargoapi.PromotionPhaseSucceeded
-				phaseError := ""
-
-				func() {
-					defer func() {
-						if err := recover(); err != nil {
-							logger.Errorf("Promotion panic: %v", err)
-							phase = kargoapi.PromotionPhaseErrored
-							phaseError = fmt.Sprintf("%v", err)
-						}
-					}()
-					if err = r.promoteFn(
-						promoCtx,
-						*promo,
-					); err != nil {
-						phase = kargoapi.PromotionPhaseErrored
-						phaseError = err.Error()
-						logger.Errorf("error executing Promotion: %s", err)
-					}
-				}()
-
-				if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
-					status.Phase = phase
-					status.Error = phaseError
-				}); err != nil {
-					logger.Errorf("error updating Promotion status: %s", err)
-				}
-
-				if promo.Status.Phase == kargoapi.PromotionPhaseSucceeded && err == nil {
-					logger.Debug("Promotion succeeded")
-				}
-			}
-		}
-	}
 }
 
 func (r *reconciler) promote(

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -2,19 +2,19 @@ package promotions
 
 import (
 	"context"
+	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	render "github.com/akuity/kargo-render"
 	"github.com/akuity/kargo/api/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
-	"github.com/akuity/kargo/internal/controller/runtime"
 	"github.com/akuity/kargo/internal/credentials"
 )
 
@@ -27,232 +27,161 @@ func TestNewPromotionReconciler(t *testing.T) {
 		render.NewService(nil),
 	)
 	require.NotNil(t, r.kargoClient)
-	require.NotNil(t, r.promoQueuesByStage)
+	require.NotNil(t, r.pqs.pendingPromoQueuesByStage)
 	require.NotNil(t, r.promoteFn)
 }
 
-func TestInitializeQueues(t *testing.T) {
+func newFakeReconciler(t *testing.T, objects ...client.Object) *reconciler {
 	scheme := k8sruntime.NewScheme()
 	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
-	r := reconciler{
-		kargoClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			&kargoapi.Promotion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-promotion",
-					Namespace: "fake-namespace",
-				},
-				Spec: &kargoapi.PromotionSpec{
-					Stage: "fake-stage",
-				},
-			},
-		).Build(),
-		promoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{},
-	}
-	err := r.initializeQueues(context.Background())
-	require.NoError(t, err)
+	kargoClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	kubeClient := fake.NewClientBuilder().Build()
+	return newReconciler(
+		kargoClient,
+		kubeClient,
+		&credentials.FakeDB{},
+		render.NewService(nil),
+	)
 }
 
-func TestNewPromotionsQueue(t *testing.T) {
-	// runtime.PriorityQueue is already tested pretty well, so what we mainly
-	// want to assert here is that our function for establishing relative priority
-	// is correct.
-	pq := newPromotionsQueue()
-
-	// The last added should be the first out if our priority logic is correct
-	now := time.Now()
-	for i := 0; i < 100; i++ {
-		err := pq.Push(&kargoapi.Promotion{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.NewTime(
-					now.Add(-1 * time.Duration(i) * time.Minute),
-				),
-			},
-		})
-		require.NoError(t, err)
-	}
-
-	// Verify objects are prioritized by creation time
-	var lastTime *time.Time
-	for {
-		object := pq.Pop()
-		if object == nil {
-			break
-		}
-		promo := object.(*kargoapi.Promotion) // nolint: forcetypeassert
-		if lastTime != nil {
-			require.Greater(t, promo.CreationTimestamp.Time, *lastTime)
-		}
-		lastTime = &promo.CreationTimestamp.Time
-	}
-}
-
-func TestSyncPromo(t *testing.T) {
+func TestReconcile(t *testing.T) {
 	testCases := []struct {
-		name       string
-		promo      *kargoapi.Promotion
-		pqs        map[types.NamespacedName]runtime.PriorityQueue
-		assertions func(
-			kargoapi.PromotionStatus,
-			map[types.NamespacedName]runtime.PriorityQueue,
-		)
+		name                  string
+		promos                []client.Object
+		promoteFn             func(context.Context, v1alpha1.Promotion) error
+		promoToReconcile      *types.NamespacedName // if nil, uses the first of the promos
+		expectPromoteFnCalled bool
+		expectedPhase         kargoapi.PromotionPhase
 	}{
 		{
-			// Existing promotions are listed at startup. We're only interested in
-			// new ones. They're identifiable by lack of a phase.
-			name: "existing promotion",
-			promo: &kargoapi.Promotion{
-				Status: kargoapi.PromotionStatus{
-					Phase: kargoapi.PromotionPhasePending,
-				},
-			},
-			assertions: func(
-				status kargoapi.PromotionStatus,
-				pqs map[types.NamespacedName]runtime.PriorityQueue,
-			) {
-				require.Equal(
-					t,
-					kargoapi.PromotionStatus{
-						Phase: kargoapi.PromotionPhasePending, // Status should be unchanged
-					},
-					status,
-				)
-				require.Empty(t, pqs)
+			name:                  "normal reconcile",
+			expectPromoteFnCalled: true,
+			expectedPhase:         kargoapi.PromotionPhaseSucceeded,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo", "fake-stage", kargoapi.PromotionPhasePending, now),
 			},
 		},
-
 		{
-			name: "promotion queue already exists",
-			promo: &kargoapi.Promotion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-name",
-					Namespace: "fake-namespace",
-				},
-				Spec: &kargoapi.PromotionSpec{
-					Stage: "fake-stage",
-				},
-			},
-			pqs: map[types.NamespacedName]runtime.PriorityQueue{
-				{Namespace: "fake-namespace", Name: "fake-stage"}: newPromotionsQueue(),
-			},
-			assertions: func(
-				status kargoapi.PromotionStatus,
-				pqs map[types.NamespacedName]runtime.PriorityQueue,
-			) {
-				require.Equal( // Status should have phase assigned
-					t,
-					kargoapi.PromotionStatus{
-						Phase: kargoapi.PromotionPhasePending,
-					},
-					status,
-				)
-				pq, ok := pqs[types.NamespacedName{
-					Namespace: "fake-namespace",
-					Name:      "fake-stage",
-				}]
-				require.True(t, ok)
-				require.Equal(t, 1, pq.Depth())
+			name:                  "promo doesn't exist",
+			promoToReconcile:      &types.NamespacedName{Namespace: "fake-namespace", Name: "fake-promo"},
+			expectPromoteFnCalled: false,
+		},
+		{
+			name:                  "promo already completed",
+			expectPromoteFnCalled: false,
+			expectedPhase:         kargoapi.PromotionPhaseErrored,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo", "fake-stage", kargoapi.PromotionPhaseErrored, now),
 			},
 		},
-
 		{
-			name: "promotion queue does not already exists",
-			promo: &kargoapi.Promotion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-name",
-					Namespace: "fake-namespace",
-				},
-				Spec: &kargoapi.PromotionSpec{
-					Stage: "fake-stage",
-				},
+			name:                  "promo already running",
+			expectPromoteFnCalled: true,
+			expectedPhase:         kargoapi.PromotionPhaseSucceeded,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo", "fake-stage", kargoapi.PromotionPhaseRunning, now),
 			},
-			pqs: map[types.NamespacedName]runtime.PriorityQueue{},
-			assertions: func(
-				status kargoapi.PromotionStatus,
-				pqs map[types.NamespacedName]runtime.PriorityQueue,
-			) {
-				require.Equal( // Status should have phase assigned
-					t,
-					kargoapi.PromotionStatus{
-						Phase: kargoapi.PromotionPhasePending,
-					},
-					status,
-				)
-				pq, ok := pqs[types.NamespacedName{
-					Namespace: "fake-namespace",
-					Name:      "fake-stage",
-				}]
-				require.True(t, ok)
-				require.Equal(t, 1, pq.Depth())
+		},
+		{
+			name:                  "promo does not have highest priority",
+			expectPromoteFnCalled: false,
+			promoToReconcile:      &types.NamespacedName{Namespace: "fake-namespace", Name: "fake-promo2"},
+			expectedPhase:         kargoapi.PromotionPhasePending,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo1", "fake-stage", kargoapi.PromotionPhasePending, before),
+				newPromo("fake-namespace", "fake-promo2", "fake-stage", "", now), // intentionally empty string phase
+			},
+		},
+		{
+			name:                  "promo has highest priority",
+			expectPromoteFnCalled: true,
+			promoToReconcile:      &types.NamespacedName{Namespace: "fake-namespace", Name: "fake-promo1"},
+			expectedPhase:         kargoapi.PromotionPhaseSucceeded,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo1", "fake-stage", kargoapi.PromotionPhasePending, before),
+				newPromo("fake-namespace", "fake-promo2", "fake-stage", kargoapi.PromotionPhasePending, now),
+			},
+		},
+		{
+			name:                  "promoteFn panics",
+			expectPromoteFnCalled: true,
+			expectedPhase:         kargoapi.PromotionPhaseErrored,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo", "fake-stage", kargoapi.PromotionPhasePending, before),
+			},
+			promoteFn: func(ctx context.Context, p v1alpha1.Promotion) error {
+				panic("expected panic")
+			},
+		},
+		{
+			name:                  "promoteFn errors",
+			expectPromoteFnCalled: true,
+			expectedPhase:         kargoapi.PromotionPhaseErrored,
+			promos: []client.Object{
+				newPromo("fake-namespace", "fake-promo", "fake-stage", kargoapi.PromotionPhasePending, before),
+			},
+			promoteFn: func(ctx context.Context, p v1alpha1.Promotion) error {
+				return errors.New("expected error")
 			},
 		},
 	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			r := reconciler{
-				promoQueuesByStage: testCase.pqs,
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			r := newFakeReconciler(t)
+			for _, p := range tc.promos {
+				err := r.kargoClient.Create(ctx, p)
+				require.NoError(t, err)
 			}
-			status := r.syncPromo(context.Background(), testCase.promo)
-			testCase.assertions(
-				status,
-				r.promoQueuesByStage,
-			)
+			promoteWasCalled := false
+			r.promoteFn = func(ctx context.Context, p v1alpha1.Promotion) error {
+				promoteWasCalled = true
+				if tc.promoteFn != nil {
+					return tc.promoteFn(ctx, p)
+				}
+				return nil
+			}
+			var req ctrl.Request
+			if tc.promoToReconcile != nil {
+				req = ctrl.Request{NamespacedName: *tc.promoToReconcile}
+			} else {
+				req = ctrl.Request{NamespacedName: types.NamespacedName{
+					Namespace: tc.promos[0].GetNamespace(),
+					Name:      tc.promos[0].GetName(),
+				}}
+			}
+
+			_, err := r.Reconcile(ctx, req)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectPromoteFnCalled, promoteWasCalled,
+				"promoteFn called: %t, expected %t", promoteWasCalled, tc.expectPromoteFnCalled)
+
+			if tc.expectedPhase != "" {
+				var updatedPromo kargoapi.Promotion
+				err = r.kargoClient.Get(ctx, req.NamespacedName, &updatedPromo)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedPhase, updatedPromo.Status.Phase)
+			}
 		})
 	}
 }
 
-func TestSerializedSync(t *testing.T) {
-	promo := &kargoapi.Promotion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fake-promo",
-			Namespace: "fake-namespace",
-		},
-		Spec: &kargoapi.PromotionSpec{
-			Stage:   "fake-stage",
-			Freight: "fake-freight",
-		},
-		Status: kargoapi.PromotionStatus{
-			Phase: kargoapi.PromotionPhasePending,
-		},
+// Tests that initalizeQueues is called properly
+func TestReconcileInitializeQueues(t *testing.T) {
+	ctx := context.TODO()
+	promos := []client.Object{
+		newPromo("fake-namespace", "fake-promo1", "fake-stage", kargoapi.PromotionPhasePending, before),
+		newPromo("fake-namespace", "fake-promo2", "fake-stage", kargoapi.PromotionPhasePending, now),
 	}
+	r := newFakeReconciler(t, promos...)
 
-	scheme := k8sruntime.NewScheme()
-	require.NoError(t, kargoapi.SchemeBuilder.AddToScheme(scheme))
-	client := fake.NewClientBuilder().
-		WithScheme(scheme).WithObjects(promo).Build()
+	// reconcile a non-existent promo to trigger initializeQueues
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "does-not-exist", Name: "does-not-exist"}}
 
-	pq := newPromotionsQueue()
-	err := pq.Push(promo)
+	_, err := r.Reconcile(ctx, req)
 	require.NoError(t, err)
 
-	r := reconciler{
-		kargoClient: client,
-		promoQueuesByStage: map[types.NamespacedName]runtime.PriorityQueue{
-			{Namespace: "fake-namespace", Name: "fake-stage"}: pq,
-		},
-		promoteFn: func(context.Context, v1alpha1.Promotion) error {
-			return nil
-		},
-	}
-
-	// Force the infinite loop under test to shut down after 3 seconds. This
-	// should be plenty of time to handle the one Promotion we've given it.
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	r.serializedSync(ctx, time.Second)
-
-	// When we're done, the queue should be empty and the Promotion should be
-	// complete.
-	require.Equal(t, 0, pq.Depth())
-	promo, err = kargoapi.GetPromotion(
-		ctx,
-		client,
-		types.NamespacedName{
-			Namespace: "fake-namespace",
-			Name:      "fake-promo",
-		},
-	)
-	require.NoError(t, err)
-	require.NotNil(t, promo)
-	require.Equal(t, kargoapi.PromotionPhaseSucceeded, promo.Status.Phase)
+	// Verifies queues got set up
+	stageKey := types.NamespacedName{Namespace: "fake-namespace", Name: "fake-stage"}
+	require.Equal(t, 2, r.pqs.pendingPromoQueuesByStage[stageKey].Depth())
 }

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -1,0 +1,139 @@
+package promotions
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// EnqueueHighestPriorityPromotionHandler is an event handler that enqueues the next
+// highest priority Promotion for reconciliation when an active Promotion becomes terminal
+type EnqueueHighestPriorityPromotionHandler struct {
+	logger      *log.Entry
+	ctx         context.Context
+	pqs         *promoQueues
+	kargoClient client.Client
+}
+
+// Create implements EventHandler.
+func (e *EnqueueHighestPriorityPromotionHandler) Create(
+	event.CreateEvent,
+	workqueue.RateLimitingInterface,
+) {
+	// No-op
+}
+
+// Delete implements EventHandler. In case a Running promotion
+// becomes deleted, we should enqueue the next one
+func (e *EnqueueHighestPriorityPromotionHandler) Delete(
+	evt event.DeleteEvent,
+	wq workqueue.RateLimitingInterface,
+) {
+	if promo, ok := evt.Object.(*kargoapi.Promotion); ok {
+		stageKey := types.NamespacedName{
+			Namespace: promo.Namespace,
+			Name:      promo.Spec.Stage,
+		}
+		e.pqs.deactivate(e.ctx, stageKey, promo.Name)
+		e.enqueueNext(stageKey, wq)
+	}
+}
+
+// Generic implements EventHandler.
+func (e *EnqueueHighestPriorityPromotionHandler) Generic(
+	event.GenericEvent,
+	workqueue.RateLimitingInterface,
+) {
+	// No-op
+}
+
+// Update implements EventHandler. This should only be called with
+// a promo that transitioned from non-terminal to terminal.
+func (e *EnqueueHighestPriorityPromotionHandler) Update(
+	evt event.UpdateEvent,
+	wq workqueue.RateLimitingInterface,
+) {
+	if evt.ObjectNew == nil {
+		e.logger.Errorf("Update event has no new object to update: %v", evt)
+		return
+	}
+	promo, ok := evt.ObjectNew.(*kargoapi.Promotion)
+	if !ok {
+		e.logger.Errorf("Failed to convert new Promotion: %v", evt.ObjectNew)
+		return
+	}
+	if promo.Status.Phase.IsTerminal() {
+		stageKey := types.NamespacedName{
+			Namespace: promo.Namespace,
+			Name:      promo.Spec.Stage,
+		}
+		// This promo just went terminal. Deactivate it and enqueue
+		// the next highest priority promo for reconciliation
+		e.pqs.deactivate(e.ctx, stageKey, promo.Name)
+		e.enqueueNext(stageKey, wq)
+	}
+}
+
+// enqueueNext enqueues the next highest priority promotion for reconciliation to the workqueue.
+// Also discards pending promotions in the queue that no longer exist
+func (e *EnqueueHighestPriorityPromotionHandler) enqueueNext(
+	stageKey types.NamespacedName,
+	wq workqueue.RateLimitingInterface,
+) {
+	e.pqs.promoQueuesByStageMu.RLock()
+	defer e.pqs.promoQueuesByStageMu.RUnlock()
+	if e.pqs.activePromoByStage[stageKey] != "" {
+		// there's already an active promotion. don't need to enqueue the next one
+		return
+	}
+	pq, ok := e.pqs.pendingPromoQueuesByStage[stageKey]
+	if !ok {
+		return
+	}
+
+	// NOTE: at first glance, this for loop appears to be expensive to do while holding
+	// the pqs mutex. But it isn't as bad as it looks, since we count on the fact that
+	// GetPromotion calls pull from the informer cache and do not involve an HTTP call.
+	// and in the common case, we only do a single iteration
+	for {
+		first := pq.Peek()
+		if first == nil {
+			// pending queue is empty
+			return
+		}
+		// Check if promo exists, and enqueue it if it does
+		firstKey := types.NamespacedName{Namespace: first.GetNamespace(), Name: first.GetName()}
+		promo, err := kargoapi.GetPromotion(e.ctx, e.kargoClient, firstKey)
+		if err != nil {
+			e.logger.Errorf("Failed to get next highest priority Promotion (%s) for enqueue: %v", firstKey, err)
+			return
+		}
+		if promo == nil {
+			// Found a promotion in the pending queue that no longer exists.
+			// Pop it and loop to the next item in the queue
+			_ = pq.Pop()
+			continue
+		}
+		wq.AddRateLimited(
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: promo.Namespace,
+					Name:      promo.Name,
+				},
+			},
+		)
+		e.logger.WithFields(log.Fields{
+			"promotion": promo.Name,
+			"namespace": promo.Namespace,
+			"stage":     promo.Spec.Stage,
+		}).Debug("enqueued promo")
+		return
+	}
+}

--- a/internal/controller/runtime/queues_test.go
+++ b/internal/controller/runtime/queues_test.go
@@ -30,25 +30,20 @@ func TestPriorityQueue(t *testing.T) {
 			},
 		}
 	}
-	objects[0] = nil // This should be invalid
+	objects[0] = nil // This will be ignored
 
-	_, err = NewPriorityQueue(
+	pq, err := NewPriorityQueue(
 		func(client.Object, client.Object) bool {
 			return true // Implementation doesn't matter for this test
 		},
 		objects...,
 	)
-	require.Error(t, err)
-	require.Equal(
-		t,
-		"the priority queue was initialized with at least one nil client.Object "+
-			"at position 0",
-		err.Error(),
-	)
+	require.NoError(t, err)
+	require.Equal(t, 49, pq.Depth()) // make sure the nil object was not added
 
 	objects = objects[1:] // Remove the problematic 0 element
 
-	pq, err := NewPriorityQueue(
+	pq, err = NewPriorityQueue(
 		func(lhs client.Object, rhs client.Object) bool {
 			// lhs has higher priority than rhs if lexically less than rhs
 			return lhs.GetName() < rhs.GetName()
@@ -59,14 +54,14 @@ func TestPriorityQueue(t *testing.T) {
 
 	// Now push a bunch...
 	for i := 0; i < 50; i++ {
-		err = pq.Push(
+		added := pq.Push(
 			&kargoapi.Promotion{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randomNamer.NameSep("-"),
 				},
 			},
 		)
-		require.NoError(t, err)
+		require.True(t, added)
 	}
 
 	// Now pop until we get a nil
@@ -87,4 +82,76 @@ func TestPriorityQueue(t *testing.T) {
 		}
 		lastName = object.GetName()
 	}
+}
+
+func TestPeek(t *testing.T) {
+	objects := []client.Object{
+		&kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bbb",
+				Namespace: "default",
+			},
+		},
+		&kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aaa",
+				Namespace: "default",
+			},
+		},
+		&kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ccc",
+				Namespace: "default",
+			},
+		},
+	}
+	pq, err := NewPriorityQueue(
+		func(lhs client.Object, rhs client.Object) bool {
+			return lhs.GetName() < rhs.GetName()
+		},
+		objects...,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, pq.Depth())
+
+	require.Equal(t, "aaa", pq.Peek().GetName())
+	require.Equal(t, "aaa", pq.Peek().GetName())
+	require.Equal(t, "aaa", pq.Pop().GetName())
+	require.Equal(t, 2, pq.Depth())
+
+	require.Equal(t, "bbb", pq.Peek().GetName())
+	require.Equal(t, "bbb", pq.Pop().GetName())
+	require.Equal(t, 1, pq.Depth())
+
+	require.Equal(t, "ccc", pq.Peek().GetName())
+	require.Equal(t, "ccc", pq.Pop().GetName())
+	require.Equal(t, 0, pq.Depth())
+	require.Nil(t, pq.Pop())
+}
+
+// TestDuplicatePush verifies when we push the same object, second one is a no-op
+func TestDuplicatePush(t *testing.T) {
+	obj1 := &kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+	obj2 := obj1.DeepCopy()
+	pq, err := NewPriorityQueue(
+		func(lhs client.Object, rhs client.Object) bool {
+			return lhs.GetName() < rhs.GetName()
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, pq.Depth())
+	require.True(t, pq.Push(obj1))
+	require.Equal(t, 1, pq.Depth())
+	require.False(t, pq.Push(obj2))
+	require.Equal(t, 1, pq.Depth())
+
+	require.Equal(t, "foo", pq.Pop().GetName())
+	require.Equal(t, 0, pq.Depth())
+	require.Nil(t, pq.Pop())
 }

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -208,9 +208,7 @@ func SetupReconcilerWithManager(
 	logger := logging.LoggerFromContext(ctx)
 	// Watch Promotions that completed and enqueue owning Stage key
 	promoOwnerHandler := &handler.EnqueueRequestForOwner{OwnerType: &kargoapi.Stage{}, IsController: true}
-	promoWentTerminal := PromoWentTerminal{
-		logger: logger,
-	}
+	promoWentTerminal := kargo.NewPromoWentTerminalPredicate(logger)
 	if err := c.Watch(&source.Kind{Type: &kargoapi.Promotion{}}, promoOwnerHandler, promoWentTerminal); err != nil {
 		return errors.Wrap(err, "unable to watch Promotions")
 	}


### PR DESCRIPTION
This change refactors the promo controller to support long lived promotions as well as make it more reactive to completions of other promos on the stage.

Changes:
1. PromoteFn is called during normal Reconcile() instead of background go routine
2. Reconcile() is a no-op for promos that are already terminal, or is not their turn to run
3. If no promotions for a stage is currently running, Reconcile() will only allow the highest priority promo to reconcile (based on creationTimestamp and name). All others will be a no-op
4. Reconcile() allows any Promotion that is already Running to continue to run. This set us up for long-lived promotions (to be implemented in future PR).
5. PriorityQueue has a Peek() function
6. PriorityQueue ignores nil objects if pushed
7. PriorityQueue is a no-op if the pushed object already exists in the queue. This allows Push() to idempotent because Reconcile() calls it repeatedly

The following video shows 20 promotions getting created via a bash command, and then the promo reconciler working through them one by one, from earliest to latest:

https://github.com/akuity/kargo/assets/12677113/fbe53b04-4146-40db-b9b6-3ddc2ebf019c

Ignore the fact that they error, that is expected.