### PR TITLE
feat: allow connecting to HTTP Git repositories

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -195,7 +195,7 @@ type GitRepoUpdate struct {
 	// RepoURL is the URL of the repository to update. This is a required field.
 	//
 	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:Pattern=`^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
+	//+kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
 	RepoURL string `json:"repoURL"`
 	// InsecureSkipTLSVerify specifies whether certificate verification errors
 	// should be ignored when connecting to the repository. This should be enabled

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -67,7 +67,7 @@ type GitSubscription struct {
 	// URL is the repository's URL. This is a required field.
 	//
 	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:Pattern=`^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
+	//+kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
 	RepoURL string `json:"repoURL"`
 	// CommitSelectionStrategy specifies the rules for how to identify the newest
 	// commit of interest in the repository specified by the RepoURL field. This
@@ -131,7 +131,7 @@ type ImageSubscription struct {
 	// revision of that source code that was used to build the image.
 	//
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:validation:Pattern=`^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
+	//+kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
 	GitRepoURL string `json:"gitRepoURL,omitempty"`
 	// ImageSelectionStrategy specifies the rules for how to identify the newest version
 	// of the image specified by the RepoURL field. This field is optional. When

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -439,7 +439,7 @@ spec:
                           description: RepoURL is the URL of the repository to update.
                             This is a required field.
                           minLength: 1
-                          pattern: ^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
+                          pattern: ^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
                           type: string
                         writeBranch:
                           description: |-

--- a/charts/kargo/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_warehouses.yaml
@@ -138,7 +138,7 @@ spec:
                           description: URL is the repository's URL. This is a required
                             field.
                           minLength: 1
-                          pattern: ^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
+                          pattern: ^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
                           type: string
                         semverConstraint:
                           description: |-
@@ -169,7 +169,7 @@ spec:
                             the source code for the image repository referenced by the RepoURL field.
                             When this is specified, Kargo MAY be able to infer and link to the exact
                             revision of that source code that was used to build the image.
-                          pattern: ^https://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
+                          pattern: ^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
                           type: string
                         ignoreTags:
                           description: |-

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/internal/git"
+	"github.com/akuity/kargo/internal/logging"
 )
 
 const (
@@ -99,6 +100,15 @@ func (k *kubernetesDatabase) Get(
 	repoURL string,
 ) (Credentials, bool, error) {
 	creds := Credentials{}
+
+	// If we are dealing with an insecure HTTP endpoint (of type Git),
+	// refuse to return any credentials
+	if credType == TypeGit && strings.HasPrefix(repoURL, "http://") {
+		logger := logging.LoggerFromContext(ctx).WithField("repoURL", repoURL)
+		logger.Warnf("refused to get credentials for insecure HTTP endpoint")
+
+		return creds, false, nil
+	}
 
 	var secret *corev1.Secret
 	var err error

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -101,9 +101,9 @@ func (k *kubernetesDatabase) Get(
 ) (Credentials, bool, error) {
 	creds := Credentials{}
 
-	// If we are dealing with an insecure HTTP endpoint (of type Git),
+	// If we are dealing with an insecure HTTP endpoint (of any type),
 	// refuse to return any credentials
-	if credType == TypeGit && strings.HasPrefix(repoURL, "http://") {
+	if strings.HasPrefix(repoURL, "http://") {
 		logger := logging.LoggerFromContext(ctx).WithField("repoURL", repoURL)
 		logger.Warnf("refused to get credentials for insecure HTTP endpoint")
 

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -321,7 +321,7 @@
                   "repoURL": {
                     "description": "RepoURL is the URL of the repository to update. This is a required field.",
                     "minLength": 1,
-                    "pattern": "^https://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
+                    "pattern": "^https?://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
                     "type": "string"
                   },
                   "writeBranch": {

--- a/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
@@ -82,7 +82,7 @@
                   "repoURL": {
                     "description": "URL is the repository's URL. This is a required field.",
                     "minLength": 1,
-                    "pattern": "^https://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
+                    "pattern": "^https?://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
                     "type": "string"
                   },
                   "semverConstraint": {
@@ -104,7 +104,7 @@
                   },
                   "gitRepoURL": {
                     "description": "GitRepoURL optionally specifies the URL of a Git repository that contains\nthe source code for the image repository referenced by the RepoURL field.\nWhen this is specified, Kargo MAY be able to infer and link to the exact\nrevision of that source code that was used to build the image.",
-                    "pattern": "^https://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
+                    "pattern": "^https?://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
                     "type": "string"
                   },
                   "ignoreTags": {


### PR DESCRIPTION
Fixes: #872

This adds support for connecting to Git repositories over an (insecure) HTTP wire as described in https://github.com/akuity/kargo/issues/872#issuecomment-1761972854, while taking into account the effect it would have on HTTP Helm repositories as observed in https://github.com/akuity/kargo/issues/872#issuecomment-1956378143.

Effectively, this means that connecting to any HTTP endpoint is now allowed as long as this does not require authentication. This includes "classic" Helm repositories served over HTTP, where basic authentication used to be supported in the past.