### PR TITLE
fix(api): bug in updated promotion endpoints

### DIFF
--- a/internal/api/promote_stage_v1alpha1.go
+++ b/internal/api/promote_stage_v1alpha1.go
@@ -97,7 +97,7 @@ func (s *server) PromoteStage(
 		)
 	}
 
-	promotion := kargo.NewPromotion(*stage, freightName)
+	promotion := kargo.NewPromotion(*stage, freight.Name)
 	if err := s.createPromotionFn(ctx, &promotion); err != nil {
 		return nil, errors.Wrap(err, "create promotion")
 	}

--- a/internal/api/promote_subscribers_v1alpha1.go
+++ b/internal/api/promote_subscribers_v1alpha1.go
@@ -121,7 +121,7 @@ func (s *server) PromoteSubscribers(
 	promoteErrs := make([]error, 0, len(subscribers))
 	createdPromos := make([]*v1alpha1.Promotion, 0, len(subscribers))
 	for _, subscriber := range subscribers {
-		newPromo := kargo.NewPromotion(subscriber, freightName)
+		newPromo := kargo.NewPromotion(subscriber, freight.Name)
 		if err := s.createPromotionFn(ctx, &newPromo); err != nil {
 			promoteErrs = append(promoteErrs, err)
 			continue


### PR DESCRIPTION
I overlooked that `freightName` can now be empty if the client provided `freightAlias` instead.