### PR TITLE
refactor(api)!: update annotations used for user -> sa mappings

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -3,7 +3,7 @@ package v1alpha1
 const (
 	AnnotationKeyRefresh = "kargo.akuity.io/refresh"
 
-	AnnotationKeyOIDCEmails   = "rbac.kargo.akuity.io/email"
+	AnnotationKeyOIDCEmails   = "rbac.kargo.akuity.io/emails"
 	AnnotationKeyOIDCGroups   = "rbac.kargo.akuity.io/groups"
-	AnnotationKeyOIDCSubjects = "rbac.kargo.akuity.io/sub"
+	AnnotationKeyOIDCSubjects = "rbac.kargo.akuity.io/subjects"
 )


### PR DESCRIPTION
Encountered this while working on docs...

Since these annotations accept multiple comma-delimited values, it seems to makes more sense if the keys end with plural nouns to reflect that.