### PR TITLE
chore(cli): update all usages and examples

### DIFF
--- a/internal/cli/cmd/apply/apply.go
+++ b/internal/cli/cmd/apply/apply.go
@@ -35,11 +35,15 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "apply [--project=project] -f (FILENAME)",
+		Use:   "apply -f FILENAME",
 		Short: "Apply a resource from a file or from stdin",
+		Args:  option.NoArgs,
 		Example: `
 # Apply a stage using the data in stage.yaml
 kargo apply -f stage.yaml
+
+# Apply the YAML resources in the stages directory
+kargo apply -f stages/
 `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmdOpts.validate(); err != nil {

--- a/internal/cli/cmd/approve/approve.go
+++ b/internal/cli/cmd/approve/approve.go
@@ -33,10 +33,10 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		Short: "Manually approve freight for promotion to a stage",
 		Args:  option.NoArgs,
 		Example: `
-# Approve a freight in a project to the QA stage
+# Approve a piece of freight for the QA stage
 kargo approve --project=my-project --freight=abc1234 --stage=qa
 
-# Approve a freight in the default project to the QA stage
+# Approve a piece of freight for the QA stage in the default project
 kargo config set-project my-project
 kargo approve --freight=abc1234 --stage=qa
 `,

--- a/internal/cli/cmd/approve/approve.go
+++ b/internal/cli/cmd/approve/approve.go
@@ -29,9 +29,17 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "approve --project=project --freight=freight --stage=stage",
-		Short:   "Manually approve freight for promotion to a stage",
-		Example: "kargo approve --project=project --freight=abc1234 --stage=qa",
+		Use:   "approve [--project=project] --freight=freight --stage=stage",
+		Short: "Manually approve freight for promotion to a stage",
+		Args:  option.NoArgs,
+		Example: `
+# Approve a freight in a project to the QA stage
+kargo approve --project=my-project --freight=abc1234 --stage=qa
+
+# Approve a freight in the default project to the QA stage
+kargo config set-project my-project
+kargo approve --freight=abc1234 --stage=qa
+`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmdOpts.validate(); err != nil {
 				return err

--- a/internal/cli/cmd/config/config.go
+++ b/internal/cli/cmd/config/config.go
@@ -4,12 +4,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
+	"github.com/akuity/kargo/internal/cli/option"
 )
 
 func NewCommand(cfg config.CLIConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
+		Use:   "config SUBCOMMAND",
 		Short: "Manage Kargo CLI configuration",
+		Args:  option.NoArgs,
 	}
 
 	// Register subcommands.

--- a/internal/cli/cmd/config/set_project.go
+++ b/internal/cli/cmd/config/set_project.go
@@ -20,7 +20,7 @@ func newSetProjectCommand(cfg config.CLIConfig) *cobra.Command {
 	cmdOpts := &setProjectOptions{Config: cfg}
 
 	cmd := &cobra.Command{
-		Use:   "set-project",
+		Use:   "set-project NAME",
 		Short: "Set the default project",
 		Args:  option.ExactArgs(1),
 		Example: `

--- a/internal/cli/cmd/create/create.go
+++ b/internal/cli/cmd/create/create.go
@@ -35,13 +35,14 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [--project=project] -f (FILENAME)",
+		Use:   "create -f FILENAME",
 		Short: "Create a resource from a file or from stdin",
+		Args:  option.NoArgs,
 		Example: `
 # Create a stage using the data in stage.yaml
 kargo create -f stage.yaml
 
-# Create project
+# Create a project
 kargo create project my-project
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/cmd/create/project.go
+++ b/internal/cli/cmd/create/project.go
@@ -33,9 +33,9 @@ func newProjectCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "project (NAME)",
+		Use:   "project NAME",
 		Short: "Create a project",
-		Args:  option.MinimumNArgs(1),
+		Args:  option.ExactArgs(1),
 		Example: `
 # Create project
 kargo create project my-project

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -21,7 +21,7 @@ func NewCommand(cfg config.CLIConfig) *cobra.Command {
 		Short: "Open the Kargo Dashboard in your default browser",
 		Args:  option.NoArgs,
 		Example: `
-# Open the Kargo Dashboard
+# Open the Kargo Dashboard in the browser
 kargo dashboard
 `,
 		RunE: func(*cobra.Command, []string) error {

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
+	"github.com/akuity/kargo/internal/cli/option"
 )
 
 type dashboardOptions struct {
@@ -16,9 +17,13 @@ func NewCommand(cfg config.CLIConfig) *cobra.Command {
 	cmdOpts := &dashboardOptions{Config: cfg}
 
 	return &cobra.Command{
-		Use:     "dashboard",
-		Short:   "Open the Kargo Dashboard in your default browser.",
-		Example: "kargo logout",
+		Use:   "dashboard",
+		Short: "Open the Kargo Dashboard in your default browser",
+		Args:  option.NoArgs,
+		Example: `
+# Open the Kargo Dashboard
+kargo dashboard
+`,
 		RunE: func(*cobra.Command, []string) error {
 			if err := cmdOpts.validate(); err != nil {
 				return err

--- a/internal/cli/cmd/delete/delete.go
+++ b/internal/cli/cmd/delete/delete.go
@@ -34,17 +34,24 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "delete [--project=project] -f (FILENAME)",
-		Short: "Delete resources by resources and names",
+		Use:   "delete (-f FILENAME | TYPE (NAME ...))",
+		Short: "Delete resources by file and names",
+		Args:  option.NoArgs,
 		Example: `
+# Delete a stage using the data in stage.yaml
+kargo delete -f stage.yaml
+
+# Delete the YAML resources in the stages directory
+kargo delete -f stages/
+
 # Delete a project
 kargo delete project my-project
 
 # Delete a stage
 kargo delete stage --project=my-project my-stage
 
-# Delete a stage using the data in stage.yaml
-kargo delete -f stage.yaml
+# Delete a warehouse
+kargo delete warehouse --project=my-project my-warehouse
 `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmdOpts.validate(); err != nil {

--- a/internal/cli/cmd/delete/project.go
+++ b/internal/cli/cmd/delete/project.go
@@ -30,12 +30,15 @@ func newProjectCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "project [NAME]...",
+		Use:   "project (NAME ...)",
 		Short: "Delete project by name",
 		Args:  option.MinimumNArgs(1),
 		Example: `
-# Delete project
+# Delete a project
 kargo delete project my-project
+
+# Delete multiple projects
+kargo delete project my-project1 my-project2
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)
@@ -69,7 +72,7 @@ func (o *deleteProjectOptions) complete(args []string) {
 // error is returned.
 func (o *deleteProjectOptions) validate() error {
 	if len(o.Names) == 0 {
-		return goerrors.New("name is required")
+		return errors.New("name is required")
 	}
 	return nil
 }

--- a/internal/cli/cmd/delete/stage.go
+++ b/internal/cli/cmd/delete/stage.go
@@ -30,12 +30,19 @@ func newStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "stage [NAME]...",
+		Use:   "stage [--project=project] (NAME ...)",
 		Short: "Delete stage by name",
 		Args:  option.MinimumNArgs(1),
 		Example: `
-# Delete stage
+# Delete a stage in a project
 kargo delete stage --project=my-project my-stage
+
+# Delete multiple stages in a project
+kargo delete stage --project=my-project my-stage1 my-stage2
+
+# Delete a stage in the default project
+kargo config set-project my-project
+kargo delete stage my-stage
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/delete/stage.go
+++ b/internal/cli/cmd/delete/stage.go
@@ -34,10 +34,10 @@ func newStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 		Short: "Delete stage by name",
 		Args:  option.MinimumNArgs(1),
 		Example: `
-# Delete a stage in a project
+# Delete a stage
 kargo delete stage --project=my-project my-stage
 
-# Delete multiple stages in a project
+# Delete multiple stages
 kargo delete stage --project=my-project my-stage1 my-stage2
 
 # Delete a stage in the default project

--- a/internal/cli/cmd/delete/warehouse.go
+++ b/internal/cli/cmd/delete/warehouse.go
@@ -34,10 +34,10 @@ func newWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Comman
 		Short: "Delete warehouse by name",
 		Args:  option.MinimumNArgs(1),
 		Example: `
-# Delete a warehouse in a project
+# Delete a warehouse
 kargo delete warehouse --project=my-project my-warehouse
 
-# Delete multiple warehouses in a project
+# Delete multiple warehouses
 kargo delete warehouse --project=my-project my-warehouse1 my-warehouse2
 
 # Delete a warehouse in the default project

--- a/internal/cli/cmd/delete/warehouse.go
+++ b/internal/cli/cmd/delete/warehouse.go
@@ -30,12 +30,19 @@ func newWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "warehouse [NAME]...",
+		Use:   "warehouse [--project=project] (NAME ...)",
 		Short: "Delete warehouse by name",
 		Args:  option.MinimumNArgs(1),
 		Example: `
-# Delete warehouse
+# Delete a warehouse in a project
 kargo delete warehouse --project=my-project my-warehouse
+
+# Delete multiple warehouses in a project
+kargo delete warehouse --project=my-project my-warehouse1 my-warehouse2
+
+# Delete a warehouse in the default project
+kargo config set-project my-project
+kargo delete warehouse my-warehouse
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -34,7 +34,7 @@ func newGetFreightCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Comma
 	}
 
 	cmd := &cobra.Command{
-		Use:   "freight --project=project [NAME...]",
+		Use:   "freight [--project=project] [NAME ...]",
 		Short: "Display one or many pieces of freight",
 		Example: `
 # List all freight in the project
@@ -45,6 +45,10 @@ kargo get freight --project=my-project -o json
 
 # Get a single piece of freight in the project
 kargo get freight --project=my-project my-freight
+
+# List all freight in the default project
+kargo config set-project my-project
+kargo get freight
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -15,8 +15,9 @@ import (
 
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get (RESOURCE) [NAME]...",
+		Use:   "get TYPE [NAME ...]",
 		Short: "Display one or many resources",
+		Args:  option.NoArgs,
 		Example: `
 # List all projects
 kargo get projects

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -34,7 +34,7 @@ func newGetProjectsCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Comm
 	}
 
 	cmd := &cobra.Command{
-		Use:     "projects [NAME...]",
+		Use:     "projects [NAME ...]",
 		Aliases: []string{"project"},
 		Short:   "Display one or many projects",
 		Example: `

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -36,7 +36,7 @@ func newGetPromotionsCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:     "promotions --project=project [--stage=stage] [NAME...]",
+		Use:     "promotions [--project=project] [--stage=stage] [NAME ...]",
 		Aliases: []string{"promotion", "promos", "promo"},
 		Short:   "Display one or many promotions",
 		Example: `
@@ -51,6 +51,10 @@ kargo get promotions --project=my-project --stage=my-stage
 
 # Get a promotion in the project
 kargo get promotions --project=my-project some-promotion
+
+# List all promotions in the default project
+kargo config set-project my-project
+kargo get promotions
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -34,7 +34,7 @@ func newGetStagesCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:     "stages --project=project [NAME...]",
+		Use:     "stages [--project=project] [NAME ...]",
 		Aliases: []string{"stage"},
 		Short:   "Display one or many stages",
 		Example: `
@@ -46,6 +46,10 @@ kargo get stages --project=my-project -o json
 
 # Get a stage in the project
 kargo get stages --project=my-project my-stage
+
+# List all stages in the default project
+kargo config set-project my-project
+kargo get stages
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -31,7 +31,7 @@ func newGetWarehousesCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:     "warehouses --project=project [NAME...]",
+		Use:     "warehouses [--project=project] [NAME ...]",
 		Aliases: []string{"warehouse"},
 		Short:   "Display one or many warehouses",
 		Example: `
@@ -43,6 +43,10 @@ kargo get warehouses --project=my-project -o json
 
 # Get a warehouse in the project
 kargo get warehouses --project=my-project my-warehouse
+
+# List all warehouses in the default project
+kargo config set-project my-project
+kargo get warehouses
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -51,10 +51,22 @@ func NewCommand(opt *option.Option) *cobra.Command {
 	cmdOpts := &loginOptions{Option: opt}
 
 	cmd := &cobra.Command{
-		Use:     "login server-address",
-		Args:    option.ExactArgs(1),
-		Short:   "Log in to a Kargo API server",
-		Example: "kargo login https://kargo.example.com --sso",
+		Use:   "login SERVER_ADDRESS (--admin | --kubeconfig | --sso)",
+		Args:  option.ExactArgs(1),
+		Short: "Log in to a Kargo API server",
+		Example: `
+# Log in using SSO
+kargo login https://kargo.example.com --sso
+
+# Log in using the admin user
+kargo login https://kargo.example.com --admin
+
+# Log in using the local kubeconfig
+kargo login https://kargo.example.com --kubeconfig
+
+# Log in using the local kubeconfig and ignore cert warnings
+kargo login https://kargo.example.com --kubeconfig --insecure-tls
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)
 

--- a/internal/cli/cmd/logout/logout.go
+++ b/internal/cli/cmd/logout/logout.go
@@ -5,13 +5,18 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
+	"github.com/akuity/kargo/internal/cli/option"
 )
 
 func NewCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:     "logout",
-		Short:   "Log out of the Kargo API server",
-		Example: "kargo logout",
+		Use:   "logout",
+		Short: "Log out of the Kargo API server",
+		Args:  option.NoArgs,
+		Example: `
+# Log out of the current Kargo API server
+kargo logout
+`,
 		RunE: func(*cobra.Command, []string) error {
 			return errors.Wrap(
 				config.DeleteCLIConfig(),

--- a/internal/cli/cmd/promote/promote.go
+++ b/internal/cli/cmd/promote/promote.go
@@ -33,7 +33,7 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "promote [--project=project] --freight=freight-id [--stage=stage] [--subscribers-of=stage]",
+		Use:   "promote [--project=project] --freight=freight (--stage=stage | --subscribers-of=stage)",
 		Short: "Manage the promotion of freight",
 		Args:  option.NoArgs,
 		Example: `

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -32,8 +32,16 @@ type refreshOptions struct {
 
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "refresh",
+		Use:   "refresh TYPE NAME [--wait]",
 		Short: "Refresh a stage or warehouse",
+		Args:  option.NoArgs,
+		Example: `
+# Refresh a warehouse
+kargo refresh warehouse --project=my-project my-warehouse
+
+# Refresh a stage
+kargo refresh stage --project=my-project my-stage
+`,
 	}
 
 	// Register subcommands.

--- a/internal/cli/cmd/refresh/stage.go
+++ b/internal/cli/cmd/refresh/stage.go
@@ -21,9 +21,19 @@ func newRefreshStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Com
 	}
 
 	cmd := &cobra.Command{
-		Use:     "stage (STAGE)",
-		Args:    option.ExactArgs(1),
-		Example: "kargo refresh stage --project=guestbook (STAGE)",
+		Use:  "stage [--project=project] NAME [--wait]",
+		Args: option.ExactArgs(1),
+		Example: `
+# Refresh a stage in a project
+kargo refresh stage --project=my-project my-stage
+
+# Refresh a stage and wait for it to complete
+kargo refresh stage --project=my-project my-stage --wait
+
+# Refresh a stage in the default project
+kargo config set-project my-project
+kargo refresh stage my-stage
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(refreshResourceTypeStage, args)
 

--- a/internal/cli/cmd/refresh/stage.go
+++ b/internal/cli/cmd/refresh/stage.go
@@ -24,7 +24,7 @@ func newRefreshStageCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Com
 		Use:  "stage [--project=project] NAME [--wait]",
 		Args: option.ExactArgs(1),
 		Example: `
-# Refresh a stage in a project
+# Refresh a stage
 kargo refresh stage --project=my-project my-stage
 
 # Refresh a stage and wait for it to complete

--- a/internal/cli/cmd/refresh/warehouse.go
+++ b/internal/cli/cmd/refresh/warehouse.go
@@ -21,9 +21,19 @@ func newRefreshWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra
 	}
 
 	cmd := &cobra.Command{
-		Use:     "warehouse (WAREHOUSE)",
-		Args:    option.ExactArgs(1),
-		Example: "kargo warehouse refresh --project=guestbook (WAREHOUSE)",
+		Use:  "warehouse [--project=project] NAME [--wait]",
+		Args: option.ExactArgs(1),
+		Example: `
+# Refresh a warehouse in a project
+kargo refresh warehouse --project=my-project my-warehouse
+
+# Refresh a warehouse and wait for it to complete
+kargo refresh warehouse --project=my-project my-warehouse --wait
+
+# Refresh a warehouse in the default project
+kargo config set-project my-project
+kargo refresh warehouse my-warehouse
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(refreshResourceTypeWarehouse, args)
 

--- a/internal/cli/cmd/refresh/warehouse.go
+++ b/internal/cli/cmd/refresh/warehouse.go
@@ -24,7 +24,7 @@ func newRefreshWarehouseCommand(cfg config.CLIConfig, opt *option.Option) *cobra
 		Use:  "warehouse [--project=project] NAME [--wait]",
 		Args: option.ExactArgs(1),
 		Example: `
-# Refresh a warehouse in a project
+# Refresh a warehouse
 kargo refresh warehouse --project=my-project my-warehouse
 
 # Refresh a warehouse and wait for it to complete

--- a/internal/cli/cmd/update/freight.go
+++ b/internal/cli/cmd/update/freight.go
@@ -30,7 +30,7 @@ func newUpdateFreightAliasCommand(cfg config.CLIConfig, opt *option.Option) *cob
 	}
 
 	cmd := &cobra.Command{
-		Use:   "freight [--project=project] (NAME) --alias=alias",
+		Use:   "freight [--project=project] NAME --alias=alias",
 		Args:  option.ExactArgs(1),
 		Short: "Update (the alias of) a Freight",
 		Example: `

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -9,8 +9,13 @@ import (
 
 func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update SUBCOMMAND",
 		Short: "Update a resource",
+		Args:  option.NoArgs,
+		Example: `
+# Update the alias of a freight for a specified project
+kargo update freight --project=my-project abc123 --alias=my-new-alias
+`,
 	}
 	option.InsecureTLS(cmd.PersistentFlags(), opt)
 	option.LocalServer(cmd.PersistentFlags(), opt)

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -36,7 +36,7 @@ func NewCommand(cfg config.CLIConfig, opt *option.Option) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "version",
+		Use:   "version [--client]",
 		Short: "Show the client and server version information",
 		Args:  option.NoArgs,
 		Example: `


### PR DESCRIPTION
Fixes #1163 

This updates all command usages, examples, etc. to use the same syntax, which matches the syntax used for `kubectl` commands.

In addition, where applicable various variations of command options have been documented in places where a command works with a series of options.