### PR TITLE
feat(cli): add `--client` flag to `kargo version`

### DIFF
--- a/internal/cli/option/flag.go
+++ b/internal/cli/option/flag.go
@@ -19,6 +19,10 @@ func LocalServer(fs *pflag.FlagSet, opt *Option) {
 	fs.BoolVar(&opt.UseLocalServer, "local-server", false, "Use local server")
 }
 
+func ClientVersion(fs *pflag.FlagSet, opt *Option) {
+	fs.BoolVar(&opt.ClientVersionOnly, "client", false, "If true, shows client version only (no server required)")
+}
+
 func Project(fs *pflag.FlagSet, opt *Option, defaultProject string) {
 	fs.StringVarP(&opt.Project, "project", "p", defaultProject, "Project")
 }

--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -18,6 +18,8 @@ type Option struct {
 	LocalServerAddress string
 	UseLocalServer     bool
 
+	ClientVersionOnly bool
+
 	Project string
 
 	IOStreams  *genericclioptions.IOStreams


### PR DESCRIPTION
Fixes: #1511 

This adds support for supplying a `--client` flag to `kargo version`, which avoids the command from attempting to collect version information from the API server.

```console
$ kargo version --client
Client Version: devel+unknown.dirty
```

In addition, the order of collecting information has been adjusted to allow partial information to be printed when the API server can not be reached before returning an error.

```console
$ kargo version
Client Version: devel+unknown.dirty
Error: get version info from server: unavailable: dial tcp [::1]:30081: connect: connection refused

$ kargo version --output yaml
apiVersion: kargo.akuity.io/v1alpha1
cli:
  buildTime: "2024-02-22T11:18:51Z"
  compiler: gc
  gitTreeDirty: true
  goVersion: go1.21.3
  platform: linux/amd64
  version: devel+unknown.dirty
kind: ComponentVersions
Error: get version info from server: unavailable: dial tcp [::1]:30081: connect: connection refused
```

However, in case `--output` is provided and the printer itself runs into an issue, this error takes precedence.

```console
$ kargo version --output go-template --template '{{ .cli.version }'
Error: new printer: error parsing template {{ .cli.version }, template: output:1: unexpected "}" in operand
```