### PR TITLE
fix: transform uname arch into valid Go arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ endif
 # Kargo development activities inside WSL2.
 GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GOARCH ?= $(shell uname -m)
+ifeq ($(GOARCH), x86_64)
+	override GOARCH = amd64
+endif
 
 ################################################################################
 # Tests                                                                        #


### PR DESCRIPTION
On an AMD64 system, `uname -m` will return `x86_64` instead of the Go accepted `amd64`. Detect when this is returned (or provided), and overwrite it with the correct value.

This ensures the `build-cli` Make target actually works on AMD64 Linux systems.