### PR TITLE
fix(chart): enhance ConfigMap/Secret checksum annotation logic

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -21,8 +21,8 @@ spec:
         {{- include "kargo.labels" . | nindent 8 }}
         {{- include "kargo.api.labels" . | nindent 8 }}
       annotations:
-        configmap/checksum: {{ include (print $.Template.BasePath "/api/configmap.yaml") . | sha256sum }}
-        secret/checksum: {{ include (print $.Template.BasePath "/api/secret.yaml") . | sha256sum }}
+        configmap/checksum: {{ pick ( include (print $.Template.BasePath "/api/configmap.yaml") . | fromYaml ) "data" | toYaml | sha256sum }}
+        secret/checksum: {{ pick ( include (print $.Template.BasePath "/api/secret.yaml") . | fromYaml ) "stringData" | toYaml | sha256sum }}
     spec:
       serviceAccount: kargo-api
       {{- with .Values.api.affinity }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "kargo.labels" . | nindent 8 }}
         {{- include "kargo.controller.labels" . | nindent 8 }}
       annotations:
-        configmap/checksum: {{ include (print $.Template.BasePath "/controller/configmap.yaml") . | sha256sum }}
+        configmap/checksum: {{ pick ( include (print $.Template.BasePath "/controller/configmap.yaml") . | fromYaml ) "data" | toYaml | sha256sum }}
     spec:
       serviceAccount: kargo-controller
       {{- with .Values.controller.affinity }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "kargo.labels" . | nindent 8 }}
         {{- include "kargo.dexServer.labels" . | nindent 8 }}
       annotations:
-        secret/checksum: {{ include (print $.Template.BasePath "/dex-server/secret.yaml") . | sha256sum }}
+        secret/checksum: {{ pick ( include (print $.Template.BasePath "/dex-server/secret.yaml") . | fromYaml ) "stringData" | toYaml | sha256sum }}
     spec:
       serviceAccount: kargo-dex-server
       {{- with .Values.api.oidc.dex.affinity }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "kargo.labels" . | nindent 8 }}
         {{- include "kargo.garbageCollector.labels" . | nindent 8 }}
       annotations:
-        configmap/checksum: {{ include (print $.Template.BasePath "/garbage-collector/configmap.yaml") . | sha256sum }}
+        configmap/checksum: {{ pick ( include (print $.Template.BasePath "/garbage-collector/configmap.yaml") . | fromYaml ) "data" | toYaml | sha256sum }}
     spec:
       template:
         spec:

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "kargo.selectorLabels" . | nindent 8 }}
         {{- include "kargo.managementController.labels" . | nindent 8 }}
       annotations:
-        configmap/checksum: {{ include (print $.Template.BasePath "/management-controller/configmap.yaml") . | sha256sum }}
+        configmap/checksum: {{ pick ( include (print $.Template.BasePath "/management-controller/configmap.yaml") . | fromYaml ) "data" | toYaml | sha256sum }}
     spec:
       serviceAccount: kargo-management-controller
       {{- with .Values.managementController.affinity }}

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "kargo.labels" . | nindent 8 }}
         {{- include "kargo.webhooksServer.labels" . | nindent 8 }}
       annotations:
-        configmap/checksum: {{ include (print $.Template.BasePath "/webhooks-server/configmap.yaml") . | sha256sum }}
+        configmap/checksum: {{ pick ( include (print $.Template.BasePath "/webhooks-server/configmap.yaml") . | fromYaml ) "data" | toYaml | sha256sum }}
     spec:
       serviceAccount: kargo-webhooks-server
       {{- with .Values.webhooksServer.affinity }}


### PR DESCRIPTION
Fixes: #1617 

By picking only the `data` or `stringData` subset for the respective ConfigMap or Secret to calculate the checksum. Ensuring only actual value changes update the annotation value.