### PR TITLE
refactor: make management controller able to create project namespaces again

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -12,6 +12,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - patch

--- a/internal/controller/management/projects/projects.go
+++ b/internal/controller/management/projects/projects.go
@@ -3,9 +3,16 @@ package projects
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -38,6 +45,25 @@ type reconciler struct {
 		*kargoapi.Project,
 		kargoapi.ProjectStatus,
 	) error
+
+	getNamespaceFn func(
+		context.Context,
+		types.NamespacedName,
+		client.Object,
+		...client.GetOption,
+	) error
+
+	createNamespaceFn func(
+		context.Context,
+		client.Object,
+		...client.CreateOption,
+	) error
+
+	updateNamespaceFn func(
+		context.Context,
+		client.Object,
+		...client.UpdateOption,
+	) error
 }
 
 // SetupReconcilerWithManager initializes a reconciler for Project resources and
@@ -64,6 +90,9 @@ func newReconciler(kubeClient client.Client) *reconciler {
 	r.getProjectFn = kargoapi.GetProject
 	r.syncProjectFn = r.syncProject
 	r.patchProjectStatusFn = r.patchProjectStatus
+	r.getNamespaceFn = r.client.Get
+	r.createNamespaceFn = r.client.Create
+	r.updateNamespaceFn = r.client.Update
 	return r
 }
 
@@ -136,13 +165,88 @@ func (r *reconciler) Reconcile(
 }
 
 func (r *reconciler) syncProject(
-	_ context.Context,
+	ctx context.Context,
 	project *kargoapi.Project,
 ) (kargoapi.ProjectStatus, error) {
 	status := *project.Status.DeepCopy()
-	// TODO: This used to create the Project's associated namespace, but the
-	// webhook now does that. This remains because it is where we will add
-	// creation of other Project-owned resources in the future.
+
+	logger := logging.LoggerFromContext(ctx)
+
+	ownerRef := metav1.NewControllerRef(
+		project,
+		kargoapi.GroupVersion.WithKind("Project"),
+	)
+	ownerRef.BlockOwnerDeletion = ptr.To(false)
+
+	ns := &corev1.Namespace{}
+	err := r.getNamespaceFn(
+		ctx,
+		types.NamespacedName{Name: project.Name},
+		ns,
+	)
+	if err == nil {
+		// We found an existing namespace with the same name as the Project. If it's
+		// owned by this Project then it was created either by a webhook or by a
+		// previous attempt to reconcile this Project, but otherwise, this is a
+		// problem.
+		for _, ownerRef := range ns.OwnerReferences {
+			if ownerRef.UID == project.UID {
+				logger.Debug("namespace exists and is owned by this Project")
+				status.Phase = kargoapi.ProjectPhaseReady
+				return status, nil
+			}
+		}
+		if ns.Labels != nil &&
+			ns.Labels[kargoapi.ProjectLabelKey] == kargoapi.LabelTrueValue &&
+			len(ns.OwnerReferences) == 0 {
+			logger.Debug(
+				"namespace exists, but is not owned by this Project, but has the " +
+					"project label; Project will take it over",
+			)
+			ns.OwnerReferences = []metav1.OwnerReference{*ownerRef}
+			controllerutil.AddFinalizer(ns, kargoapi.FinalizerName)
+			if err = r.updateNamespaceFn(ctx, ns); err != nil {
+				return status,
+					errors.Wrapf(err, "error updating namespace %q", project.Name)
+			}
+			logger.Debug("updated namespace with Project as owner")
+			status.Phase = kargoapi.ProjectPhaseReady
+			return status, nil
+		}
+		status.Phase = kargoapi.ProjectPhaseInitializationFailed
+		return status, errors.Errorf(
+			"failed to initialize Project %q because namespace %q already exists",
+			project.Name,
+			project.Name,
+		)
+	}
+	if !apierrors.IsNotFound(err) {
+		return status, errors.Wrapf(err, "error getting namespace %q", project.Name)
+	}
+
+	logger.Debug("namespace does not exist yet; creating namespace")
+
+	ns = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+			Labels: map[string]string{
+				kargoapi.ProjectLabelKey: kargoapi.LabelTrueValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+	}
+	// Project namespaces are owned by a Project. Deleting a Project automatically
+	// deletes the namespace. But we also want this to work in the other
+	// direction, where that behavior is not automatic. We add a finalizer to the
+	// namespace and use our own namespace reconciler to clear it after deleting
+	// the Project.
+	controllerutil.AddFinalizer(ns, kargoapi.FinalizerName)
+	if err := r.createNamespaceFn(ctx, ns); err != nil {
+		return status,
+			errors.Wrapf(err, "error creating namespace %q", project.Name)
+	}
+	logger.Debug("created namespace")
+
 	status.Phase = kargoapi.ProjectPhaseReady
 	return status, nil
 }

