### PR TITLE
chore(deps): drop `github.com/pkg/errors`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - depguard
     - errcheck
     - exportloopref
     - forcetypeassert
@@ -35,6 +36,13 @@ linters:
 
 # all available settings for linters we enable
 linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          # avoid reintroduction of `github.com/pkg/errors` package
+          - pkg: "github.com/pkg/errors"
+            desc: Should use `errors` package from the standard library
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.

--- a/api/v1alpha1/freight_helpers.go
+++ b/api/v1alpha1/freight_helpers.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,11 +44,11 @@ func GetFreight(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting Freight %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting Freight %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &freight, nil
@@ -72,10 +72,11 @@ func GetFreightByAlias(
 			AliasLabelKey: alias,
 		},
 	); err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"error listing Freight in namespace %q",
+		return nil, fmt.Errorf(
+			"error listing Freight with alias %q in namespace %q: %w",
+			alias,
 			project,
+			err,
 		)
 	}
 	if len(freightList.Items) == 0 {

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,7 +24,7 @@ func refreshObject(
 	)
 	patch := client.RawPatch(types.MergePatchType, patchBytes)
 	if err := c.Patch(ctx, obj, patch); err != nil {
-		return errors.Wrap(err, "patch annotation")
+		return fmt.Errorf("patch annotation: %w", err)
 	}
 	return nil
 }
