### PR TITLE
fix(chart): preventing rendering confimaps key as nil

### DIFF
--- a/charts/kargo/templates/controller/configmap.yaml
+++ b/charts/kargo/templates/controller/configmap.yaml
@@ -15,7 +15,9 @@ data:
   {{- if .Values.kubeconfigSecrets.kargo }}
   KUBECONFIG: /etc/kargo/kubeconfigs/kubeconfig.yaml
   {{- end }}
+  {{- if .Values.controller.globalCredentials.namespaces }}
   GLOBAL_CREDENTIALS_NAMESPACES: {{ join "," .Values.controller.globalCredentials.namespaces }}
+  {{- end }}
   ARGOCD_INTEGRATION_ENABLED: {{ quote .Values.controller.argocd.integrationEnabled }}
   {{- if .Values.controller.argocd.integrationEnabled }}
   {{- if .Values.kubeconfigSecrets.argocd }}
@@ -29,7 +31,11 @@ data:
   {{- if .Values.kubeconfigSecrets.rollouts }}
   ROLLOUTS_KUBECONFIG: /etc/kargo/kubeconfigs/rollouts-kubeconfig.yaml
   {{- end }}
+  {{- if .Values.controller.rollouts.analysisRunsNamespace }}
   ROLLOUTS_ANALYSIS_RUNS_NAMESPACE: {{ .Values.controller.rollouts.analysisRunsNamespace }}
+  {{- end}}
+  {{- if .Values.controller.rollouts.controllerInstanceID }}
   ROLLOUTS_CONTROLLER_INSTANCE_ID: {{ .Values.controller.rollouts.controllerInstanceID }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kargo/templates/controller/configmap.yaml
+++ b/charts/kargo/templates/controller/configmap.yaml
@@ -15,9 +15,7 @@ data:
   {{- if .Values.kubeconfigSecrets.kargo }}
   KUBECONFIG: /etc/kargo/kubeconfigs/kubeconfig.yaml
   {{- end }}
-  {{- if .Values.controller.globalCredentials.namespaces }}
-  GLOBAL_CREDENTIALS_NAMESPACES: {{ join "," .Values.controller.globalCredentials.namespaces }}
-  {{- end }}
+  GLOBAL_CREDENTIALS_NAMESPACES: {{ quote (join "," .Values.controller.globalCredentials.namespaces) }}
   ARGOCD_INTEGRATION_ENABLED: {{ quote .Values.controller.argocd.integrationEnabled }}
   {{- if .Values.controller.argocd.integrationEnabled }}
   {{- if .Values.kubeconfigSecrets.argocd }}
@@ -31,11 +29,7 @@ data:
   {{- if .Values.kubeconfigSecrets.rollouts }}
   ROLLOUTS_KUBECONFIG: /etc/kargo/kubeconfigs/rollouts-kubeconfig.yaml
   {{- end }}
-  {{- if .Values.controller.rollouts.analysisRunsNamespace }}
-  ROLLOUTS_ANALYSIS_RUNS_NAMESPACE: {{ .Values.controller.rollouts.analysisRunsNamespace }}
-  {{- end}}
-  {{- if .Values.controller.rollouts.controllerInstanceID }}
-  ROLLOUTS_CONTROLLER_INSTANCE_ID: {{ .Values.controller.rollouts.controllerInstanceID }}
-  {{- end }}
+  ROLLOUTS_ANALYSIS_RUNS_NAMESPACE: {{ quote .Values.controller.rollouts.analysisRunsNamespace }}
+  ROLLOUTS_CONTROLLER_INSTANCE_ID: {{ quote .Values.controller.rollouts.controllerInstanceID }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When running the Quick start installation script, a user may face the following error:

```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: [unknown object type "nil" in ConfigMap.data.GLOBAL_CREDENTIALS_NAMESPACES, unknown object type "nil" in ConfigMap.data.ROLLOUTS_ANALYSIS_RUNS_NAMESPACE, unknown object type "nil" in ConfigMap.data.ROLLOUTS_CONTROLLER_INSTANCE_ID]
```

The error is caused by these keys being rendered as `nil`:

```
helm template kargo oci://ghcr.io/akuity/kargo-charts/kargo \
--set api.service.type=NodePort \
--set api.service.nodePort=31444 \
--set api.adminAccount.password=admin \
--set api.adminAccount.tokenSigningKey=iwishtowashmyirishwristwatch |grep ROLLOUT
```

```
  ROLLOUTS_INTEGRATION_ENABLED: "true"
  ROLLOUTS_INTEGRATION_ENABLED: "true"
  ROLLOUTS_ANALYSIS_RUNS_NAMESPACE:
  ROLLOUTS_CONTROLLER_INSTANCE_ID:
```