### PR TITLE
chore(devx): make tilt crazy fast

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-bin/
 docs/
 ui/node_modules/

--- a/hack/tilt/ui.yaml
+++ b/hack/tilt/ui.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kargo-ui
+  namespace: kargo
+  labels:
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: kargo
+    app.kubernetes.io/name: kargo
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ui
+      app.kubernetes.io/instance: kargo
+      app.kubernetes.io/name: kargo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ui
+        app.kubernetes.io/instance: kargo
+        app.kubernetes.io/name: kargo
+    spec:
+      containers:
+      - name: ui
+        image: kargo-ui:placeholder
+        imagePullPolicy: Always
+        env:
+        - name: API_URL
+          value: http://kargo-api
+        ports:
+        - name: http
+          containerPort: 3333
+          protocol: TCP


### PR DESCRIPTION
I had a lot of conversations with @rbreeze last week about reasons he typically opts to run Kargo components as native processes instead of a local cluster. It was enlightening and inspired me to fix everything that was slowing Tilt down.

If using Tilt to develop in a local cluster, this PR will make image builds faster overall, achieve sub-second restarts on every component, and the UI component will even be live updated as code changes.

How it works:

1. Two new stages are added to the Dockerfile. These two new stages are not involved in the official image that is built and published by our release process. They are only for facilitating local development, and the differences between them and the stage that produces the official image are minor.

    There is one new stage for the back end and one for the front.

    The one for the back end copies a natively/locally built `kargo` binary from the host _instead_ of building the `kargo` binary in-container. (This allows the build to take advantage of your local Go installation's own cache -- a benefit that is lost when building in a container.) It also omits the front end.

    The one for the front end runs vite -- which is how @rbreeze runs the front end locally. It also omits the back end.

1. The updated `Tiltfile` has some new smarts.

    When a back end component is restarted, the `kargo` binary is built natively/locally and _then_ the image is rebuilt, targeting the new back end stage that just copies that binary. This achieves sub-second restarts on back end components.

    For local development only, Tilt serves the front end from a separate component (not the API server.) It's running vite, as previously mentioned. When front end code changes, the changes are instantly synced to the pod running vite. Vite already knows how to apply code changes without restarting. This means the UI is always live updating as changes are made and never requires a restart.

__Known issue:__ SSO will fail locally, but I know how to fix that and will handle it in a follow-up.

https://github.com/akuity/kargo/assets/1821014/c3258e0e-776c-40d5-b377-8032439a8136