@@ -38,7 +37,7 @@ func clearRefreshObject(
 	patchBytes := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}}`, AnnotationKeyRefresh))
 	patch := client.RawPatch(types.MergePatchType, patchBytes)
 	if err := c.Patch(ctx, obj, patch); err != nil {
-		return errors.Wrap(err, "patch annotation")
+		return fmt.Errorf("patch annotation: %w", err)
 	}
 	return nil
 }

--- a/api/v1alpha1/project_helpers.go
+++ b/api/v1alpha1/project_helpers.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,7 +25,7 @@ func GetProject(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(err, "error getting Project %q", name)
+		return nil, fmt.Errorf("error getting Project %q: %w", name, err)
 	}
 	return &project, nil
 }

--- a/api/v1alpha1/promotion_helpers.go
+++ b/api/v1alpha1/promotion_helpers.go
@@ -2,9 +2,9 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,11 +23,11 @@ func GetPromotion(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting Promotion %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting Promotion %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &promo, nil
@@ -49,7 +49,7 @@ func RefreshPromotion(
 		},
 	}
 	if err := refreshObject(ctx, c, promo, time.Now); err != nil {
-		return nil, errors.Wrap(err, "refresh")
+		return nil, fmt.Errorf("refresh: %w", err)
 	}
 	return promo, nil
 }

--- a/api/v1alpha1/stage_helpers.go
+++ b/api/v1alpha1/stage_helpers.go
@@ -2,9 +2,9 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,11 +23,11 @@ func GetStage(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting Stage %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting Stage %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &stage, nil
@@ -49,7 +49,7 @@ func RefreshStage(
 		},
 	}
 	if err := refreshObject(ctx, c, stage, time.Now); err != nil {
-		return nil, errors.Wrap(err, "refresh")
+		return nil, fmt.Errorf("refresh: %w", err)
 	}
 	return stage, nil
 }

--- a/api/v1alpha1/warehouse_helpers.go
+++ b/api/v1alpha1/warehouse_helpers.go
@@ -2,9 +2,9 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,11 +23,11 @@ func GetWarehouse(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting Warehouse %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting Warehouse %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &warehouse, nil
@@ -49,7 +49,7 @@ func RefreshWarehouse(
 		},
 	}
 	if err := refreshObject(ctx, c, warehouse, time.Now); err != nil {
-		return nil, errors.Wrap(err, "refresh")
+		return nil, fmt.Errorf("refresh: %w", err)
 	}
 	return warehouse, nil
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"github.com/akuity/kargo/internal/cli/config"
 )
 
@@ -15,7 +13,7 @@ func main() {
 	cfg, err := config.LoadCLIConfig()
 	if err != nil {
 		if !config.IsConfigNotFoundErr(err) {
-			fmt.Fprintln(os.Stderr, errors.Wrap(err, "load config"))
+			_, _ = fmt.Fprintln(os.Stderr, fmt.Errorf("load config: %w", err))
 			os.Exit(1)
 		}
 		cfg = config.NewDefaultCLIConfig()

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,18 +43,18 @@ func newAPICommand() *cobra.Command {
 			cfg := config.ServerConfigFromEnv()
 			restCfg, err := kubernetes.GetRestConfig(ctx, os.GetEnv("KUBECONFIG", ""))
 			if err != nil {
-				return errors.Wrap(err, "error loading REST config")
+				return fmt.Errorf("error loading REST config: %w", err)
 			}
 
 			scheme := runtime.NewScheme()
 			if err = kubescheme.AddToScheme(scheme); err != nil {
-				return errors.Wrap(err, "add Kubernetes api to scheme")
+				return fmt.Errorf("add Kubernetes api to scheme: %w", err)
 			}
 			if types.MustParseBool(os.GetEnv("ROLLOUTS_INTEGRATION_ENABLED", "true")) {
 				if argoRolloutsExists(ctx, restCfg) {
 					log.Info("Argo Rollouts integration is enabled")
 					if err = rollouts.AddToScheme(scheme); err != nil {
-						return errors.Wrap(err, "add argo rollouts api to scheme")
+						return fmt.Errorf("add argo rollouts api to scheme: %w", err)
 					}
 				} else {
 					log.Warn(
@@ -67,12 +66,12 @@ func newAPICommand() *cobra.Command {
 				log.Info("Argo Rollouts integration is disabled")
 			}
 			if err = kargoapi.AddToScheme(scheme); err != nil {
-				return errors.Wrap(err, "add kargo api to scheme")
+				return fmt.Errorf("add kargo api to scheme: %w", err)
 			}
 
 			internalClient, err := newClientForAPI(ctx, restCfg, scheme)
 			if err != nil {
-				return errors.Wrap(err, "create internal Kubernetes client")
+				return fmt.Errorf("create internal Kubernetes client: %w", err)
 			}
 			kubeClientOptions := kubernetes.ClientOptions{
 				NewInternalClient: func(context.Context, *rest.Config, *runtime.Scheme) (client.Client, error) {
@@ -84,7 +83,7 @@ func newAPICommand() *cobra.Command {
 			}
 			kubeClient, err := kubernetes.NewClient(ctx, restCfg, kubeClientOptions)
 			if err != nil {
-				return errors.Wrap(err, "create Kubernetes client")
+				return fmt.Errorf("create Kubernetes client: %w", err)
 			}
 
 			if cfg.AdminConfig != nil {
@@ -108,11 +107,14 @@ func newAPICommand() *cobra.Command {
 				),
 			)
 			if err != nil {
-				return errors.Wrap(err, "error creating listener")
+				return fmt.Errorf("error creating listener: %w", err)
 			}
 			defer l.Close()
 
-			return errors.Wrap(srv.Serve(ctx, l), "serve")
+			if err = srv.Serve(ctx, l); err != nil {
+				return fmt.Errorf("serve: %w", err)
+			}
+			return nil
 		},
 	}
 }
@@ -125,48 +127,46 @@ func newClientForAPI(ctx context.Context, r *rest.Config, scheme *runtime.Scheme
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "new manager")
+		return nil, fmt.Errorf("new manager: %w", err)
 	}
 
 	// Index Promotions by Stage
 	if err := kubeclient.IndexPromotionsByStage(ctx, mgr); err != nil {
-		return nil, errors.Wrap(err, "index promotions by stage")
+		return nil, fmt.Errorf("index Promotions by Stage: %w", err)
 	}
 
 	// Index Freight by Warehouse
 	if err := kubeclient.IndexFreightByWarehouse(ctx, mgr); err != nil {
-		return nil, errors.Wrap(err, "index freight by warehouse")
+		return nil, fmt.Errorf("index Freight by Warehouse: %w", err)
 	}
 
 	// Index Freight by Stages in which it has been verified
 	if err := kubeclient.IndexFreightByVerifiedStages(ctx, mgr); err != nil {
-		return nil,
-			errors.Wrap(err, "index Freight by Stages in which it has been verified")
+		return nil, fmt.Errorf("index Freight by Stages in which it has been verified: %w", err)
 	}
 
 	// Index Freight by Stages for which it is approved
 	if err :=
 		kubeclient.IndexFreightByApprovedStages(ctx, mgr); err != nil {
-		return nil,
-			errors.Wrap(err, "index Freight by Stages for which it has been approved")
+		return nil, fmt.Errorf("index Freight by Stages for which it has been approved: %w", err)
 	}
 
 	// Index ServiceAccounts by ODIC email
 	if err := kubeclient.IndexServiceAccountsByOIDCEmail(ctx, mgr); err != nil {
-		return nil, errors.Wrap(err, "index service accounts by oidc email")
+		return nil, fmt.Errorf("index ServiceAccounts by OIDC email: %w", err)
 	}
 	// Index ServiceAccounts by OIDC groups
 	if err := kubeclient.IndexServiceAccountsByOIDCGroups(ctx, mgr); err != nil {
-		return nil, errors.Wrap(err, "index service accounts by oidc groups")
+		return nil, fmt.Errorf("index ServiceAccounts by OIDC groups: %w", err)
 	}
 	// Index ServiceAccounts by OIDC subjects
 	if err := kubeclient.IndexServiceAccountsByOIDCSubjects(ctx, mgr); err != nil {
-		return nil, errors.Wrap(err, "index service accounts by oidc subjects")
+		return nil, fmt.Errorf("index ServiceAccounts by OIDC subjects: %w", err)
 	}
 
 	go func() {
 		if err := mgr.Start(ctx); err != nil {
-			panic(errors.Wrap(err, "start manager"))
+			panic(fmt.Errorf("start manager: %w", err))
 		}
 	}()
 

--- a/cmd/controlplane/garbage_collector.go
+++ b/cmd/controlplane/garbage_collector.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -37,14 +38,14 @@ func newGarbageCollectorCommand() *cobra.Command {
 				restCfg, err :=
 					kubernetes.GetRestConfig(ctx, os.GetEnv("KUBECONFIG", ""))
 				if err != nil {
-					return errors.Wrap(err, "error loading REST config")
+					return fmt.Errorf("error loading REST config: %w", err)
 				}
 				scheme := runtime.NewScheme()
 				if err = corev1.AddToScheme(scheme); err != nil {
-					return errors.Wrap(err, "error adding Kubernetes core API to scheme")
+					return fmt.Errorf("error adding Kubernetes core API to scheme: %w", err)
 				}
 				if err = kargoapi.AddToScheme(scheme); err != nil {
-					return errors.Wrap(err, "error adding Kargo API to scheme")
+					return fmt.Errorf("error adding Kargo API to scheme: %w", err)
 				}
 				if kubeClient, err = client.New(
 					restCfg,
@@ -52,7 +53,7 @@ func newGarbageCollectorCommand() *cobra.Command {
 						Scheme: scheme,
 					},
 				); err != nil {
-					return errors.Wrap(err, "error initializing Kubernetes client")
+					return fmt.Errorf("err: %w", err)
 				}
 			}
 

--- a/cmd/controlplane/version.go
+++ b/cmd/controlplane/version.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	versionpkg "github.com/akuity/kargo/internal/version"
@@ -19,7 +18,7 @@ func newVersionCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			version, err := json.MarshalIndent(versionpkg.GetVersion(), "", "  ")
 			if err != nil {
-				return errors.Wrap(err, "marshal version")
+				return fmt.Errorf("marshal version: %w", err)
 			}
 			fmt.Println(string(version))
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.10.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
@@ -118,6 +117,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/hack/codegen/prototag/main.go
+++ b/hack/codegen/prototag/main.go
@@ -16,8 +16,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/akuity/kargo/internal/proto/codegen"
 )
 
@@ -59,10 +57,10 @@ func injectTags(pkgDir string, tagMap codegen.TagMap) error {
 		ast.Walk(injector, f)
 		file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_TRUNC, 0)
 		if err != nil {
-			return errors.Wrapf(err, "open file %s", fileName)
+			return fmt.Errorf("open file %s: %w", fileName, err)
 		}
 		if err := format.Node(file, fileSet, f); err != nil {
-			return errors.Wrapf(err, "write file %s", fileName)
+			return fmt.Errorf("write file %s: %w", fileName, err)
 		}
 	}
 	return nil

--- a/internal/api/admin_login_v1alpha1.go
+++ b/internal/api/admin_login_v1alpha1.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -61,7 +62,7 @@ func (s *server) AdminLogin(
 	if err != nil {
 		return nil, connect.NewError(
 			connect.CodeInternal,
-			errors.Wrap(err, "error signing ID token"),
+			fmt.Errorf("error signing ID token: %w", err),
 		)
 	}
 

--- a/internal/api/approve_freight_v1alpha1_test.go
+++ b/internal/api/approve_freight_v1alpha1_test.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,8 +31,8 @@ func TestApproveFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -111,8 +111,8 @@ func TestApproveFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "freight")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -187,8 +187,8 @@ func TestApproveFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "Stage")
 				require.Contains(t, connErr.Message(), "not found in namespace")

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -27,7 +27,7 @@ func splitYAML(
 			if err == io.EOF {
 				break
 			}
-			return nil, nil, errors.Wrap(err, "error decoding manifest")
+			return nil, nil, fmt.Errorf("error decoding manifest: %w", err)
 		}
 		ext.Raw = bytes.TrimSpace(ext.Raw)
 		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
@@ -35,7 +35,7 @@ func splitYAML(
 		}
 		resource := unstructured.Unstructured{}
 		if err := yaml.Unmarshal(ext.Raw, &resource); err != nil {
-			return nil, nil, errors.Wrap(err, "error unmarshaling manifest")
+			return nil, nil, fmt.Errorf("error unmarshaling manifest: %w", err)
 		}
 		if resource.GroupVersionKind().Group == kargoapi.GroupVersion.Group && resource.GetKind() == "Project" {
 			projects = append(projects, resource)

--- a/internal/api/create_resource_v1alpha1.go
+++ b/internal/api/create_resource_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	sigyaml "sigs.k8s.io/yaml"
 
@@ -17,7 +17,7 @@ func (s *server) CreateResource(
 ) (*connect.Response[svcv1alpha1.CreateResourceResponse], error) {
 	projects, otherResources, err := splitYAML(req.Msg.GetManifest())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err, "parse manifest"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parse manifest: %w", err))
 	}
 	resources := append(projects, otherResources...)
 	res := make([]*svcv1alpha1.CreateResourceResult, 0, len(resources))
@@ -39,7 +39,7 @@ func (s *server) createResource(
 	if err := s.client.Create(ctx, obj); err != nil {
 		return &svcv1alpha1.CreateResourceResult{
 			Result: &svcv1alpha1.CreateResourceResult_Error{
-				Error: errors.Wrap(err, "create resource").Error(),
+				Error: fmt.Errorf("create resource: %w", err).Error(),
 			},
 		}
 	}
@@ -48,7 +48,7 @@ func (s *server) createResource(
 	if err != nil {
 		return &svcv1alpha1.CreateResourceResult{
 			Result: &svcv1alpha1.CreateResourceResult_Error{
-				Error: errors.Wrap(err, "marshal created manifest").Error(),
+				Error: fmt.Errorf("marshal created manifest: %w", err).Error(),
 			},
 		}
 	}

--- a/internal/api/delete_freight_v1alpha1.go
+++ b/internal/api/delete_freight_v1alpha1.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -40,7 +40,7 @@ func (s *server) DeleteFreight(
 		alias,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get freight")
+		return nil, err
 	}
 	if freight == nil {
 		if name != "" {
@@ -52,7 +52,7 @@ func (s *server) DeleteFreight(
 	}
 
 	if err := s.client.Delete(ctx, freight); err != nil {
-		return nil, errors.Wrap(err, "delete freight")
+		return nil, fmt.Errorf("delete freight: %w", err)
 	}
 
 	return connect.NewResponse(&svcv1alpha1.DeleteFreightResponse{}), nil

--- a/internal/api/delete_project_v1alpha1.go
+++ b/internal/api/delete_project_v1alpha1.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,10 +36,10 @@ func (s *server) DeleteProject(
 		if kubeerr.IsNotFound(err) {
 			return nil, connect.NewError(
 				connect.CodeNotFound,
-				errors.Errorf("project %q not found", name),
+				fmt.Errorf("project %q not found", name),
 			)
 		}
-		return nil, errors.Wrap(err, "delete Project")
+		return nil, fmt.Errorf("delete project: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.DeleteProjectResponse{}), nil
 }

--- a/internal/api/delete_resource_v1alpha1.go
+++ b/internal/api/delete_resource_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	sigyaml "sigs.k8s.io/yaml"
 
@@ -17,7 +17,7 @@ func (s *server) DeleteResource(
 ) (*connect.Response[svcv1alpha1.DeleteResourceResponse], error) {
 	projects, otherResources, err := splitYAML(req.Msg.GetManifest())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err, "parse manifest"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parse manifest: %w", err))
 	}
 	resources := append(otherResources, projects...)
 	res := make([]*svcv1alpha1.DeleteResourceResult, 0, len(resources))
@@ -39,7 +39,7 @@ func (s *server) deleteResource(
 	if err := s.client.Delete(ctx, obj); err != nil {
 		return &svcv1alpha1.DeleteResourceResult{
 			Result: &svcv1alpha1.DeleteResourceResult_Error{
-				Error: errors.Wrap(err, "delete resource").Error(),
+				Error: fmt.Errorf("delete resource: %w", err).Error(),
 			},
 		}
 	}
@@ -48,7 +48,7 @@ func (s *server) deleteResource(
 	if err != nil {
 		return &svcv1alpha1.DeleteResourceResult{
 			Result: &svcv1alpha1.DeleteResourceResult_Error{
-				Error: errors.Wrap(err, "marshal deleted manifest").Error(),
+				Error: fmt.Errorf("marshal deleted manifest: %w", err).Error(),
 			},
 		}
 	}

--- a/internal/api/delete_stage_v1alpha1.go
+++ b/internal/api/delete_stage_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,10 +40,10 @@ func (s *server) DeleteStage(
 			return nil, connect.NewError(connect.CodeNotFound,
 				fmt.Errorf("stage %q not found", key.String()))
 		}
-		return nil, errors.Wrap(err, "get stage")
+		return nil, fmt.Errorf("get stage: %w", err)
 	}
 	if err := s.client.Delete(ctx, &stage); err != nil && !kubeerr.IsNotFound(err) {
-		return nil, errors.Wrap(err, "delete stage")
+		return nil, fmt.Errorf("delete stage: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.DeleteStageResponse{}), nil
 }

--- a/internal/api/delete_warehouse_v1alpha1.go
+++ b/internal/api/delete_warehouse_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,10 +40,10 @@ func (s *server) DeleteWarehouse(
 			return nil, connect.NewError(connect.CodeNotFound,
 				fmt.Errorf("warehouse %q not found", key.String()))
 		}
-		return nil, errors.Wrap(err, "get warehouse")
+		return nil, fmt.Errorf("get warehouse: %w", err)
 	}
 	if err := s.client.Delete(ctx, &warehouse); err != nil && !kubeerr.IsNotFound(err) {
-		return nil, errors.Wrap(err, "delete warehouse")
+		return nil, fmt.Errorf("delete warehouse: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.DeleteWarehouseResponse{}), nil
 }

--- a/internal/api/dex/proxy.go
+++ b/internal/api/dex/proxy.go
@@ -3,13 +3,14 @@ package dex
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/pkg/errors"
 )
 
 // ProxyConfig represents configuration for a reverse proxy to a Dex server.
@@ -34,18 +35,17 @@ func ProxyConfigFromEnv() ProxyConfig {
 func NewProxy(cfg ProxyConfig) (*httputil.ReverseProxy, error) {
 	target, err := url.Parse(cfg.ServerAddr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing URL %q", cfg.ServerAddr)
+		return nil, fmt.Errorf("error parsing URL %q: %w", cfg.ServerAddr, err)
 	}
 
 	var caCertPool *x509.CertPool
 	if cfg.CACertPath != "" {
 		caCertBytes, err := os.ReadFile(cfg.CACertPath)
 		if err != nil {
-			return nil,
-				errors.Wrapf(err, "error reading CA cert file %q", cfg.CACertPath)
+			return nil, fmt.Errorf("error reading CA cert file %q: %w", cfg.CACertPath, err)
 		}
 		if caCertPool, err = buildCACertPool(caCertBytes); err != nil {
-			return nil, errors.Wrapf(err, "error building CA cert pool")
+			return nil, fmt.Errorf("error building CA cert pool: %w", err)
 		}
 	}
 

--- a/internal/api/get_freight_v1alpha1.go
+++ b/internal/api/get_freight_v1alpha1.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -40,7 +40,7 @@ func (s *server) GetFreight(
 		alias,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get freight")
+		return nil, fmt.Errorf("get freight: %w", err)
 	}
 	if freight == nil {
 		if name != "" {

--- a/internal/api/get_project_v1alpha1.go
+++ b/internal/api/get_project_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -31,7 +31,7 @@ func (s *server) GetProject(
 		if kubeerr.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, errors.Wrap(err, "get project")
+		return nil, fmt.Errorf("get project: %w", err)
 	}
 
 	return connect.NewResponse(

--- a/internal/api/get_promotion_v1alpha1.go
+++ b/internal/api/get_promotion_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -37,9 +37,9 @@ func (s *server) GetPromotion(
 	}, &promotion); err != nil {
 		if kubeerr.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound,
-				errors.Errorf("promotion %q not found", name))
+				fmt.Errorf("promotion %q not found", name))
 		}
-		return nil, errors.Wrap(err, "get promotion")
+		return nil, fmt.Errorf("get promotion: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetPromotionResponse{
 		Promotion: &promotion,

--- a/internal/api/get_stage_v1alpha1.go
+++ b/internal/api/get_stage_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,7 +38,7 @@ func (s *server) GetStage(
 		if kubeerr.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, errors.Wrap(err, "get stage")
+		return nil, fmt.Errorf("get stage: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetStageResponse{
 		Stage: &stage,

--- a/internal/api/get_warehouse_v1alpha1.go
+++ b/internal/api/get_warehouse_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,7 +38,7 @@ func (s *server) GetWarehouse(
 		if kubeerr.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		return nil, errors.Wrap(err, "get warehouse")
+		return nil, fmt.Errorf("get warehouse: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetWarehouseResponse{
 		Warehouse: &warehouse,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"embed"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -17,10 +17,10 @@ var testData embed.FS
 func mustNewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
-		panic(errors.Wrap(err, "add core v1 scheme"))
+		panic(fmt.Errorf("add core v1 to scheme: %w", err))
 	}
 	if err := kargoapi.AddToScheme(scheme); err != nil {
-		panic(errors.Wrap(err, "add kargo v1alpha1 scheme"))
+		panic(fmt.Errorf("add kargo v1alpha1 scheme: %w", err))
 	}
 	return scheme
 }
@@ -28,12 +28,12 @@ func mustNewScheme() *runtime.Scheme {
 func mustNewObject[T any](path string) *T {
 	rawObj, err := testData.ReadFile(path)
 	if err != nil {
-		panic(errors.Wrapf(err, "read file from path %q", path))
+		panic(fmt.Errorf("read file from path %q: %w", path, err))
 	}
 
 	var obj T
 	if err := yaml.Unmarshal(rawObj, &obj); err != nil {
-		panic(errors.Wrap(err, "unmarshal yaml"))
+		panic(fmt.Errorf("unmarshal yaml: %w", err))
 	}
 	return &obj
 }

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -2,11 +2,11 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	authv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -67,11 +67,10 @@ func setOptionsDefaults(opts ClientOptions) (ClientOptions, error) {
 	if opts.Scheme == nil {
 		opts.Scheme = runtime.NewScheme()
 		if err := kubescheme.AddToScheme(opts.Scheme); err != nil {
-			return opts,
-				errors.Wrap(err, "error adding Kubernetes API to scheme")
+			return opts, fmt.Errorf("error adding Kubernetes API to scheme: %w", err)
 		}
 		if err := kargoapi.AddToScheme(opts.Scheme); err != nil {
-			return opts, errors.Wrap(err, "error adding Kargo API to scheme")
+			return opts, fmt.Errorf("error adding Kargo API to scheme: %w", err)
 		}
 	}
 	if opts.NewInternalClient == nil {
@@ -147,17 +146,17 @@ func NewClient(
 ) (Client, error) {
 	var err error
 	if opts, err = setOptionsDefaults(opts); err != nil {
-		return nil, errors.Wrap(err, "error setting client options defaults")
+		return nil, fmt.Errorf("error setting client options defaults: %w", err)
 	}
 	internalClient, err :=
 		opts.NewInternalClient(ctx, restCfg, opts.Scheme)
 	if err != nil {
-		return nil, errors.Wrap(err, "error building internal client")
+		return nil, fmt.Errorf("error building internal client: %w", err)
 	}
 	internalDynamicClient, err :=
 		opts.NewInternalDynamicClient(restCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "error building internal dynamic client")
+		return nil, fmt.Errorf("error building internal dynamic client: %w", err)
 	}
 	return &client{
 		internalClient:        internalClient,
@@ -179,8 +178,7 @@ func newDefaultInternalClient(
 		},
 	)
 	if err != nil {
-		return nil,
-			errors.Wrap(err, "error creating controller-runtime cluster")
+		return nil, fmt.Errorf("error creating controller-runtime cluster: %w", err)
 	}
 	go func() {
 		err = cluster.Start(ctx)
@@ -188,7 +186,10 @@ func newDefaultInternalClient(
 	if !cluster.GetCache().WaitForCacheSync(ctx) {
 		return nil, errors.New("error waiting for cache sync")
 	}
-	return cluster.GetClient(), errors.Wrap(err, "error starting cluster")
+	if err != nil {
+		return nil, fmt.Errorf("error starting cluster: %w", err)
+	}
+	return cluster.GetClient(), nil
 }
 
 func (c *client) Get(
@@ -579,12 +580,15 @@ func GetRestConfig(ctx context.Context, path string) (*rest.Config, error) {
 	if path == "" {
 		logger.Debug("loading in-cluster REST config")
 		cfg, err := rest.InClusterConfig()
-		return cfg, errors.Wrap(err, "error loading in-cluster REST config")
+		return cfg, fmt.Errorf("error loading in-cluster REST config: %w", err)
 	}
 
 	logger.WithField("path", path).Debug("loading REST config from path")
 	cfg, err := clientcmd.BuildConfigFromFlags("", path)
-	return cfg, errors.Wrapf(err, "error loading REST config from %q", path)
+	if err != nil {
+		return cfg, fmt.Errorf("error loading REST config from %q: %w", path, err)
+	}
+	return cfg, nil
 }
 
 // gvrAndKeyFromObj extracts the group, version, and plural resource type
@@ -596,8 +600,7 @@ func gvrAndKeyFromObj(
 ) (schema.GroupVersionResource, *libClient.ObjectKey, error) {
 	gvk, err := apiutil.GVKForObject(runtimeObj, scheme)
 	if err != nil {
-		return schema.GroupVersionResource{}, nil,
-			errors.Wrap(err, "error extracting GVK from object")
+		return schema.GroupVersionResource{}, nil, fmt.Errorf("error extracting GVK from object: %w", err)
 	}
 	// In case this was a list, we trim the "List" suffix to get the kind that's
 	// IN the list.
@@ -682,7 +685,7 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 						return internalClient, nil
 					}
 					if !apierrors.IsForbidden(err) {
-						return nil, errors.Wrap(err, "review subject access")
+						return nil, fmt.Errorf("review subject access: %w", err)
 					}
 				}
 			}
@@ -697,7 +700,7 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 			ra,
 			withBearerToken(userInfo.BearerToken),
 		); err != nil {
-			return nil, errors.Wrap(err, "review subject access")
+			return nil, fmt.Errorf("review subject access: %w", err)
 		}
 		return internalClient, nil
 	}
@@ -739,7 +742,7 @@ func reviewSubjectAccess(
 ) error {
 	cfg, err := GetRestConfig(ctx, os.Getenv("KUBECONFIG"))
 	if err != nil {
-		return errors.Wrap(err, "get REST config")
+		return fmt.Errorf("get REST config: %w", err)
 	}
 
 	var opt userClientOptions
@@ -764,7 +767,7 @@ func reviewSubjectAccess(
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, "create user-specific Kubernetes client")
+		return fmt.Errorf("create user-specific Kubernetes client: %w", err)
 	}
 
 	if opt.subject != nil {
@@ -775,7 +778,7 @@ func reviewSubjectAccess(
 			},
 		}
 		if err := userClient.Create(ctx, review); err != nil {
-			return errors.Wrap(err, "submit SubjectAccessReview")
+			return fmt.Errorf("submit SubjectAccessReview: %w", err)
 		}
 		if review.Status.Allowed {
 			return nil
@@ -789,7 +792,7 @@ func reviewSubjectAccess(
 		},
 	}
 	if err := userClient.Create(ctx, review); err != nil {
-		return errors.Wrap(err, "submit SelfSubjectAccessReview")
+		return fmt.Errorf("submit SelfSubjectAccessReview: %w", err)
 	}
 	if review.Status.Allowed {
 		return nil

--- a/internal/api/kubernetes/client_test.go
+++ b/internal/api/kubernetes/client_test.go
@@ -2,9 +2,9 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/api/list_projects_v1alpha1.go
+++ b/internal/api/list_projects_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 
 	"github.com/akuity/kargo/api/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -17,7 +17,7 @@ func (s *server) ListProjects(
 ) (*connect.Response[svcv1alpha1.ListProjectsResponse], error) {
 	projects := &kargoapi.ProjectList{}
 	if err := s.client.List(ctx, projects); err != nil {
-		return nil, errors.Wrap(err, "error listing Projects")
+		return nil, fmt.Errorf("error listing Projects: %w", err)
 	}
 	projectProtos := make([]*v1alpha1.Project, len(projects.Items))
 	for i := range projects.Items {

--- a/internal/api/list_promotions_v1alpha1.go
+++ b/internal/api/list_promotions_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/api/v1alpha1"
@@ -38,7 +38,7 @@ func (s *server) ListPromotions(
 		)
 	}
 	if err := s.client.List(ctx, &list, opts...); err != nil {
-		return nil, errors.Wrap(err, "list promotions")
+		return nil, fmt.Errorf("list promotions: %w", err)
 	}
 	promotions := make([]*v1alpha1.Promotion, len(list.Items))
 	for idx := range list.Items {

--- a/internal/api/list_stages_v1alpha1.go
+++ b/internal/api/list_stages_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/api/v1alpha1"
@@ -27,7 +27,7 @@ func (s *server) ListStages(
 
 	var list kargoapi.StageList
 	if err := s.client.List(ctx, &list, client.InNamespace(project)); err != nil {
-		return nil, errors.Wrap(err, "list stages")
+		return nil, fmt.Errorf("list stages: %w", err)
 	}
 
 	stages := make([]*v1alpha1.Stage, len(list.Items))

--- a/internal/api/list_warehouses_v1alpha1.go
+++ b/internal/api/list_warehouses_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/api/v1alpha1"
@@ -27,7 +27,7 @@ func (s *server) ListWarehouses(
 
 	var list kargoapi.WarehouseList
 	if err := s.client.List(ctx, &list, client.InNamespace(project)); err != nil {
-		return nil, errors.Wrap(err, "list warehouses")
+		return nil, fmt.Errorf("list warehouses: %w", err)
 	}
 
 	warehouses := make([]*v1alpha1.Warehouse, len(list.Items))

--- a/internal/api/option/auth_test.go
+++ b/internal/api/option/auth_test.go
@@ -2,6 +2,7 @@ package option
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/internal/api/option/error.go
+++ b/internal/api/option/error.go
@@ -2,10 +2,10 @@ package option
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	libClient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,7 +25,7 @@ func NewHandlerOption(
 	if !cfg.LocalMode {
 		authInterceptor, err := newAuthInterceptor(ctx, cfg, internalClient)
 		if err != nil {
-			return nil, errors.Wrap(err, "initialize authentication interceptor")
+			return nil, fmt.Errorf("initialize authentication interceptor: %w", err)
 		}
 		interceptors = append(interceptors, authInterceptor)
 	}

--- a/internal/api/promote_stage_v1alpha1.go
+++ b/internal/api/promote_stage_v1alpha1.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -52,12 +52,12 @@ func (s *server) PromoteStage(
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get stage")
+		return nil, fmt.Errorf("get stage: %w", err)
 	}
 	if stage == nil {
 		return nil, connect.NewError(
 			connect.CodeNotFound,
-			errors.Errorf(
+			fmt.Errorf(
 				"Stage %q not found in namespace %q",
 				stageName,
 				project,
@@ -73,7 +73,7 @@ func (s *server) PromoteStage(
 		freightAlias,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get freight")
+		return nil, fmt.Errorf("get freight: %w", err)
 	}
 	if freight == nil {
 		if freightName != "" {
@@ -91,7 +91,7 @@ func (s *server) PromoteStage(
 	if !s.isFreightAvailableFn(freight, stage.Name, upstreamStages) {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf(
+			fmt.Errorf(
 				"Freight %q is not available to Stage %q",
 				freightName,
 				stageName,
@@ -118,7 +118,7 @@ func (s *server) PromoteStage(
 
 	promotion := kargo.NewPromotion(*stage, freight.Name)
 	if err := s.createPromotionFn(ctx, &promotion); err != nil {
-		return nil, errors.Wrap(err, "create promotion")
+		return nil, fmt.Errorf("create promotion: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.PromoteStageResponse{
 		Promotion: &promotion,

--- a/internal/api/promote_stage_v1alpha1_test.go
+++ b/internal/api/promote_stage_v1alpha1_test.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,8 +31,8 @@ func TestPromoteStage(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -107,8 +107,8 @@ func TestPromoteStage(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "Stage")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -199,8 +199,8 @@ func TestPromoteStage(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "freight")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -250,8 +250,8 @@ func TestPromoteStage(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Contains(t, connErr.Message(), "Freight")
 				require.Contains(t, connErr.Message(), "is not available to Stage")

--- a/internal/api/promote_subscribers_v1alpha1.go
+++ b/internal/api/promote_subscribers_v1alpha1.go
@@ -2,11 +2,10 @@ package api
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -55,12 +54,12 @@ func (s *server) PromoteSubscribers(
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get stage")
+		return nil, fmt.Errorf("get stage: %w", err)
 	}
 	if stage == nil {
 		return nil, connect.NewError(
 			connect.CodeNotFound,
-			errors.Errorf(
+			fmt.Errorf(
 				"Stage %q not found in namespace %q",
 				stageName,
 				project,
@@ -84,7 +83,7 @@ func (s *server) PromoteSubscribers(
 		freightAlias,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get freight")
+		return nil, fmt.Errorf("get freight: %w", err)
 	}
 	if freight == nil {
 		if freightName != "" {
@@ -101,7 +100,7 @@ func (s *server) PromoteSubscribers(
 	) {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf(
+			fmt.Errorf(
 				"Freight %q is not available to Stage %q",
 				freightName,
 				stageName,
@@ -111,7 +110,7 @@ func (s *server) PromoteSubscribers(
 
 	subscribers, err := s.findStageSubscribersFn(ctx, stage)
 	if err != nil {
-		return nil, errors.Wrap(err, "find stage subscribers")
+		return nil, fmt.Errorf("find stage subscribers: %w", err)
 	}
 	if len(subscribers) == 0 {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("stage %q has no subscribers", stageName))
@@ -148,8 +147,7 @@ func (s *server) PromoteSubscribers(
 	})
 
 	if len(promoteErrs) > 0 {
-		return res,
-			connect.NewError(connect.CodeInternal, goerrors.Join(promoteErrs...))
+		return res, connect.NewError(connect.CodeInternal, errors.Join(promoteErrs...))
 	}
 
 	return res, nil

--- a/internal/api/promote_subscribers_v1alpha1_test.go
+++ b/internal/api/promote_subscribers_v1alpha1_test.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,8 +33,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -109,8 +109,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "Stage")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -201,8 +201,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "freight")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -252,8 +252,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Contains(t, connErr.Message(), "Freight")
 				require.Contains(t, connErr.Message(), "not available to Stage")
@@ -362,8 +362,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "stage")
 				require.Contains(t, connErr.Message(), "has no subscribers")
@@ -499,8 +499,8 @@ func TestPromoteSubscribers(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInternal, connErr.Code())
 				require.Contains(t, connErr.Message(), "something went wrong")
 			},

--- a/internal/api/query_freights_v1alpha1_test.go
+++ b/internal/api/query_freights_v1alpha1_test.go
@@ -2,11 +2,11 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,8 +35,8 @@ func TestQueryFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Equal(t, "project should not be empty", connErr.Message())
 			},
@@ -75,8 +75,8 @@ func TestQueryFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Equal(t, "Invalid group by: bogus-group-by", connErr.Message())
 			},
@@ -133,8 +133,8 @@ func TestQueryFreight(t *testing.T) {
 				err error,
 			) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "Stage")
 				require.Contains(t, connErr.Message(), "not found in namespace")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,13 +2,14 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	goos "os"
 	"time"
 
 	"connectrpc.com/grpchealth"
-	"github.com/pkg/errors"
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
@@ -165,7 +166,7 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 
 	opts, err := option.NewHandlerOption(ctx, s.cfg, s.internalClient)
 	if err != nil {
-		return errors.Wrap(err, "error initializing handler options")
+		return fmt.Errorf("error initializing handler options: %w", err)
 	}
 	mux.Handle(grpchealth.NewHandler(NewHealthChecker(), opts))
 	path, svcHandler := svcv1alpha1connect.NewKargoServiceHandler(s, opts)
@@ -175,7 +176,7 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 		dexProxyCfg := dex.ProxyConfigFromEnv()
 		dexProxy, err := dex.NewProxy(dexProxyCfg)
 		if err != nil {
-			return errors.Wrap(err, "error initializing dex proxy")
+			return fmt.Errorf("error initializing dex proxy: %w", err)
 		}
 		mux.Handle("/dex/", dexProxy)
 	}

--- a/internal/api/update_freight_alias_v1alpha1.go
+++ b/internal/api/update_freight_alias_v1alpha1.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,7 +49,7 @@ func (s *server) UpdateFreightAlias(
 		oldAlias,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get freight")
+		return nil, fmt.Errorf("get freight: %w", err)
 	}
 	if freight == nil {
 		if name != "" {
@@ -76,7 +76,7 @@ func (s *server) UpdateFreightAlias(
 			// TODO: This should probably be a 409 Conflict, but connect doesn't seem
 			// to have that
 			connect.CodeAlreadyExists,
-			errors.Errorf(
+			fmt.Errorf(
 				"alias %q already used by another piece of Freight in namespace %q",
 				newAlias,
 				project,
@@ -106,7 +106,7 @@ func (s *server) patchFreightAlias(
 	)
 	patch := client.RawPatch(types.MergePatchType, patchBytes)
 	if err := s.client.Patch(ctx, freight, patch); err != nil {
-		return errors.Wrap(err, "patch label")
+		return fmt.Errorf("patch label: %w", err)
 	}
 	return nil
 }

--- a/internal/api/update_freight_alias_v1alpha1_test.go
+++ b/internal/api/update_freight_alias_v1alpha1_test.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,8 +27,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			server: &server{},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -40,8 +40,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			server: &server{},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -54,8 +54,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			server: &server{},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -121,8 +121,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 				require.Contains(t, connErr.Message(), "freight")
 				require.Contains(t, connErr.Message(), "not found in namespace")
@@ -156,8 +156,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInternal, connErr.Code())
 				require.Equal(t, "something went wrong", connErr.Message())
 			},
@@ -203,8 +203,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeAlreadyExists, connErr.Code())
 				require.Contains(
 					t,
@@ -248,8 +248,8 @@ func TestUpdateFreightAlias(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInternal, connErr.Code())
 				require.Equal(t, "something went wrong", connErr.Message())
 			},

--- a/internal/api/update_resource_v1alpha1.go
+++ b/internal/api/update_resource_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigyaml "sigs.k8s.io/yaml"
@@ -18,7 +18,7 @@ func (s *server) UpdateResource(
 ) (*connect.Response[svcv1alpha1.UpdateResourceResponse], error) {
 	projects, otherResources, err := splitYAML(req.Msg.GetManifest())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err, "parse manifest"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parse manifest: %w", err))
 	}
 	resources := append(projects, otherResources...)
 	res := make([]*svcv1alpha1.UpdateResourceResult, 0, len(resources))
@@ -41,7 +41,7 @@ func (s *server) updateResource(
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), currentObj); err != nil {
 		return &svcv1alpha1.UpdateResourceResult{
 			Result: &svcv1alpha1.UpdateResourceResult_Error{
-				Error: errors.Wrap(err, "get resource").Error(),
+				Error: fmt.Errorf("get resource: %w", err).Error(),
 			},
 		}
 	}
@@ -50,7 +50,7 @@ func (s *server) updateResource(
 	if err := s.client.Update(ctx, obj); err != nil {
 		return &svcv1alpha1.UpdateResourceResult{
 			Result: &svcv1alpha1.UpdateResourceResult_Error{
-				Error: errors.Wrap(err, "update resource").Error(),
+				Error: fmt.Errorf("update resource: %w", err).Error(),
 			},
 		}
 	}
@@ -59,7 +59,7 @@ func (s *server) updateResource(
 	if err != nil {
 		return &svcv1alpha1.UpdateResourceResult{
 			Result: &svcv1alpha1.UpdateResourceResult_Error{
-				Error: errors.Wrap(err, "marshal updated manifest").Error(),
+				Error: fmt.Errorf("marshal updated manifest: %w", err).Error(),
 			},
 		}
 	}

--- a/internal/api/validation/project.go
+++ b/internal/api/validation/project.go
@@ -2,9 +2,9 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -23,7 +23,7 @@ func ValidateProject(ctx context.Context, kc client.Client, project string) erro
 		if kubeerr.IsNotFound(err) {
 			return ErrProjectNotFound
 		}
-		return errors.Wrap(err, "get project")
+		return fmt.Errorf("get project: %w", err)
 	}
 	if ns.GetLabels()[kargoapi.ProjectLabelKey] != kargoapi.LabelTrueValue {
 		return field.Invalid(field.NewPath("metadata", "namespace"),

--- a/internal/api/validators.go
+++ b/internal/api/validators.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/akuity/kargo/internal/api/validation"
@@ -14,7 +15,7 @@ func validateFieldNotEmpty(fieldName string, fieldValue string) error {
 	if fieldValue == "" {
 		return connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf("%s should not be empty", fieldName),
+			fmt.Errorf("%s should not be empty", fieldName),
 		)
 	}
 	return nil
@@ -29,7 +30,7 @@ func (s *server) validateProjectExists(ctx context.Context, project string) erro
 		if ok := errors.As(err, &fieldErr); ok {
 			return connect.NewError(connect.CodeInvalidArgument, err)
 		}
-		return errors.Wrap(err, "validate project")
+		return fmt.Errorf("validate project: %w", err)
 	}
 	return nil
 }
@@ -38,7 +39,7 @@ func validateGroupByOrderBy(group string, groupBy string, orderBy string) error 
 	if group != "" && groupBy == "" {
 		return connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf("Cannot filter by group without group by"),
+			errors.New("Cannot filter by group without group by"),
 		)
 	}
 	switch groupBy {
@@ -46,21 +47,21 @@ func validateGroupByOrderBy(group string, groupBy string, orderBy string) error 
 	default:
 		return connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf("Invalid group by: %s", groupBy),
+			fmt.Errorf("Invalid group by: %s", groupBy),
 		)
 	}
 	switch orderBy {
 	case OrderByTag:
 		if groupBy != GroupByImageRepository && groupBy != GroupByChartRepository {
 			return connect.NewError(connect.CodeInvalidArgument,
-				errors.Errorf("Tag ordering only valid when grouping by: %s, %s",
+				fmt.Errorf("Tag ordering only valid when grouping by: %s, %s",
 					GroupByImageRepository, GroupByChartRepository))
 		}
 	case OrderByFirstSeen, "":
 	default:
 		return connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.Errorf("Invalid order by: %s", orderBy),
+			fmt.Errorf("Invalid order by: %s", orderBy),
 		)
 	}
 

--- a/internal/api/validators_test.go
+++ b/internal/api/validators_test.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,8 +26,8 @@ func TestValidateFieldNotEmpty(t *testing.T) {
 			fieldValue: "",
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Equal(t, "project should not be empty", connErr.Message())
 			},
@@ -69,8 +69,8 @@ func TestValidateProjectExists(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeNotFound, connErr.Code())
 			},
 		},
@@ -87,8 +87,8 @@ func TestValidateProjectExists(t *testing.T) {
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 			},
 		},
@@ -146,8 +146,8 @@ func TestValidateGroupByOrderBy(t *testing.T) {
 			groupBy: "",
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Equal(
 					t,
@@ -161,8 +161,8 @@ func TestValidateGroupByOrderBy(t *testing.T) {
 			groupBy: "bogus-group-by",
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Contains(t, connErr.Message(), "Invalid group by")
 			},
@@ -173,8 +173,8 @@ func TestValidateGroupByOrderBy(t *testing.T) {
 			orderBy: OrderByTag,
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Contains(
 					t,
@@ -188,8 +188,8 @@ func TestValidateGroupByOrderBy(t *testing.T) {
 			orderBy: "bogus-order-by",
 			assertions: func(err error) {
 				require.Error(t, err)
-				connErr, ok := err.(*connect.Error)
-				require.True(t, ok)
+				var connErr *connect.Error
+				require.True(t, errors.As(err, &connErr))
 				require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 				require.Contains(t, connErr.Message(), "Invalid order by")
 			},

--- a/internal/api/watch_promotion_v1alpha1.go
+++ b/internal/api/watch_promotion_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -42,7 +42,7 @@ func (s *server) WatchPromotion(
 		if kubeerr.IsNotFound(err) {
 			return connect.NewError(connect.CodeNotFound, err)
 		}
-		return errors.Wrap(err, "get promotion")
+		return fmt.Errorf("get promotion: %w", err)
 	}
 
 	opts := metav1.ListOptions{
@@ -50,7 +50,7 @@ func (s *server) WatchPromotion(
 	}
 	w, err := s.client.Watch(ctx, &kargoapi.Promotion{}, project, opts)
 	if err != nil {
-		return errors.Wrap(err, "watch promotion")
+		return fmt.Errorf("watch promotion: %w", err)
 	}
 	defer w.Stop()
 	for {
@@ -63,17 +63,17 @@ func (s *server) WatchPromotion(
 			}
 			u, ok := e.Object.(*unstructured.Unstructured)
 			if !ok {
-				return errors.Errorf("unexpected object type %T", e.Object)
+				return fmt.Errorf("unexpected object type %T", e.Object)
 			}
 			var promotion *kargoapi.Promotion
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &promotion); err != nil {
-				return errors.Wrap(err, "from unstructured")
+				return fmt.Errorf("from unstructured: %w", err)
 			}
 			if err := stream.Send(&svcv1alpha1.WatchPromotionResponse{
 				Promotion: promotion,
 				Type:      string(e.Type),
 			}); err != nil {
-				return errors.Wrap(err, "send response")
+				return fmt.Errorf("send response: %w", err)
 			}
 		}
 	}

--- a/internal/api/watch_warehouses_v1alpha1.go
+++ b/internal/api/watch_warehouses_v1alpha1.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,7 +40,7 @@ func (s *server) WatchWarehouses(
 			if kubeerr.IsNotFound(err) {
 				return connect.NewError(connect.CodeNotFound, err)
 			}
-			return errors.Wrap(err, "get warehouse")
+			return fmt.Errorf("get warehouse: %w", err)
 		}
 	}
 
@@ -48,10 +48,9 @@ func (s *server) WatchWarehouses(
 	if name != "" {
 		opts.FieldSelector = fields.OneTermEqualSelector(metav1.ObjectNameField, name).String()
 	}
-	w, err :=
-		s.client.Watch(ctx, &kargoapi.Warehouse{}, project, opts)
+	w, err := s.client.Watch(ctx, &kargoapi.Warehouse{}, project, opts)
 	if err != nil {
-		return errors.Wrap(err, "watch warehouse")
+		return fmt.Errorf("watch warehouse: %w", err)
 	}
 	defer w.Stop()
 	for {
@@ -64,17 +63,17 @@ func (s *server) WatchWarehouses(
 			}
 			u, ok := e.Object.(*unstructured.Unstructured)
 			if !ok {
-				return errors.Errorf("unexpected object type %T", e.Object)
+				return fmt.Errorf("unexpected object type %T", e.Object)
 			}
 			var warehouse *kargoapi.Warehouse
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &warehouse); err != nil {
-				return errors.Wrap(err, "from unstructured")
+				return fmt.Errorf("from unstructured: %w", err)
 			}
 			if err := stream.Send(&svcv1alpha1.WatchWarehousesResponse{
 				Warehouse: warehouse,
 				Type:      string(e.Type),
 			}); err != nil {
-				return errors.Wrap(err, "send response")
+				return fmt.Errorf("send response: %w", err)
 			}
 		}
 	}

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -3,10 +3,11 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -42,7 +43,7 @@ func GetClientFromConfig(
 	skipTLSVerify := opts.InsecureTLS || cfg.InsecureSkipTLSVerify
 	cfg, err := newTokenRefresher().refreshToken(ctx, cfg, skipTLSVerify)
 	if err != nil {
-		return nil, errors.Wrap(err, "error refreshing token")
+		return nil, fmt.Errorf("error refreshing token: %w", err)
 	}
 	return GetClient(cfg.APIAddress, cfg.BearerToken, skipTLSVerify), nil
 }

--- a/internal/cli/client/errors.go
+++ b/internal/cli/client/errors.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/akuity/kargo/internal/cli/config"
 )

--- a/internal/cli/client/token_refresher.go
+++ b/internal/cli/client/token_refresher.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -112,10 +113,7 @@ func redeemRefreshToken(
 		connect.NewRequest(&v1alpha1.GetPublicConfigRequest{}),
 	)
 	if err != nil {
-		return "", "", errors.Wrap(
-			err,
-			"error retrieving public configuration from server",
-		)
+		return "", "", fmt.Errorf("error retrieving public configuration from server: %w", err)
 	}
 
 	if res.Msg.OidcConfig == nil {
@@ -124,7 +122,7 @@ func redeemRefreshToken(
 
 	provider, err := oidc.NewProvider(ctx, res.Msg.OidcConfig.IssuerUrl)
 	if err != nil {
-		return "", "", errors.Wrap(err, "error initializing OIDC provider")
+		return "", "", fmt.Errorf("error initializing OIDC provider: %w", err)
 	}
 
 	cfg := oauth2.Config{

--- a/internal/cli/client/token_refresher_test.go
+++ b/internal/cli/client/token_refresher_test.go
@@ -2,11 +2,11 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/internal/cli/config"

--- a/internal/cli/cmd/approve/approve.go
+++ b/internal/cli/cmd/approve/approve.go
@@ -2,10 +2,10 @@ package approve
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/client"
@@ -76,7 +76,7 @@ func (o *approvalOptions) addFlags(cmd *cobra.Command) {
 	option.Stage(cmd.Flags(), &o.Stage, "The stage for which to approve the freight.")
 
 	if err := cmd.MarkFlagRequired(option.StageFlag); err != nil {
-		panic(errors.Wrapf(err, "could not mark %s flag as required", option.StageFlag))
+		panic(fmt.Errorf("could not mark %s flag as required: %w", option.StageFlag, err))
 	}
 
 	cmd.MarkFlagsOneRequired(option.FreightFlag, option.FreightAliasFlag)
@@ -90,25 +90,25 @@ func (o *approvalOptions) validate() error {
 	// While the flags are marked as required, a user could still provide an empty
 	// string. This is a check to ensure that the flags are not empty.
 	if o.Project == "" {
-		errs = append(errs, errors.Errorf("%s is required", option.ProjectFlag))
+		errs = append(errs, fmt.Errorf("%s is required", option.ProjectFlag))
 	}
 	if o.FreightName == "" && o.FreightAlias == "" {
 		errs = append(
 			errs,
-			errors.Errorf("either %s or %s is required", option.FreightFlag, option.FreightAliasFlag),
+			fmt.Errorf("either %s or %s is required", option.FreightFlag, option.FreightAliasFlag),
 		)
 	}
 	if o.Stage == "" {
-		errs = append(errs, errors.Errorf("%s is required", option.StageFlag))
+		errs = append(errs, fmt.Errorf("%s is required", option.StageFlag))
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // run performs the approval of a freight based on the options.
 func (o *approvalOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if _, err = kargoSvcCli.ApproveFreight(
@@ -122,7 +122,7 @@ func (o *approvalOptions) run(ctx context.Context) error {
 			},
 		),
 	); err != nil {
-		return errors.Wrap(err, "approve freight")
+		return fmt.Errorf("approve freight: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/cmd/config/set_project.go
+++ b/internal/cli/cmd/config/set_project.go
@@ -1,9 +1,9 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -50,7 +50,7 @@ func (o *setProjectOptions) run() error {
 	o.Config.Project = o.Project
 
 	if err := config.SaveCLIConfig(o.Config); err != nil {
-		return errors.Wrap(err, "save cli config")
+		return fmt.Errorf("save cli config: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/cmd/create/create.go
+++ b/internal/cli/cmd/create/create.go
@@ -2,11 +2,10 @@ package create
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -79,13 +78,13 @@ func (o *createOptions) addFlags(cmd *cobra.Command) {
 	option.Filenames(cmd.Flags(), &o.Filenames, "Filename or directory to use to create resource(s).")
 
 	if err := cmd.MarkFlagRequired(option.FilenameFlag); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as required"))
+		panic(fmt.Errorf("could not mark filename flag as required: %w", err))
 	}
 	if err := cmd.MarkFlagFilename(option.FilenameFlag, ".yaml", ".yml"); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as filename"))
+		panic(fmt.Errorf("could not mark filename flag as filename: %w", err))
 	}
 	if err := cmd.MarkFlagDirname(option.FilenameFlag); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as dirname"))
+		panic(fmt.Errorf("could not mark filename flag as dirname: %w", err))
 	}
 }
 
@@ -105,24 +104,24 @@ func (o *createOptions) validate() error {
 func (o *createOptions) run(ctx context.Context) error {
 	manifest, err := yaml.Read(o.Filenames)
 	if err != nil {
-		return errors.Wrap(err, "read manifests")
+		return fmt.Errorf("read manifests: %w", err)
 	}
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return errors.Wrap(err, "create printer")
+		return fmt.Errorf("create printer: %w", err)
 	}
 
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	resp, err := kargoSvcCli.CreateResource(ctx, connect.NewRequest(&kargosvcapi.CreateResourceRequest{
 		Manifest: manifest,
 	}))
 	if err != nil {
-		return errors.Wrap(err, "create resource")
+		return fmt.Errorf("create resource: %w", err)
 	}
 
 	resCap := len(resp.Msg.GetResults())
@@ -139,11 +138,11 @@ func (o *createOptions) run(ctx context.Context) error {
 	for _, r := range successRes {
 		var obj unstructured.Unstructured
 		if err := sigyaml.Unmarshal(r.CreatedResourceManifest, &obj); err != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "%s",
-				errors.Wrap(err, "Error: unmarshal created manifest"))
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Error: %s",
+				fmt.Errorf("unmarshal created manifest: %w", err))
 			continue
 		}
 		_ = printer.PrintObj(&obj, o.IOStreams.Out)
 	}
-	return goerrors.Join(createErrs...)
+	return errors.Join(createErrs...)
 }

--- a/internal/cli/cmd/create/project.go
+++ b/internal/cli/cmd/create/project.go
@@ -2,10 +2,11 @@ package create
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -90,7 +91,7 @@ func (o *createProjectOptions) validate() error {
 func (o *createProjectOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	project := &kargoapi.Project{
@@ -104,7 +105,7 @@ func (o *createProjectOptions) run(ctx context.Context) error {
 	}
 	projectBytes, err := sigyaml.Marshal(project)
 	if err != nil {
-		return errors.Wrap(err, "marshal project")
+		return fmt.Errorf("marshal project: %w", err)
 	}
 
 	resp, err := kargoSvcCli.CreateResource(
@@ -116,18 +117,18 @@ func (o *createProjectOptions) run(ctx context.Context) error {
 		),
 	)
 	if err != nil {
-		return errors.Wrap(err, "create resource")
+		return fmt.Errorf("create resource: %w", err)
 	}
 
 	project = &kargoapi.Project{}
 	projectBytes = resp.Msg.GetResults()[0].GetCreatedResourceManifest()
 	if err = sigyaml.Unmarshal(projectBytes, project); err != nil {
-		return errors.Wrap(err, "unmarshal project")
+		return fmt.Errorf("unmarshal project: %w", err)
 	}
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return errors.Wrap(err, "new printer")
+		return fmt.Errorf("new printer: %w", err)
 	}
 	return printer.PrintObj(project, o.IOStreams.Out)
 }

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -1,8 +1,10 @@
 package dashboard
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/bacongobbler/browser"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -46,8 +48,8 @@ func (o *dashboardOptions) validate() error {
 
 // run opens the Kargo Dashboard in the default browser.
 func (o *dashboardOptions) run() error {
-	return errors.Wrap(
-		browser.Open(o.Config.APIAddress),
-		"error opening dashboard in default browser",
-	)
+	if err := browser.Open(o.Config.APIAddress); err != nil {
+		return fmt.Errorf("error opening dashboard in default browser: %w", err)
+	}
+	return nil
 }

--- a/internal/cli/cmd/delete/delete.go
+++ b/internal/cli/cmd/delete/delete.go
@@ -2,11 +2,10 @@ package delete
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -90,13 +89,13 @@ func (o *deleteOptions) addFlags(cmd *cobra.Command) {
 	option.Filenames(cmd.Flags(), &o.Filenames, "Filename or directory to use to delete resource(s).")
 
 	if err := cmd.MarkFlagRequired(option.FilenameFlag); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as required"))
+		panic(fmt.Errorf("could not mark filename flag as required: %w", err))
 	}
 	if err := cmd.MarkFlagFilename(option.FilenameFlag, ".yaml", ".yml"); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as filename"))
+		panic(fmt.Errorf("could not mark filename flag as filename: %w", err))
 	}
 	if err := cmd.MarkFlagDirname(option.FilenameFlag); err != nil {
-		panic(errors.Wrap(err, "could not mark filename flag as dirname"))
+		panic(fmt.Errorf("could not mark filename flag as dirname: %w", err))
 	}
 }
 
@@ -116,19 +115,19 @@ func (o *deleteOptions) validate() error {
 func (o *deleteOptions) run(ctx context.Context) error {
 	manifest, err := yaml.Read(o.Filenames)
 	if err != nil {
-		return errors.Wrap(err, "read manifests")
+		return fmt.Errorf("read manifests: %w", err)
 	}
 
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	resp, err := kargoSvcCli.DeleteResource(ctx, connect.NewRequest(&kargosvcapi.DeleteResourceRequest{
 		Manifest: manifest,
 	}))
 	if err != nil {
-		return errors.Wrap(err, "delete resource")
+		return fmt.Errorf("delete resource: %w", err)
 	}
 
 	resCap := len(resp.Msg.GetResults())
@@ -145,17 +144,17 @@ func (o *deleteOptions) run(ctx context.Context) error {
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return errors.Wrap(err, "create printer")
+		return fmt.Errorf("create printer: %w", err)
 	}
 
 	for _, r := range successRes {
 		var obj unstructured.Unstructured
 		if err := sigyaml.Unmarshal(r.DeletedResourceManifest, &obj); err != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "%s",
-				errors.Wrap(err, "Error: unmarshal deleted manifest"))
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Error: %s",
+				fmt.Errorf("unmarshal deleted manifest: %w", err))
 			continue
 		}
 		_ = printer.PrintObj(&obj, o.IOStreams.Out)
 	}
-	return goerrors.Join(deleteErrs...)
+	return errors.Join(deleteErrs...)
 }

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -2,11 +2,11 @@ package get
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -107,7 +107,7 @@ func (o *getFreightOptions) validate() error {
 	// While the flags are marked as required, a user could still provide an empty
 	// string. This is a check to ensure that the flags are not empty.
 	if o.Project == "" {
-		return errors.Errorf("%s is required", option.ProjectFlag)
+		return fmt.Errorf("%s is required", option.ProjectFlag)
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func (o *getFreightOptions) validate() error {
 func (o *getFreightOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if len(o.Names) == 0 && len(o.Aliases) == 0 {
@@ -129,7 +129,7 @@ func (o *getFreightOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			return errors.Wrap(err, "query freight")
+			return fmt.Errorf("query freight: %w", err)
 		}
 
 		// We didn't specify any groupBy, so there should be one group with an
@@ -151,7 +151,7 @@ func (o *getFreightOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			errs = append(errs, errors.Wrapf(err, "get freight %s", name))
+			errs = append(errs, fmt.Errorf("get freight %s: %w", name, err))
 			continue
 		}
 		res = append(res, resp.Msg.GetFreight())
@@ -167,16 +167,16 @@ func (o *getFreightOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			errs = append(errs, errors.Wrapf(err, "get freight %s", alias))
+			errs = append(errs, fmt.Errorf("get freight %s: %w", alias, err))
 			continue
 		}
 		res = append(res, resp.Msg.GetFreight())
 	}
 
 	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
-		return errors.Wrap(err, "print freight")
+		return fmt.Errorf("print freight: %w", err)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func newFreightTable(list *metav1.List) *metav1.Table {

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -1,7 +1,8 @@
 package get
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +61,7 @@ func printObjects[T runtime.Object](
 	if flags.OutputFlagSpecified != nil && flags.OutputFlagSpecified() {
 		printer, err := flags.ToPrinter()
 		if err != nil {
-			return errors.Wrap(err, "new printer")
+			return fmt.Errorf("new printer: %w", err)
 		}
 		if len(list.Items) == 1 {
 			return printer.PrintObj(list.Items[0].Object, streams.Out)

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -2,12 +2,12 @@ package get
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 	"slices"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -84,7 +84,7 @@ func (o *getProjectsOptions) complete(args []string) {
 func (o *getProjectsOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if len(o.Names) == 0 {
@@ -93,7 +93,7 @@ func (o *getProjectsOptions) run(ctx context.Context) error {
 			ctx,
 			connect.NewRequest(&v1alpha1.ListProjectsRequest{}),
 		); err != nil {
-			return errors.Wrap(err, "list projects")
+			return fmt.Errorf("list projects: %w", err)
 		}
 		return printObjects(resp.Msg.GetProjects(), o.PrintFlags, o.IOStreams)
 	}
@@ -117,9 +117,9 @@ func (o *getProjectsOptions) run(ctx context.Context) error {
 	}
 
 	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
-		return errors.Wrap(err, "print projects")
+		return fmt.Errorf("print projects: %w", err)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func newProjectTable(list *metav1.List) *metav1.Table {

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -2,12 +2,12 @@ package get
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 	"slices"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -124,7 +124,7 @@ func (o *getPromotionsOptions) validate() error {
 func (o *getPromotionsOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if len(o.Names) == 0 {
@@ -138,7 +138,7 @@ func (o *getPromotionsOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			return errors.Wrap(err, "list promotions")
+			return fmt.Errorf("list promotions: %w", err)
 		}
 		return printObjects(resp.Msg.GetPromotions(), o.PrintFlags, o.IOStreams)
 	}
@@ -163,9 +163,9 @@ func (o *getPromotionsOptions) run(ctx context.Context) error {
 	}
 
 	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
-		return errors.Wrap(err, "print promotions")
+		return fmt.Errorf("print promotions: %w", err)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func newPromotionTable(list *metav1.List) *metav1.Table {

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -2,12 +2,12 @@ package get
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 	"slices"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -112,7 +112,7 @@ func (o *getStagesOptions) validate() error {
 func (o *getStagesOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if len(o.Names) == 0 {
@@ -125,7 +125,7 @@ func (o *getStagesOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			return errors.Wrap(err, "list stages")
+			return fmt.Errorf("list stages: %w", err)
 		}
 		return printObjects(resp.Msg.GetStages(), o.PrintFlags, o.IOStreams)
 	}
@@ -150,9 +150,9 @@ func (o *getStagesOptions) run(ctx context.Context) error {
 	}
 
 	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
-		return errors.Wrap(err, "print stages")
+		return fmt.Errorf("print stages: %w", err)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func newStageTable(list *metav1.List) *metav1.Table {

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -2,11 +2,11 @@ package get
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 	"slices"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -113,7 +113,7 @@ func (o *getWarehousesOptions) validate() error {
 func (o *getWarehousesOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if len(o.Names) == 0 {
@@ -126,7 +126,7 @@ func (o *getWarehousesOptions) run(ctx context.Context) error {
 				},
 			),
 		); err != nil {
-			return errors.Wrap(err, "list warehouses")
+			return fmt.Errorf("list warehouses: %w", err)
 		}
 		return printObjects(resp.Msg.GetWarehouses(), o.PrintFlags, o.IOStreams)
 	}
@@ -151,7 +151,7 @@ func (o *getWarehousesOptions) run(ctx context.Context) error {
 	}
 
 	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
-		return errors.Wrap(err, "print warehouses")
+		return fmt.Errorf("print warehouses: %w", err)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }

--- a/internal/cli/cmd/logout/logout.go
+++ b/internal/cli/cmd/logout/logout.go
@@ -1,7 +1,8 @@
 package logout
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -18,10 +19,10 @@ func NewCommand() *cobra.Command {
 kargo logout
 `,
 		RunE: func(*cobra.Command, []string) error {
-			return errors.Wrap(
-				config.DeleteCLIConfig(),
-				"error deleting CLI configuration",
-			)
+			if err := config.DeleteCLIConfig(); err != nil {
+				return fmt.Errorf("error deleting CLI configuration: %w", err)
+			}
+			return nil
 		},
 	}
 }

