### PR TITLE
refactor: add finalizer to stages in controller instead of webhook

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -533,10 +533,17 @@ func (r *reconciler) Reconcile(
 				err = fmt.Errorf("error removing finalizer: %w", err)
 			}
 		}
-	} else if stage.Spec.PromotionMechanisms == nil {
-		newStatus, err = r.syncControlFlowStage(ctx, stage)
 	} else {
-		newStatus, err = r.syncNormalStage(ctx, stage)
+		err = kargoapi.AddFinalizer(ctx, r.kargoClient, stage)
+		if err != nil {
+			newStatus = stage.Status
+		} else {
+			if stage.Spec.PromotionMechanisms == nil {
+				newStatus, err = r.syncControlFlowStage(ctx, stage)
+			} else {
+				newStatus, err = r.syncNormalStage(ctx, stage)
+			}
+		}
 	}
 	if err != nil {
 		newStatus.Message = err.Error()

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -61,7 +59,7 @@ func newWebhook(kubeClient client.Client) *webhook {
 	return w
 }
 
-func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
+func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
 	stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
 
 	// Sync the convenience shard field with the shard label
@@ -72,19 +70,6 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 		stage.Labels[kargoapi.ShardLabelKey] = stage.Spec.Shard
 	} else if stage.Labels[kargoapi.ShardLabelKey] != "" {
 		stage.Spec.Shard = stage.Labels[kargoapi.ShardLabelKey]
-	}
-
-	req, err := admission.RequestFromContext(ctx)
-	if err != nil {
-		return apierrors.NewInternalError(
-			fmt.Errorf("error getting admission request from context: %w", err),
-		)
-	}
-
-	// Determine if this is a create or update. We don't want to add a finalizer
-	// during update, because that would make it impossible to remove!
-	if req.Operation == admissionv1.Create {
-		controllerutil.AddFinalizer(stage, kargoapi.FinalizerName)
 	}
 
 	return nil

--- a/internal/webhook/stage/webhook_test.go
+++ b/internal/webhook/stage/webhook_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -76,34 +75,6 @@ func TestDefault(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, testShardName, stage.Labels[kargoapi.ShardLabelKey])
 				require.Equal(t, testShardName, stage.Spec.Shard)
-			},
-		},
-		{
-			name:      "finalizer gets added on create",
-			operation: admissionv1.Create,
-			stage: &kargoapi.Stage{
-				Spec: &kargoapi.StageSpec{},
-			},
-			assertions: func(t *testing.T, stage *kargoapi.Stage, err error) {
-				require.NoError(t, err)
-				require.True(
-					t,
-					controllerutil.ContainsFinalizer(stage, kargoapi.FinalizerName),
-				)
-			},
-		},
-		{
-			name:      "finalizer does not get added on update",
-			operation: admissionv1.Update,
-			stage: &kargoapi.Stage{
-				Spec: &kargoapi.StageSpec{},
-			},
-			assertions: func(t *testing.T, stage *kargoapi.Stage, err error) {
-				require.NoError(t, err)
-				require.False(
-					t,
-					controllerutil.ContainsFinalizer(stage, kargoapi.FinalizerName),
-				)
 			},
 		},
 	}


### PR DESCRIPTION
@gdsoumya had a discussion offline and decided this was preferable because it means the finalizer only ever gets added to Stages if the controller is actually running...

This makes it easier to delete Stages that have never been reconciled.