### PR TITLE
refactor(cli): restructure commands, option flags and validation

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	cobracompletefig "github.com/withfig/autocomplete-tools/integrations/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/akuity/kargo/internal/api"
@@ -86,7 +87,7 @@ func NewRootCommand(
 		},
 	}
 
-	opt.IOStreams = &genericclioptions.IOStreams{
+	opt.IOStreams = &genericiooptions.IOStreams{
 		In:     cmd.InOrStdin(),
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	go.uber.org/ratelimit v0.3.0
 	golang.org/x/crypto v0.20.0
-	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
 	golang.org/x/net v0.21.0
 	golang.org/x/oauth2 v0.17.0
 	golang.org/x/sync v0.6.0
@@ -54,6 +53,7 @@ require (
 require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.6.0 // indirect
 	sigs.k8s.io/kustomize/api v0.16.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.16.0 // indirect

--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -20,8 +20,49 @@ import (
 	kargosvcapi "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type applyOptions struct {
+	*option.Option
+
+	Filenames []string
+}
+
+// addFlags adds the flags for the apply options to the provided command.
+func (o *applyOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+
+	// TODO: Factor out server flags to a higher level (root?) as they are
+	//   common to almost all commands.
+	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
+	option.LocalServer(cmd.PersistentFlags(), o.Option)
+
+	option.Filenames(cmd.Flags(), &o.Filenames, "Filename or directory to use to apply the resource(s)")
+
+	if err := cmd.MarkFlagRequired(option.FilenameFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as required"))
+	}
+	if err := cmd.MarkFlagFilename(option.FilenameFlag, ".yaml", ".yml"); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as filename"))
+	}
+	if err := cmd.MarkFlagDirname(option.FilenameFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as dirname"))
+	}
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *applyOptions) validate() error {
+	// While the filename flag is marked as required, a user could still
+	// provide an empty string. This is a check to ensure that the flag is
+	// not empty.
+	if len(o.Filenames) == 0 {
+		return errors.New("filename is required")
+	}
+	return nil
+}
+
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	var filenames []string
+	cmdOpts := &applyOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:   "apply [--project=project] -f (FILENAME)",
 		Short: "Apply a resource from a file or from stdin",
@@ -31,24 +72,25 @@ kargo apply -f stage.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if len(filenames) == 0 {
-				return errors.New("filename is required")
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
 
-			rawManifest, err := yaml.Read(filenames)
+			rawManifest, err := yaml.Read(cmdOpts.Filenames)
 			if err != nil {
 				return errors.Wrap(err, "read manifests")
 			}
 
 			var printer printers.ResourcePrinter
-			if ptr.Deref(opt.PrintFlags.OutputFormat, "") != "" {
-				printer, err = opt.PrintFlags.ToPrinter()
+			if ptr.Deref(cmdOpts.PrintFlags.OutputFormat, "") != "" {
+				printer, err = cmdOpts.PrintFlags.ToPrinter()
 				if err != nil {
 					return errors.Wrap(err, "new printer")
 				}
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
+			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
@@ -81,7 +123,7 @@ kargo apply -f stage.yaml
 			for _, r := range createdRes {
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.CreatedResourceManifest, &obj); err != nil {
-					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
+					fmt.Fprintf(cmdOpts.IOStreams.ErrOut, "%s",
 						errors.Wrap(err, "Error: unmarshal created manifest"))
 					continue
 				}
@@ -90,15 +132,15 @@ kargo apply -f stage.yaml
 						Namespace: obj.GetNamespace(),
 						Name:      obj.GetName(),
 					}.String()
-					fmt.Fprintf(opt.IOStreams.Out, "%s Created: %q\n", obj.GetKind(), name)
+					fmt.Fprintf(cmdOpts.IOStreams.Out, "%s Created: %q\n", obj.GetKind(), name)
 					continue
 				}
-				_ = printer.PrintObj(&obj, opt.IOStreams.Out)
+				_ = printer.PrintObj(&obj, cmdOpts.IOStreams.Out)
 			}
 			for _, r := range updatedRes {
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.UpdatedResourceManifest, &obj); err != nil {
-					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
+					fmt.Fprintf(cmdOpts.IOStreams.ErrOut, "%s",
 						errors.Wrap(err, "Error: unmarshal updated manifest"))
 					continue
 				}
@@ -107,17 +149,17 @@ kargo apply -f stage.yaml
 						Namespace: obj.GetNamespace(),
 						Name:      obj.GetName(),
 					}.String()
-					fmt.Fprintf(opt.IOStreams.Out, "%s Updated: %q\n", obj.GetKind(), name)
+					fmt.Fprintf(cmdOpts.IOStreams.Out, "%s Updated: %q\n", obj.GetKind(), name)
 					continue
 				}
-				_ = printer.PrintObj(&obj, opt.IOStreams.Out)
+				_ = printer.PrintObj(&obj, cmdOpts.IOStreams.Out)
 			}
 			return goerrors.Join(errs...)
 		},
 	}
-	opt.PrintFlags.AddFlags(cmd)
-	option.Filenames(cmd.Flags(), &filenames, "apply")
-	option.InsecureTLS(cmd.PersistentFlags(), opt)
-	option.LocalServer(cmd.PersistentFlags(), opt)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }

--- a/internal/cli/cmd/approve/approve.go
+++ b/internal/cli/cmd/approve/approve.go
@@ -1,6 +1,8 @@
 package approve
 
 import (
+	goerrors "errors"
+
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -11,8 +13,58 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type approvalOptions struct {
+	*option.Option
+
+	Freight string
+	Stage   string
+}
+
+// addFlags adds the flags for the approval options to the provided command.
+func (o *approvalOptions) addFlags(cmd *cobra.Command) {
+	// TODO: Factor out server flags to a higher level (root?) as they are
+	//   common to almost all commands.
+	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
+	option.LocalServer(cmd.PersistentFlags(), o.Option)
+
+	option.Project(cmd.Flags(), &o.Project, o.Project,
+		"The Project the Freight belongs to. If not set, the default project will be used.")
+	option.Freight(cmd.Flags(), &o.Freight, "The ID of the Freight to approve.")
+	option.Stage(cmd.Flags(), &o.Stage, "The Stage to approve the Freight to.")
+
+	if err := cmd.MarkFlagRequired(option.FreightFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark freight flag as required"))
+	}
+	if err := cmd.MarkFlagRequired(option.StageFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark stage flag as required"))
+	}
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *approvalOptions) validate() error {
+	var errs []error
+
+	if o.Project == "" {
+		errs = append(errs, errors.New("project is required"))
+	}
+
+	// While the freight and stage flags are marked as required, a user could
+	// still provide an empty string. This is a check to ensure that the flags
+	// are not empty.
+	if o.Freight == "" {
+		errs = append(errs, errors.New("freight is required"))
+	}
+	if o.Stage == "" {
+		errs = append(errs, errors.New("stage is required"))
+	}
+
+	return goerrors.Join(errs...)
+}
+
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	var freight, stage string
+	cmdOpts := &approvalOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:     "approve --project=project --freight=freight --stage=stage",
 		Short:   "Manually approve freight for promotion to a stage",
@@ -20,18 +72,11 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
-			project := opt.Project
-			if project == "" {
-				return errors.New("project is required")
-			}
-			if freight == "" {
-				return errors.New("freight is required")
-			}
-			if stage == "" {
-				return errors.New("stage is required")
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
+			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
@@ -40,9 +85,9 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 				ctx,
 				connect.NewRequest(
 					&v1alpha1.ApproveFreightRequest{
-						Project: project,
-						Id:      freight,
-						Stage:   stage,
+						Project: cmdOpts.Project,
+						Id:      cmdOpts.Freight,
+						Stage:   cmdOpts.Stage,
 					},
 				),
 			); err != nil {
@@ -51,8 +96,9 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 			return nil
 		},
 	}
-	option.Project(cmd.Flags(), opt, opt.Project)
-	option.Freight(cmd.Flags(), &freight)
-	option.Stage(cmd.Flags(), &stage)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }

--- a/internal/cli/cmd/config/config.go
+++ b/internal/cli/cmd/config/config.go
@@ -12,7 +12,8 @@ func NewCommand(cfg config.CLIConfig) *cobra.Command {
 		Short: "Manage Kargo CLI configuration",
 	}
 
-	// Subcommands
+	// Register subcommands.
 	cmd.AddCommand(newSetProjectCommand(cfg))
+
 	return cmd
 }

--- a/internal/cli/cmd/config/set_project.go
+++ b/internal/cli/cmd/config/set_project.go
@@ -10,7 +10,15 @@ import (
 	"github.com/akuity/kargo/internal/cli/option"
 )
 
+type setProjectOptions struct {
+	Config config.CLIConfig
+
+	Project string
+}
+
 func newSetProjectCommand(cfg config.CLIConfig) *cobra.Command {
+	cmdOpts := &setProjectOptions{Config: cfg}
+
 	cmd := &cobra.Command{
 		Use:   "set-project",
 		Short: "Set the default project",
@@ -23,14 +31,26 @@ kargo config set-project my-project
 kargo config set-project ""
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			project := strings.TrimSpace(strings.ToLower(args[0]))
-			cfg.Project = project
+			cmdOpts.complete(args)
 
-			if err := config.SaveCLIConfig(cfg); err != nil {
-				return errors.Wrap(err, "save cli config")
-			}
-			return nil
+			return cmdOpts.run()
 		},
 	}
 	return cmd
+}
+
+// complete sets the options from the command arguments.
+func (o *setProjectOptions) complete(args []string) {
+	o.Project = strings.TrimSpace(strings.ToLower(args[0]))
+}
+
+// run sets the default project in the CLI configuration using the provided
+// options.
+func (o *setProjectOptions) run() error {
+	o.Config.Project = o.Project
+
+	if err := config.SaveCLIConfig(o.Config); err != nil {
+		return errors.Wrap(err, "save cli config")
+	}
+	return nil
 }

