### PR TITLE
fix: add permissions for nightly cli build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,6 +202,9 @@ jobs:
 
   publish-unstable-cli:
     needs: publish-image
+    permissions:
+      id-token: write
+      contents: read
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
We need to add permissions for OIDC for nightly cli builds.

Fixes: https://github.com/akuity/kargo/actions/runs/6661699931/job/18105128095

cc: @krancour 