### PR TITLE
fix(chart): warnings in chart install/upgrade

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -28,7 +28,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  name: kargo-api-server-manage-project-secrets
   verbs:
   - create
 - apiGroups:

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -27,7 +27,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  name: kargo-api-server-manage-project-secrets
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
This cherry-picks #1518 into the `release-0.4` branch.

Until recently I hadn't considered this bug critical enough to warrant a patch release. If you `helm install` you only get warnings.

It has come to light that if you use Argo CD to gitops your Kargo, this actually prevents a successful sync.