--- a/internal/cli/cmd/promote/promote.go
+++ b/internal/cli/cmd/promote/promote.go
@@ -2,11 +2,10 @@ package promote
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -132,33 +131,33 @@ func (o *promotionOptions) validate() error {
 	// While the flags are marked as required, a user could still provide an empty
 	// string. This is a check to ensure that the flags are not empty.
 	if o.Project == "" {
-		errs = append(errs, errors.Errorf("%s is required", option.ProjectFlag))
+		errs = append(errs, fmt.Errorf("%s is required", option.ProjectFlag))
 	}
 	if o.FreightName == "" && o.FreightAlias == "" {
 		errs = append(
 			errs,
-			errors.Errorf("either %s or %s is required", option.FreightFlag, option.FreightAliasFlag),
+			fmt.Errorf("either %s or %s is required", option.FreightFlag, option.FreightAliasFlag),
 		)
 	}
 	if o.Stage == "" && o.SubscribersOf == "" {
 		errs = append(
 			errs,
-			errors.Errorf("either %s or %s is required", option.StageFlag, option.SubscribersOfFlag),
+			fmt.Errorf("either %s or %s is required", option.StageFlag, option.SubscribersOfFlag),
 		)
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // run performs the promotion of the freight using the options.
 func (o *promotionOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return errors.Wrap(err, "new printer")
+		return fmt.Errorf("new printer: %w", err)
 	}
 
 	switch {
@@ -175,7 +174,7 @@ func (o *promotionOptions) run(ctx context.Context) error {
 			),
 		)
 		if err != nil {
-			return errors.Wrap(err, "promote stage")
+			return fmt.Errorf("promote stage: %w", err)
 		}
 		_ = printer.PrintObj(res.Msg.GetPromotion(), o.IOStreams.Out)
 		return nil

--- a/internal/cli/cmd/refresh/refresh.go
+++ b/internal/cli/cmd/refresh/refresh.go
@@ -2,12 +2,11 @@ package refresh
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/client"
@@ -85,14 +84,14 @@ func (o *refreshOptions) validate() error {
 		errs = append(errs, errors.New("name is required"))
 	}
 
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // run performs the refresh operation based on the provided options.
 func (o *refreshOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	switch o.ResourceType {
@@ -109,7 +108,7 @@ func (o *refreshOptions) run(ctx context.Context) error {
 		}))
 	}
 	if err != nil {
-		return errors.Wrapf(err, "refresh %s", o.ResourceType)
+		return fmt.Errorf("refresh %s: %w", o.ResourceType, err)
 	}
 
 	if o.Wait {
@@ -120,7 +119,7 @@ func (o *refreshOptions) run(ctx context.Context) error {
 			err = waitForStage(ctx, kargoSvcCli, o.Project, o.Name)
 		}
 		if err != nil {
-			return errors.Wrapf(err, "wait %s", o.ResourceType)
+			return fmt.Errorf("wait %s: %w", o.ResourceType, err)
 		}
 	}
 	fmt.Printf("%s '%s/%s' refreshed\n", o.ResourceType, o.Project, o.Name)

--- a/internal/cli/cmd/refresh/stage.go
+++ b/internal/cli/cmd/refresh/stage.go
@@ -2,9 +2,10 @@ package refresh
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -61,7 +62,7 @@ func waitForStage(
 		Name:    name,
 	}))
 	if err != nil {
-		return errors.Wrap(err, "watch stage")
+		return fmt.Errorf("watch stage: %w", err)
 	}
 	defer func() {
 		if conn, connErr := res.Conn(); connErr == nil {
@@ -71,7 +72,7 @@ func waitForStage(
 	for {
 		if !res.Receive() {
 			if err = res.Err(); err != nil {
-				return errors.Wrap(err, "watch stage")
+				return fmt.Errorf("watch stage: %w", err)
 			}
 			return errors.New("unexpected end of watch stream")
 		}

--- a/internal/cli/cmd/refresh/warehouse.go
+++ b/internal/cli/cmd/refresh/warehouse.go
@@ -2,9 +2,10 @@ package refresh
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -61,7 +62,7 @@ func waitForWarehouse(
 		Name:    name,
 	}))
 	if err != nil {
-		return errors.Wrap(err, "watch warehouse")
+		return fmt.Errorf("watch warehouse: %w", err)
 	}
 	defer func() {
 		if conn, connErr := res.Conn(); connErr == nil {
@@ -71,7 +72,7 @@ func waitForWarehouse(
 	for {
 		if !res.Receive() {
 			if err = res.Err(); err != nil {
-				return errors.Wrap(err, "watch warehouse")
+				return fmt.Errorf("watch warehouse: %w", err)
 			}
 			return errors.New("unexpected end of watch stream")
 		}

--- a/internal/cli/cmd/server/server.go
+++ b/internal/cli/cmd/server/server.go
@@ -2,9 +2,10 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -77,17 +78,17 @@ func (o *serverOptions) run(ctx context.Context) error {
 
 	restCfg, err := config.GetConfig()
 	if err != nil {
-		return errors.Wrap(err, "get REST config")
+		return fmt.Errorf("get REST config: %w", err)
 	}
 
 	client, err := kubernetes.NewClient(ctx, restCfg, kubernetes.ClientOptions{})
 	if err != nil {
-		return errors.Wrap(err, "error creating Kubernetes client")
+		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
 	l, err := net.Listen("tcp", o.address)
 	if err != nil {
-		return errors.Wrap(err, "start local server")
+		return fmt.Errorf("start local server: %w", err)
 	}
 	defer l.Close() // nolint: errcheck
 
@@ -99,7 +100,7 @@ func (o *serverOptions) run(ctx context.Context) error {
 		client,
 	)
 	if err := srv.Serve(ctx, l); err != nil {
-		return errors.Wrap(err, "serve error")
+		return fmt.Errorf("serve error: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/cmd/update/freight.go
+++ b/internal/cli/cmd/update/freight.go
@@ -2,10 +2,10 @@ package update
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akuity/kargo/internal/cli/client"
@@ -77,7 +77,7 @@ func (o *updateFreightAliasOptions) addFlags(cmd *cobra.Command) {
 	option.NewAlias(cmd.Flags(), &o.NewAlias, "The new alias to be assigned to the freight.")
 
 	if err := cmd.MarkFlagRequired(option.NewAliasFlag); err != nil {
-		panic(errors.Wrapf(err, "could not mark %s flag as required", option.NewAliasFlag))
+		panic(fmt.Errorf("could not mark %s flag as required: %w", option.NewAliasFlag, err))
 	}
 
 	cmd.MarkFlagsOneRequired(option.NameFlag, option.OldAliasFlag)
@@ -91,25 +91,25 @@ func (o *updateFreightAliasOptions) validate() error {
 	// While the flags are marked as required, a user could still provide an empty
 	// string. This is a check to ensure that the flags are not empty.
 	if o.Project == "" {
-		errs = append(errs, errors.Errorf("%s is required", option.ProjectFlag))
+		errs = append(errs, fmt.Errorf("%s is required", option.ProjectFlag))
 	}
 	if o.Name == "" && o.OldAlias == "" {
 		errs = append(
 			errs,
-			errors.Errorf("either %s or %s is required", option.NameFlag, option.OldAliasFlag),
+			fmt.Errorf("either %s or %s is required", option.NameFlag, option.OldAliasFlag),
 		)
 	}
 	if o.NewAlias == "" {
-		errs = append(errs, errors.Errorf("%s is required", option.NewAliasFlag))
+		errs = append(errs, fmt.Errorf("%s is required", option.NewAliasFlag))
 	}
-	return goerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // run updates the freight alias using the options.
 func (o *updateFreightAliasOptions) run(ctx context.Context) error {
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, o.Config, o.ClientOptions)
 	if err != nil {
-		return errors.Wrap(err, "get client from config")
+		return fmt.Errorf("get client from config: %w", err)
 	}
 
 	if _, err = kargoSvcCli.UpdateFreightAlias(
@@ -123,7 +123,7 @@ func (o *updateFreightAliasOptions) run(ctx context.Context) error {
 			},
 		),
 	); err != nil {
-		return errors.Wrap(err, "update freight alias")
+		return fmt.Errorf("update freight alias: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -98,18 +97,18 @@ func (o *versionOptions) run(ctx context.Context) error {
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return errors.Wrap(err, "new printer")
+		return fmt.Errorf("new printer: %w", err)
 	}
 	obj, err := componentVersionsToRuntimeObject(&svcv1alpha1.ComponentVersions{
 		Server: serverVersion,
 		Cli:    cliVersion,
 	})
 	if err != nil {
-		return errors.Wrap(err, "map component versions to runtime object")
+		return fmt.Errorf("map component versions to runtime object: %w", err)
 	}
 
 	if err := printer.PrintObj(obj, o.IOStreams.Out); err != nil {
-		return errors.Wrap(err, "printing object")
+		return fmt.Errorf("printing object: %w", err)
 	}
 	return serverErr
 }
@@ -125,7 +124,7 @@ func getServerVersion(
 
 	kargoSvcCli, err := client.GetClientFromConfig(ctx, cfg, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "get client from config")
+		return nil, fmt.Errorf("get client from config: %w", err)
 	}
 
 	resp, err := kargoSvcCli.GetVersionInfo(
@@ -133,7 +132,7 @@ func getServerVersion(
 		connect.NewRequest(&svcv1alpha1.GetVersionInfoRequest{}),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "get version info from server")
+		return nil, fmt.Errorf("get version info from server: %w", err)
 	}
 
 	return resp.Msg.GetVersionInfo(), nil
@@ -142,11 +141,11 @@ func getServerVersion(
 func componentVersionsToRuntimeObject(v *svcv1alpha1.ComponentVersions) (runtime.Object, error) {
 	data, err := protojson.Marshal(v)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal component versions")
+		return nil, fmt.Errorf("marshal component versions: %w", err)
 	}
 	var content map[string]any
 	if err := json.Unmarshal(data, &content); err != nil {
-		return nil, errors.Wrap(err, "unmarshal component versions")
+		return nil, fmt.Errorf("unmarshal component versions: %w", err)
 	}
 	u := &unstructured.Unstructured{}
 	u.SetUnstructuredContent(content)

--- a/internal/cli/config/errors.go
+++ b/internal/cli/config/errors.go
@@ -1,9 +1,8 @@
 package config
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type ErrConfigNotFound struct {

--- a/internal/controller/argocd/api/v1alpha1/application_helpers.go
+++ b/internal/controller/argocd/api/v1alpha1/application_helpers.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,11 +28,11 @@ func GetApplication(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting Argo CD Application %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting Argo CD Application %q in namespace %q: %w",
 			name,
 			namespace,
+			err,
 		)
 	}
 	return &app, nil

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -1,7 +1,8 @@
 package controller
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -28,7 +29,10 @@ func GetShardPredicate(shard string) (predicate.Predicate, error) {
 				},
 			},
 		)
-		return pred, errors.Wrap(err, "error creating default selector predicate")
+		if err != nil {
+			return nil, fmt.Errorf("error creating default selector predicate: %w", err)
+		}
+		return pred, nil
 	}
 	pred, err := predicate.LabelSelectorPredicate(
 		*metav1.SetAsLabelSelector(
@@ -39,18 +43,21 @@ func GetShardPredicate(shard string) (predicate.Predicate, error) {
 			),
 		),
 	)
-	return pred, errors.Wrap(err, "error creating shard selector predicate")
+	if err != nil {
+		return nil, fmt.Errorf("error creating shard selector predicate: %w", err)
+	}
+	return pred, nil
 }
 
 func GetShardRequirement(shard string) (*labels.Requirement, error) {
 	req, err := labels.NewRequirement(kargoapi.ShardLabelKey, selection.Equals, []string{shard})
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating shard label selector")
+		return nil, fmt.Errorf("error creating shard label selector: %w", err)
 	}
 	if shard == "" {
 		req, err = labels.NewRequirement(kargoapi.ShardLabelKey, selection.DoesNotExist, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, "error creating default label selector")
+			return nil, fmt.Errorf("error creating default label selector: %w", err)
 		}
 	}
 
@@ -67,7 +74,7 @@ func GetCredentialsRequirement() (*labels.Requirement, error) {
 		credentials.TypeImage.String(),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating credentials label selector")
+		return nil, fmt.Errorf("error creating credentials label selector: %w", err)
 	}
 	return req, nil
 }

--- a/internal/controller/management/namespaces/namespaces.go
+++ b/internal/controller/management/namespaces/namespaces.go
@@ -2,8 +2,8 @@ package namespaces
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,11 +117,11 @@ func (r *reconciler) Reconcile(
 			},
 		),
 	); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "error deleting Project %q", ns.Name)
+		return ctrl.Result{}, fmt.Errorf("error deleting Project %q: %w", ns.Name, err)
 	}
 	if controllerutil.RemoveFinalizer(ns, kargoapi.FinalizerName) {
 		if err := r.updateNamespaceFn(ctx, ns); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "error removing finalizer")
+			return ctrl.Result{}, fmt.Errorf("error removing finalizer: %w", err)
 		}
 	}
 	logger.Debug("done reconciling Namespace")

