### PR TITLE
fix(docs): error in overview page front matter

### DIFF
--- a/docs/docs/10-overview.md
+++ b/docs/docs/10-overview.md
@@ -1,8 +1,7 @@
 ---
 slug: /
 sidebar_label: Overview
-description: Find out more about Kargo - a next-generation continuous delivery and application lifecycle
-orchestration platform for Kubernetes
+description: Find out more about Kargo - a next-generation continuous delivery and application lifecycle orchestration platform for Kubernetes
 ---
 
 # What is Kargo?


### PR DESCRIPTION
This fixes an error that is stopping the docs site from building.

I'm not sure if this is somehow related to the issue @rbreeze is currently looking at, but this needs to be fixed either way.