### PR TITLE
fix(chart): warnings in chart install/upgrade

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -28,7 +28,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  name: kargo-api-server-manage-project-secrets
   verbs:
   - create
 - apiGroups:

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -27,7 +27,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  name: kargo-api-server-manage-project-secrets
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
Fixes #1513

In two places, an RBAC rule like this was used in an attempt to constrain creation of RoleBindings _only_ to ones named `kargo-api-server-manage-project-secrets`.

```
- apiGroups:
  - rbac.authorization.k8s.io
  resources:
  - rolebindings
  name: kargo-api-server-manage-project-secrets
  verbs:
  - create
```

`name` was the wrong field name. I was looking for `resourceNames`. 🤦‍♂️ 

After attempting the following, I've now learned that resource _creation_ (and deletion) can not actually be constrained by resource name:

```
- apiGroups:
  - rbac.authorization.k8s.io
  resources:
  - rolebindings
  resourceName:
  - kargo-api-server-manage-project-secrets
  verbs:
  - create
```

This PR just removes this constraint instead and that fixes the installation warnings.

cc @christianh814 