--- a/internal/controller/promotion/argocd_test.go
+++ b/internal/controller/promotion/argocd_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/promotion/composite.go
+++ b/internal/controller/promotion/composite.go
@@ -2,8 +2,7 @@ package promotion
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/logging"
@@ -62,10 +61,10 @@ func (c *compositeMechanism) Promote(
 		var otherStatus *kargoapi.PromotionStatus
 		otherStatus, newFreight, err = childMechanism.Promote(ctx, stage, promo, newFreight)
 		if err != nil {
-			return nil, newFreight, errors.Wrapf(
-				err,
-				"error executing %s",
+			return nil, newFreight, fmt.Errorf(
+				"error executing %s: %w",
 				childMechanism.GetName(),
+				err,
 			)
 		}
 		newStatus = aggregateGitPromoStatus(newStatus, *otherStatus)

--- a/internal/controller/promotion/composite_test.go
+++ b/internal/controller/promotion/composite_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -2,13 +2,13 @@ package promotion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -1,11 +1,11 @@
 package promotion
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/promotion/kustomize.go
+++ b/internal/controller/promotion/kustomize.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/kustomize"
@@ -71,11 +69,11 @@ func (k *kustomizer) apply(
 		}
 		dir := filepath.Join(workingDir, imgUpdate.Path)
 		if err := k.setImageFn(dir, fqImageRef); err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error updating image %q to %q using Kustomize",
+			return nil, fmt.Errorf(
+				"error updating image %q to %q using Kustomize: %w",
 				imgUpdate.Image,
 				fqImageRef,
+				err,
 			)
 		}
 		changeSummary = append(

--- a/internal/controller/promotion/kustomize_test.go
+++ b/internal/controller/promotion/kustomize_test.go
@@ -1,9 +1,9 @@
 package promotion
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/promotion/render.go
+++ b/internal/controller/promotion/render.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
@@ -117,10 +115,10 @@ func (b *kargoRenderMechanism) doSingleUpdate(
 		update.RepoURL,
 	)
 	if err != nil {
-		return newFreight, errors.Wrapf(
-			err,
-			"error obtaining credentials for git repo %q",
+		return newFreight, fmt.Errorf(
+			"error obtaining credentials for git repo %q: %w",
 			update.RepoURL,
+			err,
 		)
 	}
 	repoCreds := git.RepoCredentials{}
@@ -173,10 +171,10 @@ func (b *kargoRenderMechanism) doSingleUpdate(
 
 	res, err := b.renderManifestsFn(req)
 	if err != nil {
-		return newFreight, errors.Wrapf(
-			err,
-			"error rendering manifests for git repo %q via Kargo Render",
+		return newFreight, fmt.Errorf(
+			"error rendering manifests for git repo %q via Kargo Render: %w",
 			update.RepoURL,
+			err,
 		)
 	}
 	switch res.ActionTaken {

--- a/internal/controller/promotion/render_test.go
+++ b/internal/controller/promotion/render_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/internal/controller/rollouts/api/v1alpha1/analysis_helpers.go
+++ b/internal/controller/rollouts/api/v1alpha1/analysis_helpers.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -21,11 +21,11 @@ func GetAnalysisTemplate(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting AnalysisTemplate %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting AnalysisTemplate %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &at, nil
@@ -41,11 +41,11 @@ func GetAnalysisRun(
 		if err = client.IgnoreNotFound(err); err == nil {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(
-			err,
-			"error getting AnalysisRun %q in namespace %q",
+		return nil, fmt.Errorf(
+			"error getting AnalysisRun %q in namespace %q: %w",
 			namespacedName.Name,
 			namespacedName.Namespace,
+			err,
 		)
 	}
 	return &ar, nil

--- a/internal/controller/runtime/queues.go
+++ b/internal/controller/runtime/queues.go
@@ -2,9 +2,9 @@ package runtime
 
 import (
 	"container/heap"
+	"errors"
 	"sync"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/controller/stages/health_test.go
+++ b/internal/controller/stages/health_test.go
@@ -2,9 +2,9 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -2,10 +2,10 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controller/stages/verification_test.go
+++ b/internal/controller/stages/verification_test.go
@@ -2,10 +2,10 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controller/warehouses/aliases.go
+++ b/internal/controller/warehouses/aliases.go
@@ -2,8 +2,8 @@ package warehouses
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -20,10 +20,10 @@ func (r *reconciler) getAvailableFreightAlias(
 			&freight,
 			client.MatchingLabels{kargoapi.AliasLabelKey: alias},
 		); err != nil {
-			return "", errors.Wrapf(
-				err,
-				"error checking for existence of Freight with alias %q",
+			return "", fmt.Errorf(
+				"error checking for existence of Freight with alias %q: %w",
 				alias,
+				err,
 			)
 		}
 		if len(freight.Items) == 0 {

--- a/internal/controller/warehouses/git_test.go
+++ b/internal/controller/warehouses/git_test.go
@@ -2,11 +2,11 @@ package warehouses
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 

--- a/internal/controller/warehouses/helm.go
+++ b/internal/controller/warehouses/helm.go
@@ -2,8 +2,7 @@ package warehouses
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
@@ -33,10 +32,10 @@ func (r *reconciler) selectCharts(
 		creds, ok, err :=
 			r.credentialsDB.Get(ctx, namespace, credentials.TypeHelm, sub.RepoURL)
 		if err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error obtaining credentials for chart repository %q",
+			return nil, fmt.Errorf(
+				"error obtaining credentials for chart repository %q: %w",
 				sub.RepoURL,
+				err,
 			)
 		}
 
@@ -60,29 +59,29 @@ func (r *reconciler) selectCharts(
 		)
 		if err != nil {
 			if sub.Name == "" {
-				return nil, errors.Wrapf(
-					err,
-					"error searching for latest version of chart in repository %q",
+				return nil, fmt.Errorf(
+					"error searching for latest version of chart in repository %q: %w",
 					sub.RepoURL,
+					err,
 				)
 			}
-			return nil, errors.Wrapf(
-				err,
-				"error searching for latest version of chart %q in repository %q",
+			return nil, fmt.Errorf(
+				"error searching for latest version of chart %q in repository %q: %w",
 				sub.Name,
 				sub.RepoURL,
+				err,
 			)
 		}
 
 		if vers == "" {
 			logger.Error("found no suitable chart version")
 			if sub.Name == "" {
-				return nil, errors.Errorf(
+				return nil, fmt.Errorf(
 					"found no suitable version of chart in repository %q",
 					sub.RepoURL,
 				)
 			}
-			return nil, errors.Errorf(
+			return nil, fmt.Errorf(
 				"found no suitable version of chart %q in repository %q",
 				sub.Name,
 				sub.RepoURL,

--- a/internal/controller/warehouses/helm_test.go
+++ b/internal/controller/warehouses/helm_test.go
@@ -2,9 +2,9 @@ package warehouses
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -33,10 +32,10 @@ func (r *reconciler) selectImages(
 		creds, ok, err :=
 			r.credentialsDB.Get(ctx, namespace, credentials.TypeImage, sub.RepoURL)
 		if err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error obtaining credentials for image repo %q",
+			return nil, fmt.Errorf(
+				"error obtaining credentials for image repo %q: %w",
 				sub.RepoURL,
+				err,
 			)
 		}
 		var regCreds *image.Credentials
@@ -52,10 +51,10 @@ func (r *reconciler) selectImages(
 
 		tag, digest, err := r.getImageRefsFn(ctx, *sub, regCreds)
 		if err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error getting latest suitable image %q",
+			return nil, fmt.Errorf(
+				"error getting latest suitable image %q: %w",
 				sub.RepoURL,
+				err,
 			)
 		}
 		imgs = append(
@@ -110,22 +109,22 @@ func getImageRefs(
 		},
 	)
 	if err != nil {
-		return "", "", errors.Wrapf(
-			err,
-			"error creating image selector for image %q",
+		return "", "", fmt.Errorf(
+			"error creating image selector for image %q: %w",
 			sub.RepoURL,
+			err,
 		)
 	}
 	img, err := imageSelector.Select(ctx)
 	if err != nil {
-		return "", "", errors.Wrapf(
-			err,
-			"error fetching newest applicable image %q",
+		return "", "", fmt.Errorf(
+			"error fetching newest applicable image %q: %w",
 			sub.RepoURL,
+			err,
 		)
 	}
 	if img == nil {
-		return "", "", errors.Errorf("found no applicable image %q", sub.RepoURL)
+		return "", "", fmt.Errorf("found no applicable image %q", sub.RepoURL)
 	}
 	return img.Tag, img.Digest.String(), nil
 }

--- a/internal/controller/warehouses/images_test.go
+++ b/internal/controller/warehouses/images_test.go
@@ -2,10 +2,10 @@ package warehouses
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"

--- a/internal/controller/warehouses/warehouses_test.go
+++ b/internal/controller/warehouses/warehouses_test.go
@@ -2,9 +2,9 @@ package warehouses
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,10 +1,9 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
-
-	"github.com/pkg/errors"
 )
 
 // ExitError is an error type that is produced by the Exec() function when a
@@ -46,6 +45,8 @@ func Exec(cmd *exec.Cmd) ([]byte, error) {
 			ExitCode: exitErr.ExitCode(),
 		}
 	}
-	return res,
-		errors.Wrapf(err, "error executing cmd [%s]: %s", cmd.String(), string(res))
+	if err != nil {
+		err = fmt.Errorf("error executing cmd [%s]: %s: %w", cmd.String(), string(res), err)
+	}
+	return res, err
 }

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,11 +1,11 @@
 package exec
 
 import (
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/garbage/collector_test.go
+++ b/internal/garbage/collector_test.go
@@ -2,11 +2,11 @@ package garbage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/gitprovider/github/github.go
+++ b/internal/gitprovider/github/github.go
@@ -2,12 +2,12 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/google/go-github/v56/github"
-	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/akuity/kargo/internal/gitprovider"
@@ -150,7 +150,7 @@ func parseGitHubURL(u string) (string, string, error) {
 	regex := regexp.MustCompile(`^https\://github\.com/([\w-]+)/([\w-]+).*`)
 	parts := regex.FindStringSubmatch(u)
 	if len(parts) != 3 {
-		return "", "", errors.Errorf("error parsing github repository URL %q", u)
+		return "", "", fmt.Errorf("error parsing github repository URL %q", u)
 	}
 	return parts[1], parts[2], nil
 }

--- a/internal/image/digest_selector.go
+++ b/internal/image/digest_selector.go
@@ -2,8 +2,9 @@ package image
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/akuity/kargo/internal/logging"
@@ -47,7 +48,7 @@ func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
 
 	tags, err := d.repoClient.getTags(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing tags")
+		return nil, fmt.Errorf("error listing tags: %w", err)
 	}
 	if len(tags) == 0 {
 		logger.Trace("found no tags")
@@ -61,7 +62,7 @@ func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
 		}
 		image, err := d.repoClient.getImageByTag(ctx, tag, d.platform)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving image with tag %q", tag)
+			return nil, fmt.Errorf("error retrieving image with tag %q: %w", tag, err)
 		}
 		if image == nil {
 			logger.Tracef(

--- a/internal/image/lexical_selector.go
+++ b/internal/image/lexical_selector.go
@@ -2,10 +2,10 @@ package image
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"sort"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/akuity/kargo/internal/logging"
@@ -50,7 +50,7 @@ func (l *lexicalSelector) Select(ctx context.Context) (*Image, error) {
 
 	tags, err := l.repoClient.getTags(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing tags")
+		return nil, fmt.Errorf("error listing tags: %w", err)
 	}
 	if len(tags) == 0 {
 		logger.Trace("found no tags")
@@ -79,7 +79,7 @@ func (l *lexicalSelector) Select(ctx context.Context) (*Image, error) {
 	tag := tags[0]
 	image, err := l.repoClient.getImageByTag(ctx, tag, l.platform)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error retrieving image with tag %q", tag)
+		return nil, fmt.Errorf("error retrieving image with tag %q: %w", tag, err)
 	}
 	if image == nil {
 		logger.Tracef(

--- a/internal/image/platform_constraint.go
+++ b/internal/image/platform_constraint.go
@@ -3,8 +3,6 @@ package image
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // platformConstraint represents an operating system, system architecture, and
@@ -35,8 +33,7 @@ func ValidatePlatformConstraint(platformStr string) bool {
 func parsePlatformConstraint(platformStr string) (platformConstraint, error) {
 	tokens := strings.SplitN(platformStr, "/", 3)
 	if len(tokens) < 2 {
-		return platformConstraint{},
-			errors.Errorf("error parsing platform constraint %q", platformStr)
+		return platformConstraint{}, fmt.Errorf("error parsing platform constraint %q", platformStr)
 	}
 	platform := platformConstraint{
 		os:   tokens[0],

--- a/internal/image/repository_client_test.go
+++ b/internal/image/repository_client_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/distribution/distribution/v3/registry/client/auth/challenge"
 	"github.com/opencontainers/go-digest"
 	"github.com/patrickmn/go-cache"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/image/selector.go
+++ b/internal/image/selector.go
@@ -2,9 +2,8 @@ package image
 
 import (
 	"context"
+	"fmt"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 // SelectionStrategy represents a strategy for selecting a single image from a
@@ -85,10 +84,10 @@ func NewSelector(
 	if opts.AllowRegex != "" {
 		var err error
 		if allowRegex, err = regexp.Compile(opts.AllowRegex); err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error compiling regular expression %q",
+			return nil, fmt.Errorf(
+				"error compiling regular expression %q: %w",
 				opts.AllowRegex,
+				err,
 			)
 		}
 	}
@@ -97,18 +96,17 @@ func NewSelector(
 	if opts.Platform != "" {
 		p, err := parsePlatformConstraint(opts.Platform)
 		if err != nil {
-			return nil,
-				errors.Wrapf(err, "error parsing platform constraint %q", opts.Platform)
+			return nil, fmt.Errorf("error parsing platform constraint %q: %w", opts.Platform, err)
 		}
 		platform = &p
 	}
 
 	repoClient, err := newRepositoryClient(repoURL, opts.InsecureSkipTLSVerify, opts.Creds)
 	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"error creating repository client for image %q",
+		return nil, fmt.Errorf(
+			"error creating repository client for image %q: %w",
 			repoURL,
+			err,
 		)
 	}
 
@@ -138,7 +136,7 @@ func NewSelector(
 			platform,
 		)
 	default:
-		return nil, errors.Errorf("invalid image selection strategy %q", strategy)
+		return nil, fmt.Errorf("invalid image selection strategy %q", strategy)
 	}
 }
 

--- a/internal/image/semver_selector.go
+++ b/internal/image/semver_selector.go
@@ -2,11 +2,11 @@ package image
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/akuity/kargo/internal/logging"
@@ -34,10 +34,10 @@ func newSemVerSelector(
 	if constraint != "" {
 		var err error
 		if semverConstraint, err = semver.NewConstraint(constraint); err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"error parsing semver constraint %q",
+			return nil, fmt.Errorf(
+				"error parsing semver constraint %q: %w",
 				constraint,
+				err,
 			)
 		}
 	}
@@ -64,7 +64,7 @@ func (s *semVerSelector) Select(ctx context.Context) (*Image, error) {
 
 	tags, err := s.repoClient.getTags(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing tags")
+		return nil, fmt.Errorf("error listing tags: %w", err)
 	}
 	if len(tags) == 0 {
 		logger.Trace("found no tags")
@@ -103,7 +103,7 @@ func (s *semVerSelector) Select(ctx context.Context) (*Image, error) {
 	tag := images[0].Tag
 	image, err := s.repoClient.getImageByTag(ctx, tag, s.platform)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error retrieving image with tag %q", tag)
+		return nil, fmt.Errorf("error retrieving image with tag %q: %w", tag, err)
 	}
 	if image == nil {
 		logger.Tracef(

--- a/internal/kargo-render/render.go
+++ b/internal/kargo-render/render.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
-
 	"github.com/akuity/kargo/internal/controller/git"
 	libExec "github.com/akuity/kargo/internal/exec"
 )
@@ -75,10 +73,12 @@ func RenderManifests(req Request) (Response, error) { // nolint: revive
 	res := Response{}
 	resBytes, err := libExec.Exec(buildRenderCmd(req))
 	if err != nil {
-		return res, errors.Wrap(err, "error rendering manifests")
+		return res, fmt.Errorf("error rendering manifests: %w", err)
 	}
-	err = json.Unmarshal(resBytes, &res)
-	return res, errors.Wrap(err, "error unmarshalling response")
+	if err = json.Unmarshal(resBytes, &res); err != nil {
+		err = fmt.Errorf("error unmarshalling response: %w", err)
+	}
+	return res, err
 }
 
 func buildRenderCmd(req Request) *exec.Cmd {

--- a/internal/proto/codegen/ast.go
+++ b/internal/proto/codegen/ast.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/fatih/structtag"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -122,11 +121,11 @@ func parseFieldTags(field *ast.Field) (*structtag.Tags, error) {
 	// Remove backquotes from field tag value
 	rawTag, err := strconv.Unquote(field.Tag.Value)
 	if err != nil {
-		return nil, errors.Wrap(err, "unquote field tag value")
+		return nil, fmt.Errorf("unquote field tag value: %w", err)
 	}
 	tags, err := structtag.Parse(rawTag)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse field tag")
+		return nil, fmt.Errorf("parse field tag: %w", err)
 	}
 	return tags, nil
 }

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -1,9 +1,9 @@
 package strings
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // SplitLast splits a specified string on the last occurrence of the specified
@@ -17,7 +17,7 @@ func SplitLast(s, sep string) (string, string, error) {
 	}
 	i := strings.LastIndex(s, sep)
 	if i < 0 {
-		return "", "", errors.Errorf(
+		return "", "", fmt.Errorf(
 			"string %q contains no occurrences of separator %q",
 			s,
 			sep,

--- a/internal/webhook/freight/webhook.go
+++ b/internal/webhook/freight/webhook.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -110,7 +109,7 @@ func (w *webhook) ValidateCreate(
 			return nil, apierrors.NewConflict(
 				freightGroupResource,
 				freight.Name,
-				errors.Errorf(
+				fmt.Errorf(
 					"alias %q already used by another piece of Freight in namespace %q",
 					alias,
 					freight.Namespace,
@@ -161,7 +160,7 @@ func (w *webhook) ValidateUpdate(
 			return nil, apierrors.NewConflict(
 				freightGroupResource,
 				freight.Name,
-				errors.Errorf(
+				fmt.Errorf(
 					"alias %q already used by another piece of Freight in namespace %q",
 					alias,
 					freight.Namespace,
@@ -205,7 +204,7 @@ func (w *webhook) ValidateDelete(
 			kubeclient.StagesByFreightIndexField: freight.ID,
 		},
 	); err != nil {
-		return nil, errors.Wrap(err, "list stages")
+		return nil, fmt.Errorf("list stages: %w", err)
 	}
 	if len(list.Items) > 0 {
 		stages := make([]string, len(list.Items))

--- a/internal/webhook/promotion/webhook.go
+++ b/internal/webhook/promotion/webhook.go
@@ -2,8 +2,8 @@ package promotion
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	authzv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,15 +96,15 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrapf(
-			err,
-			"error finding Stage %q in namespace %q",
+		return fmt.Errorf(
+			"error finding Stage %q in namespace %q: %w",
 			promo.Spec.Stage,
 			promo.Namespace,
+			err,
 		)
 	}
 	if stage == nil {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"could not find Stage %q in namespace %q",
 			promo.Spec.Stage,
 			promo.Namespace,
@@ -176,7 +176,7 @@ func (w *webhook) authorize(
 		return apierrors.NewForbidden(
 			promotionGroupResource,
 			promo.Name,
-			errors.Errorf(
+			fmt.Errorf(
 				"error retrieving admission request from context; refusing to "+
 					"%s Promotion",
 				action,
@@ -202,7 +202,7 @@ func (w *webhook) authorize(
 		return apierrors.NewForbidden(
 			promotionGroupResource,
 			promo.Name,
-			errors.Errorf(
+			fmt.Errorf(
 				"error creating SubjectAccessReview; refusing to %s Promotion",
 				action,
 			),
@@ -213,7 +213,7 @@ func (w *webhook) authorize(
 		return apierrors.NewForbidden(
 			promotionGroupResource,
 			promo.Name,
-			errors.Errorf(
+			fmt.Errorf(
 				"subject %q is not permitted to %s Promotions for Stage %q",
 				req.UserInfo.Username,
 				action,

--- a/internal/webhook/promotion/webhook_test.go
+++ b/internal/webhook/promotion/webhook_test.go
@@ -2,9 +2,9 @@ package promotion
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	authzv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
In favor of Go's built-in error wrapping since 1.13 (~2019).

As discussed previously in https://github.com/akuity/kargo/pull/1561#discussion_r1510081840