### PR TITLE
chore: Update to kargo-render v0.1.0-rc34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.33 as back-end-dev
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.34 as back-end-dev
 
 USER root
 
@@ -103,7 +103,7 @@ CMD ["pnpm", "dev"]
 # - the official image we publish
 # - purposefully last so that it is the default target when building
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.33 as final
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.34 as final
 
 USER root
 


### PR DESCRIPTION
kargo-rencer rc.34 introduced significant changes to the `kargo-render.yaml` file structure.

The underlying error I am trying to work around is:

```
Error: error loading Kargo Render configuration from repo: error normalizing and validating Kargo
Render configuration: error validating Kargo Render configuration:
branchConfigs.0.appConfigs.testservice.configManagement: Must validate one and only one schema (oneOf);
branchConfigs.0.appConfigs.testservice.configManagement: Additional property path is not allowed;
branchConfigs.0.appConfigs.testservice.configManagement.helm: Additional property valueFiles is not allowed
```

I believe this is because my `kargo-render.yaml` file is set up to work with rc.34, but kargo is still importing rc.33.