### PR TITLE
chore(chart): bump appVersion to v0.4.3

### DIFF
--- a/charts/kargo/Chart.yaml
+++ b/charts/kargo/Chart.yaml
@@ -3,7 +3,7 @@ name: kargo
 description: Kargo
 type: application
 version: 0.1.0
-appVersion: v0.1.0
+appVersion: v0.4.3
 sources:
 - https://github.com/akuity/kargo
 maintainers:


### PR DESCRIPTION
When installing the quick start script, it installs kargo `v0.1.0` and some pods are in `CrashLoopBackOff` with the error:

```
time="2024-03-10T16:56:38Z" level=info msg="Starting Kargo Webhooks Server" commit=9203c78b0b9fc37023a5bb5952a1a0edac2f9bfd version=v0.1.0
time="2024-03-10T16:56:38Z" level=error msg="index PromotionPolicies by Stage: no matches for kind \"PromotionPolicy\" in version \"kargo.akuity.io/v1alpha1\""
```

Updating the helm release to v0.4.3 solved my problem, hence I believe other users can benefit from having `appVersion` bumped to `v0.4.3`.

Long-term: May this version be bumped as part of the CI?

As a side note, I managed to install Kargo using the local chart templates from the #1594 