### PR TITLE
feat(webhook): detect duplicate warehouse subs

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -14,6 +14,7 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/git"
+	"github.com/akuity/kargo/internal/helm"
 	"github.com/akuity/kargo/internal/logging"
 )
 
@@ -150,7 +151,7 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 	credType Type,
 	repoURL string,
 ) (*corev1.Secret, error) {
-	repoURL = normalizeChartRepositoryURL( // This should be safe even on non-chart repo URLs
+	repoURL = helm.NormalizeChartRepositoryURL( // This should be safe even on non-chart repo URLs
 		git.NormalizeGitURL(repoURL), // This should be safe even on non-Git URLs
 	)
 
@@ -183,7 +184,7 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 		if !ok {
 			continue
 		}
-		url := normalizeChartRepositoryURL( // This should be safe even on non-chart repo URLs
+		url := helm.NormalizeChartRepositoryURL( // This should be safe even on non-chart repo URLs
 			git.NormalizeGitURL( // This should be safe even on non-Git URLs
 				string(urlBytes),
 			),
@@ -218,18 +219,6 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 	}
 
 	return nil, nil
-}
-
-// NormalizeURL normalizes a chart repository URL for purposes of comparison.
-// Crucially, this function removes the oci:// prefix from the URL if there is
-// one.
-func normalizeChartRepositoryURL(repo string) string {
-	return strings.TrimPrefix(
-		strings.ToLower(
-			strings.TrimSpace(repo),
-		),
-		"oci://",
-	)
 }
 
 func secretToCreds(secret *corev1.Secret) Credentials {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -213,3 +213,15 @@ func UpdateChartDependencies(homePath, chartPath string) error {
 		chartPath,
 	)
 }
+
+// NormalizeChartRepositoryURL normalizes a chart repository URL for purposes
+// of comparison. Crucially, this function removes the oci:// prefix from the
+// URL if there is one.
+func NormalizeChartRepositoryURL(repo string) string {
+	return strings.TrimPrefix(
+		strings.ToLower(
+			strings.TrimSpace(repo),
+		),
+		"oci://",
+	)
+}


### PR DESCRIPTION
Fixes: #1583 

This adds validation to ensure a Warehouse does not contain multiple subscription entries pointing to the same URL, or in the case of a HTTP/S Helm chart, to the same URL and chart name.

```console
$ kubectl apply -f warehouse.yaml
The Warehouse "my-warehouse" is invalid:
* spec.subscriptions[2].image: Invalid value: "nginx": subscription for image repository already exists at "spec.subscriptions[0].image"
* spec.subscriptions[4].git: Invalid value: "https://github.com/example/kargo-demo.git": subscription for Git repository already exists at "spec.subscriptions[1].git"
* spec.subscriptions[5].chart: Invalid value: "https://example.com/charts/": subscription for chart "nginx" already exists at "spec.subscriptions[3].chart"
* spec.subscriptions[7].chart: Invalid value: "oci://foo": subscription for chart already exists at "spec.subscriptions[6].chart"
```