### PR TITLE
feat(webhook): allow legacy project ns to be adopted by project when created

### DIFF
--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -15,6 +15,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - kargo.akuity.io


### PR DESCRIPTION
Fixes #1443

Draft because this is built on top of #1417, which should be merged first.

```
If the namespace exists:

    If it's already owned by the Project:
        Done

    If it's labeled like a Project and not already owned by anything else:
        Project adopts it

    If the project label is not present on the namespace or the namespace has an existing owner:
        Conflict
```