### PR TITLE
refactor(cli)!: change `update freight-alias` command to `update freight`

### DIFF
--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -131,9 +131,9 @@ resource as it progresses through the `Stage`s of a pipeline.
 This is conveniently accomplished via the Kargo CLI:
 
 ```shell
-kargo update freight-alias \
+kargo update freight \
   f5f87aa23c9e97f43eb83dd63768ee41f5ba3766 \
-  frozen-tauntaun \
+  --alias frozen-tauntaun \
   --project kargo-demo
 ```
 

--- a/internal/cli/cmd/update/freight.go
+++ b/internal/cli/cmd/update/freight.go
@@ -15,17 +15,29 @@ func newUpdateFreightAliasCommand(
 	cfg config.CLIConfig,
 	opt *option.Option,
 ) *cobra.Command {
+	var alias string
 	cmd := &cobra.Command{
-		Use:     "freight-alias --project=project NAME ALIAS",
-		Args:    option.ExactArgs(2),
-		Short:   "Update a freight alias",
-		Example: "kargo update freight-alias --project=guestbook abc1234 foobar",
+		Use:   "freight [--project=project] (NAME) --alias=alias",
+		Args:  option.ExactArgs(1),
+		Short: "Update (the alias of) a Freight",
+		Example: `
+# Update the alias of a freight for a specified project
+kargo update freight --project=my-project abc123 --alias=my-new-alias
+
+# Update the alias of a freight for the default project
+kargo config set project my-project
+kargo update freight abc123 --alias=my-new-alias
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			project := opt.Project
 			if project == "" {
 				return errors.New("project is required")
+			}
+
+			if alias == "" {
+				return errors.New("alias is required")
 			}
 
 			kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opt)
@@ -39,7 +51,7 @@ func newUpdateFreightAliasCommand(
 					&v1alpha1.UpdateFreightAliasRequest{
 						Project: project,
 						Freight: args[0],
-						Alias:   args[1],
+						Alias:   alias,
 					},
 				),
 			); err != nil {
@@ -49,6 +61,10 @@ func newUpdateFreightAliasCommand(
 			return nil
 		},
 	}
+
 	option.Project(cmd.Flags(), opt, opt.Project)
+
+	cmd.Flags().StringVar(&alias, "alias", "", "A unique alias for the Freight")
+
 	return cmd
 }

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -10,7 +10,7 @@ import (
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update a freight alias",
+		Short: "Update a resource",
 	}
 	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	option.LocalServer(cmd.PersistentFlags(), opt)


### PR DESCRIPTION
xref: https://github.com/akuity/kargo/issues/1163#issuecomment-1966752230

This refactors the `kargo update freight-alias` command to `kargo update freight`, to avoid it accepting multi-positional arguments while simultaneously aligning it with other commands like `kargo create`, `kargo delete` and `kargo refresh`.

Effectively, this means that instead of running:

```shell
kargo update freight-alias --project=my-project abc123 my-new-alias
```

one should now run:

```shell
kargo update freight --project=my-project abc123 --alias=my-new-alias
```

As Freight besides the alias is immutable, this may still not be perfect as it _could_ imply other updates can be facilitated as well. However, it is the best "uniform" alternative I could think of at the moment when comparing it to other existing commands.