### PR TITLE
fix(devx): mount permission issues on Linux

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,3 +22,25 @@ RUN go install github.com/bufbuild/buf/cmd/buf@${BUF_VERSION} \
     && apt-get update && apt-get install nodejs -y \
     && curl -fsSL https://get.pnpm.io/install.sh | bash \
     && mv /root/.local/share/pnpm/pnpm /usr/bin
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# To ensure mounts end up with the right permissions on Linux systems,
+# create a non-root user with the provided UID and GUID.
+RUN addgroup --gid ${GROUP_ID} user \
+    && adduser --disabled-password --gecos '' --uid ${USER_ID} --gid ${GROUP_ID} user \
+    && mkdir -p /workspaces/kargo/ui/node_modules \
+    && chown -R ${USER_ID}:${GROUP_ID} /workspaces/kargo
+
+USER user
+
+# Configure user writable Go Mod cache path and prepare it to ensure
+# it does not end up being owned by root when mounted
+ENV GOMODCACHE=/home/user/gocache
+RUN mkdir -p $GOMODCACHE
+
+# Configure user writable "global" NPM bin directory,
+# and add to path
+ENV NPM_CONFIG_PREFIX=/home/user/.npm-global
+ENV PATH=$NPM_CONFIG_PREFIX/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -152,15 +152,22 @@ codegen:
 DOCKER_CMD := $(CONTAINER_RUNTIME) run \
 	-it \
 	--rm \
-	-v gomodcache:/go/pkg/mod \
+	-v gomodcache:/home/user/gocache \
 	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/kargo \
 	-v /workspaces/kargo/ui/node_modules \
 	-w /workspaces/kargo \
 	kargo:dev-tools
 
+DEV_TOOLS_BUILD_OPTS =
+ifeq ($(GOOS),linux)
+	DEV_TOOLS_BUILD_OPTS += --build-arg USER_ID=$(shell id -u)
+	DEV_TOOLS_BUILD_OPTS += --build-arg GROUP_ID=$(shell id -g)
+endif
+
 .PHONY: hack-build-dev-tools
 hack-build-dev-tools:
-	$(CONTAINER_RUNTIME) build -f Dockerfile.dev -t kargo:dev-tools .
+	$(CONTAINER_RUNTIME) build $(DEV_TOOLS_BUILD_OPTS) \
+ 		-f Dockerfile.dev -t kargo:dev-tools .
 
 .PHONY: hack-lint
 hack-lint: hack-build-dev-tools


### PR DESCRIPTION
Fixes #1506 

This addresses an issue observed on Linux systems where files written to mount paths would end up being owned by root, or files could not be read because they were _not_ owned by the container's user.

It is achieved by creating a user within the development image with the same UID and GID as the caller on the host, while ensuring mount target paths do exist for this user and group before the container starts.

This effectively makes the `hack-build-cli` target work while also delivering smoother operations with `hack-codegen`.

In the future, we should likely rethink the way we work with tooling dependencies and their versions. As this problem was harder to tackle due to the `codegen` target performing system-global installations.