### PR TITLE
chore(docs): fixing link for concepts in working-with-freight.md

### DIFF
--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -19,7 +19,7 @@ Kargo seeks to progress from one stage to another.
 
 :::info
 To learn the fundamentals of freight and the warehouses that produce freight,
-visit the [concepts doc](./concepts).
+visit the [concepts doc](../concepts).
 :::
 
 The remainder of this page describes features of freight that will enabled you


### PR DESCRIPTION
The current link for key concepts is broken in https://kargo.akuity.io/how-to-guides/working-with-freight