### PR TITLE
fix(ui): undo #1423 -- release-0.3

### DIFF
--- a/ui/src/features/project/project-details/project-details.tsx
+++ b/ui/src/features/project/project-details/project-details.tsx
@@ -91,7 +91,6 @@ export const ProjectDetails = () => {
     onSuccess: () => {
       message.success('Warehouse successfully refreshed');
       setPromotingStage(undefined);
-      refetchFreightData();
     }
   });
 


### PR DESCRIPTION
This reverts #1423 / commit ce84805cfa7eb99be8864b87367e3bdae1b9fb84.

#1423 blindly cherry-picked a small fix from `main` without realizing that there were _other_ things needed from `main` in order for it to work. #1423 therefore created a new bug.

We've since discovered that synchronously refreshing the freightline after Warehouse sync is not the improvement we're really looking for, regardless. Since the Warehouse refresh is carried out asynchronously by the controller, there is no guarantee of a synchronously refreshed freightline showing any new Freight.
