### PR TITLE
fix flakey priority queue test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b
 	golang.org/x/crypto v0.14.0
 	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
 	golang.org/x/net v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -787,8 +787,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b h1:fo0GUa0B+vxSZ8bgnL3fpCPHReM/QPlALdak9T/Zw5Y=
-github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/controller/runtime/queues_test.go
+++ b/internal/controller/runtime/queues_test.go
@@ -3,8 +3,8 @@ package runtime
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/technosophos/moniker"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,12 +21,13 @@ func TestPriorityQueue(t *testing.T) {
 		err.Error(),
 	)
 
-	randomNamer := moniker.New()
 	objects := make([]client.Object, 50)
 	for i := range objects {
 		objects[i] = &kargoapi.Promotion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: randomNamer.NameSep("-"),
+				// UUIDs contain enough randomness that we know we're not accidentally
+				// creating a list that's already ordered by name.
+				Name: uuid.New().String(),
 			},
 		}
 	}
@@ -57,7 +58,7 @@ func TestPriorityQueue(t *testing.T) {
 		added := pq.Push(
 			&kargoapi.Promotion{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randomNamer.NameSep("-"),
+					Name: uuid.New().String(),
 				},
 			},
 		)


### PR DESCRIPTION
The priority queue doesn't grow when one adds a duplicate key.

Sometimes we were getting unlucky and the random names we generated for queue elements weren't entirely unique.

This was sometimes causing an assertion about the queue's depth to fail.

This PR stops using names generated from the moniker library and starts using UUIDs as unique "names" instead:

1. They're guaranteed unique

2. UUIDs are partly random, so we know we're not accidentally building a queue that's already ordered. i.e. We can still assert the queue reorders itself by priority. 