### PR TITLE
refactor(cli): restrict common flags to subcommands branches where they're applicable

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -94,8 +94,6 @@ func NewRootCommand(
 		return nil, err
 	}
 	opt.PrintFlags = genericclioptions.NewPrintFlags("").WithTypeSetter(scheme)
-	option.InsecureTLS(cmd.PersistentFlags(), opt)
-	option.LocalServer(cmd.PersistentFlags(), opt)
 
 	cmd.AddCommand(apply.NewCommand(cfg, opt))
 	cmd.AddCommand(cliconfigcmd.NewCommand(cfg))

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -72,6 +72,7 @@ func newVersionCommand(
 		},
 	}
 	opt.PrintFlags.AddFlags(cmd)
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	return cmd
 }
 

--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -116,5 +116,7 @@ kargo apply -f stage.yaml
 	}
 	opt.PrintFlags.AddFlags(cmd)
 	option.Filenames(cmd.Flags(), &filenames, "apply")
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
 	return cmd
 }

--- a/internal/cli/cmd/create/create.go
+++ b/internal/cli/cmd/create/create.go
@@ -94,6 +94,8 @@ kargo create project my-project
 	}
 	opt.PrintFlags.AddFlags(cmd)
 	option.Filenames(cmd.Flags(), &filenames, "apply")
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
 
 	// Subcommands
 	cmd.AddCommand(newProjectCommand(cfg, opt))

--- a/internal/cli/cmd/delete/delete.go
+++ b/internal/cli/cmd/delete/delete.go
@@ -84,6 +84,8 @@ kargo delete -f stage.yaml
 		},
 	}
 	option.Filenames(cmd.Flags(), &filenames, "apply")
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
 
 	// Subcommands
 	cmd.AddCommand(newProjectCommand(cfg, opt))

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -28,6 +28,9 @@ kargo get stages --project=my-project
 kargo get promotions --project=my-project --stage=my-stage
 `,
 	}
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
+
 	// Subcommands
 	cmd.AddCommand(newGetFreightCommand(cfg, opt))
 	cmd.AddCommand(newGetProjectsCommand(cfg, opt))

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -154,6 +154,7 @@ func NewCommand(opt *option.Option) *cobra.Command {
 		"Log in using OpenID Connect and the server's configured identity "+
 			"provider; mutually exclusive with --admin and --kubeconfig",
 	)
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	return cmd
 }
 

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -19,6 +19,9 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		Use:   "refresh",
 		Short: "Refresh a stage or warehouse",
 	}
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
+
 	cmd.AddCommand(newRefreshWarehouseCommand(cfg, opt))
 	cmd.AddCommand(newRefreshStageCommand(cfg, opt))
 	return cmd

--- a/internal/cli/cmd/stage/stage.go
+++ b/internal/cli/cmd/stage/stage.go
@@ -12,6 +12,9 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		Use:   "stage",
 		Short: "Manage stages",
 	}
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
+
 	cmd.AddCommand(newPromoteCommand(cfg, opt))
 	cmd.AddCommand(newEnableAutoPromotion(cfg, opt))
 	cmd.AddCommand(newDisableAutoPromotion(cfg, opt))

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -12,6 +12,9 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		Use:   "update",
 		Short: "Update a freight alias",
 	}
+	option.InsecureTLS(cmd.PersistentFlags(), opt)
+	option.LocalServer(cmd.PersistentFlags(), opt)
+
 	cmd.AddCommand(newUpdateFreightAliasCommand(cfg, opt))
 	return cmd
 }


### PR DESCRIPTION
Fixes #1353 