### PR TITLE
fix: stage reconciler failures if cache is stale

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -714,7 +714,12 @@ func (r *reconciler) syncNormalStage(
 		}
 
 		// Initiate or follow-up on verification if required
-		if status.Phase == kargoapi.StagePhaseVerifying && stage.Spec.Verification != nil {
+		// NOTE: If stage cache is stale, phase can be StagePhaseNotApplicable
+		//       even though current freight is not empty in that case
+		//       check if verification step is necessary and if yes execute
+		//       step irrespective of phase
+		if (status.Phase == kargoapi.StagePhaseVerifying || status.Phase == kargoapi.StagePhaseNotApplicable) &&
+			stage.Spec.Verification != nil {
 			if status.CurrentFreight.VerificationInfo == nil {
 				if status.Health == nil || status.Health.Status == kargoapi.HealthStateHealthy {
 					log.Debug("starting verification")


### PR DESCRIPTION
Sometimes the controller cache for stages is stale and doesn't show updated result of a promotion leading to a situation where CurrentFreight is nil temporary and so it sets the phase as NotApplicable. But in reality the CurrentFreight is already updated in live state but because the controller has now patched the phase as not applicable any future reconciliations completely skip the verification step as phase doesn't match the required value.