### PR TITLE
fix(cli): handle CLI config file not found error

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,8 +15,11 @@ func main() {
 	ctx := context.Background()
 	cfg, err := config.LoadCLIConfig()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrap(err, "load config"))
-		os.Exit(1)
+		if !config.IsConfigNotFoundErr(err) {
+			fmt.Fprintln(os.Stderr, errors.Wrap(err, "load config"))
+			os.Exit(1)
+		}
+		cfg = config.NewDefaultCLIConfig()
 	}
 	cmd, err := NewRootCommand(option.NewOption(cfg), &rootState{})
 	if err != nil {

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -26,7 +26,7 @@ func GetClientFromConfig(ctx context.Context, opt *option.Option) (
 	}
 	cfg, err := config.LoadCLIConfig()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "load cli config")
 	}
 	skipTLSVerify := opt.InsecureTLS || cfg.InsecureSkipTLSVerify
 	if cfg, err =

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -28,6 +28,11 @@ func GetClientFromConfig(ctx context.Context, opt *option.Option) (
 	if err != nil {
 		return nil, errors.Wrap(err, "load cli config")
 	}
+	if cfg.APIAddress == "" || cfg.BearerToken == "" {
+		return nil, errors.New(
+			"seems like you are not logged in; please use `kargo login` to authenticate",
+		)
+	}
 	skipTLSVerify := opt.InsecureTLS || cfg.InsecureSkipTLSVerify
 	if cfg, err =
 		newTokenRefresher().refreshToken(ctx, cfg, skipTLSVerify); err != nil {

--- a/internal/cli/cmd/config/set.go
+++ b/internal/cli/cmd/config/set.go
@@ -20,7 +20,7 @@ func newSetCommand() *cobra.Command {
 kargo config set project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.EnsureCLIConfig()
+			cfg, err := config.LoadCLIConfig()
 			if err != nil {
 				return errors.Wrap(err, "ensure cli config")
 			}

--- a/internal/cli/cmd/config/set.go
+++ b/internal/cli/cmd/config/set.go
@@ -20,9 +20,9 @@ func newSetCommand() *cobra.Command {
 kargo config set project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.LoadCLIConfig()
+			cfg, err := config.EnsureCLIConfig()
 			if err != nil {
-				return errors.Wrap(err, "load cli config")
+				return errors.Wrap(err, "ensure cli config")
 			}
 
 			key := strings.ToLower(args[0])

--- a/internal/cli/cmd/config/unset.go
+++ b/internal/cli/cmd/config/unset.go
@@ -20,9 +20,9 @@ func newUnsetCommand() *cobra.Command {
 kargo config unset project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.LoadCLIConfig()
+			cfg, err := config.EnsureCLIConfig()
 			if err != nil {
-				return errors.Wrap(err, "load cli config")
+				return errors.Wrap(err, "ensure cli config")
 			}
 
 			key := strings.ToLower(args[0])

--- a/internal/cli/cmd/config/unset.go
+++ b/internal/cli/cmd/config/unset.go
@@ -20,7 +20,7 @@ func newUnsetCommand() *cobra.Command {
 kargo config unset project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.EnsureCLIConfig()
+			cfg, err := config.LoadCLIConfig()
 			if err != nil {
 				return errors.Wrap(err, "ensure cli config")
 			}

--- a/internal/cli/cmd/create/project.go
+++ b/internal/cli/cmd/create/project.go
@@ -36,7 +36,7 @@ kargo create project my-project
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.CreateProject(ctx,
 				connect.NewRequest(&kargosvcapi.CreateProjectRequest{

--- a/internal/cli/cmd/delete/project.go
+++ b/internal/cli/cmd/delete/project.go
@@ -27,7 +27,7 @@ kargo delete project my-project
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			var resErr error

--- a/internal/cli/cmd/delete/stage.go
+++ b/internal/cli/cmd/delete/stage.go
@@ -27,7 +27,7 @@ kargo delete stage --project=my-project my-stage
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			project := opt.Project

--- a/internal/cli/cmd/delete/warehouse.go
+++ b/internal/cli/cmd/delete/warehouse.go
@@ -27,7 +27,7 @@ kargo delete warehouse --project=my-project my-warehouse
 			ctx := cmd.Context()
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			project := opt.Project

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -42,7 +42,7 @@ kargo get freight --project=my-project my-freight
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.QueryFreight(ctx, connect.NewRequest(&v1alpha1.QueryFreightRequest{
 				Project: project,

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -32,7 +32,7 @@ kargo get projects -o json
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.ListProjects(ctx, connect.NewRequest(&v1alpha1.ListProjectsRequest{}))
 			if err != nil {

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -60,7 +60,7 @@ kargo get promotions --project=my-project some-promotion
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.ListPromotions(ctx, connect.NewRequest(req))
 			if err != nil {

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -43,7 +43,7 @@ kargo get stages --project=my-project my-stage
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.ListStages(ctx, connect.NewRequest(&v1alpha1.ListStagesRequest{
 				Project: project,

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -40,7 +40,7 @@ kargo get warehouses --project=my-project my-warehouse
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 			resp, err := kargoSvcCli.ListWarehouses(
 				ctx,

--- a/internal/cli/cmd/update/freight-alias.go
+++ b/internal/cli/cmd/update/freight-alias.go
@@ -26,7 +26,7 @@ func newUpdateFreightAliasCommand(opt *option.Option) *cobra.Command {
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, opt)
 			if err != nil {
-				return errors.New("get client from config")
+				return errors.Wrap(err, "get client from config")
 			}
 
 			if _, err = kargoSvcCli.UpdateFreightAlias(

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -63,6 +63,28 @@ type CLIConfig struct {
 	Project string `json:"project,omitempty"`
 }
 
+// NewDefaultCLIConfig returns a new default CLI configuration.
+func NewDefaultCLIConfig() CLIConfig {
+	return CLIConfig{}
+}
+
+// EnsureCLIConfig returns Kargo CLI configuration if exists,
+// otherwise creates a default CLI configuration to the
+// Kargo home directory and returns it.
+func EnsureCLIConfig() (CLIConfig, error) {
+	cfg, err := loadCLIConfig(xdgConfigPath)
+	if err != nil {
+		if IsConfigNotFoundErr(err) {
+			defaultCfg := NewDefaultCLIConfig()
+			if err = SaveCLIConfig(defaultCfg); err != nil {
+				return defaultCfg, errors.Wrap(err, "save default cli config")
+			}
+			return defaultCfg, nil
+		}
+	}
+	return cfg, nil
+}
+
 // LoadCLIConfig loads Kargo CLI configuration from a file in the Kargo home
 // directory.
 func LoadCLIConfig() (CLIConfig, error) {

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -68,23 +68,6 @@ func NewDefaultCLIConfig() CLIConfig {
 	return CLIConfig{}
 }
 
-// EnsureCLIConfig returns Kargo CLI configuration if exists,
-// otherwise creates a default CLI configuration to the
-// Kargo home directory and returns it.
-func EnsureCLIConfig() (CLIConfig, error) {
-	cfg, err := loadCLIConfig(xdgConfigPath)
-	if err != nil {
-		if IsConfigNotFoundErr(err) {
-			defaultCfg := NewDefaultCLIConfig()
-			if err = SaveCLIConfig(defaultCfg); err != nil {
-				return defaultCfg, errors.Wrap(err, "save default cli config")
-			}
-			return defaultCfg, nil
-		}
-	}
-	return cfg, nil
-}
-
 // LoadCLIConfig loads Kargo CLI configuration from a file in the Kargo home
 // directory.
 func LoadCLIConfig() (CLIConfig, error) {

--- a/internal/cli/config/errors.go
+++ b/internal/cli/config/errors.go
@@ -1,9 +1,18 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 type ErrConfigNotFound struct {
 	Path string
+}
+
+func IsConfigNotFoundErr(target error) bool {
+	var err *ErrConfigNotFound
+	return errors.As(target, &err)
 }
 
 func NewConfigNotFoundErr(path string) error {


### PR DESCRIPTION
Fixes https://github.com/akuity/kargo/issues/1341

Currently, the CLI entrypoint and some commands assumes that the config file exists in the home directory. So all commands and config-related commands (e.g. `config set`, `config unset`) are failing if the config file does not exist.

This commit fixes this issue by returning an default config if the config file does not exists in the CLI entrypoint and creates the config file if necessary in config-related commands.