### PR TITLE
chore(controller): change image selection func and variable names for clarity

### DIFF
--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -14,7 +14,7 @@ import (
 	"github.com/akuity/kargo/internal/logging"
 )
 
-func (r *reconciler) getLatestImages(
+func (r *reconciler) selectImages(
 	ctx context.Context,
 	namespace string,
 	subs []kargoapi.RepoSubscription,

--- a/internal/controller/warehouses/images_test.go
+++ b/internal/controller/warehouses/images_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/akuity/kargo/internal/image"
 )
 
-func TestGetLatestImages(t *testing.T) {
+func TestSelectImages(t *testing.T) {
 	testCases := []struct {
 		name       string
 		reconciler *reconciler
@@ -100,7 +100,7 @@ func TestGetLatestImages(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
-				testCase.reconciler.getLatestImages(
+				testCase.reconciler.selectImages(
 					context.Background(),
 					"fake-namespace",
 					[]kargoapi.RepoSubscription{

--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -52,7 +52,7 @@ type reconciler struct {
 
 	checkoutTagFn func(repo git.Repo, tag string) error
 
-	getLatestImagesFn func(
+	selectImagesFn func(
 		ctx context.Context,
 		namespace string,
 		subs []kargoapi.RepoSubscription,
@@ -153,7 +153,7 @@ func newReconciler(
 	r.getLastCommitIDFn = r.getLastCommitID
 	r.listTagsFn = r.listTags
 	r.checkoutTagFn = r.checkoutTag
-	r.getLatestImagesFn = r.getLatestImages
+	r.selectImagesFn = r.selectImages
 	r.getImageRefsFn = getImageRefs
 	r.selectChartsFn = r.selectCharts
 	r.selectChartVersionFn = helm.SelectChartVersion
@@ -300,7 +300,7 @@ func (r *reconciler) getLatestFreightFromRepos(
 	}
 	logger.Debug("synced git repo subscriptions")
 
-	latestImages, err := r.getLatestImagesFn(
+	selectedImages, err := r.selectImagesFn(
 		ctx,
 		warehouse.Namespace,
 		warehouse.Spec.Subscriptions,
@@ -330,7 +330,7 @@ func (r *reconciler) getLatestFreightFromRepos(
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Commits: selectedCommits,
-		Images:  latestImages,
+		Images:  selectedImages,
 		Charts:  selectedCharts,
 	}
 	freight.UpdateID()

--- a/internal/controller/warehouses/warehouses_test.go
+++ b/internal/controller/warehouses/warehouses_test.go
@@ -33,7 +33,7 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, e.getLastCommitIDFn)
 	require.NotNil(t, e.listTagsFn)
 	require.NotNil(t, e.checkoutTagFn)
-	require.NotNil(t, e.getLatestImagesFn)
+	require.NotNil(t, e.selectImagesFn)
 	require.NotNil(t, e.getImageRefsFn)
 	require.NotNil(t, e.selectChartsFn)
 	require.NotNil(t, e.selectChartVersionFn)
@@ -245,7 +245,7 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 				) ([]kargoapi.GitCommit, error) {
 					return nil, nil
 				},
-				getLatestImagesFn: func(
+				selectImagesFn: func(
 					context.Context,
 					string,
 					[]kargoapi.RepoSubscription,
@@ -274,7 +274,7 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 				) ([]kargoapi.GitCommit, error) {
 					return nil, nil
 				},
-				getLatestImagesFn: func(
+				selectImagesFn: func(
 					context.Context,
 					string,
 					[]kargoapi.RepoSubscription,
@@ -315,7 +315,7 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 						},
 					}, nil
 				},
-				getLatestImagesFn: func(
+				selectImagesFn: func(
 					context.Context,
 					string,
 					[]kargoapi.RepoSubscription,


### PR DESCRIPTION
Over the course of other recent PRs, variables and functions involved in the Warehouse reconciler's selection of commits and charts have been changed to avoid use of the term "latest," which can be misleading, since user-defined selection criteria often results in selection of a commit or chart that is _not_ the most recent.

This PR applies similar name changes to variables and functions involved in the Warehouse reconciler's selection of container images.

There are no functional changes in this PR. This is purely for readability and clarity of code.