### PR TITLE
fix(controller): when updating a values.yaml, make sure image tags that look like a number are still treated as strings

### DIFF
--- a/internal/controller/promotion/helm.go
+++ b/internal/controller/promotion/helm.go
@@ -125,7 +125,7 @@ func buildValuesFilesChanges(
 	tagsByImage := map[string]string{}
 	digestsByImage := make(map[string]string, len(images))
 	for _, image := range images {
-		tagsByImage[image.RepoURL] = "'" + image.Tag + "'"
+		tagsByImage[image.RepoURL] = image.Tag
 		digestsByImage[image.RepoURL] = image.Digest
 	}
 	changesByFile := make(map[string]map[string]string, len(imageUpdates))
@@ -157,7 +157,7 @@ func buildValuesFilesChanges(
 				fmt.Sprintf("%s:%s", imageUpdate.Image, tag)
 			fqImageRef = fmt.Sprintf("%s:%s", imageUpdate.Image, tag)
 		case kargoapi.ImageUpdateValueTypeTag:
-			changesByFile[imageUpdate.ValuesFilePath][imageUpdate.Key] = tag
+			changesByFile[imageUpdate.ValuesFilePath][imageUpdate.Key] = "'" + tag + "'"
 			fqImageRef = fmt.Sprintf("%s:%s", imageUpdate.Image, tag)
 		case kargoapi.ImageUpdateValueTypeImageAndDigest:
 			changesByFile[imageUpdate.ValuesFilePath][imageUpdate.Key] =

--- a/internal/controller/promotion/helm.go
+++ b/internal/controller/promotion/helm.go
@@ -125,7 +125,7 @@ func buildValuesFilesChanges(
 	tagsByImage := map[string]string{}
 	digestsByImage := make(map[string]string, len(images))
 	for _, image := range images {
-		tagsByImage[image.RepoURL] = image.Tag
+		tagsByImage[image.RepoURL] = "'" + image.Tag + "'"
 		digestsByImage[image.RepoURL] = image.Digest
 	}
 	changesByFile := make(map[string]map[string]string, len(imageUpdates))

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -321,7 +321,7 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 		t,
 		map[string]map[string]string{
 			"fake-values.yaml": {
-				"fake-key":        "fake-url:'fake-tag'",
+				"fake-key":        "fake-url:fake-tag",
 				"second-fake-key": "'second-fake-tag'",
 			},
 			"another-fake-values.yaml": {
@@ -334,8 +334,8 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 	require.Equal(
 		t,
 		[]string{
-			"updated fake-values.yaml to use image fake-url:'fake-tag'",
-			"updated fake-values.yaml to use image second-fake-url:'second-fake-tag'",
+			"updated fake-values.yaml to use image fake-url:fake-tag",
+			"updated fake-values.yaml to use image second-fake-url:second-fake-tag",
 			"updated another-fake-values.yaml to use image third-fake-url@third-fake-digest",
 			"updated another-fake-values.yaml to use image fourth-fake-url@fourth-fake-digest",
 		},

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -321,8 +321,8 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 		t,
 		map[string]map[string]string{
 			"fake-values.yaml": {
-				"fake-key":        "fake-url:fake-tag",
-				"second-fake-key": "second-fake-tag",
+				"fake-key":        "fake-url:'fake-tag'",
+				"second-fake-key": "'second-fake-tag'",
 			},
 			"another-fake-values.yaml": {
 				"third-fake-key":  "third-fake-url@third-fake-digest",
@@ -334,8 +334,8 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 	require.Equal(
 		t,
 		[]string{
-			"updated fake-values.yaml to use image fake-url:fake-tag",
-			"updated fake-values.yaml to use image second-fake-url:second-fake-tag",
+			"updated fake-values.yaml to use image fake-url:'fake-tag'",
+			"updated fake-values.yaml to use image second-fake-url:'second-fake-tag'",
 			"updated another-fake-values.yaml to use image third-fake-url@third-fake-digest",
 			"updated another-fake-values.yaml to use image fourth-fake-url@fourth-fake-digest",
 		},


### PR DESCRIPTION
Fixes #876 

![image](https://github.com/akuity/kargo/assets/22935317/f6a118cb-fb60-4763-b778-0223c79851b3)
