### PR TITLE
feat(ui): Refresh token exchange

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -12,6 +12,7 @@ import { queryClient } from './config/query-client';
 import { themeConfig } from './config/themeConfig';
 import { AuthContextProvider } from './features/auth/context/auth-context-provider';
 import { ProtectedRoute } from './features/auth/protected-route';
+import { TokenRenew } from './features/auth/token-renew';
 import { MainLayout } from './features/common/layout/main-layout';
 import { Login } from './pages/login/login';
 import { Projects } from './pages/projects';
@@ -35,6 +36,7 @@ export const App = () => (
                   </Route>
                 </Route>
                 <Route path={paths.login} element={<Login />} />
+                <Route path={paths.tokenRenew} element={<TokenRenew />} />
               </Routes>
             </BrowserRouter>
           </AuthContextProvider>

--- a/ui/src/config/auth.ts
+++ b/ui/src/config/auth.ts
@@ -1,0 +1,4 @@
+export const authTokenKey = 'auth_token';
+export const refreshTokenKey = 'refresh_token';
+
+export const redirectToQueryParam = 'redirectTo';

--- a/ui/src/config/paths.ts
+++ b/ui/src/config/paths.ts
@@ -4,5 +4,6 @@ export const paths = {
   project: '/project/:name',
   stage: '/project/:name/stage/:stageName',
 
-  login: '/login'
+  login: '/login',
+  tokenRenew: '/token-renew'
 };

--- a/ui/src/features/auth/context/auth-context-provider.tsx
+++ b/ui/src/features/auth/context/auth-context-provider.tsx
@@ -19,6 +19,8 @@ export const AuthContextProvider = ({ children }: PropsWithChildren) => {
 
   const logout = React.useCallback(() => {
     localStorage.removeItem(authTokenKey);
+    localStorage.removeItem(refreshTokenKey);
+
     setToken(null);
   }, []);
 

--- a/ui/src/features/auth/context/auth-context-provider.tsx
+++ b/ui/src/features/auth/context/auth-context-provider.tsx
@@ -1,15 +1,20 @@
 import React, { PropsWithChildren } from 'react';
 
-import { authTokenKey } from '@ui/config/transport';
+import { authTokenKey, refreshTokenKey } from '@ui/config/auth';
 
 import { AuthContext } from './auth-context';
 
 export const AuthContextProvider = ({ children }: PropsWithChildren) => {
   const [token, setToken] = React.useState(localStorage.getItem(authTokenKey));
 
-  const login = React.useCallback((t: string) => {
-    localStorage.setItem(authTokenKey, t);
-    setToken(t);
+  const login = React.useCallback((token: string, refreshToken?: string) => {
+    localStorage.setItem(authTokenKey, token);
+
+    if (refreshToken) {
+      localStorage.setItem(refreshTokenKey, refreshToken);
+    }
+
+    setToken(token);
   }, []);
 
   const logout = React.useCallback(() => {

--- a/ui/src/features/auth/context/auth-context.tsx
+++ b/ui/src/features/auth/context/auth-context.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export interface AuthContextType {
   isLoggedIn: boolean;
-  login: (token: string) => void;
+  login: (token: string, authToken?: string) => void;
   logout: () => void;
 }
 

--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -79,7 +79,14 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
     url.searchParams.set('code_challenge_method', 'S256');
     url.searchParams.set('redirect_uri', redirectURI);
     url.searchParams.set('response_type', 'code');
-    url.searchParams.set('scope', oidcConfig.scopes.join(' '));
+    url.searchParams.set(
+      'scope',
+      [
+        ...oidcConfig.scopes,
+        // Add offline_access scope if it does not exist
+        ...(oidcConfig.scopes.includes('offline_access') ? [] : ['offline_access'])
+      ].join(' ')
+    );
 
     window.location.replace(url.toString());
   };

--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -141,7 +141,7 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
         return;
       }
 
-      onLogin(result.id_token);
+      onLogin(result.id_token, result.refresh_token);
     })();
   }, [as, client, location]);
 

--- a/ui/src/features/auth/protected-route.tsx
+++ b/ui/src/features/auth/protected-route.tsx
@@ -1,6 +1,8 @@
+import { TransportProvider } from '@bufbuild/connect-query';
 import { Navigate, Outlet } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
+import { transportWithAuth } from '@ui/config/transport';
 
 import { useAuthContext } from './context/use-auth-context';
 
@@ -11,5 +13,9 @@ export const ProtectedRoute = () => {
     return <Navigate to={paths.login} replace />;
   }
 
-  return <Outlet />;
+  return (
+    <TransportProvider transport={transportWithAuth}>
+      <Outlet />
+    </TransportProvider>
+  );
 };

