### PR TITLE
refactor: no special treatment for ns in api server apply

### DIFF
--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -37,8 +37,7 @@ func splitYAML(
 		if err := yaml.Unmarshal(ext.Raw, &resource); err != nil {
 			return nil, nil, errors.Wrap(err, "error unmarshaling manifest")
 		}
-		if (resource.GroupVersionKind().Group == kargoapi.GroupVersion.Group && resource.GetKind() == "Project") ||
-			(resource.GroupVersionKind().Group == "" && resource.GetKind() == "Namespace") {
+		if resource.GroupVersionKind().Group == kargoapi.GroupVersion.Group && resource.GetKind() == "Project" {
 			projects = append(projects, resource)
 		} else {
 			otherResources = append(otherResources, resource)


### PR DESCRIPTION
#1388 removed the API server's permissions to create and delete namespaces.

This is now done indirectly via Project resources instead.

With this in mind, having the API server prioritizing namespace creation over creation of other resources doesn't make sense.

The choices are either:

* Restore the API server's permission to create namespaces so the special treatment makes sense again.
* Remove this special treatment.

I've chosen the latter, because I think it's a good thing that the API server (the component with the most attackable surface area) doesn't have that powerful permission.