### PR TITLE
make vite bind to 0.0.0.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "dev:local-api": "API_URL=http://localhost:8080 vite",
     "build": "vite build",
     "lint": "eslint --ignore-path .gitignore . --max-warnings=0",


### PR DESCRIPTION
Vite serves the UI during development only, so this has no bearing on anything but devx.

Making vite bind to 0.0.0.0 instead of 127.0.0.1 only makes it possible to run vite in a container without affecting the ability to run it as a native process.