### PR TITLE
feat(controller): watch only Secrets w/ Kargo labels

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -1,11 +1,12 @@
 package v1alpha1
 
 const (
-	AliasLabelKey   = "kargo.akuity.io/alias"
-	FreightLabelKey = "kargo.akuity.io/freight"
-	ProjectLabelKey = "kargo.akuity.io/project"
-	ShardLabelKey   = "kargo.akuity.io/shard"
-	StageLabelKey   = "kargo.akuity.io/stage"
+	AliasLabelKey          = "kargo.akuity.io/alias"
+	FreightLabelKey        = "kargo.akuity.io/freight"
+	ProjectLabelKey        = "kargo.akuity.io/project"
+	ShardLabelKey          = "kargo.akuity.io/shard"
+	StageLabelKey          = "kargo.akuity.io/stage"
+	CredentialTypeLabelKey = "kargo.akuity.io/cred-type" // nolint: gosec
 
 	LabelTrueValue = "true"
 

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -61,7 +61,7 @@ func GetShardRequirement(shard string) (*labels.Requirement, error) {
 // resources that have a credential type label set to one of the supported
 // credential types.
 func GetCredentialsRequirement() (*labels.Requirement, error) {
-	req, err := labels.NewRequirement(credentials.CredentialTypeLabelKey, selection.In, []string{
+	req, err := labels.NewRequirement(kargoapi.CredentialTypeLabelKey, selection.In, []string{
 		credentials.TypeGit.String(),
 		credentials.TypeHelm.String(),
 		credentials.TypeImage.String(),

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/credentials"
 )
 
 // GetShardPredicate constructs a predicate used as an event filter for various
@@ -53,5 +54,20 @@ func GetShardRequirement(shard string) (*labels.Requirement, error) {
 		}
 	}
 
+	return req, nil
+}
+
+// GetCredentialsRequirement returns a label requirement that matches only
+// resources that have a credential type label set to one of the supported
+// credential types.
+func GetCredentialsRequirement() (*labels.Requirement, error) {
+	req, err := labels.NewRequirement(credentials.CredentialTypeLabelKey, selection.In, []string{
+		credentials.TypeGit.String(),
+		credentials.TypeHelm.String(),
+		credentials.TypeImage.String(),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating credentials label selector")
+	}
 	return req, nil
 }

--- a/internal/controller/labels_test.go
+++ b/internal/controller/labels_test.go
@@ -69,29 +69,29 @@ func TestGetCredentialsRequirement(t *testing.T) {
 		{
 			name: "credential type label set to git",
 			labels: labels.Set{
-				credentials.CredentialTypeLabelKey: credentials.TypeGit.String(),
+				kargoapi.CredentialTypeLabelKey: credentials.TypeGit.String(),
 			},
 			matches: true,
 		},
 		{
 			name: "credential type label set to helm and other labels",
 			labels: labels.Set{
-				credentials.CredentialTypeLabelKey: credentials.TypeHelm.String(),
-				"other":                            "label",
+				kargoapi.CredentialTypeLabelKey: credentials.TypeHelm.String(),
+				"other":                         "label",
 			},
 			matches: true,
 		},
 		{
 			name: "credential type label set to image",
 			labels: labels.Set{
-				credentials.CredentialTypeLabelKey: credentials.TypeImage.String(),
+				kargoapi.CredentialTypeLabelKey: credentials.TypeImage.String(),
 			},
 			matches: true,
 		},
 		{
 			name: "credential type label set to unknown type",
 			labels: labels.Set{
-				credentials.CredentialTypeLabelKey: "unknown",
+				kargoapi.CredentialTypeLabelKey: "unknown",
 			},
 			matches: false,
 		},

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/git"
 	"github.com/akuity/kargo/internal/logging"
 )
@@ -31,10 +32,6 @@ const (
 	TypeHelm Type = "helm"
 	// TypeImage represents credentials for an image repository.
 	TypeImage Type = "image"
-
-	// CredentialTypeLabelKey is the key for a label used to identify the type
-	// of credentials stored in a Secret.
-	CredentialTypeLabelKey = "kargo.akuity.io/cred-type" // nolint: gosec
 )
 
 // Credentials generically represents any type of repository credential.
@@ -164,7 +161,7 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 		&client.ListOptions{
 			Namespace: namespace,
 			LabelSelector: labels.Set(map[string]string{
-				CredentialTypeLabelKey: credType.String(),
+				kargoapi.CredentialTypeLabelKey: credType.String(),
 			}).AsSelector(),
 		},
 	); err != nil {

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -19,6 +19,11 @@ import (
 // Type is a string type used to represent a type of Credentials.
 type Type string
 
+// String returns the string representation of a Type.
+func (t Type) String() string {
+	return string(t)
+}
+
 const (
 	// TypeGit represents credentials for a Git repository.
 	TypeGit Type = "git"
@@ -27,9 +32,9 @@ const (
 	// TypeImage represents credentials for an image repository.
 	TypeImage Type = "image"
 
-	// credentialTypeLabelKey is the key for a label used to identify the type
+	// CredentialTypeLabelKey is the key for a label used to identify the type
 	// of credentials stored in a Secret.
-	credentialTypeLabelKey = "kargo.akuity.io/cred-type" // nolint: gosec
+	CredentialTypeLabelKey = "kargo.akuity.io/cred-type" // nolint: gosec
 )
 
 // Credentials generically represents any type of repository credential.
@@ -159,7 +164,7 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 		&client.ListOptions{
 			Namespace: namespace,
 			LabelSelector: labels.Set(map[string]string{
-				credentialTypeLabelKey: string(credType),
+				CredentialTypeLabelKey: credType.String(),
 			}).AsSelector(),
 		},
 	); err != nil {

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 func TestNewKubernetesDatabase(t *testing.T) {
@@ -41,7 +43,7 @@ func TestGet(t *testing.T) {
 	)
 
 	testLabels := map[string]string{
-		CredentialTypeLabelKey: testCredType.String(),
+		kargoapi.CredentialTypeLabelKey: testCredType.String(),
 	}
 
 	projectCredentialWithRepoURL := &corev1.Secret{

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -41,7 +41,7 @@ func TestGet(t *testing.T) {
 	)
 
 	testLabels := map[string]string{
-		credentialTypeLabelKey: string(testCredType),
+		CredentialTypeLabelKey: testCredType.String(),
 	}
 
 	projectCredentialWithRepoURL := &corev1.Secret{


### PR DESCRIPTION
Fixes #1554 

This configures the Kargo manager client to only watch Secrets with a `kargo.akuity.io/cred-type` label set to a recognized type.

When testing this with 100 randomly generated Secrets in the `default` namespace using:

```shell
for i in {1..100}; do head -c 500000 /dev/urandom | base64 | kubectl create secret generic random-$i --from-file=my-file=/dev/stdin; done
```

This makes the memory consumption as reported by kube-metrics go from 199Mi before the patch to 14Mi afterwards.