--- a/internal/controller/management/projects/projects_test.go
+++ b/internal/controller/management/projects/projects_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -20,6 +24,9 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, r.getProjectFn)
 	require.NotNil(t, r.syncProjectFn)
 	require.NotNil(t, r.patchProjectStatusFn)
+	require.NotNil(t, r.getNamespaceFn)
+	require.NotNil(t, r.createNamespaceFn)
+	require.NotNil(t, r.updateNamespaceFn)
 }
 
 func TestReconcile(t *testing.T) {
@@ -173,13 +180,203 @@ func TestSyncProject(t *testing.T) {
 		)
 	}{
 		{
-			name: "success",
+			name: "error getting namespace",
 			project: &kargoapi.Project{
 				Status: kargoapi.ProjectStatus{
 					Phase: kargoapi.ProjectPhaseInitializing,
 				},
 			},
-			reconciler: &reconciler{},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error getting namespace")
+				// Status is unchanged
+				require.Equal(t, initialStatus, newStatus)
+			},
+		},
+		{
+			name: "namespace exists, is not owned by project, but is labeled " +
+				"as a project; error updating namespace",
+			project: &kargoapi.Project{},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					_ context.Context,
+					_ types.NamespacedName,
+					obj client.Object,
+					_ ...client.GetOption,
+				) error {
+					ns, ok := obj.(*corev1.Namespace)
+					require.True(t, ok)
+					ns.Labels = map[string]string{
+						kargoapi.ProjectLabelKey: kargoapi.LabelTrueValue,
+					}
+					return nil
+				},
+				updateNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.UpdateOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
+				require.Error(t, err)
+				// Status should reflect the failure
+				require.Contains(t, err.Error(), "error updating namespace")
+				require.Contains(t, err.Error(), "something went wrong")
+				// And is otherwise unchanged
+				newStatus.Message = initialStatus.Message
+				require.Equal(t, initialStatus, newStatus)
+			},
+		},
+		{
+			name: "namespace exists, is not owned by project, but is labeled " +
+				"as a project; success updating namespace",
+			project: &kargoapi.Project{},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					_ context.Context,
+					_ types.NamespacedName,
+					obj client.Object,
+					_ ...client.GetOption,
+				) error {
+					ns, ok := obj.(*corev1.Namespace)
+					require.True(t, ok)
+					ns.Labels = map[string]string{
+						kargoapi.ProjectLabelKey: kargoapi.LabelTrueValue,
+					}
+					return nil
+				},
+				updateNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.UpdateOption,
+				) error {
+					return nil
+				},
+			},
+			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
+				require.NoError(t, err)
+				require.Equal(t, newStatus.Phase, kargoapi.ProjectPhaseReady)
+				require.Empty(t, newStatus.Message)
+			},
+		},
+		{
+			name:    "namespace exists, is not owned by project, and is not labeled as a project",
+			project: &kargoapi.Project{},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return nil
+				},
+			},
+			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
+				require.Error(t, err)
+				// Status should reflect the unrecoverable failure
+				require.Equal(t, newStatus.Phase, kargoapi.ProjectPhaseInitializationFailed)
+				require.Contains(t, err.Error(), "failed to initialize Project")
+			},
+		},
+		{
+			name: "namespace exists and is owned by project",
+			project: &kargoapi.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("fake-uid"),
+				},
+			},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					_ context.Context,
+					_ types.NamespacedName,
+					obj client.Object,
+					_ ...client.GetOption,
+				) error {
+					ns := obj.(*corev1.Namespace) // nolint: forcetypeassert
+					ns.OwnerReferences = []metav1.OwnerReference{
+						{
+							UID: types.UID("fake-uid"),
+						},
+					}
+					return nil
+				},
+			},
+			assertions: func(_, newStatus kargoapi.ProjectStatus, err error) {
+				require.NoError(t, err)
+				// Status should reflect that the Project is in a ready state
+				require.Equal(t, newStatus.Phase, kargoapi.ProjectPhaseReady)
+			},
+		},
+		{
+			name: "namespace does not exist; error creating it",
+			project: &kargoapi.Project{
+				Status: kargoapi.ProjectStatus{
+					Phase: kargoapi.ProjectPhaseInitializing,
+				},
+			},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "")
+				},
+				createNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(initialStatus, newStatus kargoapi.ProjectStatus, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error creating namespace")
+				// Status is unchanged
+				require.Equal(t, initialStatus, newStatus)
+			},
+		},
+		{
+			name: "namespace does not exist; success creating it",
+			project: &kargoapi.Project{
+				Status: kargoapi.ProjectStatus{
+					Phase: kargoapi.ProjectPhaseInitializing,
+				},
+			},
+			reconciler: &reconciler{
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "")
+				},
+				createNamespaceFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return nil
+				},
+			},
 			assertions: func(_, newStatus kargoapi.ProjectStatus, err error) {
 				require.NoError(t, err)
 				// Status should reflect that the Project is in a ready state

--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -121,9 +121,9 @@ func (w *webhook) ValidateCreate(
 			types.NamespacedName{Name: project.Name},
 			ns,
 		); err == nil {
-			// We found an existing namespace with the same name as the Project. If it's
-			// owned by this Project then it was created on a previous attempt to
-			// reconcile this Project, but otherwise, this could be a problem.
+			// We found an existing namespace with the same name as the Project. If
+			// it's owned by this Project then it was created on a previous attempt to
+			// create this Project, but otherwise, this could be a problem.
 			for _, ownerRef := range ns.OwnerReferences {
 				if ownerRef.UID == project.UID {
 					logger.Debug("namespace exists and is owned by this Project")


### PR DESCRIPTION
Since #1431 we rely on a webhook to create Project namespaces synchronously. Although this was a valid decision made for well-documented reasons, one undesired side-effect has been difficulty bootstraping Kargo with a default Project already in place:

* If the Project is applied before the webhook registration, Project creation succeeds, but creation of the underlying namespace does not take place. If the manifests contain additional resources that belong in that namespace, their creation will fail.

* If the webhook registration is applied before the Project, Project creation will fail since the webhook server isn't running yet. Creation of the underlying namespace does not take place and, as above, if the manifests contain additional resources that belong in that namespace, their creation will fail.

Some unsatisfactory solutions we explored included:

* Ensuring the webhook server is ready _before_ attempting to create the Project.

    This was deemed to be difficult, or at least annoying.

* "Create projects the hard way" by directly creating an appropriately labeled namespace.

    This loses out on the benefits of _having_ a Project resource. Those aren't significant now, but will be of increasing consequence over time.

We settled on _partially_ rolling back #1431, allowing for a Project's underlying namespace to be created synchronously by a webhook _or_ asynchronously by the management controller. This ability enables a better option:

* "Create projects the hard way" by directly creating an appropriately labeled namespace, but _avoid_ losing out on the additional benefits of having a proper Project resource by _also_ defining that. It must _precede_ registration of the webhook, but that's easy enough to ensure. When Kargo comes up, the Project resource will be reconciled and will "adopt" the corresponding namespace at that time (a process we're already using in the webhook since #1443).

cc @gdsoumya