--- a/internal/cli/cmd/create/project.go
+++ b/internal/cli/cmd/create/project.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -20,15 +21,16 @@ import (
 
 type createProjectOptions struct {
 	*option.Option
-}
+	Config config.CLIConfig
 
-// addFlags adds the flags for the create project options to the provided command.
-func (o *createProjectOptions) addFlags(cmd *cobra.Command) {
-	o.PrintFlags.AddFlags(cmd)
+	Name string
 }
 
 func newProjectCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	cmdOpts := &createProjectOptions{Option: opt}
+	cmdOpts := &createProjectOptions{
+		Option: opt,
+		Config: cfg,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "project (NAME)",
@@ -39,59 +41,13 @@ func newProjectCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command 
 kargo create project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			cmdOpts.complete(args)
 
-			name := strings.TrimSpace(args[0])
-			if name == "" {
-				return errors.New("name is required")
-			}
-
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
 
-			project := &kargoapi.Project{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: kargoapi.GroupVersion.String(),
-					Kind:       "Project",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-			}
-			projectBytes, err := sigyaml.Marshal(project)
-			if err != nil {
-				return errors.Wrap(err, "marshal project")
-			}
-
-			resp, err := kargoSvcCli.CreateResource(
-				ctx,
-				connect.NewRequest(
-					&kargosvcapi.CreateResourceRequest{
-						Manifest: projectBytes,
-					},
-				),
-			)
-			if err != nil {
-				return errors.Wrap(err, "create resource")
-			}
-
-			project = &kargoapi.Project{}
-			projectBytes = resp.Msg.GetResults()[0].GetCreatedResourceManifest()
-			if err = sigyaml.Unmarshal(projectBytes, project); err != nil {
-				return errors.Wrap(err, "unmarshal project")
-			}
-
-			if ptr.Deref(cmdOpts.PrintFlags.OutputFormat, "") == "" {
-				_, _ = fmt.Fprintf(cmdOpts.IOStreams.Out, "Project Created: %q\n", name)
-				return nil
-			}
-			printer, err := cmdOpts.PrintFlags.ToPrinter()
-			if err != nil {
-				return errors.Wrap(err, "new printer")
-			}
-			return printer.PrintObj(project, cmdOpts.IOStreams.Out)
+			return cmdOpts.run(cmd.Context())
 		},
 	}
 
@@ -99,4 +55,74 @@ kargo create project my-project
 	cmdOpts.addFlags(cmd)
 
 	return cmd
+}
+
+// addFlags adds the flags for the create project options to the provided command.
+func (o *createProjectOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+}
+
+// complete sets the options from the command arguments.
+func (o *createProjectOptions) complete(args []string) {
+	o.Name = strings.TrimSpace(args[0])
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *createProjectOptions) validate() error {
+	if o.Name == "" {
+		return errors.New("name is required")
+	}
+	return nil
+}
+
+// run creates a project using the provided options.
+func (o *createProjectOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
+	}
+
+	project := &kargoapi.Project{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kargoapi.GroupVersion.String(),
+			Kind:       "Project",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.Name,
+		},
+	}
+	projectBytes, err := sigyaml.Marshal(project)
+	if err != nil {
+		return errors.Wrap(err, "marshal project")
+	}
+
+	resp, err := kargoSvcCli.CreateResource(
+		ctx,
+		connect.NewRequest(
+			&kargosvcapi.CreateResourceRequest{
+				Manifest: projectBytes,
+			},
+		),
+	)
+	if err != nil {
+		return errors.Wrap(err, "create resource")
+	}
+
+	project = &kargoapi.Project{}
+	projectBytes = resp.Msg.GetResults()[0].GetCreatedResourceManifest()
+	if err = sigyaml.Unmarshal(projectBytes, project); err != nil {
+		return errors.Wrap(err, "unmarshal project")
+	}
+
+	if ptr.Deref(o.PrintFlags.OutputFormat, "") == "" {
+		_, _ = fmt.Fprintf(o.IOStreams.Out, "Project Created: %q\n", o.Name)
+		return nil
+	}
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return errors.Wrap(err, "new printer")
+	}
+	return printer.PrintObj(project, o.IOStreams.Out)
 }

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -8,22 +8,41 @@ import (
 	"github.com/akuity/kargo/internal/cli/config"
 )
 
+type dashboardOptions struct {
+	Config config.CLIConfig
+}
+
 func NewCommand(cfg config.CLIConfig) *cobra.Command {
+	cmdOpts := &dashboardOptions{Config: cfg}
+
 	return &cobra.Command{
 		Use:     "dashboard",
 		Short:   "Open the Kargo Dashboard in your default browser.",
 		Example: "kargo logout",
 		RunE: func(*cobra.Command, []string) error {
-			if cfg.APIAddress == "" {
-				return errors.New(
-					"seems like you are not logged in; please use `kargo login` to authenticate",
-				)
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
-
-			return errors.Wrap(
-				browser.Open(cfg.APIAddress),
-				"error opening dashboard in default browser",
-			)
+			return cmdOpts.run()
 		},
 	}
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *dashboardOptions) validate() error {
+	if o.Config.APIAddress == "" {
+		return errors.New(
+			"seems like you are not logged in; please use `kargo login` to authenticate",
+		)
+	}
+	return nil
+}
+
+// run opens the Kargo Dashboard in the default browser.
+func (o *dashboardOptions) run() error {
+	return errors.Wrap(
+		browser.Open(o.Config.APIAddress),
+		"error opening dashboard in default browser",
+	)
 }

--- a/internal/cli/cmd/delete/delete.go
+++ b/internal/cli/cmd/delete/delete.go
@@ -19,8 +19,49 @@ import (
 	kargosvcapi "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type deleteOptions struct {
+	*option.Option
+
+	Filenames []string
+}
+
+// addFlags adds the flags for the delete options to the provided command.
+func (o *deleteOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+
+	// TODO: Factor out server flags to a higher level (root?) as they are
+	//   common to almost all commands.
+	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
+	option.LocalServer(cmd.PersistentFlags(), o.Option)
+
+	option.Filenames(cmd.Flags(), &o.Filenames, "Filename or directory to use to delete resource(s).")
+
+	if err := cmd.MarkFlagRequired(option.FilenameFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as required"))
+	}
+	if err := cmd.MarkFlagFilename(option.FilenameFlag, ".yaml", ".yml"); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as filename"))
+	}
+	if err := cmd.MarkFlagDirname(option.FilenameFlag); err != nil {
+		panic(errors.Wrap(err, "could not mark filename flag as dirname"))
+	}
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *deleteOptions) validate() error {
+	// While the filename flag is marked as required, a user could still
+	// provide an empty string. This is a check to ensure that the flag is
+	// not empty.
+	if len(o.Filenames) == 0 {
+		return errors.New("filename is required")
+	}
+	return nil
+}
+
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	var filenames []string
+	cmdOpts := &deleteOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:   "delete [--project=project] -f (FILENAME)",
 		Short: "Delete resources by resources and names",
@@ -36,16 +77,17 @@ kargo delete -f stage.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if len(filenames) == 0 {
-				return errors.New("filename is required")
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
 
-			manifest, err := yaml.Read(filenames)
+			manifest, err := yaml.Read(cmdOpts.Filenames)
 			if err != nil {
 				return errors.Wrap(err, "read manifests")
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
+			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
@@ -71,7 +113,7 @@ kargo delete -f stage.yaml
 			for _, r := range successRes {
 				var obj unstructured.Unstructured
 				if err := sigyaml.Unmarshal(r.DeletedResourceManifest, &obj); err != nil {
-					fmt.Fprintf(opt.IOStreams.ErrOut, "%s",
+					fmt.Fprintf(cmdOpts.IOStreams.ErrOut, "%s",
 						errors.Wrap(err, "Error: unmarshal deleted manifest"))
 					continue
 				}
@@ -79,14 +121,14 @@ kargo delete -f stage.yaml
 					Namespace: obj.GetNamespace(),
 					Name:      obj.GetName(),
 				}.String(), "/")
-				fmt.Fprintf(opt.IOStreams.Out, "%s Deleted: %q\n", obj.GetKind(), name)
+				fmt.Fprintf(cmdOpts.IOStreams.Out, "%s Deleted: %q\n", obj.GetKind(), name)
 			}
 			return goerrors.Join(deleteErrs...)
 		},
 	}
-	option.Filenames(cmd.Flags(), &filenames, "apply")
-	option.InsecureTLS(cmd.PersistentFlags(), opt)
-	option.LocalServer(cmd.PersistentFlags(), opt)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
 
 	// Subcommands
 	cmd.AddCommand(newProjectCommand(cfg, opt))

