### PR TITLE
make authorizing client wrapper check all admin-designated namespaces for SA mappings

### DIFF
--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -51,12 +51,15 @@ func newAPICommand() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "create internal Kubernetes client")
 			}
-			kubeClient, err := kubernetes.NewClient(ctx, restCfg, kubernetes.ClientOptions{
-				KargoNamespace: cfg.KargoNamespace,
+			kubeClientOptions := kubernetes.ClientOptions{
 				NewInternalClient: func(context.Context, *rest.Config, *runtime.Scheme) (client.Client, error) {
 					return internalClient, nil
 				},
-			})
+			}
+			if cfg.OIDCConfig != nil {
+				kubeClientOptions.GlobalServiceAccountNamespaces = cfg.OIDCConfig.GlobalServiceAccountNamespaces
+			}
+			kubeClient, err := kubernetes.NewClient(ctx, restCfg, kubeClientOptions)
 			if err != nil {
 				return errors.Wrap(err, "create Kubernetes client")
 			}

--- a/internal/api/kubernetes/client_test.go
+++ b/internal/api/kubernetes/client_test.go
@@ -471,7 +471,7 @@ func TestGetAuthorizedClient(t *testing.T) {
 			if testCase.userInfo != nil {
 				ctx := user.ContextWithInfo(context.Background(), *testCase.userInfo)
 				testCase.assert(
-					getAuthorizedClient("")(
+					getAuthorizedClient(nil)(
 						ctx,
 						testInternalClient,
 						"", // Verb doesn't matter for these tests

--- a/internal/api/user/user.go
+++ b/internal/api/user/user.go
@@ -29,9 +29,9 @@ type Info struct {
 	// constructing an ad-hoc Kubernetes client, this token will be used directly.
 	// When this is non-empty, all other fields should have an empty value.
 	BearerToken string
-	// ServiceAccounts is the map of the ServiceAccounts that are mapped to the user
-	// by `rbac.kargo.akuity.io` annotations.
-	ServiceAccounts map[string]map[types.NamespacedName]struct{}
+	// ServiceAccountsByNamespace is the mapping of namespace names to sets of
+	// ServiceAccounts that a user has been mapped to.
+	ServiceAccountsByNamespace map[string]map[types.NamespacedName]struct{}
 }
 
 // ContextWithInfo returns a context.Context that has been augmented with


### PR DESCRIPTION
This is a follow-up to #1190, which forgot to make the API server's authorizing kube client wrapper evaluate the SAs in admin-designated namespaces for suitability.

@devholic you know this part of the code well, so I'm hoping you can do the review for this one. 🙏 
