### PR TITLE
fix(chart): add permissions for k8s generic gc to "promote"

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -158,6 +158,8 @@ k8s_resource(
     'kargo-webhooks-server:clusterrole',
     'kargo-webhooks-server:clusterrolebinding',
     'kargo-webhooks-server:configmap',
+    'kargo-webhooks-server-generic-gc:clusterrole',
+    'kargo-webhooks-server-generic-gc:clusterrolebinding',
     'kargo-webhooks-server:serviceaccount',
     'kargo-webhooks-server-ns-controller:clusterrole',
     'kargo-webhooks-server-ns-controller:clusterrolebinding'

--- a/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role-binding.yaml
@@ -30,4 +30,20 @@ subjects:
 - kind: ServiceAccount
   namespace: kube-system
   name: namespace-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kargo-webhooks-server-generic-gc
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-webhooks-server-generic-gc
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: generic-garbage-collector
 {{- end }}

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -72,4 +72,25 @@ rules:
   - stages
   verbs:
   - promote
+---
+# This cluster role is custom for the generic garbage collector. It will not
+# actually be able to carry our promotions because it lacks permission to create
+# Promotion resources, but having the custom promote verb on Stages allows it to
+# delete Promotion resources associated with any Stage when the Stage is
+# deleted. Without this, the webhook would prevent that and Stage deletions
+# would not cascade to related Promotions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kargo-webhooks-server-generic-gc
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.webhooksServer.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - kargo.akuity.io
+  resources:
+  - stages
+  verbs:
+  - promote
 {{- end }}


### PR DESCRIPTION
This fix gives permission to "promote" (not really) to the Kubernetes generic garbage collector, which needs the permission for the same reason the namespace controller always has. See comments in the chart for further explanation.

This will allow deletion of a Stage to properly cascade to the Promotions it owns -- which was not happening before. This _may_ be a factor in some issues that @gdsoumya has reported to me offline that occur when managing Kargo Projects via Argo CD.