### PR TITLE
chore: exclude generated code from coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,11 @@ jobs:
           ${{ runner.os }}-go-
     - name: Run unit tests
       run: make test-unit
+    - name: Remove generated code from report
+      run: |
+        grep -v .pb.go coverage.txt | grep -v zz_generated | grep -v service.connect.go > coverage.tmp
+        rm coverage.txt
+        mv coverage.tmp coverage.txt
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
     - name: Remove generated code from report
       run: |
         grep -v .pb.go coverage.txt | grep -v zz_generated | grep -v service.connect.go > coverage.tmp
-        rm coverage.txt
         mv coverage.tmp coverage.txt
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
Massive amounts of generated code are ruining our coverage numbers.

In fact #1515 reduced us from ~50% to ~20%.

After a bit of research, grep is the most direct way to fix this.
