### PR TITLE
small codegen fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ DOCKER_CMD := $(CONTAINER_RUNTIME) run \
 	--rm \
 	-v gomodcache:/go/pkg/mod \
 	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/kargo \
+	-v /workspaces/kargo/ui/node_modules \
 	-w /workspaces/kargo \
 	kargo:dev-tools
 


### PR DESCRIPTION
This fixes two minor issues:

1. After switching from Docker Desktop to OrbStack `make hack-codegen` stopped working for me.

    `make hack-codegen` as opposed to just `make codegen` runs code generation tasks in a container. I recommend this for _everyone_ who executes codegen because there are a number of different tools involved that _need_ to be at exact versions.

    It turns out OrbStack doesn't deal with hard links well and pnpm _uses_ hard links. Docker Desktop also had this same problem once upon a time.

     This means the `pnpm install` command that's run as part of that target tends to fail if you're using OrbStack.

2. `make hack-codegen` running `pnpm install` _in the `ui/` dir within a container_ was iffy to begin with.

    Supposing any of the modules in use had native extensions, after running this in the container, your _local_ `ui/node_modules` would be overwritten with native extensions for Linux rather than for your own host OS. Surprise!

    This is a really esoteric problem and it probably hasn't actually caused anyone any grief up until now, but it would be better to be safe than sorry.

There is a common solution to both problems -- just "exclude" `ui/node_modules` from the volume that we mount into the container.

The way to do this is _after_ mounting the project directory into the container, an anonymous volume can be mounted to the `ui/node_modules` subdir in the container.

This prevents both the container and host from being contaminated with each others `pnpm install` results.