### PR TITLE
fix(controller): make tag selector ignore references in an oci image index that don't look like they refer to an image

### DIFF
--- a/internal/image/repository_client.go
+++ b/internal/image/repository_client.go
@@ -578,7 +578,18 @@ func (r *repositoryClient) extractTagFromCollection(
 		digest,
 	)
 
-	refs := collection.References()
+	refs := make([]distribution.Descriptor, 0, len(collection.References()))
+	for _, ref := range collection.References() {
+		if ref.Platform == nil ||
+			ref.Platform.OS == "unknown" || ref.Platform.OS == "" ||
+			ref.Platform.Architecture == "unknown" || ref.Platform.Architecture == "" {
+			// This reference doesn't look like a reference to an image. It might
+			// be an attestation or something else. Skip it.
+			continue
+		}
+		refs = append(refs, ref)
+	}
+
 	if len(refs) == 0 {
 		return nil, errors.Errorf(
 			"empty V2 manifest list or OCI index %s is not supported",

--- a/internal/image/repository_client_test.go
+++ b/internal/image/repository_client_test.go
@@ -689,7 +689,14 @@ func TestExtractTagFromCollection(t *testing.T) {
 			name: "with platform constraint -- no refs matched",
 			collection: &manifestlist.DeserializedManifestList{
 				ManifestList: manifestlist.ManifestList{
-					Manifests: []manifestlist.ManifestDescriptor{{}},
+					Manifests: []manifestlist.ManifestDescriptor{
+						{
+							Platform: manifestlist.PlatformSpec{
+								OS:           "linux",
+								Architecture: "arm64",
+							},
+						},
+					},
 				},
 			},
 			platform: &platformConstraint{
@@ -845,7 +852,14 @@ func TestExtractTagFromCollection(t *testing.T) {
 			name: "without platform constraint -- error getting tag by digest",
 			collection: &manifestlist.DeserializedManifestList{
 				ManifestList: manifestlist.ManifestList{
-					Manifests: []manifestlist.ManifestDescriptor{{}},
+					Manifests: []manifestlist.ManifestDescriptor{
+						{
+							Platform: manifestlist.PlatformSpec{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+						},
+					},
 				},
 			},
 			client: &repositoryClient{
@@ -870,7 +884,14 @@ func TestExtractTagFromCollection(t *testing.T) {
 			name: "without platform constraint -- no tag found",
 			collection: &manifestlist.DeserializedManifestList{
 				ManifestList: manifestlist.ManifestList{
-					Manifests: []manifestlist.ManifestDescriptor{{}},
+					Manifests: []manifestlist.ManifestDescriptor{
+						{
+							Platform: manifestlist.PlatformSpec{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+						},
+					},
 				},
 			},
 			client: &repositoryClient{
@@ -891,7 +912,14 @@ func TestExtractTagFromCollection(t *testing.T) {
 			name: "without platform constraint -- success",
 			collection: &manifestlist.DeserializedManifestList{
 				ManifestList: manifestlist.ManifestList{
-					Manifests: []manifestlist.ManifestDescriptor{{}},
+					Manifests: []manifestlist.ManifestDescriptor{
+						{
+							Platform: manifestlist.PlatformSpec{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+						},
+					},
 				},
 			},
 			client: &repositoryClient{


### PR DESCRIPTION
Fixes #1267