### PR TITLE
docs: update roadmap

### DIFF
--- a/docs/docs/50-roadmap.md
+++ b/docs/docs/50-roadmap.md
@@ -33,14 +33,27 @@ __Status:__ Completed
 
 ## v0.4.0
 
+__Status:__ Completed
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `Warehouse` Rules/Filters | feature | Introduced optional tag-based constraints on Git repository subscriptions. |
+| Project Management | feature | <ul><li>Introduced `Project` CRD to simplify project initialization.</li><li>Removed `PromotionPolicy` CRD and folded its functionality directly into the `Project` CRD.</li></ul> |
+
+## v0.5.0
+
 __Status:__ In Progress
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `Warehouse` Rules/Filters | feature | Introduce features to constrain the conditions under which new `Freight` is produced. |
-| Project Management | feature | <ul><li>Introduce `Project` CRD to simplify onboarding and project lifecycle management.</li><li>Aggregate important status information at the `Project` level.</li><li>Introduce additional `PromotionPolicy` options.</li><li>Credential management via CLI and UI.</li></ul> |
+| Project Management | feature | Add sensible `ServiceAccount`s, `Role`s, and `RoleBinding`s to boilerplate project setup. |
+| `Warehouse` Rules/Filters | feature | Introduce optional path-based constraints on Git repository subscriptions. |
+| UI Improvements | feature | <ul><li>Enabled credential management via UI.</li><li> UI features are lagging behind back end advancements. This release will have a strong focus on getting caught up. </li></ul> |
+| CLI Improvements | refactor | The CLI will receive a near-total overhaul to make the tree of sub-commands more intuitive, with greater consistency in documentation and usage from command to command. |
+| Promotion Mechanism Extensibility | design/proposal | User-defined promotion mechanisms. |
+| [Patch Promotions](https://github.com/akuity/kargo/issues/1250) | poc | Support a generalized option to promote arbitrary configuration (e.g. strings, files, and directories) to other paths of the Git repository. |
 
-## v0.5.0
+## v0.6.0
 
 __Status:__
 
@@ -48,15 +61,15 @@ __Status:__
 | ---- | ---- | ----------- |
 | Promotion Mechanism Extensibility | feature | User-defined promotion mechanisms. |
 
-## v0.6.0 .. v0.n.0
+## v0.7.0 .. v0.n.0
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Freight Enrichment | feature | Enhance Freight metadata for improved insight into Freight contents and the expected result of promoting a piece of Freight to a given environment. This data will be exposed to the UI and CLI tools. |
-| Improved Microservice Support | feature | Filters for Freightlines (for example, filter by Warehouse). Add the ability to merge parallel Freightlines at a control flow Stages. |
+| `Project` Improvements | feature | <ul><li>Permit promotion policies to "freeze" `Freight` production and/or promotions based on time or other constraints.</li><li>Aggregate useful project-level status and statistics in `ProjectStatus`.</li></ul> |
+| `Freight` Enrichment | feature | Enhance `Freight` metadata for improved insight into contents and the expected result of promoting a piece of `Freight` to a given `Stage`. |
+| Improved Microservice Support | feature | Filters for Freightlines (for example, filter by `Warehouse`). Add the ability to merge parallel pipelines at a "junction" `Stage`. |
 | `kargo init` | feature | Addition of an `init` sub-command to the Kargo CLI for streamlining project / pipeline creation. |
-| Standalone Image Writeback` | feature | Write back image changes without having to subscribe to an image repository. |
-| PromotionPolicy Improvements | feature | Add the ability to "freeze" Stages to prevent promotions. |
+| Standalone Image Writeback | feature | Write back image changes without having to subscribe to an image repository. |
 
 ## Criteria for 1.0.0 Release
 


### PR DESCRIPTION
v0.4.0 was overly ambitious in scope. Factors like company off-site, PTO, and technical challenges imposed a dose of reality.

This PR proposes partially re-purposing v0.5.0 to further the objectives of v0.4.0 and to play catch up on things like UI.

It makes a commitment to design/proposal work for extensible promotion mechanisms in the v0.5.0 time frame, but defers implementation to v0.6.0.

@jessesuen @christianh814 let's connect offline about all of this.