### PR TITLE
chore: minor endpoint cleanup

### DIFF
--- a/internal/api/delete_project_v1alpha1.go
+++ b/internal/api/delete_project_v1alpha1.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -33,12 +32,6 @@ func (s *server) DeleteProject(
 			},
 		},
 	); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(
-				connect.CodeNotFound,
-				fmt.Errorf("project %q not found", name),
-			)
-		}
 		return nil, fmt.Errorf("delete project: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.DeleteProjectResponse{}), nil

--- a/internal/api/delete_warehouse_v1alpha1.go
+++ b/internal/api/delete_warehouse_v1alpha1.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -30,19 +29,15 @@ func (s *server) DeleteWarehouse(
 		return nil, err
 	}
 
-	var warehouse kargoapi.Warehouse
-	key := client.ObjectKey{
-		Namespace: project,
-		Name:      name,
-	}
-	if err := s.client.Get(ctx, key, &warehouse); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(connect.CodeNotFound,
-				fmt.Errorf("warehouse %q not found", key.String()))
-		}
-		return nil, fmt.Errorf("get warehouse: %w", err)
-	}
-	if err := s.client.Delete(ctx, &warehouse); err != nil && !kubeerr.IsNotFound(err) {
+	if err := s.client.Delete(
+		ctx,
+		&kargoapi.Warehouse{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: project,
+				Name:      name,
+			},
+		},
+	); err != nil {
 		return nil, fmt.Errorf("delete warehouse: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.DeleteWarehouseResponse{}), nil

--- a/internal/api/get_project_v1alpha1.go
+++ b/internal/api/get_project_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -28,9 +27,6 @@ func (s *server) GetProject(
 		},
 		&project,
 	); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
 		return nil, fmt.Errorf("get project: %w", err)
 	}
 

--- a/internal/api/get_promotion_v1alpha1.go
+++ b/internal/api/get_promotion_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -35,10 +34,6 @@ func (s *server) GetPromotion(
 		Namespace: project,
 		Name:      name,
 	}, &promotion); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(connect.CodeNotFound,
-				fmt.Errorf("promotion %q not found", name))
-		}
 		return nil, fmt.Errorf("get promotion: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetPromotionResponse{

--- a/internal/api/get_stage_v1alpha1.go
+++ b/internal/api/get_stage_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -35,9 +34,6 @@ func (s *server) GetStage(
 		Namespace: project,
 		Name:      name,
 	}, &stage); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
 		return nil, fmt.Errorf("get stage: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetStageResponse{

--- a/internal/api/get_warehouse_v1alpha1.go
+++ b/internal/api/get_warehouse_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -35,9 +34,6 @@ func (s *server) GetWarehouse(
 		Namespace: project,
 		Name:      name,
 	}, &warehouse); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
 		return nil, fmt.Errorf("get warehouse: %w", err)
 	}
 	return connect.NewResponse(&svcv1alpha1.GetWarehouseResponse{

--- a/internal/api/watch_promotion_v1alpha1.go
+++ b/internal/api/watch_promotion_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -39,9 +38,6 @@ func (s *server) WatchPromotion(
 		Namespace: project,
 		Name:      name,
 	}, &kargoapi.Promotion{}); err != nil {
-		if kubeerr.IsNotFound(err) {
-			return connect.NewError(connect.CodeNotFound, err)
-		}
 		return fmt.Errorf("get promotion: %w", err)
 	}
 

--- a/internal/api/watch_promotions_v1alpha1.go
+++ b/internal/api/watch_promotions_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,9 +35,6 @@ func (s *server) WatchPromotions(
 			Namespace: project,
 			Name:      stage,
 		}, &kargoapi.Stage{}); err != nil {
-			if kubeerr.IsNotFound(err) {
-				return connect.NewError(connect.CodeNotFound, err)
-			}
 			return fmt.Errorf("get stage: %w", err)
 		}
 	}

--- a/internal/api/watch_stages_v1alpha1.go
+++ b/internal/api/watch_stages_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -37,9 +36,6 @@ func (s *server) WatchStages(
 			Namespace: project,
 			Name:      name,
 		}, &kargoapi.Stage{}); err != nil {
-			if kubeerr.IsNotFound(err) {
-				return connect.NewError(connect.CodeNotFound, err)
-			}
 			return fmt.Errorf("get stage: %w", err)
 		}
 	}

--- a/internal/api/watch_warehouses_v1alpha1.go
+++ b/internal/api/watch_warehouses_v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -37,9 +36,6 @@ func (s *server) WatchWarehouses(
 			Namespace: project,
 			Name:      name,
 		}, &kargoapi.Warehouse{}); err != nil {
-			if kubeerr.IsNotFound(err) {
-				return connect.NewError(connect.CodeNotFound, err)
-			}
 			return fmt.Errorf("get warehouse: %w", err)
 		}
 	}


### PR DESCRIPTION
Working on resolving merge conflicts in #1566, I noticed some weirdness in existing endpoints.

This PR:

* Removes unnecessary gets before deletes.
* Removes unnecessary wrapping of Kubernetes "not found" errors as connect "not found" errors. Our error interceptor is already smart enough to do that. We don't need to do it explicitly.