### PR TITLE
chore: calculate unstable version as X.Y+1.0 instead of X.Y.Z+1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,8 @@ jobs:
       id: unstable-version
       run: |
         set -xue
-        LATEST_VERSION=$(go list -f {{.Version}} -mod=mod -m github.com/akuity/kargo@main | cut -f1 -d'-')
+        # Once Kargo goes to v2, we need to replace github.com/akuity/kargo with github.com/akuity/kargo/v2 on the next line
+        LATEST_VERSION=$(go list -m -versions github.com/akuity/kargo | awk '{print $NF}' | awk -F "." '{print $1"."$2".0"}')
         NEW_VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${LATEST_VERSION}")
         echo "unstable-version=${NEW_VERSION}-unstable-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
     - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       run: |
         set -xue
         LATEST_VERSION=$(go list -f {{.Version}} -mod=mod -m github.com/akuity/kargo@main | cut -f1 -d'-')
-        NEW_VERSION=$(awk 'BEGIN {FS=OFS="."} {$3++; print}' <<< "${LATEST_VERSION}")
+        NEW_VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${LATEST_VERSION}")
         echo "unstable-version=${NEW_VERSION}-unstable-$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Unstable nightly (which is built off of main) is currently being produced as `v0.4.1-unstable-20240313`, even though there is an officially released v0.4.2, v0.4.3. This will bump the Y (in X.Y) rather than current Z in (X.Y.Z).

Here is how it will calculate nightly version after this change:

```
$ LATEST_VERSION=$(go list -m -versions github.com/akuity/kargo | awk '{print $NF}' | awk -F "." '{print $1"."$2".0"}')

$ NEW_VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${LATEST_VERSION}")

$ echo "unstable-version=${NEW_VERSION}-unstable-$(date +'%Y%m%d')"
unstable-version=v0.5.0-unstable-20240313
```
