### PR TITLE
fix(api): print `.name` as stage's current freight

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -111,7 +111,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name=Current Freight,type=string,JSONPath=`.status.currentFreight.id`
+//+kubebuilder:printcolumn:name=Current Freight,type=string,JSONPath=`.status.currentFreight.name`
 //+kubebuilder:printcolumn:name=Health,type=string,JSONPath=`.status.health.status`
 //+kubebuilder:printcolumn:name=Phase,type=string,JSONPath=`.status.phase`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.currentFreight.id
+    - jsonPath: .status.currentFreight.name
       name: Current Freight
       type: string
     - jsonPath: .status.health.status


### PR DESCRIPTION
Fixes an issue introduced in #1609, after which the "current freight" column for `kubectl get stages` would always be empty.