### PR TITLE
feat(cli): Add kargo dashboard command

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/akuity/kargo/internal/cli/cmd/approve"
 	cliconfigcmd "github.com/akuity/kargo/internal/cli/cmd/config"
 	"github.com/akuity/kargo/internal/cli/cmd/create"
+	"github.com/akuity/kargo/internal/cli/cmd/dashboard"
 	"github.com/akuity/kargo/internal/cli/cmd/delete"
 	"github.com/akuity/kargo/internal/cli/cmd/get"
 	"github.com/akuity/kargo/internal/cli/cmd/login"
@@ -107,6 +108,7 @@ func NewRootCommand(
 	cmd.AddCommand(stage.NewCommand(cfg, opt))
 	cmd.AddCommand(refresh.NewCommand(cfg, opt))
 	cmd.AddCommand(update.NewCommand(cfg, opt))
+	cmd.AddCommand(dashboard.NewCommand(cfg))
 	cmd.AddCommand(newVersionCommand(cfg, opt))
 	cmd.AddCommand(
 		cobracompletefig.CreateCompletionSpecCommand(

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -1,0 +1,29 @@
+package dashboard
+
+import (
+	"github.com/bacongobbler/browser"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/akuity/kargo/internal/cli/config"
+)
+
+func NewCommand(cfg config.CLIConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:     "dashboard",
+		Short:   "Open the Kargo Dashboard in your default browser.",
+		Example: "kargo logout",
+		RunE: func(*cobra.Command, []string) error {
+			if cfg.APIAddress == "" {
+				return errors.New(
+					"seems like you are not logged in; please use `kargo login` to authenticate",
+				)
+			}
+
+			return errors.Wrap(
+				browser.Open(cfg.APIAddress),
+				"error opening dashboard in default browser",
+			)
+		},
+	}
+}


### PR DESCRIPTION
This should close #549 .

Just to note this will not work in development when using tilt (it won't break but it will open the API Url which in the Tilt method is not currently the URL for the dashboard).