--- a/internal/cli/cmd/delete/project.go
+++ b/internal/cli/cmd/delete/project.go
@@ -1,13 +1,14 @@
 package delete
 
 import (
+	"context"
 	goerrors "errors"
 	"fmt"
+	"slices"
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/akuity/kargo/internal/cli/client"
 	"github.com/akuity/kargo/internal/cli/config"
@@ -17,19 +18,16 @@ import (
 
 type deleteProjectOptions struct {
 	*option.Option
+	Config config.CLIConfig
+
+	Names []string
 }
 
-// addFlags adds the flags for the delete project options to the provided
-// command.
-func (o *deleteProjectOptions) addFlags(cmd *cobra.Command) {
-	o.PrintFlags.AddFlags(cmd)
-}
-
-func newProjectCommand(
-	cfg config.CLIConfig,
-	opt *option.Option,
-) *cobra.Command {
-	cmdOpts := &deleteProjectOptions{Option: opt}
+func newProjectCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &deleteProjectOptions{
+		Option: opt,
+		Config: cfg,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "project [NAME]...",
@@ -40,23 +38,13 @@ func newProjectCommand(
 kargo delete project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
+			cmdOpts.complete(args)
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
 			}
 
-			var resErr error
-			for _, name := range slices.Compact(args) {
-				if _, err := kargoSvcCli.DeleteProject(ctx, connect.NewRequest(&v1alpha1.DeleteProjectRequest{
-					Name: name,
-				})); err != nil {
-					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
-					continue
-				}
-				_, _ = fmt.Fprintf(cmdOpts.IOStreams.Out, "Project Deleted: %q\n", name)
-			}
-			return resErr
+			return cmdOpts.run(cmd.Context())
 		},
 	}
 
@@ -64,4 +52,44 @@ kargo delete project my-project
 	cmdOpts.addFlags(cmd)
 
 	return cmd
+}
+
+// addFlags adds the flags for the delete project options to the provided
+// command.
+func (o *deleteProjectOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+}
+
+// complete sets the options from the command arguments.
+func (o *deleteProjectOptions) complete(args []string) {
+	o.Names = slices.Compact(args)
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *deleteProjectOptions) validate() error {
+	if len(o.Names) == 0 {
+		return goerrors.New("name is required")
+	}
+	return nil
+}
+
+// run removes the project(s) based on the options.
+func (o *deleteProjectOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
+	}
+
+	var resErr error
+	for _, name := range o.Names {
+		if _, err := kargoSvcCli.DeleteProject(ctx, connect.NewRequest(&v1alpha1.DeleteProjectRequest{
+			Name: name,
+		})); err != nil {
+			resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
+			continue
+		}
+		_, _ = fmt.Fprintf(o.IOStreams.Out, "Project Deleted: %q\n", name)
+	}
+	return resErr
 }

--- a/internal/cli/cmd/delete/project.go
+++ b/internal/cli/cmd/delete/project.go
@@ -15,10 +15,22 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type deleteProjectOptions struct {
+	*option.Option
+}
+
+// addFlags adds the flags for the delete project options to the provided
+// command.
+func (o *deleteProjectOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+}
+
 func newProjectCommand(
 	cfg config.CLIConfig,
 	opt *option.Option,
 ) *cobra.Command {
+	cmdOpts := &deleteProjectOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:   "project [NAME]...",
 		Short: "Delete project by name",
@@ -29,7 +41,7 @@ kargo delete project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
+			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
@@ -42,12 +54,14 @@ kargo delete project my-project
 					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
 					continue
 				}
-				_, _ = fmt.Fprintf(opt.IOStreams.Out, "Project Deleted: %q\n", name)
+				_, _ = fmt.Fprintf(cmdOpts.IOStreams.Out, "Project Deleted: %q\n", name)
 			}
 			return resErr
 		},
 	}
-	opt.PrintFlags.AddFlags(cmd)
-	option.Project(cmd.Flags(), opt, opt.Project)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }

--- a/internal/cli/cmd/delete/stage.go
+++ b/internal/cli/cmd/delete/stage.go
@@ -15,7 +15,30 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type deleteStageOptions struct {
+	*option.Option
+}
+
+// addFlags adds the flags for the delete stage options to the provided command.
+func (o *deleteStageOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+
+	option.Project(cmd.Flags(), &o.Project, o.Project,
+		"The Project for which to delete Stages. If not set, the default project will be used.")
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *deleteStageOptions) validate() error {
+	if o.Project == "" {
+		return errors.New("project is required")
+	}
+	return nil
+}
+
 func newStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &deleteStageOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:   "stage [NAME]...",
 		Short: "Delete stage by name",
@@ -26,31 +49,33 @@ kargo delete stage --project=my-project my-stage
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
 
-			project := opt.Project
-			if project == "" {
-				return errors.New("project is required")
-			}
-
 			var resErr error
 			for _, name := range slices.Compact(args) {
 				if _, err := kargoSvcCli.DeleteStage(ctx, connect.NewRequest(&v1alpha1.DeleteStageRequest{
-					Project: project,
+					Project: cmdOpts.Project,
 					Name:    name,
 				})); err != nil {
 					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
 					continue
 				}
-				_, _ = fmt.Fprintf(opt.IOStreams.Out, "Stage Deleted: %q\n", name)
+				_, _ = fmt.Fprintf(cmdOpts.IOStreams.Out, "Stage Deleted: %q\n", name)
 			}
 			return resErr
 		},
 	}
-	opt.PrintFlags.AddFlags(cmd)
-	option.Project(cmd.Flags(), opt, opt.Project)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }

