### PR TITLE
upgrade golang image used in ci and release processes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
   lint-go:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
   lint-charts:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
   lint-proto:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
     needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,7 +159,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -208,7 +208,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21.3-bookworm
+      image: golang:1.21.4-bookworm
     steps:
     - name: Install awscli
       run: |


### PR DESCRIPTION
A counterpart to #1096 so there's parity between local containerized tests and CI / release processes.