### PR TITLE
fix: eliminate double reconcile during refresh requests

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -67,6 +67,7 @@ func SetupReconcilerWithManager(
 		For(&kargoapi.Promotion{}).
 		WithEventFilter(changePredicate).
 		WithEventFilter(shardPredicate).
+		WithEventFilter(kargo.IgnoreClearRefreshUpdates{}).
 		WithOptions(controller.CommonOptions()).
 		Build(reconciler)
 	if err != nil {

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -220,6 +220,7 @@ func SetupReconcilerWithManager(
 			),
 		).
 		WithEventFilter(shardPredicate).
+		WithEventFilter(kargo.IgnoreClearRefreshUpdates{}).
 		WithOptions(controller.CommonOptions()).
 		Build(newReconciler(kargoMgr.GetClient(), argoMgr.GetClient()))
 	if err != nil {

--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -20,6 +20,7 @@ import (
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/helm"
 	"github.com/akuity/kargo/internal/image"
+	"github.com/akuity/kargo/internal/kargo"
 	"github.com/akuity/kargo/internal/kubeclient"
 	"github.com/akuity/kargo/internal/logging"
 )
@@ -122,6 +123,7 @@ func SetupReconcilerWithManager(
 				),
 			).
 			WithEventFilter(shardPredicate).
+			WithEventFilter(kargo.IgnoreClearRefreshUpdates{}).
 			WithOptions(controller.CommonOptions()).
 			Complete(newReconciler(mgr.GetClient(), credentialsDB)),
 		"error building Warehouse reconciler",


### PR DESCRIPTION
Currently when someone clicks refresh on a Stage, Warehouse, we get two reconciles:
1. first reconcile happens because refresh annotation was set by kargo-api
2. second reconcile happens because controller patches the objects annotation to clear the refresh annotation

This introduces a predicate which will filter out the event if the update event was to clear the annotation, preventing the second reconcile.