### PR TITLE
fix(docs): Fix incorrect login command & UI url

### DIFF
--- a/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
+++ b/docs/docs/40-contributor-guide/10-hacking-on-kargo.mdx
@@ -312,14 +312,14 @@ as native processes.
     You can log in using:
 
     ```shell
-    bin/kargo-<os>-<arch> login https://localhost:30081 \
+    bin/kargo-<os>-<arch> login http://localhost:30081 \
       --admin \
       --password admin \
       --insecure-skip-tls-verify
     ```
 
 1. If necessary, access the Kargo UI at
-   [localhost:30081](https://localhost:30081).
+   [localhost:30082](http://localhost:30082).
 
     The admin account password is `admin`.
 


### PR DESCRIPTION
When attempting to get Kargo up and running following the Quickstart documentation I ran into the following error when running the kargo login command as specified in the docs:
`Error: error retrieving public configuration from server: unavailable: http: server gave HTTP response to HTTPS client`

I have also confirmed that the config is note actually save properly when this error occurs so it seems to defintely be an issue.

Once I resolved that by changing https -> http, I ran into one more issue because the Kargo UI was not available at the specified URL, (https://localhost:30081) it was only available at http:localhost:30082). Looking through the code a bit this seems to make sense and just be an error in the documentation.

However, I'm brand new to the project so please point out anything I have missed.