--- a/internal/cli/cmd/delete/warehouse.go
+++ b/internal/cli/cmd/delete/warehouse.go
@@ -1,13 +1,14 @@
 package delete
 
 import (
+	"context"
 	goerrors "errors"
 	"fmt"
+	"slices"
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/akuity/kargo/internal/cli/client"
 	"github.com/akuity/kargo/internal/cli/config"
@@ -17,6 +18,40 @@ import (
 
 type deleteWarehouseOptions struct {
 	*option.Option
+	Config config.CLIConfig
+
+	Names []string
+}
+
+func newWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &deleteWarehouseOptions{
+		Option: opt,
+		Config: cfg,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "warehouse [NAME]...",
+		Short: "Delete warehouse by name",
+		Args:  option.MinimumNArgs(1),
+		Example: `
+# Delete warehouse
+kargo delete warehouse --project=my-project my-warehouse
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdOpts.complete(args)
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
+			return cmdOpts.run(cmd.Context())
+		},
+	}
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
+	return cmd
 }
 
 // addFlags adds the flags for the delete warehouse options to the provided
@@ -28,63 +63,49 @@ func (o *deleteWarehouseOptions) addFlags(cmd *cobra.Command) {
 		"The Project for which to delete Warehouses. If not set, the default project will be used.")
 }
 
+// complete sets the options from the command arguments.
+func (o *deleteWarehouseOptions) complete(args []string) {
+	o.Names = slices.Compact(args)
+}
+
 // validate performs validation of the options. If the options are invalid, an
 // error is returned.
 func (o *deleteWarehouseOptions) validate() error {
+	var errs []error
+
 	if o.Project == "" {
-		return errors.New("project is required")
+		errs = append(errs, errors.New("project is required"))
 	}
-	return nil
+
+	if len(o.Names) == 0 {
+		errs = append(errs, errors.New("at least one warehouse name is required"))
+	}
+
+	return goerrors.Join(errs...)
 }
 
-func newWarehouseCommand(
-	cfg config.CLIConfig,
-	opt *option.Option,
-) *cobra.Command {
-	cmdOpts := &deleteWarehouseOptions{Option: opt}
-
-	cmd := &cobra.Command{
-		Use:   "warehouse [NAME]...",
-		Short: "Delete warehouse by name",
-		Args:  option.MinimumNArgs(1),
-		Example: `
-# Delete warehouse
-kargo delete warehouse --project=my-project my-warehouse
-`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			if err := cmdOpts.validate(); err != nil {
-				return err
-			}
-
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
-			}
-
-			var resErr error
-			for _, name := range slices.Compact(args) {
-				if _, err := kargoSvcCli.DeleteWarehouse(
-					ctx,
-					connect.NewRequest(
-						&v1alpha1.DeleteWarehouseRequest{
-							Project: cmdOpts.Project,
-							Name:    name,
-						},
-					),
-				); err != nil {
-					resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
-					continue
-				}
-				_, _ = fmt.Fprintf(cmdOpts.IOStreams.Out, "Warehouse Deleted: %q\n", name)
-			}
-			return resErr
-		},
+// run removes the warehouse(s) based on the options.
+func (o *deleteWarehouseOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
 	}
 
-	// Register the option flags on the command.
-	cmdOpts.addFlags(cmd)
-
-	return cmd
+	var resErr error
+	for _, name := range o.Names {
+		if _, err := kargoSvcCli.DeleteWarehouse(
+			ctx,
+			connect.NewRequest(
+				&v1alpha1.DeleteWarehouseRequest{
+					Project: o.Project,
+					Name:    name,
+				},
+			),
+		); err != nil {
+			resErr = goerrors.Join(resErr, errors.Wrap(err, "Error"))
+			continue
+		}
+		_, _ = fmt.Fprintf(o.IOStreams.Out, "Warehouse Deleted: %q\n", name)
+	}
+	return resErr
 }

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -1,13 +1,14 @@
 package get
 
 import (
+	"context"
 	goerrors "errors"
+	"slices"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 
@@ -21,30 +22,16 @@ import (
 
 type getFreightOptions struct {
 	*option.Option
+	Config config.CLIConfig
+
+	Names []string
 }
 
-// addFlags adds the flags for the get freight options to the provided command.
-func (o *getFreightOptions) addFlags(cmd *cobra.Command) {
-	o.PrintFlags.AddFlags(cmd)
-
-	option.Project(cmd.Flags(), &o.Project, o.Project,
-		"The Project for which to list Freight. If not set, the default project will be used.")
-}
-
-// validate performs validation of the options. If the options are invalid, an
-// error is returned.
-func (o *getFreightOptions) validate() error {
-	if o.Project == "" {
-		return errors.New("project is required")
+func newGetFreightCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &getFreightOptions{
+		Option: opt,
+		Config: cfg,
 	}
-	return nil
-}
-
-func newGetFreightCommand(
-	cfg config.CLIConfig,
-	opt *option.Option,
-) *cobra.Command {
-	cmdOpts := &getFreightOptions{Option: opt}
 
 	cmd := &cobra.Command{
 		Use:   "freight --project=project [NAME...]",
@@ -60,64 +47,13 @@ kargo get freight --project=my-project -o json
 kargo get freight --project=my-project my-freight
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			cmdOpts.complete(args)
 
 			if err := cmdOpts.validate(); err != nil {
 				return err
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
-			}
-			resp, err := kargoSvcCli.QueryFreight(ctx, connect.NewRequest(&v1alpha1.QueryFreightRequest{
-				Project: cmdOpts.Project,
-			}))
-			if err != nil {
-				return errors.Wrap(err, "query freight")
-			}
-
-			names := slices.Compact(args)
-			// We didn't specify any groupBy, so there should be one group with an
-			// empty key
-			freight := resp.Msg.GetGroups()[""]
-			res := make([]*kargoapi.Freight, 0, len(freight.Freight))
-			var resErr error
-			if len(names) == 0 {
-				for _, f := range freight.Freight {
-					res = append(res, typesv1alpha1.FromFreightProto(f))
-				}
-			} else {
-				freightByName := make(map[string]*kargoapi.Freight, len(freight.Freight))
-				freightByAlias := make(map[string]*kargoapi.Freight, len(freight.Freight))
-				for _, f := range freight.Freight {
-					fr := typesv1alpha1.FromFreightProto(f)
-					freightByName[f.GetMetadata().GetName()] = fr
-					if f.GetMetadata().GetLabels() != nil {
-						freightByAlias[f.GetMetadata().GetLabels()[kargoapi.AliasLabelKey]] = fr
-					}
-				}
-				selectedFreight := make(map[string]struct{}, len(names))
-				for _, name := range names {
-					f, ok := freightByName[name]
-					if !ok {
-						f, ok = freightByAlias[name]
-					}
-					if ok {
-						if _, selected := selectedFreight[f.Name]; !selected {
-							res = append(res, f)
-							selectedFreight[f.Name] = struct{}{}
-						}
-					} else {
-						resErr =
-							goerrors.Join(err, errors.Errorf("freight %q not found", name))
-					}
-				}
-			}
-			if err := printObjects(cmdOpts.Option, res); err != nil {
-				return err
-			}
-			return resErr
+			return cmdOpts.run(cmd.Context())
 		},
 	}
 
@@ -125,6 +61,83 @@ kargo get freight --project=my-project my-freight
 	cmdOpts.addFlags(cmd)
 
 	return cmd
+}
+
+// addFlags adds the flags for the get freight options to the provided command.
+func (o *getFreightOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+
+	option.Project(cmd.Flags(), &o.Project, o.Project,
+		"The Project for which to list Freight. If not set, the default project will be used.")
+}
+
+// complete sets the options from the command arguments.
+func (o *getFreightOptions) complete(args []string) {
+	o.Names = slices.Compact(args)
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *getFreightOptions) validate() error {
+	if o.Project == "" {
+		return errors.New("project is required")
+	}
+	return nil
+}
+
+// run gets the freight from the server and prints it to the console.
+func (o *getFreightOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
+	}
+	resp, err := kargoSvcCli.QueryFreight(ctx, connect.NewRequest(&v1alpha1.QueryFreightRequest{
+		Project: o.Project,
+	}))
+	if err != nil {
+		return errors.Wrap(err, "query freight")
+	}
+
+	// We didn't specify any groupBy, so there should be one group with an
+	// empty key
+	freight := resp.Msg.GetGroups()[""]
+	res := make([]*kargoapi.Freight, 0, len(freight.Freight))
+	var resErr error
+	if len(o.Names) == 0 {
+		for _, f := range freight.Freight {
+			res = append(res, typesv1alpha1.FromFreightProto(f))
+		}
+	} else {
+		freightByName := make(map[string]*kargoapi.Freight, len(freight.Freight))
+		freightByAlias := make(map[string]*kargoapi.Freight, len(freight.Freight))
+		for _, f := range freight.Freight {
+			fr := typesv1alpha1.FromFreightProto(f)
+			freightByName[f.GetMetadata().GetName()] = fr
+			if f.GetMetadata().GetLabels() != nil {
+				freightByAlias[f.GetMetadata().GetLabels()[kargoapi.AliasLabelKey]] = fr
+			}
+		}
+		selectedFreight := make(map[string]struct{}, len(o.Names))
+		for _, name := range o.Names {
+			f, ok := freightByName[name]
+			if !ok {
+				f, ok = freightByAlias[name]
+			}
+			if ok {
+				if _, selected := selectedFreight[f.Name]; !selected {
+					res = append(res, f)
+					selectedFreight[f.Name] = struct{}{}
+				}
+			} else {
+				resErr =
+					goerrors.Join(err, errors.Errorf("freight %q not found", name))
+			}
+		}
+	}
+	if err := printObjects(o.Option, res); err != nil {
+		return err
+	}
+	return resErr
 }
 
 func newFreightTable(list *metav1.List) *metav1.Table {

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -34,7 +34,7 @@ kargo get promotions --project=my-project --stage=my-stage
 	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	option.LocalServer(cmd.PersistentFlags(), opt)
 
-	// Subcommands
+	// Register subcommands.
 	cmd.AddCommand(newGetFreightCommand(cfg, opt))
 	cmd.AddCommand(newGetProjectsCommand(cfg, opt))
 	cmd.AddCommand(newGetPromotionsCommand(cfg, opt))

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -28,6 +28,9 @@ kargo get stages --project=my-project
 kargo get promotions --project=my-project --stage=my-stage
 `,
 	}
+
+	// TODO: Factor out server flags to a higher level (root?) as they are
+	//   common to almost all commands.
 	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	option.LocalServer(cmd.PersistentFlags(), opt)
 

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -19,10 +19,21 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type getProjectsOptions struct {
+	*option.Option
+}
+
+// addFlags adds the flags for the get projects options to the provided command.
+func (o *getProjectsOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+}
+
 func newGetProjectsCommand(
 	cfg config.CLIConfig,
 	opt *option.Option,
 ) *cobra.Command {
+	cmdOpts := &getProjectsOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:     "projects [NAME...]",
 		Aliases: []string{"project"},
@@ -37,7 +48,7 @@ kargo get projects -o json
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
+			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
 			if err != nil {
 				return errors.Wrap(err, "get client from config")
 			}
@@ -66,13 +77,16 @@ kargo get projects -o json
 					}
 				}
 			}
-			if err := printObjects(opt, res); err != nil {
+			if err := printObjects(cmdOpts.Option, res); err != nil {
 				return err
 			}
 			return resErr
 		},
 	}
-	opt.PrintFlags.AddFlags(cmd)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }
 

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -1,12 +1,13 @@
 package get
 
 import (
+	"context"
 	goerrors "errors"
+	"slices"
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	typesv1alpha1 "github.com/akuity/kargo/internal/api/types/v1alpha1"
@@ -18,31 +19,16 @@ import (
 
 type getWarehousesOptions struct {
 	*option.Option
+	Config config.CLIConfig
+
+	Names []string
 }
 
-// addFlags adds the flags for the get warehouses options to the provided
-// command.
-func (o *getWarehousesOptions) addFlags(cmd *cobra.Command) {
-	o.PrintFlags.AddFlags(cmd)
-
-	option.Project(cmd.Flags(), &o.Project, o.Project,
-		"The Project for which to list Warehouses. If not set, the default project will be used.")
-}
-
-// validate performs validation of the options. If the options are invalid, an
-// error is returned.
-func (o *getWarehousesOptions) validate() error {
-	if o.Project == "" {
-		return errors.New("project is required")
+func newGetWarehousesCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &getWarehousesOptions{
+		Option: opt,
+		Config: cfg,
 	}
-	return nil
-}
-
-func newGetWarehousesCommand(
-	cfg config.CLIConfig,
-	opt *option.Option,
-) *cobra.Command {
-	cmdOpts := &getWarehousesOptions{Option: opt}
 
 	cmd := &cobra.Command{
 		Use:     "warehouses --project=project [NAME...]",
@@ -59,55 +45,13 @@ kargo get warehouses --project=my-project -o json
 kargo get warehouses --project=my-project my-warehouse
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			cmdOpts.complete(args)
 
 			if err := cmdOpts.validate(); err != nil {
 				return err
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, cmdOpts.Option)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
-			}
-			resp, err := kargoSvcCli.ListWarehouses(
-				ctx,
-				connect.NewRequest(
-					&v1alpha1.ListWarehousesRequest{
-						Project: cmdOpts.Project,
-					},
-				),
-			)
-			if err != nil {
-				return errors.Wrap(err, "list warehouses")
-			}
-
-			names := slices.Compact(args)
-			res := make([]*kargoapi.Warehouse, 0, len(resp.Msg.GetWarehouses()))
-			var resErr error
-			if len(names) == 0 {
-				for _, w := range resp.Msg.GetWarehouses() {
-					res = append(res, typesv1alpha1.FromWarehouseProto(w))
-				}
-			} else {
-				warehousesByName :=
-					make(map[string]*kargoapi.Warehouse, len(resp.Msg.GetWarehouses()))
-				for _, w := range resp.Msg.GetWarehouses() {
-					warehousesByName[w.GetMetadata().GetName()] =
-						typesv1alpha1.FromWarehouseProto(w)
-				}
-				for _, name := range names {
-					if warehouse, ok := warehousesByName[name]; ok {
-						res = append(res, warehouse)
-					} else {
-						resErr =
-							goerrors.Join(err, errors.Errorf("warehouse %q not found", name))
-					}
-				}
-			}
-			if err := printObjects(cmdOpts.Option, res); err != nil {
-				return err
-			}
-			return resErr
+			return cmdOpts.run(cmd.Context())
 		},
 	}
 
@@ -115,4 +59,73 @@ kargo get warehouses --project=my-project my-warehouse
 	cmdOpts.addFlags(cmd)
 
 	return cmd
+}
+
+// addFlags adds the flags for the get warehouses options to the provided
+// command.
+func (o *getWarehousesOptions) addFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+
+	option.Project(cmd.Flags(), &o.Project, o.Project,
+		"The Project for which to list Warehouses. If not set, the default project will be used.")
+}
+
+// complete sets the options from the command arguments.
+func (o *getWarehousesOptions) complete(args []string) {
+	o.Names = slices.Compact(args)
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *getWarehousesOptions) validate() error {
+	if o.Project == "" {
+		return errors.New("project is required")
+	}
+	return nil
+}
+
+// run gets the warehouses from the server and prints them to the console.
+func (o *getWarehousesOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
+	}
+	resp, err := kargoSvcCli.ListWarehouses(
+		ctx,
+		connect.NewRequest(
+			&v1alpha1.ListWarehousesRequest{
+				Project: o.Project,
+			},
+		),
+	)
+	if err != nil {
+		return errors.Wrap(err, "list warehouses")
+	}
+
+	res := make([]*kargoapi.Warehouse, 0, len(resp.Msg.GetWarehouses()))
+	var resErr error
+	if len(o.Names) == 0 {
+		for _, w := range resp.Msg.GetWarehouses() {
+			res = append(res, typesv1alpha1.FromWarehouseProto(w))
+		}
+	} else {
+		warehousesByName :=
+			make(map[string]*kargoapi.Warehouse, len(resp.Msg.GetWarehouses()))
+		for _, w := range resp.Msg.GetWarehouses() {
+			warehousesByName[w.GetMetadata().GetName()] =
+				typesv1alpha1.FromWarehouseProto(w)
+		}
+		for _, name := range o.Names {
+			if warehouse, ok := warehousesByName[name]; ok {
+				res = append(res, warehouse)
+			} else {
+				resErr =
+					goerrors.Join(err, errors.Errorf("warehouse %q not found", name))
+			}
+		}
+	}
+	if err := printObjects(o.Option, res); err != nil {
+		return err
+	}
+	return resErr
 }

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -36,10 +36,41 @@ const defaultRandStringCharSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 //go:embed assets
 var assets embed.FS
 
