### PR TITLE
chore: add awscli for nightly build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,6 +210,9 @@ jobs:
     container:
       image: golang:1.21.3-bookworm
     steps:
+    - name: Install awscli
+      run: |
+        apt update && apt install awscli -y
     - name: Checkout code
       uses: actions/checkout@v4
     - uses: actions/cache@v3


### PR DESCRIPTION
🤦 I did not realize that the CLI images were built in a container.  The container by default does not include the awscli.

Fixes: https://github.com/akuity/kargo/actions/workflows/release.yaml?query=event%3Aschedule