--- a/ui/src/features/auth/token-renew.tsx
+++ b/ui/src/features/auth/token-renew.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query';
+import { notification } from 'antd';
+import * as oauth from 'oauth4webapi';
+import React from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { redirectToQueryParam, refreshTokenKey } from '@ui/config/auth';
+import { paths } from '@ui/config/paths';
+import { getPublicConfig } from '@ui/gen/service/v1alpha1/service-KargoService_connectquery';
+
+import { LoadingState } from '../common';
+
+import { useAuthContext } from './context/use-auth-context';
+
+export const TokenRenew = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { login: onLogin, logout } = useAuthContext();
+
+  const { data, isError } = useQuery(getPublicConfig.useQuery());
+
+  const issuerUrl = React.useMemo(() => {
+    try {
+      return data?.oidcConfig?.issuerUrl ? new URL(data?.oidcConfig?.issuerUrl) : undefined;
+    } catch (err) {
+      notification.error({
+        message: 'Invalid issuerURL',
+        placement: 'bottomRight'
+      });
+    }
+  }, [data?.oidcConfig?.issuerUrl]);
+
+  const client = React.useMemo(
+    () =>
+      data?.oidcConfig?.clientId
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { client_id: data?.oidcConfig?.clientId, token_endpoint_auth_method: 'none' as any }
+        : undefined,
+    [data?.oidcConfig?.clientId]
+  );
+
+  const { data: as, isError: isASError } = useQuery({
+    queryKey: [issuerUrl],
+    queryFn: () =>
+      issuerUrl &&
+      oauth
+        .discoveryRequest(issuerUrl)
+        .then((response) => oauth.processDiscoveryResponse(issuerUrl, response))
+        .then((response) => {
+          if (response.code_challenge_methods_supported?.includes('S256') !== true) {
+            throw new Error('OIDC config fetch error');
+          }
+
+          return response;
+        }),
+    enabled: !!issuerUrl
+  });
+
+  React.useEffect(() => {
+    const refreshToken = localStorage.getItem(refreshTokenKey);
+
+    if (!refreshToken) {
+      navigate(paths.home);
+
+      return;
+    }
+
+    if (!as || !client) {
+      return;
+    }
+
+    (async () => {
+      const response = await oauth.refreshTokenGrantRequest(as, client, refreshToken);
+
+      const result = await oauth.processRefreshTokenResponse(as, client, response);
+      if (oauth.isOAuth2Error(result) || !result.id_token) {
+        notification.error({
+          message: 'OIDC: Proccess Authorization Code Grant Response error',
+          placement: 'bottomRight'
+        });
+        logout();
+        return;
+      }
+
+      onLogin(result.id_token, result.refresh_token);
+      navigate(searchParams.get(redirectToQueryParam) || paths.home);
+    })();
+  }, [as, client]);
+
+  React.useEffect(() => {
+    if (isError || isASError) {
+      logout();
+      navigate(paths.login);
+    }
+  }, [isError, isASError]);
+
+  return (
+    <div className='pt-40'>
+      <LoadingState />
+    </div>
+  );
+};

--- a/ui/src/features/project/project-details/project-details.tsx
+++ b/ui/src/features/project/project-details/project-details.tsx
@@ -19,7 +19,7 @@ import { graphlib, layout } from 'dagre';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { transport } from '@ui/config/transport';
+import { transportWithAuth } from '@ui/config/transport';
 import { ColorContext } from '@ui/context/colors';
 import { LoadingState } from '@ui/features/common';
 import { getAlias } from '@ui/features/common/freight-label';
@@ -108,7 +108,7 @@ export const ProjectDetails = () => {
     const cancel = new AbortController();
 
     const watchStages = async () => {
-      const promiseClient = createPromiseClient(KargoService, transport);
+      const promiseClient = createPromiseClient(KargoService, transportWithAuth);
       const stream = promiseClient.watchStages({ project: name }, { signal: cancel.signal });
       let stages = data.stages.slice();
 

--- a/ui/src/features/stage/promotions.tsx
+++ b/ui/src/features/stage/promotions.tsx
@@ -13,7 +13,7 @@ import { format } from 'date-fns';
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { transport } from '@ui/config/transport';
+import { transportWithAuth } from '@ui/config/transport';
 import { listPromotions } from '@ui/gen/service/v1alpha1/service-KargoService_connectquery';
 import { KargoService } from '@ui/gen/service/v1alpha1/service_connect';
 import { ListPromotionsResponse } from '@ui/gen/service/v1alpha1/service_pb';
@@ -36,7 +36,7 @@ export const Promotions = () => {
     const cancel = new AbortController();
 
     const watchPromotions = async () => {
-      const promiseClient = createPromiseClient(KargoService, transport);
+      const promiseClient = createPromiseClient(KargoService, transportWithAuth);
       const stream = promiseClient.watchPromotions(
         { project: projectName, stage: stageName },
         { signal: cancel.signal }


### PR DESCRIPTION
Fixes #877 

In this PR, I implemented a refresh token exchange.

How it works: when the token is expired before any API call, the user is redirected to the token renewal page, where the loader is visible for a second, and after the token exchange process, the user is redirected to the previous page.

The perfect solution is a request in the background, but unfortunately, we can't use React hooks inside the interceptor for now (library limitations), which is needed for our auth flow.