### PR TITLE
fix(controller): add another nil check in stages by analysis runs indexer

### DIFF
--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -60,7 +60,8 @@ func indexStagesByAnalysisRun(shardName string) client.IndexerFunc {
 
 		stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
 		if stage.Status.CurrentFreight == nil ||
-			stage.Status.CurrentFreight.VerificationInfo == nil {
+			stage.Status.CurrentFreight.VerificationInfo == nil ||
+			stage.Status.CurrentFreight.VerificationInfo.AnalysisRun == nil {
 			return nil
 		}
 		return []string{


### PR DESCRIPTION
I found that if there is an error launching an AnalysisRun, it is possible for `stage.Status.CurrentFreight.VerificationInfo` to be non-nil, while `tage.Status.CurrentFreight.VerificationInfo.AnalysisRun` _is_ nil.