### PR TITLE
fix(docs): remove superfluous detail from quickstart

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -320,7 +320,6 @@ the previous section.
         kargo.akuity.io/secret-type: repository
     stringData:
       type: git
-      project: default
       url: ${GITOPS_REPO_URL}
       username: ${GITHUB_USERNAME}
       password: ${GITHUB_PAT}


### PR DESCRIPTION
This is leftover from when the quickstart used to borrow a secret from Argo CD.

The quickstart no longer demonstrates that behavior, so the field removed by this PR was a useless detail and a distraction.