### PR TITLE
fix(crds): stage validation issue with kargo render promo mechs

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -251,7 +251,7 @@ type KargoRenderPromotionMechanism struct {
 	// not use digests by default.)
 	//
 	//+kubebuilder:validation:Optional
-	Images []KargoRenderImageUpdate `json:"images"`
+	Images []KargoRenderImageUpdate `json:"images,omitempty"`
 }
 
 // KargoRenderImageUpdate describes how an image can be incorporated into a


### PR DESCRIPTION
Fixes issue @christianh814 reported to me offline.

Example Stage:

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: test
  namespace: kargo-demo
spec:
  subscriptions:
    warehouse: kargo-demo
  promotionMechanisms:
    gitRepoUpdates:
    - repoURL: https://github.com/krancour/kargo-demo-gitops-2.git
      writeBranch: stage/test # Write to stage-specific branch
      render: {}
    argoCDAppUpdates:
    - appName: kargo-demo-test
  verification:
    analysisTemplates:
    - name: kargo-demo
```

Error when applying:

```
Error from server (Invalid): error when creating "kargo.yaml": Stage.kargo.akuity.io "test" is invalid: spec.promotionMechanisms.gitRepoUpdates[0].render.images: Invalid value: "null": spec.promotionMechanisms.gitRepoUpdates[0].render.images in body must be of type array: "null"
```

The `render` field was meant to be optional, but was incorrectly missing `omitmepty=true` from the struct tags.

Somehow, this didn't matter _until_ we added a defaulting webhook for Stages in #1406

Adding the missing struct tag fixes everything.