### PR TITLE
docs: update concepts and how to sections for v0.4

### DIFF
--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -140,11 +140,6 @@ kargo update freight-alias \
 This can also be accomplished via `kubectl` commands `apply`, `edit`, `patch`,
 etc.
 
-:::note
-Aliases cannot currently be updated via the Kargo UI, but this will be addressed
-in the `v0.4.0` release.
-:::
-
 ## Manual Approvals
 
 The [concepts doc](http://localhost:3000/concepts#verifications) describes the
@@ -160,19 +155,18 @@ arise, in which case it may sometimes be desirable to bypass one or more
 `Stage`s in the pipeline.
 
 To enable this, Kargo provides the ability to manually approve a `Freight`
-resource for promotion to any given `Stage`. At present, this can be
-accomplished only through the Kargo UI:
+resource for promotion to any given `Stage`. This is conveniently accomplished
+via the Kargo CLI:
 
-1. Click the three dots in the upper-right corner of any `Freight` resource
-   select __Manually Approve__.
-
-1. Click on the `Stage` resource for which you wish to approve the `Freight`.
+```shell
+kargo approve \
+  --freight f5f87aa23c9e97f43eb83dd63768ee41f5ba3766 \
+  --stage prod \
+  --project kargo-demo
+```
 
 :::note
-Manual approvals cannot currently be granted via the Kargo CLI, but this will be
-addressed in the `v0.4.0` release.
-
-Manual approvals also cannot be granted via `kubectl` due to technical factors
+Manual approvals cannot be granted via `kubectl` due to technical factors
 preventing `kubectl` from updating `status` subresources of Kargo resources.
 :::
 

--- a/docs/docs/30-how-to-guides/20-managing-credentials.md
+++ b/docs/docs/30-how-to-guides/20-managing-credentials.md
@@ -36,10 +36,10 @@ The `name` of such a secret is inconsequential and may follow any convention
 preferred by the user.
 
 :::info
-Kargo uses Kubernetes namespaces to demarcate project boundaries, so related
-`Stage` resources always share a namespace.
+Kargo uses Kubernetes `Namespace`s to demarcate project boundaries, so related
+`Stage` resources always share a `Namespace`.
 
-Secrets representing credentials will typically exist in the same namespace as
+Secrets representing credentials will typically exist in the same `Namespace` as
 the `Stage` resources that will require them. There are exceptions to this rule,
 which are covered in the next section.
 :::
@@ -76,72 +76,23 @@ fully-supported at this time.
 
 In cases where one or more sets of credentials are needed widely across _all_
 Kargo projects, the administrator/operator installing Kargo may opt-in to
-designating one or more namespaces as homes for "global" credentials using the
+designating one or more `Namespace`s as homes for "global" credentials using the
 `controller.globalCredentials.namespaces` setting in Kargo's Helm chart.
 Refer to
 [the advanced section of the installation guide](./10-installing-kargo.md#advanced-installation)
 for more details.
 
+:::note
+Any matching credentials found in a `Project`/`Namespace` take precedence over
+those found in a global credentials `Namespace`.
+:::
+
 :::caution
 It is important to understand the security implications of this feature. Any
-credentials stored in a global credentials namespace will be available to _all_
-Kargo projects.
+credentials stored in a global credentials `Namespace` will be available to
+_all_ Kargo projects.
 :::
 
-## Borrowing Credentials from Argo CD
-
-In many cases, Kargo and Argo CD will _both_ require credentials for the same
-GitOps and/or Helm chart repositories. (Argo CD never has need for container
-image repositories.) With this being the case, Kargo has support for _borrowing_
-repository credentials from Argo CD.
-
-Argo CD credentials are represented as Kubernetes `Secret` resources that are
-formatted identically to those described in the previous section, except that:
-
-* They should always be in the namespace that Argo CD runs in -- commonly
-  `argocd`.
-
-* Credentials for an individual repository must be labeled
-  `argocd.argoproj.io/secret-type: repository`.
-
-* Credentials for multiple repositories whose URLs begin with a common pattern
-  must be labeled `argocd.argoproj.io/secret-type: repo-creds`.
-
-:::info
-Consult
-[the Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories)
-for more information.
+:::caution
+Versions of Kargo prior to v0.4.0 used a different mechanism for managing global
 :::
-
-Since it would be a security risk to allow Kargo to borrow credentials from Argo
-CD without the consent of the corresponding `Secret`'s owner, Kargo requires
-Argo CD credentials to be specially annotated to indicate Kargo projects
-(namespaces) that are permitted to borrow them. Without this annotation, Kargo
-will refuse to borrow credentials from Argo CD. This annotation takes the form
-`kargo.akuity.io/authorized-projects:<projects>` where `<projects>` is a
-comma-separated list of Kargo projects (Kubernetes namespaces containing related
-`Stage` resources).
-
-Similarly to when retrieving credentials directly from a Kargo project's own
-namespace, when borrowing credentials from Argo CD (if permitted) Kargo gives
-precedence to `Secret` resources labeled
-`argocd.argoproj.io/secret-type: repository` over those labeled
-`argocd.argoproj.io/secret-type: repo-creds`.
-
-Altogether, the order of precedence for credentials is:
-
-1. Secrets in the same namespace as the `Stage` resource that are also
-   labeled `kargo.akuity.io/secret-type: repository`.
-
-1. Secrets in the same namespace as the `Stage` resource that are also
-   labeled `kargo.akuity.io/secret-type: repo-creds`.
-
-1. Secrets in Argo CD's namespace that are also labeled
-   `argocd.argoproj.io/secret-type: repository` and whose
-   `kargo.akuity.io/authorized-projects` annotation contains the namespace of
-   the `Stage` resource.
-
-1. Secrets in Argo CD's namespace that are also labeled
-   `argocd.argoproj.io/secret-type: repo-creds` and whose
-   `kargo.akuity.io/authorized-projects` annotation contains the namespace of
-   the `Stage` resource.


### PR DESCRIPTION
General doc updates covering major changes in v0.4.0 and other miscellaneous fixes. Quickstart updates in a separate PR. 

Highlights:

* Document Project CRD
* Remove PromotionPolicy CRD docs / combine with Project CRD docs (PromotionPolicy is no longer a top-level type)
* Be more clear about the _two_ ways Freight can become qualified for promotion to a Stage -- verification upstream or manual approval (Changed in v0.3.0, but there were bits of doc we didn't update thoroughly enough.)
* Remove docs re: Argo CD "credential sharing"