### PR TITLE
fix(cli): don't involve kubeconfig in reading bytes from files

### DIFF
--- a/internal/cli/option/kubernetes.go
+++ b/internal/cli/option/kubernetes.go
@@ -21,8 +21,8 @@ func ReadManifests(filenames ...string) ([]byte, error) {
 		}
 		var fileBytes []byte
 		if fileInfo.IsDir() {
-			dirEntries, err := os.ReadDir(filename)
-			if err != nil {
+			var dirEntries []os.DirEntry
+			if dirEntries, err = os.ReadDir(filename); err != nil {
 				return nil, err
 			}
 			dirFiles := make([]string, 0, len(dirEntries))

--- a/internal/cli/option/kubernetes.go
+++ b/internal/cli/option/kubernetes.go
@@ -2,43 +2,52 @@ package option
 
 import (
 	"bytes"
-
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/resource"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"os"
+	"path"
+	"path/filepath"
 )
 
+// TODO: Test this
 func ReadManifests(filenames ...string) ([]byte, error) {
-	buildRes, err := cmdutil.NewFactory(&genericclioptions.ConfigFlags{}).
-		NewBuilder().
-		Unstructured().
-		FilenameParam(false, &resource.FilenameOptions{
-			Filenames: filenames,
-			Recursive: false,
-		}).
-		Flatten().
-		Do().
-		Infos()
-	if err != nil {
-		return nil, errors.Wrap(err, "build resources")
-	}
-
-	var buf bytes.Buffer
-	enc := yaml.NewEncoder(&buf)
-	defer func() {
-		_ = enc.Close()
-	}()
-	for _, info := range buildRes {
-		u, ok := info.Object.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.Errorf("expected *unstructured.Unstructured, got %T", info.Object)
+	var allBytes [][]byte
+	for _, filename := range filenames {
+		var err error
+		if filename, err = filepath.Abs(filename); err != nil {
+			return nil, err
 		}
-		if err := enc.Encode(&u.Object); err != nil {
-			return nil, errors.Wrap(err, "encode object")
+		fileInfo, err := os.Stat(filename)
+		if err != nil {
+			return nil, err
+		}
+		var fileBytes []byte
+		if fileInfo.IsDir() {
+			dirEntries, err := os.ReadDir(filename)
+			if err != nil {
+				return nil, err
+			}
+			dirFiles := make([]string, 0, len(dirEntries))
+			for _, dirEntry := range dirEntries {
+				dirFiles = append(dirFiles, path.Join(filename, dirEntry.Name()))
+			}
+			if fileBytes, err = ReadManifests(dirFiles...); err != nil {
+				return nil, err
+			}
+		} else {
+			// Check file extension
+			ext := filepath.Ext(filename)
+			if ext != ".yaml" && ext != ".yml" {
+				continue
+			}
+			if fileBytes, err = os.ReadFile(filename); err != nil {
+				return nil, err
+			}
+		}
+		if len(fileBytes) > 0 {
+			if fileBytes[len(fileBytes)-1] == '\n' {
+				fileBytes = fileBytes[:len(fileBytes)-1]
+			}
+			allBytes = append(allBytes, fileBytes)
 		}
 	}
-	return buf.Bytes(), nil
+	return bytes.Join(allBytes, []byte("\n---\n")), nil
 }


### PR DESCRIPTION
This fixes an issue @jessesuen discovered wherein kubeconfig is getting caught up in `kargo create`, `apply`, and `delete` reading bytes from files.

This fix is quick and dirty due to its urgency. It works, but there is no test coverage.

I will improve this in a follow-up and worry about getting this into `main` later.