### PR TITLE
fix(cli): fix bug with output flag

### DIFF
--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -66,6 +66,7 @@ func printObjects[T runtime.Object](
 		if len(list.Items) == 1 {
 			return printer.PrintObj(list.Items[0].Object, streams.Out)
 		}
+		return printer.PrintObj(list, streams.Out)
 	}
 
 	var t T


### PR DESCRIPTION
Noticed that I could only get yaml or json output if only a single object was passed to `printObjects`.

This fixes it.