### PR TITLE
fix: configuring kubernetesDatabaseConfig with env vars

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -78,8 +78,8 @@ type kubernetesDatabase struct {
 // kubernetesDatabase struct. It uses the functional options pattern to allow
 // for easy configuration.
 type kubernetesDatabaseConfig struct {
-	argoCDNamespace             string   `envconfig:"ARGOCD_NAMESPACE" default:"argocd"`
-	globalCredentialsNamespaces []string `envconfig:"GLOBAL_CREDENTIALS_NAMESPACES" default:""`
+	ArgoCDNamespace             string   `envconfig:"ARGOCD_NAMESPACE" default:"argocd"`
+	GlobalCredentialsNamespaces []string `envconfig:"GLOBAL_CREDENTIALS_NAMESPACES" default:""`
 
 	kargoClient client.Client
 	// it set we know that "borrowing ArgoCD creds" is enabled
@@ -172,7 +172,7 @@ func (k *kubernetesDatabase) Get(
 	}
 
 	// Check global credentials namespaces for credentials
-	for _, globalCredsNamespace := range k.globalCredentialsNamespaces {
+	for _, globalCredsNamespace := range k.GlobalCredentialsNamespaces {
 		// Check shared creds namespace for credentials
 		if secret, err = getCredentialsSecret(
 			ctx,
@@ -221,7 +221,7 @@ func (k *kubernetesDatabase) Get(
 	if secret, err = getCredentialsSecret(
 		ctx,
 		k.argoClient,
-		k.argoCDNamespace,
+		k.ArgoCDNamespace,
 		labels.Set(map[string]string{
 			argoCDSecretTypeLabelKey: repositorySecretTypeLabelValue,
 		}).AsSelector(),
@@ -237,7 +237,7 @@ func (k *kubernetesDatabase) Get(
 		if secret, err = getCredentialsSecret(
 			ctx,
 			k.argoClient,
-			k.argoCDNamespace,
+			k.ArgoCDNamespace,
 			labels.Set(map[string]string{
 				argoCDSecretTypeLabelKey: repoCredsSecretTypeLabelValue,
 			}).AsSelector(),

--- a/internal/credentials/credentials_options.go
+++ b/internal/credentials/credentials_options.go
@@ -4,13 +4,13 @@ import "sigs.k8s.io/controller-runtime/pkg/client"
 
 func WithArgoCDNamespace(namespace string) KubernetesDatabaseOption {
 	return func(config *kubernetesDatabaseConfig) {
-		config.argoCDNamespace = namespace
+		config.ArgoCDNamespace = namespace
 	}
 }
 
 func WithGlobalCredentialsNamespaces(namespaces []string) KubernetesDatabaseOption {
 	return func(config *kubernetesDatabaseConfig) {
-		config.globalCredentialsNamespaces = namespaces
+		config.GlobalCredentialsNamespaces = namespaces
 	}
 }
 

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -22,7 +22,7 @@ func TestNewKubernetesDatabase(t *testing.T) {
 	require.NotNil(t, d)
 	k, ok := d.(*kubernetesDatabase)
 	require.True(t, ok)
-	require.Equal(t, testArgoCDNameSpace, k.argoCDNamespace)
+	require.Equal(t, testArgoCDNameSpace, k.ArgoCDNamespace)
 	require.Same(t, testClient, k.kargoClient)
 	require.Same(t, testClient, k.argoClient)
 }


### PR DESCRIPTION
As kubernetesDatabaseConfig has private vars, envconf didn't fill their content from defined env vars