### PR TITLE
refactor: create project namespaces synchronously

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -12,7 +12,6 @@ rules:
   resources:
   - namespaces
   verbs:
-  - create
   - get
   - list
   - patch

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -12,6 +12,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - watch

--- a/charts/kargo/templates/webhooks/webhooks.yaml
+++ b/charts/kargo/templates/webhooks/webhooks.yaml
@@ -82,7 +82,7 @@ webhooks:
   failurePolicy: Fail
 - name: project.kargo.akuity.io
   admissionReviewVersions: ["v1"]
-  sideEffects: None
+  sideEffects: NoneOnDryRun
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}

--- a/internal/controller/management/projects/projects_test.go
+++ b/internal/controller/management/projects/projects_test.go
@@ -6,11 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -24,8 +20,6 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, r.getProjectFn)
 	require.NotNil(t, r.syncProjectFn)
 	require.NotNil(t, r.patchProjectStatusFn)
-	require.NotNil(t, r.getNamespaceFn)
-	require.NotNil(t, r.createNamespaceFn)
 }
 
 func TestReconcile(t *testing.T) {
@@ -179,135 +173,13 @@ func TestSyncProject(t *testing.T) {
 		)
 	}{
 		{
-			name: "error getting namespace",
+			name: "success",
 			project: &kargoapi.Project{
 				Status: kargoapi.ProjectStatus{
 					Phase: kargoapi.ProjectPhaseInitializing,
 				},
 			},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
-					context.Context,
-					types.NamespacedName,
-					client.Object,
-					...client.GetOption,
-				) error {
-					return errors.New("something went wrong")
-				},
-			},
-			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error getting namespace")
-				// Status is unchanged
-				require.Equal(t, initialStatus, newStatus)
-			},
-		},
-		{
-			name:    "namespace exists and is not owned by project",
-			project: &kargoapi.Project{},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
-					context.Context,
-					types.NamespacedName,
-					client.Object,
-					...client.GetOption,
-				) error {
-					return nil
-				},
-			},
-			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				// Status should reflect the unrecoverable failure
-				require.Equal(t, newStatus.Phase, kargoapi.ProjectPhaseInitializationFailed)
-				require.Contains(t, err.Error(), "failed to initialize Project")
-			},
-		},
-		{
-			name: "namespace exists and is owned by project",
-			project: &kargoapi.Project{
-				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("fake-uid"),
-				},
-			},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
-					_ context.Context,
-					_ types.NamespacedName,
-					obj client.Object,
-					_ ...client.GetOption,
-				) error {
-					ns := obj.(*corev1.Namespace) // nolint: forcetypeassert
-					ns.OwnerReferences = []metav1.OwnerReference{
-						{
-							UID: types.UID("fake-uid"),
-						},
-					}
-					return nil
-				},
-			},
-			assertions: func(_, newStatus kargoapi.ProjectStatus, err error) {
-				require.NoError(t, err)
-				// Status should reflect that the Project is in a ready state
-				require.Equal(t, newStatus.Phase, kargoapi.ProjectPhaseReady)
-			},
-		},
-		{
-			name: "namespace does not exist; error creating it",
-			project: &kargoapi.Project{
-				Status: kargoapi.ProjectStatus{
-					Phase: kargoapi.ProjectPhaseInitializing,
-				},
-			},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
-					context.Context,
-					types.NamespacedName,
-					client.Object,
-					...client.GetOption,
-				) error {
-					return apierrors.NewNotFound(schema.GroupResource{}, "")
-				},
-				createNamespaceFn: func(
-					context.Context,
-					client.Object,
-					...client.CreateOption,
-				) error {
-					return errors.New("something went wrong")
-				},
-			},
-			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error creating namespace")
-				// Status is unchanged
-				require.Equal(t, initialStatus, newStatus)
-			},
-		},
-		{
-			name: "namespace does not exist; success creating it",
-			project: &kargoapi.Project{
-				Status: kargoapi.ProjectStatus{
-					Phase: kargoapi.ProjectPhaseInitializing,
-				},
-			},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
-					context.Context,
-					types.NamespacedName,
-					client.Object,
-					...client.GetOption,
-				) error {
-					return apierrors.NewNotFound(schema.GroupResource{}, "")
-				},
-				createNamespaceFn: func(
-					context.Context,
-					client.Object,
-					...client.CreateOption,
-				) error {
-					return nil
-				},
-			},
+			reconciler: &reconciler{},
 			assertions: func(_, newStatus kargoapi.ProjectStatus, err error) {
 				require.NoError(t, err)
 				// Status should reflect that the Project is in a ready state

--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -3,17 +3,22 @@ package project
 import (
 	"context"
 
+	"github.com/containerd/log"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/logging"
 )
 
 var projectGroupResource = schema.GroupResource{
@@ -22,8 +27,6 @@ var projectGroupResource = schema.GroupResource{
 }
 
 type webhook struct {
-	client client.Client
-
 	// The following behaviors are overridable for testing purposes:
 
 	getNamespaceFn func(
@@ -31,6 +34,12 @@ type webhook struct {
 		types.NamespacedName,
 		client.Object,
 		...client.GetOption,
+	) error
+
+	createNamespaceFn func(
+		context.Context,
+		client.Object,
+		...client.CreateOption,
 	) error
 }
 
@@ -44,8 +53,8 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 func newWebhook(kubeClient client.Client) *webhook {
 	return &webhook{
-		client:         kubeClient,
-		getNamespaceFn: kubeClient.Get,
+		getNamespaceFn:    kubeClient.Get,
+		createNamespaceFn: kubeClient.Create,
 	}
 }
 
@@ -53,31 +62,89 @@ func (w *webhook) ValidateCreate(
 	ctx context.Context,
 	obj runtime.Object,
 ) (admission.Warnings, error) {
-	project := obj.(*kargoapi.Project) // nolint: forcetypeassert
-	// Validate that a namespace matching the project name doesn't already exist.
-	namespace := &corev1.Namespace{}
-	if err := w.getNamespaceFn(
-		ctx,
-		client.ObjectKey{Name: project.Name},
-		namespace,
-	); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			// This is good. The namespace doesn't already exist.
-			return nil, nil
-		}
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
 		return nil, apierrors.NewInternalError(
-			errors.Wrapf(err, "error getting namespace %q", project.Name),
+			errors.Wrap(err, "error getting admission request from context"),
 		)
 	}
-	return nil, apierrors.NewConflict(
-		projectGroupResource,
-		project.Name,
-		errors.Errorf(
-			"cannot create Project %q because namespace %q already exists",
-			project.Name,
-			project.Name,
-		),
-	)
+	if req.DryRun == nil || !*req.DryRun {
+		project := obj.(*kargoapi.Project) // nolint: forcetypeassert
+
+		logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
+			"project": project.Name,
+			"name":    project.Name,
+		})
+
+		// We handle creation of a Project's associated namespace synchronously in
+		// this webhook so that the namespace is guaranteed to exist before
+		// other resources (appearing below the Project) in a manifest will not fail
+		// to create due to the namespace not existing yet.
+
+		// There is no guarantee that just because this is a create request that
+		// there wasn't a previous attempt to create this Project that failed. If
+		// that is the case, the namespace may already exist.
+		ns := &corev1.Namespace{}
+		if err = w.getNamespaceFn(
+			ctx,
+			types.NamespacedName{Name: project.Name},
+			ns,
+		); err == nil {
+			// We found an existing namespace with the same name as the Project. If it's
+			// owned by this Project then it was created on a previous attempt to
+			// reconcile this Project, but otherwise, this is a problem.
+			for _, ownerRef := range ns.OwnerReferences {
+				if ownerRef.UID == project.UID {
+					logger.Debug("namespace exists and is owned by this Project")
+					return nil, nil
+				}
+			}
+			return nil, apierrors.NewConflict(
+				projectGroupResource,
+				project.Name,
+				errors.Errorf(
+					"failed to initialize Project %q because namespace %q already exists",
+					project.Name,
+					project.Name,
+				),
+			)
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, apierrors.NewInternalError(
+				errors.Wrapf(err, "error getting namespace %q", project.Name),
+			)
+		}
+
+		logger.Debug("namespace does not exist yet; creating namespace")
+
+		ownerRef := metav1.NewControllerRef(
+			project,
+			kargoapi.GroupVersion.WithKind("Project"),
+		)
+		ownerRef.BlockOwnerDeletion = ptr.To(false)
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: project.Name,
+				Labels: map[string]string{
+					kargoapi.ProjectLabelKey: kargoapi.LabelTrueValue,
+				},
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		}
+		// Project namespaces are owned by a Project. Deleting a Project
+		// automatically deletes the namespace. But we also want this to work in the
+		// other direction, where that behavior is not automatic. We add a finalizer
+		// to the namespace and use our own namespace reconciler to clear it after
+		// deleting the Project.
+		controllerutil.AddFinalizer(ns, kargoapi.FinalizerName)
+		if err := w.createNamespaceFn(ctx, ns); err != nil {
+			return nil, apierrors.NewInternalError(
+				errors.Wrapf(err, "error creating namespace %q", project.Name),
+			)
+		}
+		logger.Debug("created namespace")
+	}
+	return nil, nil
 }
 
 func (w *webhook) ValidateUpdate(

--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -3,8 +3,8 @@ package project
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -3,7 +3,7 @@ package project
 import (
 	"context"
 
-	"github.com/containerd/log"
+	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/webhook/project/webhook_test.go
+++ b/internal/webhook/project/webhook_test.go
@@ -7,13 +7,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
+
+func TestNewWebhook(t *testing.T) {
+	w := newWebhook(fake.NewClientBuilder().Build())
+	require.NotNil(t, w)
+	require.NotNil(t, w.getNamespaceFn)
+	require.NotNil(t, w.createNamespaceFn)
+}
 
 func TestValidateCreate(t *testing.T) {
 	testCases := []struct {
@@ -21,6 +34,7 @@ func TestValidateCreate(t *testing.T) {
 		webhook    *webhook
 		assertions func(error)
 	}{
+
 		{
 			name: "error getting namespace",
 			webhook: &webhook{
@@ -37,15 +51,12 @@ func TestValidateCreate(t *testing.T) {
 				require.Error(t, err)
 				statusErr, ok := err.(*apierrors.StatusError)
 				require.True(t, ok)
-				require.Equal(
-					t,
-					int32(http.StatusInternalServerError),
-					statusErr.ErrStatus.Code,
-				)
+				require.Equal(t, int32(http.StatusInternalServerError), statusErr.ErrStatus.Code)
 			},
 		},
+
 		{
-			name: "namespace already exists",
+			name: "namespace exists and is not owned by project",
 			webhook: &webhook{
 				getNamespaceFn: func(
 					context.Context,
@@ -63,8 +74,32 @@ func TestValidateCreate(t *testing.T) {
 				require.Equal(t, int32(http.StatusConflict), statusErr.ErrStatus.Code)
 			},
 		},
+
 		{
-			name: "success",
+			name: "namespace exists and is owned by project",
+			webhook: &webhook{
+				getNamespaceFn: func(
+					_ context.Context,
+					_ types.NamespacedName,
+					obj client.Object,
+					_ ...client.GetOption,
+				) error {
+					ns := obj.(*corev1.Namespace) // nolint: forcetypeassert
+					ns.OwnerReferences = []metav1.OwnerReference{
+						{
+							UID: types.UID("fake-uid"),
+						},
+					}
+					return nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "namespace does not exist; error creating it",
 			webhook: &webhook{
 				getNamespaceFn: func(
 					context.Context,
@@ -72,11 +107,45 @@ func TestValidateCreate(t *testing.T) {
 					client.Object,
 					...client.GetOption,
 				) error {
-					return &apierrors.StatusError{
-						ErrStatus: metav1.Status{
-							Code: http.StatusNotFound,
-						},
-					}
+					return apierrors.NewNotFound(schema.GroupResource{}, "")
+				},
+				createNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				statusErr, ok := err.(*apierrors.StatusError)
+				require.True(t, ok)
+				require.Equal(
+					t,
+					int32(http.StatusInternalServerError),
+					statusErr.ErrStatus.Code,
+				)
+			},
+		},
+
+		{
+			name: "namespace does not exist; success creating it",
+			webhook: &webhook{
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "")
+				},
+				createNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return nil
 				},
 			},
 			assertions: func(err error) {
@@ -85,10 +154,22 @@ func TestValidateCreate(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		ctx := admission.NewContextWithRequest(
+			context.Background(),
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					DryRun: ptr.To(false),
+				},
+			},
+		)
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := testCase.webhook.ValidateCreate(
-				context.Background(),
-				&kargoapi.Project{},
+				ctx,
+				&kargoapi.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: types.UID("fake-uid"),
+					},
+				},
 			)
 			testCase.assertions(err)
 		})


### PR DESCRIPTION
Fixes #1415 

#1388 began creating the namespace associated with a Project asynchronously as part of Project reconciliation.

Although rarely encountered, it became possible for creation of resources _in_ the Project's namespace to fail because the Project was not yet reconciled for the first time.

This change absolves the Project reconciler of responsibility for namespace creation and makes that task the responsibility of the Project validation webhook. This webhook used to at least check for availability of the namespace, but now it creates it. Namespace creation is synchronous now, which eliminates the potential for the failure described.


