### PR TITLE
fix: add KLOG_LEVEL to set kubernetes logging level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 )
 
 require (
+	github.com/bombsimon/logrusr/v4 v4.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.6.0 // indirect
 	sigs.k8s.io/kustomize/api v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bombsimon/logrusr/v4 v4.1.0 h1:uZNPbwusB0eUXlO8hIUwStE6Lr5bLN6IgYgG+75kuh4=
+github.com/bombsimon/logrusr/v4 v4.1.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"strconv"
 
+	"github.com/bombsimon/logrusr/v4"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/akuity/kargo/internal/os"
 )
@@ -23,6 +25,8 @@ func init() {
 	}
 	globalLogger.Logger.SetLevel(level)
 	SetKLogLevel(os.GetEnvInt("KLOG_LEVEL", 0))
+
+	runtimelog.SetLogger(logrusr.New(globalLogger))
 }
 
 // ContextWithLogger returns a context.Context that has been augmented with

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -2,8 +2,11 @@ package logging
 
 import (
 	"context"
+	"flag"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 
 	"github.com/akuity/kargo/internal/os"
 )
@@ -19,6 +22,7 @@ func init() {
 		panic(err)
 	}
 	globalLogger.Logger.SetLevel(level)
+	SetKLogLevel(os.GetEnvInt("KLOG_LEVEL", 0))
 }
 
 // ContextWithLogger returns a context.Context that has been augmented with
@@ -35,4 +39,11 @@ func LoggerFromContext(ctx context.Context) *log.Entry {
 		return ctx.Value(loggerContextKey{}).(*log.Entry) // nolint: forcetypeassert
 	}
 	return globalLogger
+}
+
+// SetKLogLevel set the klog level for the k8s go-client
+func SetKLogLevel(klogLevel int) {
+	klog.InitFlags(nil)
+	klog.SetOutput(globalLogger.Writer())
+	_ = flag.Set("v", strconv.Itoa(klogLevel))
 }

--- a/internal/os/env.go
+++ b/internal/os/env.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"os"
+	"strconv"
 )
 
 // GetEnv retrieves the value of an environment variable having the specified
@@ -12,4 +13,19 @@ func GetEnv(key, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+// GetEnvInt retrieves the value of an environment variable having the specified
+// key. If the value is empty string, or cannot parse as an int, a specified
+// default is returned instead.
+func GetEnvInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+	value, err := strconv.ParseInt(valueStr, 10, 0)
+	if err != nil {
+		return defaultValue
+	}
+	return int(value)
 }


### PR DESCRIPTION
Changes:
1. Introduces an env var `KLOG_LEVEL` which will set the Kubernetes integer log level for the go-client. This is often necessary to debug issues, such as https://github.com/akuity/kargo/issues/1414
2. Calls `sigs.k8s.io/controller-runtime/pkg/log` `SetLogger` to silence the `log.SetLogger(...) was never called; logs will not be displayed.` error.

Example output of `KLOG_LEVEL=7`:

```
INFO[0000] Starting Kargo Controller                     commit= version=devel+unknown.dirty
I0124 11:33:23.520710   98235 loader.go:395] Config loaded from file:  /Users/jesse/.kube/config
I0124 11:33:23.523716   98235 loader.go:395] Config loaded from file:  /Users/jesse/.kube/config
I0124 11:33:23.524361   98235 round_trippers.go:463] GET https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/argoproj.io/v1alpha1/namespaces/argocd/applications?limit=1
I0124 11:33:23.524371   98235 round_trippers.go:469] Request Headers:
I0124 11:33:23.524377   98235 round_trippers.go:473]     Accept: application/json
I0124 11:33:23.524381   98235 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:33:24.367709   98235 round_trippers.go:574] Response Status: 200 OK in 843 milliseconds
INFO[0000] Argo CD integration is enabled
I0124 11:33:24.450512   98235 loader.go:395] Config loaded from file:  /Users/jesse/.kube/config
I0124 11:33:24.452092   98235 round_trippers.go:463] GET https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/argoproj.io/v1alpha1/analysistemplates?limit=1
I0124 11:33:24.452114   98235 round_trippers.go:469] Request Headers:
I0124 11:33:24.452132   98235 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:33:24.452146   98235 round_trippers.go:473]     Accept: application/json
I0124 11:33:24.502206   98235 round_trippers.go:574] Response Status: 200 OK in 50 milliseconds
INFO[0001] Argo Rollouts integration is enabled
I0124 11:33:24.505987   98235 round_trippers.go:463] GET https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1
I0124 11:33:24.506007   98235 round_trippers.go:469] Request Headers:
I0124 11:33:24.506022   98235 round_trippers.go:473]     Accept: application/json, */*
I0124 11:33:24.506032   98235 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:33:24.546336   98235 round_trippers.go:574] Response Status: 200 OK in 40 milliseconds
I0124 11:33:24.549154   98235 reflector.go:289] Starting reflector *v1alpha1.Freight (10h56m17.351977301s) from sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105
I0124 11:33:24.549206   98235 reflector.go:289] Starting reflector *v1alpha1.Stage (10h3m10.939444747s) from sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105
I0124 11:33:24.549236   98235 reflector.go:325] Listing and watching *v1alpha1.Freight from sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105
I0124 11:33:24.549238   98235 reflector.go:325] Listing and watching *v1alpha1.Stage from sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105
I0124 11:33:24.549649   98235 round_trippers.go:463] GET https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/stages?limit=500&resourceVersion=0
I0124 11:33:24.549660   98235 round_trippers.go:463] GET https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/freights?limit=500&resourceVersion=0
I0124 11:33:24.550251   98235 round_trippers.go:469] Request Headers:
I0124 11:33:24.550280   98235 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:33:24.550300   98235 round_trippers.go:473]     Accept: application/json, */*
I0124 11:33:24.549669   98235 round_trippers.go:469] Request Headers:
I0124 11:33:24.550472   98235 round_trippers.go:473]     Accept: application/json, */*
I0124 11:33:24.550492   98235 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
...
...
...
I0124 11:37:12.474561   98381 round_trippers.go:574] Response Status: 200 OK in 125 milliseconds
I0124 11:37:12.547855   98381 request.go:629] Waited for 303.150292ms due to client-side throttling, not priority and fairness, request: PATCH:https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/namespaces/kargo-guestbook/stages/ab-test-b
I0124 11:37:12.548071   98381 round_trippers.go:463] PATCH https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/namespaces/kargo-guestbook/stages/ab-test-b
I0124 11:37:12.548088   98381 round_trippers.go:469] Request Headers:
I0124 11:37:12.548105   98381 round_trippers.go:473]     Accept: application/json, */*
I0124 11:37:12.548117   98381 round_trippers.go:473]     Content-Type: application/merge-patch+json
I0124 11:37:12.548129   98381 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:37:12.604022   98381 round_trippers.go:574] Response Status: 200 OK in 55 milliseconds
I0124 11:37:13.471348   98381 round_trippers.go:463] POST https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/namespaces/kargo-guestbook/freights
I0124 11:37:13.471416   98381 round_trippers.go:469] Request Headers:
I0124 11:37:13.471434   98381 round_trippers.go:473]     Content-Type: application/json
I0124 11:37:13.471446   98381 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:37:13.471457   98381 round_trippers.go:473]     Accept: application/json, */*
I0124 11:37:13.531146   98381 round_trippers.go:574] Response Status: 409 Conflict in 59 milliseconds
I0124 11:37:14.060542   98381 round_trippers.go:463] POST https://REDACTED.gr7.us-west-2.eks.amazonaws.com/apis/kargo.akuity.io/v1alpha1/namespaces/kargo-simple/freights
I0124 11:37:14.060597   98381 round_trippers.go:469] Request Headers:
I0124 11:37:14.060613   98381 round_trippers.go:473]     Accept: application/json, */*
I0124 11:37:14.060623   98381 round_trippers.go:473]     Content-Type: application/json
I0124 11:37:14.060633   98381 round_trippers.go:473]     User-Agent: controlplane/v0.0.0 (darwin/arm64) kubernetes/$Format
I0124 11:37:14.121427   98381 round_trippers.go:574] Response Status: 409 Conflict in 60 milliseconds
```