### PR TITLE
Fix garbage-collector affinity indentation

### DIFF
--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -23,7 +23,7 @@ spec:
           serviceAccountName: kargo-garbage-collector
           {{- with .Values.garbageCollector.affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: garbage-collector


### PR DESCRIPTION
Garbage collector affinities are under indented, resulting in invalid yaml