### PR TITLE
fix error invoking kargo render

### DIFF
--- a/internal/kargo-render/render.go
+++ b/internal/kargo-render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -100,7 +101,7 @@ func buildRenderCmd(req Request) *exec.Cmd {
 	}
 	cmd := exec.Command(cmdTokens[0], cmdTokens[1:]...) // nolint: gosec
 	cmd.Env = append(
-		cmd.Env,
+		os.Environ(),
 		fmt.Sprintf("KARGO_RENDER_REPO_PASSWORD=%s", req.RepoCreds.Password),
 	)
 	return cmd


### PR DESCRIPTION
This is a follow-up to #1109.

I'm not sure how it was that I ever observed #1109 working correctly. All Kargo Render CLI invocations now fail.

The issue is that once `cmd.Env` for the child process exec'ing Kargo Render becomes non-nil (as it did starting in #1109), the child process no longer inherits its parent's environment -- the Go docs say so:

```golang
// Env specifies the environment of the process.
// Each entry is of the form "key=value".
// If Env is nil, the new process uses the current process's
// environment.
// If Env contains duplicate environment keys, only the last
// value in the slice for each duplicate key is used.
// As a special case on Windows, SYSTEMROOT is always added if
// missing and not explicitly set to the empty string.
Env []string
```

This causes `PATH` to be missing when the Kargo CLI spawns its own child processes to execute `git` commands.

This PR fixes the issue.