### PR TITLE
docs: Metadata changes

### DIFF
--- a/docs/docs/10-overview.md
+++ b/docs/docs/10-overview.md
@@ -1,7 +1,8 @@
 ---
 slug: /
-title: Overview
-Description: What is Kargo?
+sidebar_label: Overview
+description: Find out more about Kargo - a next-generation continuous delivery and application lifecycle
+orchestration platform for Kubernetes
 ---
 
 # What is Kargo?

--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -1,9 +1,8 @@
 ---
-title: Concepts
-description: Concepts
+sidebar_label: Key Concepts
+description: Find out more about key Kargo concepts - stage, freight, promotion, subscription, and more
 ---
-
-This section covers important Kargo concepts.
+# Key Kargo Concepts
 
 ## The Basics
 

--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Key Concepts
-description: Find out more about key Kargo concepts - stage, freight, promotion, subscription, and more
+description: Find out more about key Kargo concepts - stages, freight, warehouses, promotions, and more
 ---
 # Key Kargo Concepts
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Find out how to quickstart Kargo and progress changes through multiple stages by interacting with your GitOps repository and Argo CD Application resources
+description: Learn about Kargo by progressing a change through multiple stages in a local Kubernetes cluster
 sidebar_label: Quickstart
 ---
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Find out how to quickstart Kargo and progress changes through multiple stages byinteracting with your GitOps repository and Argo CD Application resources
+description: Find out how to quickstart Kargo and progress changes through multiple stages by interacting with your GitOps repository and Argo CD Application resources
 sidebar_label: Quickstart
 ---
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -1,11 +1,12 @@
 ---
-description: Kargo Quickstart
+description: Find out how to quickstart Kargo and progress changes through multiple stages byinteracting with your GitOps repository and Argo CD `Application` resources
+sidebar_label: Quickstart
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Quickstart
+# Kargo Quickstart
 
 This guide presents a basic introduction to Kargo. Together, we will:
 

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Find out how to quickstart Kargo and progress changes through multiple stages byinteracting with your GitOps repository and Argo CD `Application` resources
+description: Find out how to quickstart Kargo and progress changes through multiple stages byinteracting with your GitOps repository and Argo CD Application resources
 sidebar_label: Quickstart
 ---
 

--- a/docs/docs/30-how-to-guides/10-installing-kargo.md
+++ b/docs/docs/30-how-to-guides/10-installing-kargo.md
@@ -1,5 +1,6 @@
 ---
-description: Installing Kargo
+description: Learn how to install Kargo using this step-by-step guide
+sidebar_label: Installing Kargo
 ---
 
 # Installing Kargo

--- a/docs/docs/30-how-to-guides/20-managing-credentials.md
+++ b/docs/docs/30-how-to-guides/20-managing-credentials.md
@@ -1,5 +1,6 @@
 ---
-description: Managing credentials
+description: Find out how to manage credentials with Kargo
+sidebar_label: Managing credetials
 ---
 
 # Managing Credentials

--- a/docs/docs/30-how-to-guides/20-managing-credentials.md
+++ b/docs/docs/30-how-to-guides/20-managing-credentials.md
@@ -1,6 +1,6 @@
 ---
 description: Find out how to manage credentials with Kargo
-sidebar_label: Managing credetials
+sidebar_label: Managing credentials
 ---
 
 # Managing Credentials

--- a/docs/docs/30-how-to-guides/20-managing-credentials.md
+++ b/docs/docs/30-how-to-guides/20-managing-credentials.md
@@ -1,5 +1,5 @@
 ---
-description: Find out how to manage credentials with Kargo
+description: Find out how to manage repository credentials for use by Kargo
 sidebar_label: Managing credentials
 ---
 

--- a/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
+++ b/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
@@ -1,5 +1,6 @@
 ---
-description: Hacking on Kargo
+description: Find out how to quickly set up developer environement and start contributing to Kargo
+sidebar_label: Hacking on Kargo
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
+++ b/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
@@ -1,5 +1,5 @@
 ---
-description: Find out how to quickly set up developer environement and start contributing to Kargo
+description: Learn how to set up a development environment to begin contributing to Kargo
 sidebar_label: Hacking on Kargo
 ---
 

--- a/docs/docs/40-contributor-guide/20-signing-commits.md
+++ b/docs/docs/40-contributor-guide/20-signing-commits.md
@@ -1,5 +1,6 @@
 ---
-description: Signing commits
+description: Find out how to sign commits when contributing to Kargo
+sidebar_label: Signing commits
 ---
 
 # Signing Commits

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Code of conduct
-description: Contributor Covenant Code of Conduct for Kargo open source project
+description: Contributor Code of Conduct for Kargo open source project
 ---
 
 # Kargo Contributor Code of Conduct

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -1,9 +1,9 @@
 ---
-title: Code of conduct
-description: Code of conduct
+sidebar_label: Code of conduct
+description: Contributor Covenant Code of Conduct for Kargo open source project
 ---
 
-# Contributor Covenant Code of Conduct
+# Kargo Contributor Code of Conduct
 
 ## Our Pledge
 

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Code of conduct
-description: Contributor Code of Conduct for Kargo open source project
+description: Contributor Code of Conduct for the open source Kargo project
 ---
 
 # Kargo Contributor Code of Conduct

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -3,7 +3,7 @@ sidebar_label: Code of conduct
 description: Contributor Code of Conduct for the open source Kargo project
 ---
 
-# Kargo Contributor Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 

--- a/docs/docs/40-contributor-guide/index.md
+++ b/docs/docs/40-contributor-guide/index.md
@@ -1,8 +1,9 @@
 ---
-description: Contributor guide
+description: A comprehensive introduction for developers who are looking to get involved with contributing directly to the Kargo project
+sidebar_label: Contributor guide
 ---
 
-# Contributor Guide
+# Kargo Contributor Guide
 
 This contributor guide is intended as a comprehensive introduction for
 developers who are looking to get involved with contributing directly to the

--- a/docs/docs/50-roadmap.md
+++ b/docs/docs/50-roadmap.md
@@ -1,9 +1,9 @@
 ---
-title: Roadmap
-Description: Kargo Roadmap
+sidebar_label: Roadmap
+Description: See what's on the roadmap of Kargo and find out more about the latest releases
 ---
 
-# Roadmap
+# Kargo Roadmap
 
 Over a series of releases, Kargo's maintainers intend to establish and settle into a predictable, but yet to be determined release cadence.
 


### PR DESCRIPTION
Added SEO changes to Kargo docs

In short:

- meta title is inherited from the first H1 of the document
- `sidebar_label` exists only in the context of navigating through the docs
- `description` serves as metadata description and should be a bit longer (55+ chars)