### PR TITLE
fix(ui): Freightline items overflow with 2+ items

### DIFF
--- a/ui/src/features/freightline/freight-contents.tsx
+++ b/ui/src/features/freightline/freight-contents.tsx
@@ -20,7 +20,7 @@ export const FreightContents = (props: {
     } & React.PropsWithChildren
   ) => (
     <Tooltip
-      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 ${
+      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-full ${
         promoting && highlighted ? 'bg-transparent' : ''
       }`}
       overlay={props.overlay}
@@ -33,7 +33,7 @@ export const FreightContents = (props: {
 
   return (
     <div
-      className={`hover:text-white flex flex-col justify-center items-center font-mono text-xs flex-shrink min-w-min w-full ${
+      className={`hover:text-white flex flex-col justify-start items-center font-mono text-xs flex-shrink min-w-min w-full overflow-y-auto max-h-full ${
         highlighted ? 'text-white' : 'text-gray-500'
       }`}
     >

--- a/ui/src/features/freightline/freight-item.tsx
+++ b/ui/src/features/freightline/freight-item.tsx
@@ -46,7 +46,9 @@ export const FreightItem = ({
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
     >
-      <div className='flex w-full h-full mb-1 items-center justify-center'>{children}</div>
+      <div className='flex w-full h-full mb-1 items-center justify-center overflow-hidden'>
+        {children}
+      </div>
       <div className='mt-auto w-full'>
         <div
           className={`w-full text-center font-mono text-xs truncate ${


### PR DESCRIPTION
Fixes #830

If there are 2+ freight items, a vertical scrollbar appears and users can scroll through every item (the scroll bar disappeared for the screenshot): 
![CleanShot 2024-01-02 at 14 10 59@2x](https://github.com/akuity/kargo/assets/6250584/732b9cb4-c1de-4d77-9800-900505aca2e1)
