### PR TITLE
update ci triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches:
-    - main
+  merge_group:
   push:
     branches:
     - main
+    - release-*
 
 jobs:
 


### PR DESCRIPTION
Make CI run for:

- Any PR, regardless of target branch (since we sometimes PR to other branches now)
- Merge queue trigger -- again, regardless of target branch (merge queue not enabled yet in repo settings)
- Post-merge for branches that looks like they're for maintenance of older releases