### PR TITLE
use higher port numbers in the quickstart

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -144,11 +144,11 @@ docker logout ghcr.io
 
 At the end of this process:
 
-* The Argo CD dashboard will be accessible at [localhost:8443](https://localhost:8443).
+* The Argo CD dashboard will be accessible at [localhost:31443](https://localhost:31443).
 
   The username and password are both `admin`.
 
-* The Kargo dashboard will be accessible at [localhost:8444](https://localhost:8444).
+* The Kargo dashboard will be accessible at [localhost:31444](https://localhost:31444).
 
   The admin password is `admin`.
 
@@ -287,7 +287,7 @@ spec:
 EOF
 ```
 
-If you visit [your Argo CD dashboard](https://localhost:8443), you will notice
+If you visit [your Argo CD dashboard](https://localhost:31443), you will notice
 all three Argo CD `Application`s have not yet synced because they're not
 configured to do so automatically, and in fact, the branches referenced by their
 `targetRevision` fields do not even exist yet.
@@ -320,7 +320,7 @@ the previous section.
 1. Then, log into Kargo:
 
     ```shell
-    kargo login https://localhost:8444 \
+    kargo login https://localhost:31444 \
       --admin \
       --password admin \
       --insecure-skip-tls-verify
@@ -553,7 +553,7 @@ the previous section.
     We can repeat the command above until our `Promotion` is in a `Healthy`
     state and we can further validate the success of this entire process by
     visiting the test instance of our site at
-    [localhost:8081](http://localhost:8081).
+    [localhost:30081](http://localhost:30081).
 
     If we once again view the `status` of our `test` `Stage` in more detail, we
     will see that it now reflects its current `Freight`, and the history of all
@@ -645,8 +645,8 @@ command to progress the `Freight` from `stage` to `uat` and again from `uat` to
 :::info
 The `uat` and `prod` instances of our site should be accessible at:
 
-* `uat`: [localhost:8082](http://localhost:8082)
-* `prod`: [localhost:8083](http://localhost:8083)
+* `uat`: [localhost:30082](http://localhost:30082)
+* `prod`: [localhost:30083](http://localhost:30083)
 :::
 
 :::info

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -3,8 +3,8 @@
 k3d cluster create kargo-quickstart \
   --no-lb \
   --k3s-arg '--disable=traefik@server:0' \
-  -p '8443-8444:31443-31444@servers:0:direct' \
-  -p '8081-8083:30081-30083@servers:0:direct' \
+  -p '31443-31444:31443-31444@servers:0:direct' \
+  -p '30081-30083:30081-30083@servers:0:direct' \
   --wait
 
 helm install cert-manager cert-manager \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -9,15 +9,15 @@ name: kargo-quickstart
 nodes:
 - extraPortMappings:
   - containerPort: 31443 # Argo CD dashboard
-    hostPort: 8443
+    hostPort: 31443
   - containerPort: 31444 # Kargo dashboard
-    hostPort: 8444
+    hostPort: 31444
   - containerPort: 30081 # test application instance
-    hostPort: 8081
+    hostPort: 30081
   - containerPort: 30082 # UAT application instance
-    hostPort: 8082
+    hostPort: 30082
   - containerPort: 30083 # prod application instance
-    hostPort: 8083
+    hostPort: 30083
   
 EOF
 


### PR DESCRIPTION
#1204 added some new options to the quickstart -- run in Docker Desktop or OrbStack _without_ involving kind or k3s.

That PR overlooked that kind and k3s were both coming up with port mappings from host 8xxx range to Kubernetes node 3xxxx range.

That is fine, because a host can use any port numbers.

When using Docker Desktop or OrbStack no port forwarding is required because both of those automatically set up port forwarding so any nodeport on the node is exposed on the _same_ port on the host.

Nodeports, however, are restricted to >= 30000.

This PR makes all cases use ports >= 30000 on both sides of the mapping (host and node).