### PR TITLE
fix(ui): Node view styles improvements

### DIFF
--- a/ui/src/features/project/project-details/nodes/repo-node.module.less
+++ b/ui/src/features/project/project-details/nodes/repo-node.module.less
@@ -30,6 +30,9 @@
   color: #777;
   font-size: 11px;
   text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;;
 
   &:hover {
     text-decoration: underline;

--- a/ui/src/features/project/project-details/nodes/repo-node.tsx
+++ b/ui/src/features/project/project-details/nodes/repo-node.tsx
@@ -9,11 +9,8 @@ import { NodeType, NodesRepoType } from '../types';
 
 import * as styles from './repo-node.module.less';
 
-const MAX_CHARS = 19;
-
 type Props = {
   nodeData: NodesRepoType;
-  height: number;
   children?: React.ReactNode;
 };
 
@@ -31,13 +28,15 @@ const ico = {
   [NodeType.REPO_CHART]: faAnchor
 };
 
-export const RepoNode = ({ nodeData, height, children }: Props) => {
+export const RepoNode = ({ nodeData, children }: Props) => {
   const type = nodeData.type;
   const value = type === NodeType.REPO_CHART ? nodeData.data.registryUrl : nodeData.data.repoUrl;
   return (
-    <div style={{ height }} className={styles.node}>
-      <h3 className='flex justify-between'>
-        <span>{nodeData.warehouseName}</span>
+    <div className={styles.node}>
+      <h3 className='flex justify-between gap-2'>
+        <div className='text-ellipsis whitespace-nowrap overflow-hidden'>
+          {nodeData.warehouseName}
+        </div>
         {nodeData.type !== NodeType.REPO_CHART && <FontAwesomeIcon icon={faBuilding} />}
       </h3>
       <div className={styles.body}>
@@ -54,8 +53,7 @@ export const RepoNode = ({ nodeData, height, children }: Props) => {
               target='_blank'
               rel='noreferrer'
             >
-              {value.length > MAX_CHARS && '...'}
-              {value.substring(value.length - MAX_CHARS)}
+              {value}
             </a>
           </Tooltip>
         </div>

--- a/ui/src/features/project/project-details/nodes/stage-node.module.less
+++ b/ui/src/features/project/project-details/nodes/stage-node.module.less
@@ -3,10 +3,9 @@
   border-radius: 10px;
 
   h3 {
-    padding: 0.7em 0.5em;
+    padding: 0.7em 0.75em;
     color: white;
     font-weight: 600;
-    margin-left: 0.25em;
     font-size: 15px;
   }
 

--- a/ui/src/features/project/project-details/nodes/stage-node.tsx
+++ b/ui/src/features/project/project-details/nodes/stage-node.tsx
@@ -46,7 +46,7 @@ export const StageNode = ({
         }}
       >
         <h3 className='flex items-center text-white justify-between'>
-          <div className='text-ellipsis whitespace-nowrap overflow-hidden h-8'>
+          <div className='text-ellipsis whitespace-nowrap overflow-hidden'>
             {stage.metadata?.name}
           </div>
           {stage.status?.currentPromotion ? (

--- a/ui/src/features/project/project-details/project-details.tsx
+++ b/ui/src/features/project/project-details/project-details.tsx
@@ -152,6 +152,7 @@ export const ProjectDetails = () => {
                 ? NodeType.REPO_IMAGE
                 : NodeType.REPO_GIT;
             n.push({
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               data: sub.chart || sub.image || sub.git || ({} as any),
               stageName: stage.metadata?.name || '',
               warehouseName: cur.metadata?.name || '',
@@ -379,7 +380,7 @@ export const ProjectDetails = () => {
                         />
                       </>
                     ) : (
-                      <RepoNode nodeData={node} height={node.height}>
+                      <RepoNode nodeData={node}>
                         <div className='flex w-full'>
                           <Button
                             onClick={() =>


### PR DESCRIPTION
Improvements:
- Too long warehouse name truncated
- Fixed styles in the warehouse node view (the border-bottom is not visible)
- Added truncating styles to the repo link instead of characters limitation (chars have different widths, so sometimes the link has two lines)
- Aligned health status in the stage node view

Before:
![image](https://github.com/akuity/kargo/assets/7262558/ef773c00-8795-4aae-bb0b-5535538c714e)


After:
![image](https://github.com/akuity/kargo/assets/7262558/f4892e16-7186-4690-992d-b742d28bafdb)