+type loginOptions struct {
+	*option.Option
+
+	UseAdmin      bool
+	UseKubeconfig bool
+	UseSSO        bool
+	Password      string
+	CallbackPort  int
+}
+
+// addFlags adds the flags for the login options to the provided command.
+func (o *loginOptions) addFlags(cmd *cobra.Command) {
+	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
+
+	cmd.Flags().BoolVar(&o.UseAdmin, "admin", false,
+		"Log in as the Kargo admin user. If set, --kubeconfig and --sso must not be set.")
+	cmd.Flags().BoolVar(&o.UseKubeconfig, "kubeconfig", false,
+		"Log in using a token obtained from the local Kubernetes configuration's current context. "+
+			"If set, --admin and --sso must not be set.")
+	cmd.Flags().StringVar(&o.Password, "password", "",
+		"Specify the password for non-interactive admin user login. Only used when --admin is specified.")
+	cmd.Flags().BoolVar(&o.UseSSO, "sso", false,
+		"Log in using OpenID Connect and the server's configured identity provider. "+
+			"If set, --admin and --kubeconfig must not be set.")
+	cmd.Flags().IntVar(&o.CallbackPort, "port", 0,
+		"Port to use for the callback URL; 0 selects any available, unprivileged port. "+
+			"Only used when --sso is specified.")
+
+	cmd.MarkFlagsOneRequired("admin", "kubeconfig", "sso")
+	cmd.MarkFlagsMutuallyExclusive("admin", "kubeconfig", "sso")
+}
+
 func NewCommand(opt *option.Option) *cobra.Command {
-	var useAdmin, useKubeconfig, useSSO bool
-	var password string
-	var callbackPort int
+	cmdOpts := &loginOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:     "login server-address",
 		Args:    option.ExactArgs(1),
@@ -48,53 +79,43 @@ func NewCommand(opt *option.Option) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			var flagCount int
-			if useAdmin {
-				flagCount++
-			}
-			if useKubeconfig {
-				flagCount++
-			}
-			if useSSO {
-				flagCount++
-			}
-			if flagCount != 1 {
-				return errors.Errorf(
-					"please specify exactly one of --admin, --kubeconfig, or --sso",
-				)
-			}
-
 			serverAddress := args[0]
+
 			var bearerToken, refreshToken string
 			var err error
-			if useAdmin {
+
+			switch {
+			case cmdOpts.UseAdmin:
 				for {
-					if password != "" {
+					if cmdOpts.Password != "" {
 						break
 					}
 					prompt := &survey.Password{
 						Message: "Admin user password",
 					}
-					if err = survey.AskOne(prompt, &password); err != nil {
+					if err = survey.AskOne(prompt, &cmdOpts.Password); err != nil {
 						return err
 					}
 				}
-				if bearerToken, err =
-					adminLogin(ctx, serverAddress, password, opt.InsecureTLS); err != nil {
+				if bearerToken, err = adminLogin(ctx, serverAddress, cmdOpts.Password, cmdOpts.InsecureTLS); err != nil {
 					return err
 				}
-			} else if useKubeconfig {
+			case cmdOpts.UseKubeconfig:
 				if bearerToken, err = kubeconfigLogin(ctx); err != nil {
 					return err
 				}
-			} else {
-				if bearerToken, refreshToken, err =
-					ssoLogin(ctx, serverAddress, callbackPort, opt.InsecureTLS); err != nil {
+			case cmdOpts.UseSSO:
+				if bearerToken, refreshToken, err = ssoLogin(
+					ctx, serverAddress, cmdOpts.CallbackPort, cmdOpts.InsecureTLS,
+				); err != nil {
 					return err
 				}
+			default:
+				// This should never happen.
+				return errors.New("internal error: no login method selected")
 			}
 
-			if opt.InsecureTLS {
+			if cmdOpts.InsecureTLS {
 				// When the user specifies during login that they want to ignore cert
 				// warnings, we will force them to periodically re-assess that choice
 				// by NOT using refresh tokens and requiring them to re-authenticate
@@ -108,53 +129,16 @@ func NewCommand(opt *option.Option) *cobra.Command {
 					APIAddress:            serverAddress,
 					BearerToken:           bearerToken,
 					RefreshToken:          refreshToken,
-					InsecureSkipTLSVerify: opt.InsecureTLS,
+					InsecureSkipTLSVerify: cmdOpts.InsecureTLS,
 				},
 			)
 			return errors.Wrap(err, "error persisting configuration")
 		},
 	}
-	cmd.Flags().BoolVarP(
-		&useAdmin,
-		"admin",
-		"a",
-		false,
-		"Log in as the Kargo admin user; mutually exclusive with --kubeconfig and "+
-			"--sso",
-	)
-	cmd.Flags().BoolVarP(
-		&useKubeconfig,
-		"kubeconfig",
-		"k",
-		false,
-		"Log in using a token obtained from the local Kubernetes configuration's "+
-			"current context; mutually exclusive with --admin and --sso",
-	)
-	cmd.Flags().StringVarP(
-		&password,
-		"password",
-		"P",
-		"",
-		"Specify the password for non-interactive admin user login; only used "+
-			"with --admin",
-	)
-	cmd.Flags().IntVarP(
-		&callbackPort,
-		"port",
-		"p",
-		0,
-		"Port to use for the callback URL; 0 selects any available, "+
-			"unprivileged port; only used with --sso",
-	)
-	cmd.Flags().BoolVarP(
-		&useSSO,
-		"sso",
-		"s",
-		false,
-		"Log in using OpenID Connect and the server's configured identity "+
-			"provider; mutually exclusive with --admin and --kubeconfig",
-	)
-	option.InsecureTLS(cmd.PersistentFlags(), opt)
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }
 

--- a/internal/cli/cmd/promote/promote.go
+++ b/internal/cli/cmd/promote/promote.go
@@ -1,6 +1,7 @@
 package promote
 
 import (
+	"context"
 	goerrors "errors"
 	"fmt"
 
@@ -16,13 +17,53 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
-// promotionOptions holds the options for the promote command.
 type promotionOptions struct {
 	*option.Option
+	Config config.CLIConfig
 
 	Freight       string
 	Stage         string
 	SubscribersOf string
+}
+
+func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &promotionOptions{
+		Option: opt,
+		Config: cfg,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "promote [--project=project] --freight=freight-id [--stage=stage] [--subscribers-of=stage]",
+		Short: "Manage the promotion of freight",
+		Args:  option.NoArgs,
+		Example: `
+# Promote a freight to a stage for a specific project
+kargo promote --project=my-project --freight=abc123 --stage=dev
+
+# Promote a freight to subscribers of a stage for a specific project
+kargo promote --project=my-project --freight=abc123 --subscribers-of=dev
+
+# Promote a freight to a stage for the default project
+kargo config set-project my-project
+kargo promote --freight=abc123 --stage=dev
+
+# Promote a freight to subscribers of a stage for the default project
+kargo config set-project my-project
+kargo promote --freight=abc123 --subscribers-of=dev
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
+			return cmdOpts.run(cmd.Context())
+		},
+	}
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
+	return cmd
 }
 
 // addFlags adds the flags for the promotion options to the provided command.
@@ -70,96 +111,62 @@ func (o *promotionOptions) validate() error {
 	return goerrors.Join(errs...)
 }
 
-func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	cmdOpts := &promotionOptions{Option: opt}
-
-	cmd := &cobra.Command{
-		Use:   "promote [--project=project] --freight=freight-id [--stage=stage] [--subscribers-of=stage]",
-		Short: "Manage the promotion of freight",
-		Args:  option.NoArgs,
-		Example: `
-# Promote a freight to a stage for a specific project
-kargo promote --project=my-project --freight=abc123 --stage=dev
-
-# Promote a freight to subscribers of a stage for a specific project
-kargo promote --project=my-project --freight=abc123 --subscribers-of=dev
-
-# Promote a freight to a stage for the default project
-kargo config set-project my-project
-kargo promote --freight=abc123 --stage=dev
-
-# Promote a freight to subscribers of a stage for the default project
-kargo config set-project my-project
-kargo promote --freight=abc123 --subscribers-of=dev
-`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			if err := cmdOpts.validate(); err != nil {
-				return err
-			}
-
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
-			if err != nil {
-				return err
-			}
-
-			switch {
-			case cmdOpts.Stage != "":
-				res, err := kargoSvcCli.PromoteStage(ctx, connect.NewRequest(&v1alpha1.PromoteStageRequest{
-					Project: cmdOpts.Project,
-					Name:    cmdOpts.Stage,
-					Freight: cmdOpts.Freight,
-				}))
-				if err != nil {
-					return errors.Wrap(err, "promote stage")
-				}
-				if ptr.Deref(cmdOpts.PrintFlags.OutputFormat, "") == "" {
-					fmt.Fprintf(cmdOpts.IOStreams.Out,
-						"Promotion Created: %q\n", res.Msg.GetPromotion().GetMetadata().GetName())
-					return nil
-				}
-				printer, err := cmdOpts.PrintFlags.ToPrinter()
-				if err != nil {
-					return errors.Wrap(err, "new printer")
-				}
-				promo := typesv1alpha1.FromPromotionProto(res.Msg.GetPromotion())
-				_ = printer.PrintObj(promo, cmdOpts.IOStreams.Out)
-				return nil
-			case cmdOpts.SubscribersOf != "":
-				res, promoteErr := kargoSvcCli.PromoteSubscribers(ctx, connect.NewRequest(&v1alpha1.PromoteSubscribersRequest{
-					Project: cmdOpts.Project,
-					Stage:   cmdOpts.SubscribersOf,
-					Freight: cmdOpts.Freight,
-				}))
-				if ptr.Deref(cmdOpts.PrintFlags.OutputFormat, "") == "" {
-					if res != nil && res.Msg != nil {
-						for _, p := range res.Msg.GetPromotions() {
-							fmt.Fprintf(cmdOpts.IOStreams.Out, "Promotion Created: %q\n", *p.Metadata.Name)
-						}
-					}
-					if promoteErr != nil {
-						return errors.Wrap(promoteErr, "promote subscribers")
-					}
-					return nil
-				}
-
-				printer, printerErr := cmdOpts.PrintFlags.ToPrinter()
-				if printerErr != nil {
-					return errors.Wrap(printerErr, "new printer")
-				}
-				for _, p := range res.Msg.GetPromotions() {
-					kubeP := typesv1alpha1.FromPromotionProto(p)
-					_ = printer.PrintObj(kubeP, cmdOpts.IOStreams.Out)
-				}
-				return promoteErr
-			}
-			return nil
-		},
+// run performs the promotion of the freight using the options.
+func (o *promotionOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return err
 	}
 
-	// Register the option flags on the command.
-	cmdOpts.addFlags(cmd)
+	switch {
+	case o.Stage != "":
+		res, err := kargoSvcCli.PromoteStage(ctx, connect.NewRequest(&v1alpha1.PromoteStageRequest{
+			Project: o.Project,
+			Name:    o.Stage,
+			Freight: o.Freight,
+		}))
+		if err != nil {
+			return errors.Wrap(err, "promote stage")
+		}
+		if ptr.Deref(o.PrintFlags.OutputFormat, "") == "" {
+			fmt.Fprintf(o.IOStreams.Out,
+				"Promotion Created: %q\n", res.Msg.GetPromotion().GetMetadata().GetName())
+			return nil
+		}
+		printer, err := o.PrintFlags.ToPrinter()
+		if err != nil {
+			return errors.Wrap(err, "new printer")
+		}
+		promo := typesv1alpha1.FromPromotionProto(res.Msg.GetPromotion())
+		_ = printer.PrintObj(promo, o.IOStreams.Out)
+		return nil
+	case o.SubscribersOf != "":
+		res, promoteErr := kargoSvcCli.PromoteSubscribers(ctx, connect.NewRequest(&v1alpha1.PromoteSubscribersRequest{
+			Project: o.Project,
+			Stage:   o.SubscribersOf,
+			Freight: o.Freight,
+		}))
+		if ptr.Deref(o.PrintFlags.OutputFormat, "") == "" {
+			if res != nil && res.Msg != nil {
+				for _, p := range res.Msg.GetPromotions() {
+					fmt.Fprintf(o.IOStreams.Out, "Promotion Created: %q\n", *p.Metadata.Name)
+				}
+			}
+			if promoteErr != nil {
+				return errors.Wrap(promoteErr, "promote subscribers")
+			}
+			return nil
+		}
 
-	return cmd
+		printer, printerErr := o.PrintFlags.ToPrinter()
+		if printerErr != nil {
+			return errors.Wrap(printerErr, "new printer")
+		}
+		for _, p := range res.Msg.GetPromotions() {
+			kubeP := typesv1alpha1.FromPromotionProto(p)
+			_ = printer.PrintObj(kubeP, o.IOStreams.Out)
+		}
+		return promoteErr
+	}
+	return nil
 }

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -14,16 +14,47 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+type refreshOptions struct {
+	*option.Option
+
+	Wait bool
+}
+
+// addFlags adds the flags for the refresh options to the provided command.
+func (o *refreshOptions) addFlags(cmd *cobra.Command) {
+	// TODO: Factor out server flags to a higher level (root?) as they are
+	//   common to almost all commands.
+	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
+	option.LocalServer(cmd.PersistentFlags(), o.Option)
+
+	option.Project(cmd.PersistentFlags(), &o.Project, o.Project,
+		"The Project the resource belongs to. If not set, the default project will be used.")
+	option.Wait(cmd.PersistentFlags(), &o.Wait, false, "Wait for the refresh to complete.")
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *refreshOptions) validate() error {
+	if o.Project == "" {
+		return errors.New("project is required")
+	}
+	return nil
+}
+
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &refreshOptions{Option: opt}
+
 	cmd := &cobra.Command{
 		Use:   "refresh",
 		Short: "Refresh a stage or warehouse",
 	}
-	option.InsecureTLS(cmd.PersistentFlags(), opt)
-	option.LocalServer(cmd.PersistentFlags(), opt)
 
-	cmd.AddCommand(newRefreshWarehouseCommand(cfg, opt))
-	cmd.AddCommand(newRefreshStageCommand(cfg, opt))
+	cmd.AddCommand(newRefreshWarehouseCommand(cfg, cmdOpts))
+	cmd.AddCommand(newRefreshStageCommand(cfg, cmdOpts))
+
+	// Register the option flags on the (root) command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }
 
@@ -34,36 +65,36 @@ const (
 
 func refreshObject(
 	cfg config.CLIConfig,
-	opt *option.Option,
+	opt *refreshOptions,
 	resourceType string,
-	wait bool,
 ) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
-		if err != nil {
-			return err
-		}
 
-		project := opt.Project
-		if project == "" {
-			return errors.New("project is required")
-		}
 		name := strings.TrimSpace(args[0])
 		if name == "" {
 			return errors.New("name is required")
 		}
 
+		if err := opt.validate(); err != nil {
+			return err
+		}
+
+		kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt.Option)
+		if err != nil {
+			return err
+		}
+
 		switch resourceType {
 		case refreshResourceTypeWarehouse:
 			_, err = kargoSvcCli.RefreshWarehouse(ctx, connect.NewRequest(&v1alpha1.RefreshWarehouseRequest{
-				Project: project,
+				Project: opt.Project,
 				Name:    name,
 			}))
 
 		case refreshResourceTypeStage:
 			_, err = kargoSvcCli.RefreshStage(ctx, connect.NewRequest(&v1alpha1.RefreshStageRequest{
-				Project: project,
+				Project: opt.Project,
 				Name:    name,
 			}))
 		}
@@ -71,18 +102,18 @@ func refreshObject(
 			return errors.Wrapf(err, "refresh %s", resourceType)
 		}
 
-		if wait {
+		if opt.Wait {
 			switch resourceType {
 			case refreshResourceTypeWarehouse:
-				err = waitForWarehouse(ctx, kargoSvcCli, project, name)
+				err = waitForWarehouse(ctx, kargoSvcCli, opt.Project, name)
 			case refreshResourceTypeStage:
-				err = waitForStage(ctx, kargoSvcCli, project, name)
+				err = waitForStage(ctx, kargoSvcCli, opt.Project, name)
 			}
 			if err != nil {
 				return errors.Wrapf(err, "wait %s", resourceType)
 			}
 		}
-		fmt.Printf("%s '%s/%s' refreshed\n", resourceType, project, name)
+		fmt.Printf("%s '%s/%s' refreshed\n", resourceType, opt.Project, name)
 		return nil
 	}
 }

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -1,6 +1,8 @@
 package refresh
 
 import (
+	"context"
+	goerrors "errors"
 	"fmt"
 	"strings"
 
@@ -14,10 +16,31 @@ import (
 	v1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
+const (
+	refreshResourceTypeWarehouse = "warehouse"
+	refreshResourceTypeStage     = "stage"
+)
+
 type refreshOptions struct {
 	*option.Option
+	Config config.CLIConfig
 
-	Wait bool
+	ResourceType string
+	Name         string
+	Wait         bool
+}
+
+func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "Refresh a stage or warehouse",
+	}
+
+	// Register subcommands.
+	cmd.AddCommand(newRefreshWarehouseCommand(cfg, opt))
+	cmd.AddCommand(newRefreshStageCommand(cfg, opt))
+
+	return cmd
 }
 
 // addFlags adds the flags for the refresh options to the provided command.
@@ -27,93 +50,73 @@ func (o *refreshOptions) addFlags(cmd *cobra.Command) {
 	option.InsecureTLS(cmd.PersistentFlags(), o.Option)
 	option.LocalServer(cmd.PersistentFlags(), o.Option)
 
-	option.Project(cmd.PersistentFlags(), &o.Project, o.Project,
+	option.Project(cmd.Flags(), &o.Project, o.Project,
 		"The Project the resource belongs to. If not set, the default project will be used.")
-	option.Wait(cmd.PersistentFlags(), &o.Wait, false, "Wait for the refresh to complete.")
+	option.Wait(cmd.Flags(), &o.Wait, false, "Wait for the refresh to complete.")
+}
+
+// complete sets the resource type for the refresh options, and further parses
+// the command arguments to set the resource name.
+func (o *refreshOptions) complete(resourceType string, args []string) {
+	o.ResourceType = resourceType
+	o.Name = strings.TrimSpace(args[0])
 }
 
 // validate performs validation of the options. If the options are invalid, an
 // error is returned.
 func (o *refreshOptions) validate() error {
+	var errs []error
+
+	if o.ResourceType == "" {
+		errs = append(errs, errors.New("resource type is required"))
+	}
+
 	if o.Project == "" {
-		return errors.New("project is required")
-	}
-	return nil
-}
-
-func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
-	cmdOpts := &refreshOptions{Option: opt}
-
-	cmd := &cobra.Command{
-		Use:   "refresh",
-		Short: "Refresh a stage or warehouse",
+		errs = append(errs, errors.New("project is required"))
 	}
 
-	cmd.AddCommand(newRefreshWarehouseCommand(cfg, cmdOpts))
-	cmd.AddCommand(newRefreshStageCommand(cfg, cmdOpts))
+	if o.Name == "" {
+		errs = append(errs, errors.New("name is required"))
+	}
 
-	// Register the option flags on the (root) command.
-	cmdOpts.addFlags(cmd)
-
-	return cmd
+	return goerrors.Join(errs...)
 }
 
-const (
-	refreshResourceTypeWarehouse = "warehouse"
-	refreshResourceTypeStage     = "stage"
-)
+// run performs the refresh operation based on the provided options.
+func (o *refreshOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return err
+	}
 
-func refreshObject(
-	cfg config.CLIConfig,
-	opt *refreshOptions,
-	resourceType string,
-) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
+	switch o.ResourceType {
+	case refreshResourceTypeWarehouse:
+		_, err = kargoSvcCli.RefreshWarehouse(ctx, connect.NewRequest(&v1alpha1.RefreshWarehouseRequest{
+			Project: o.Project,
+			Name:    o.Name,
+		}))
 
-		name := strings.TrimSpace(args[0])
-		if name == "" {
-			return errors.New("name is required")
-		}
+	case refreshResourceTypeStage:
+		_, err = kargoSvcCli.RefreshStage(ctx, connect.NewRequest(&v1alpha1.RefreshStageRequest{
+			Project: o.Project,
+			Name:    o.Name,
+		}))
+	}
+	if err != nil {
+		return errors.Wrapf(err, "refresh %s", o.ResourceType)
+	}
 
-		if err := opt.validate(); err != nil {
-			return err
-		}
-
-		kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt.Option)
-		if err != nil {
-			return err
-		}
-
-		switch resourceType {
+	if o.Wait {
+		switch o.ResourceType {
 		case refreshResourceTypeWarehouse:
-			_, err = kargoSvcCli.RefreshWarehouse(ctx, connect.NewRequest(&v1alpha1.RefreshWarehouseRequest{
-				Project: opt.Project,
-				Name:    name,
-			}))
-
+			err = waitForWarehouse(ctx, kargoSvcCli, o.Project, o.Name)
 		case refreshResourceTypeStage:
-			_, err = kargoSvcCli.RefreshStage(ctx, connect.NewRequest(&v1alpha1.RefreshStageRequest{
-				Project: opt.Project,
-				Name:    name,
-			}))
+			err = waitForStage(ctx, kargoSvcCli, o.Project, o.Name)
 		}
 		if err != nil {
-			return errors.Wrapf(err, "refresh %s", resourceType)
+			return errors.Wrapf(err, "wait %s", o.ResourceType)
 		}
-
-		if opt.Wait {
-			switch resourceType {
-			case refreshResourceTypeWarehouse:
-				err = waitForWarehouse(ctx, kargoSvcCli, opt.Project, name)
-			case refreshResourceTypeStage:
-				err = waitForStage(ctx, kargoSvcCli, opt.Project, name)
-			}
-			if err != nil {
-				return errors.Wrapf(err, "wait %s", resourceType)
-			}
-		}
-		fmt.Printf("%s '%s/%s' refreshed\n", resourceType, opt.Project, name)
-		return nil
 	}
+	fmt.Printf("%s '%s/%s' refreshed\n", o.ResourceType, o.Project, o.Name)
+	return nil
 }

--- a/internal/cli/cmd/refresh/stage.go
+++ b/internal/cli/cmd/refresh/stage.go
@@ -14,16 +14,30 @@ import (
 	"github.com/akuity/kargo/pkg/api/service/v1alpha1/svcv1alpha1connect"
 )
 
-func newRefreshStageCommand(
-	cfg config.CLIConfig,
-	opt *refreshOptions,
-) *cobra.Command {
+func newRefreshStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &refreshOptions{
+		Option: opt,
+		Config: cfg,
+	}
+
 	cmd := &cobra.Command{
 		Use:     "stage (STAGE)",
 		Args:    option.ExactArgs(1),
 		Example: "kargo refresh stage --project=guestbook (STAGE)",
-		RunE:    refreshObject(cfg, opt, refreshResourceTypeStage),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdOpts.complete(refreshResourceTypeStage, args)
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
+			return cmdOpts.run(cmd.Context())
+		},
 	}
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }
 

--- a/internal/cli/cmd/refresh/stage.go
+++ b/internal/cli/cmd/refresh/stage.go
@@ -16,17 +16,14 @@ import (
 
 func newRefreshStageCommand(
 	cfg config.CLIConfig,
-	opt *option.Option,
+	opt *refreshOptions,
 ) *cobra.Command {
-	var wait bool
 	cmd := &cobra.Command{
 		Use:     "stage (STAGE)",
 		Args:    option.ExactArgs(1),
 		Example: "kargo refresh stage --project=guestbook (STAGE)",
-		RunE:    refreshObject(cfg, opt, "stage", wait),
+		RunE:    refreshObject(cfg, opt, refreshResourceTypeStage),
 	}
-	option.Wait(cmd.Flags(), &wait)
-	option.Project(cmd.Flags(), opt, opt.Project)
 	return cmd
 }
 

--- a/internal/cli/cmd/refresh/warehouse.go
+++ b/internal/cli/cmd/refresh/warehouse.go
@@ -14,16 +14,30 @@ import (
 	"github.com/akuity/kargo/pkg/api/service/v1alpha1/svcv1alpha1connect"
 )
 
-func newRefreshWarehouseCommand(
-	cfg config.CLIConfig,
-	opt *refreshOptions,
-) *cobra.Command {
+func newRefreshWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &refreshOptions{
+		Option: opt,
+		Config: cfg,
+	}
+
 	cmd := &cobra.Command{
 		Use:     "warehouse (WAREHOUSE)",
 		Args:    option.ExactArgs(1),
 		Example: "kargo warehouse refresh --project=guestbook (WAREHOUSE)",
-		RunE:    refreshObject(cfg, opt, refreshResourceTypeWarehouse),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdOpts.complete(refreshResourceTypeWarehouse, args)
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
+			return cmdOpts.run(cmd.Context())
+		},
 	}
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
 	return cmd
 }
 

--- a/internal/cli/cmd/refresh/warehouse.go
+++ b/internal/cli/cmd/refresh/warehouse.go
@@ -16,17 +16,14 @@ import (
 
 func newRefreshWarehouseCommand(
 	cfg config.CLIConfig,
-	opt *option.Option,
+	opt *refreshOptions,
 ) *cobra.Command {
-	var wait bool
 	cmd := &cobra.Command{
 		Use:     "warehouse (WAREHOUSE)",
 		Args:    option.ExactArgs(1),
 		Example: "kargo warehouse refresh --project=guestbook (WAREHOUSE)",
-		RunE:    refreshObject(cfg, opt, "warehouse", wait),
+		RunE:    refreshObject(cfg, opt, refreshResourceTypeWarehouse),
 	}
-	option.Wait(cmd.Flags(), &wait)
-	option.Project(cmd.Flags(), opt, opt.Project)
 	return cmd
 }
 

--- a/internal/cli/cmd/update/freight.go
+++ b/internal/cli/cmd/update/freight.go
@@ -1,7 +1,9 @@
 package update
 
 import (
+	"context"
 	goerrors "errors"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
@@ -15,45 +17,17 @@ import (
 
 type updateFreightAliasOptions struct {
 	*option.Option
+	Config config.CLIConfig
 
+	Name  string
 	Alias string
 }
 
-// addFlags adds the flags for the update freight alias options to the provided
-// command.
-func (o *updateFreightAliasOptions) addFlags(cmd *cobra.Command) {
-	option.Project(cmd.Flags(), &o.Project, o.Project,
-		"The Project for which to list Promotions. If not set, the default project will be used.")
-	cmd.Flags().StringVar(&o.Alias, "alias", "", "A unique alias for the Freight")
-
-	if err := cmd.MarkFlagRequired("alias"); err != nil {
-		panic(errors.Wrap(err, "could not mark alias flag as required"))
+func newUpdateFreightAliasCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
+	cmdOpts := &updateFreightAliasOptions{
+		Option: opt,
+		Config: cfg,
 	}
-}
-
-// validate performs validation of the options. If the options are invalid, an
-// error is returned.
-func (o *updateFreightAliasOptions) validate() error {
-	var errs []error
-
-	if o.Project == "" {
-		errs = append(errs, errors.New("project is required"))
-	}
-
-	// While the alias flag is marked as required, a user could still provide
-	// an empty string. This is a check to ensure that the flag is not empty.
-	if o.Alias == "" {
-		errs = append(errs, errors.New("alias is required"))
-	}
-
-	return goerrors.Join(errs...)
-}
-
-func newUpdateFreightAliasCommand(
-	cfg config.CLIConfig,
-	opt *option.Option,
-) *cobra.Command {
-	cmdOpts := &updateFreightAliasOptions{Option: opt}
 
 	cmd := &cobra.Command{
 		Use:   "freight [--project=project] (NAME) --alias=alias",
@@ -68,31 +42,13 @@ kargo config set-project my-project
 kargo update freight abc123 --alias=my-new-alias
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			cmdOpts.complete(args)
 
 			if err := cmdOpts.validate(); err != nil {
 				return err
 			}
 
-			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
-			if err != nil {
-				return errors.Wrap(err, "get client from config")
-			}
-
-			if _, err = kargoSvcCli.UpdateFreightAlias(
-				ctx,
-				connect.NewRequest(
-					&v1alpha1.UpdateFreightAliasRequest{
-						Project: cmdOpts.Project,
-						Freight: args[0],
-						Alias:   cmdOpts.Alias,
-					},
-				),
-			); err != nil {
-				return errors.Wrap(err, "update freight alias")
-			}
-
-			return nil
+			return cmdOpts.run(cmd.Context())
 		},
 	}
 
@@ -100,4 +56,65 @@ kargo update freight abc123 --alias=my-new-alias
 	cmdOpts.addFlags(cmd)
 
 	return cmd
+}
+
+// addFlags adds the flags for the update freight alias options to the provided
+// command.
+func (o *updateFreightAliasOptions) addFlags(cmd *cobra.Command) {
+	option.Project(cmd.Flags(), &o.Project, o.Project,
+		"The Project for which to list Promotions. If not set, the default project will be used.")
+	cmd.Flags().StringVar(&o.Alias, "alias", "", "A unique alias for the Freight")
+
+	if err := cmd.MarkFlagRequired("alias"); err != nil {
+		panic(errors.Wrap(err, "could not mark alias flag as required"))
+	}
+}
+
+// complete sets the options from the command arguments.
+func (o *updateFreightAliasOptions) complete(args []string) {
+	o.Name = strings.TrimSpace(args[0])
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *updateFreightAliasOptions) validate() error {
+	var errs []error
+
+	if o.Project == "" {
+		errs = append(errs, errors.New("project is required"))
+	}
+
+	if o.Name == "" {
+		errs = append(errs, errors.New("name is required"))
+	}
+
+	// While the alias flag is marked as required, a user could still provide
+	// an empty string. This is a check to ensure that the flag is not empty.
+	if o.Alias == "" {
+		errs = append(errs, errors.New("alias is required"))
+	}
+
+	return goerrors.Join(errs...)
+}
+
+// run updates the freight alias using the options.
+func (o *updateFreightAliasOptions) run(ctx context.Context) error {
+	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.Option)
+	if err != nil {
+		return errors.Wrap(err, "get client from config")
+	}
+
+	if _, err = kargoSvcCli.UpdateFreightAlias(
+		ctx,
+		connect.NewRequest(
+			&v1alpha1.UpdateFreightAliasRequest{
+				Project: o.Project,
+				Freight: o.Name,
+				Alias:   o.Alias,
+			},
+		),
+	); err != nil {
+		return errors.Wrap(err, "update freight alias")
+	}
+	return nil
 }

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -15,6 +15,8 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	option.LocalServer(cmd.PersistentFlags(), opt)
 
+	// Register subcommands.
 	cmd.AddCommand(newUpdateFreightAliasCommand(cfg, opt))
+
 	return cmd
 }

--- a/internal/cli/option/flag.go
+++ b/internal/cli/option/flag.go
@@ -1,14 +1,36 @@
 package option
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
 )
 
-func Filenames(fs *pflag.FlagSet, filenames *[]string, verb string) {
-	fs.StringSliceVarP(filenames, "filename", "f", nil,
-		fmt.Sprintf("Filename, directory, or URL to files to use to %s the resource", verb))
+const (
+	// FilenameFlag is the flag name for the filename flag.
+	FilenameFlag = "filename"
+	// FilenameShortFlag is the short flag name for the filename flag.
+	FilenameShortFlag = "f"
+
+	// ProjectFlag is the flag name for the project flag.
+	ProjectFlag = "project"
+	// ProjectShortFlag is the short flag name for the project flag.
+	ProjectShortFlag = "p"
+
+	// FreightFlag is the flag name for the freight flag.
+	FreightFlag = "freight"
+
+	// StageFlag is the flag name for the stage flag.
+	StageFlag = "stage"
+
+	// SubscribersOfFlag is the flag name for the subscribers-of flag.
+	SubscribersOfFlag = "subscribers-of"
+
+	// WaitFlag is the flag name for the wait flag.
+	WaitFlag = "wait"
+)
+
+// Filenames adds the FilenameFlag and FilenameShortFlag to the provided flag set.
+func Filenames(fs *pflag.FlagSet, filenames *[]string, usage string) {
+	fs.StringSliceVarP(filenames, FilenameFlag, FilenameShortFlag, nil, usage)
 }
 
 func InsecureTLS(fs *pflag.FlagSet, opt *Option) {
@@ -23,22 +45,27 @@ func ClientVersion(fs *pflag.FlagSet, opt *Option) {
 	fs.BoolVar(&opt.ClientVersionOnly, "client", false, "If true, shows client version only (no server required)")
 }
 
-func Project(fs *pflag.FlagSet, opt *Option, defaultProject string) {
-	fs.StringVarP(&opt.Project, "project", "p", defaultProject, "Project")
+// Project adds the ProjectFlag and ProjectShortFlag to the provided flag set.
+func Project(fs *pflag.FlagSet, project *string, defaultProject, usage string) {
+	fs.StringVarP(project, ProjectFlag, ProjectShortFlag, defaultProject, usage)
 }
 
-func Stage(fs *pflag.FlagSet, stage *string) {
-	fs.StringVar(stage, "stage", "", "Stage")
+// Stage adds the StageFlag to the provided flag set.
+func Stage(fs *pflag.FlagSet, stage *string, usage string) {
+	fs.StringVar(stage, StageFlag, "", usage)
 }
 
-func SubscribersOf(fs *pflag.FlagSet, subscribersOf *string) {
-	fs.StringVar(subscribersOf, "subscribers-of", "", "Subscribers of a Stage")
+// SubscribersOf adds the SubscribersOfFlag to the provided flag set.
+func SubscribersOf(fs *pflag.FlagSet, subscribersOf *string, usage string) {
+	fs.StringVar(subscribersOf, SubscribersOfFlag, "", usage)
 }
 
-func Freight(fs *pflag.FlagSet, freight *string) {
-	fs.StringVar(freight, "freight", "", "Freight ID")
+// Freight adds the FreightFlag to the provided flag set.
+func Freight(fs *pflag.FlagSet, freight *string, usage string) {
+	fs.StringVar(freight, FreightFlag, "", usage)
 }
 
-func Wait(fs *pflag.FlagSet, wait *bool) {
-	fs.BoolVar(wait, "wait", false, "Wait until refresh completes")
+// Wait adds the WaitFlag to the provided flag set.
+func Wait(fs *pflag.FlagSet, wait *bool, defaultWait bool, usage string) {
+	fs.BoolVar(wait, WaitFlag, defaultWait, usage)
 }

--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/cli/config"
@@ -22,7 +23,7 @@ type Option struct {
 
 	Project string
 
-	IOStreams  *genericclioptions.IOStreams
+	IOStreams  *genericiooptions.IOStreams
 	PrintFlags *genericclioptions.PrintFlags
 }
 


### PR DESCRIPTION
Touches into #1163

This pull request achieves multiple things:

1. Commands no longer make use of lengthy in-line `func`s to perform an action. Instead, they are built around "option" `struct`s with methods to add flags, parse command arguments, validate, and run the actual command logic. By doing this, we introduce a separation of concerns while also allowing things to (hypothetically) be tested without relying on further Cobra functionalities.
2. Flags are now registered as required, mutually exclusive, taking file and/or directory inputs, etc. using Cobra features. Which improves out-of-the-box validation, while also enriching the shell completion instructions. For more information around this, see e.g. https://pkg.go.dev/github.com/spf13/cobra#Command.MarkFlagRequired

#### Example boilerplate new command

```go
struct fooOptions {
	SomeArg  string
	SomeFlag string
}

func NewCommand() *cobra.Command {
	cmdOpts := &fooOptions{}

	cmd := &cobra.Command{
		Use:   "foo (ARG) --some-flag=value",
		Args:   option.ExactArgs(1),
		Short: "Perform a demo operation",
		// Other Cobra fields omitted for brevity...
		RunE: func(cmd *cobra.Command, args []string) error {
			cmdOpts.complete(args)

			if err := cmdOpts.validate(); err != nil {
				return err
			}

			return cmdOpts.run()
		},
	}

	// Register the option flags on the command.
	cmdOpts.addFlags(cmd)

	return cmd
}

func (o *fooOpts) addFlags(cmd *cobra.Command) {
	cmd.Flags().StringVar(&o.SomeFlag, "some-flag", "", "An example flag which requires a value")

	if err := cmd.MarkFlagRequired("some-flag"); err != nil {
		panic(errors.Wrap(err, "could not mark some-flag flag as required"))
	}
}

func (o *fooOpts) complete(args []string) {
	o.SomeArg = strings.TrimSpace(args[0])
}

func (o *fooOpts) validate() error {
	var errs []error

	if o.SomeArg = "" {
		errs = append(errs, errors.New("arg is required"))
	}

	if o.SomeFlag == "" {
		errs = append(errs, errors.New("some-flag is required"))
	}

	return errors.Join(err...)
}

func (o *fooOpts) run() error {
	// Do something intelligent with arg and flag...

	return nil
}
```
