### PR TITLE
feat(controller): capture warehouse field in freight references

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -319,10 +319,11 @@ func (r *reconciler) promote(
 	}
 
 	targetFreightRef := kargoapi.FreightReference{
-		Name:    targetFreight.Name,
-		Commits: targetFreight.Commits,
-		Images:  targetFreight.Images,
-		Charts:  targetFreight.Charts,
+		Name:      targetFreight.Name,
+		Commits:   targetFreight.Commits,
+		Images:    targetFreight.Images,
+		Charts:    targetFreight.Charts,
+		Warehouse: targetFreight.Warehouse,
 	}
 
 	err = kubeclient.PatchStatus(ctx, r.kargoClient, stage, func(status *kargoapi.StageStatus) {


### PR DESCRIPTION
This probably should have been included in #1615.

There's no technical harm in this information not being included in `CurrentFreight` and `History`, but I feel better seeing it.