### PR TITLE
on new freight, enqueue subscribed stages

### DIFF
--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -25,6 +25,7 @@ const (
 	PromotionPoliciesByStageIndexField   = "stage"
 	StagesByArgoCDApplicationsIndexField = "applications"
 	StagesByUpstreamStagesIndexField     = "upstreamStages"
+	StagesByWarehouseIndexField          = "warehouse"
 )
 
 func IndexStagesByArgoCDApplications(ctx context.Context, mgr ctrl.Manager, shardName string) error {
@@ -234,4 +235,21 @@ func indexStagesByUpstreamStages(obj client.Object) []string {
 		upstreamStages[i] = upstreamStage.Name
 	}
 	return upstreamStages
+}
+
+func IndexStagesByWarehouse(ctx context.Context, mgr ctrl.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&kargoapi.Stage{},
+		StagesByWarehouseIndexField,
+		indexStagesByWarehouse,
+	)
+}
+
+func indexStagesByWarehouse(obj client.Object) []string {
+	stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
+	if stage.Spec.Subscriptions.Warehouse != "" {
+		return []string{stage.Spec.Subscriptions.Warehouse}
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes #1157

This PR indexes Stages by Warehouse. Whenever new Freight is created, a new event handler finds Stages subscribed to the Warehouse that created the Freight and enqueues them for reconciliation.

This makes Stages that subscribe directly to Warehouses far more responsive.

There is a tiny bit of renaming of existing event handlers in this PR. I've added two in the past two days and wanted to adopt a different naming convention that seems it can be applied consistently as the number of handlers likely grows.

cc @tal-hason 