### PR TITLE
fix(api): improve error handling in create/update/apply resource endpoints

### DIFF
--- a/internal/api/create_or_update_resource_v1alpha1.go
+++ b/internal/api/create_or_update_resource_v1alpha1.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigyaml "sigs.k8s.io/yaml"
 
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -22,14 +22,18 @@ func (s *server) CreateOrUpdateResource(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parse manifest: %w", err))
 	}
 	resources := append(projects, otherResources...)
-	res := make([]*svcv1alpha1.CreateOrUpdateResourceResult, 0, len(resources))
+	results := make([]*svcv1alpha1.CreateOrUpdateResourceResult, 0, len(resources))
 	for _, r := range resources {
 		resource := r // Avoid implicit memory aliasing
-		res = append(res, s.createOrUpdateResource(ctx, &resource))
+		result, err := s.createOrUpdateResource(ctx, &resource)
+		if err != nil && len(resources) == 1 {
+			return nil, err
+		}
+		results = append(results, result)
 	}
 	return &connect.Response[svcv1alpha1.CreateOrUpdateResourceResponse]{
 		Msg: &svcv1alpha1.CreateOrUpdateResourceResponse{
-			Results: res,
+			Results: results,
 		},
 	}, nil
 }
@@ -37,45 +41,69 @@ func (s *server) CreateOrUpdateResource(
 func (s *server) createOrUpdateResource(
 	ctx context.Context,
 	obj *unstructured.Unstructured,
-) *svcv1alpha1.CreateOrUpdateResourceResult {
-	if err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), obj.DeepCopy()); err != nil {
-		if kubeerr.IsNotFound(err) {
-			// Create if resource not found
-			switch res := s.createResource(ctx, obj).Result.(type) {
-			case *svcv1alpha1.CreateResourceResult_CreatedResourceManifest:
-				return &svcv1alpha1.CreateOrUpdateResourceResult{
-					Result: &svcv1alpha1.CreateOrUpdateResourceResult_CreatedResourceManifest{
-						CreatedResourceManifest: res.CreatedResourceManifest,
-					},
-				}
-			case *svcv1alpha1.CreateResourceResult_Error:
-				return newCreateOrUpdateResourceResultError(errors.New(res.Error))
-			default:
-				return newCreateOrUpdateResourceResultError(fmt.Errorf("unknown result type %T", res))
-			}
+) (*svcv1alpha1.CreateOrUpdateResourceResult, error) {
+	// Note: It would be tempting to blindly attempt creating the resource and
+	// then update it instead if it already exists, but many resource types have
+	// defaulting and/or validating webhooks and what we do not want is for some
+	// error from a webhook to obscure the fact that the resource already exists.
+	// So we'll explicitly check if the resource exists and then decide whether to
+	// create or update it.
+	existingObj := obj.DeepCopy()
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), existingObj); err != nil {
+		if !kubeerr.IsNotFound(err) {
+			return &svcv1alpha1.CreateOrUpdateResourceResult{
+				Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
+					Error: fmt.Errorf("get resource: %w", err).Error(),
+				},
+			}, err
 		}
-		return newCreateOrUpdateResourceResultError(err)
+		existingObj = nil
 	}
 
-	// Update if resource found
-	switch res := s.updateResource(ctx, obj).Result.(type) {
-	case *svcv1alpha1.UpdateResourceResult_UpdatedResourceManifest:
+	if existingObj == nil { // Create the resource
+		if err := s.client.Create(ctx, obj); err != nil {
+			return &svcv1alpha1.CreateOrUpdateResourceResult{
+				Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
+					Error: fmt.Errorf("create resource: %w", err).Error(),
+				},
+			}, err
+		}
+		createdManifest, err := sigyaml.Marshal(obj)
+		if err != nil {
+			return &svcv1alpha1.CreateOrUpdateResourceResult{
+				Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
+					Error: fmt.Errorf("marshal created manifest: %w", err).Error(),
+				},
+			}, err
+		}
 		return &svcv1alpha1.CreateOrUpdateResourceResult{
-			Result: &svcv1alpha1.CreateOrUpdateResourceResult_UpdatedResourceManifest{
-				UpdatedResourceManifest: res.UpdatedResourceManifest,
+			Result: &svcv1alpha1.CreateOrUpdateResourceResult_CreatedResourceManifest{
+				CreatedResourceManifest: createdManifest,
 			},
-		}
-	case *svcv1alpha1.UpdateResourceResult_Error:
-		return newCreateOrUpdateResourceResultError(errors.New(res.Error))
-	default:
-		return newCreateOrUpdateResourceResultError(fmt.Errorf("unknown result type %T", res))
+		}, nil
 	}
-}
 
-func newCreateOrUpdateResourceResultError(err error) *svcv1alpha1.CreateOrUpdateResourceResult {
-	return &svcv1alpha1.CreateOrUpdateResourceResult{
-		Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
-			Error: fmt.Errorf("create or update resource: %w", err).Error(),
-		},
+	// If we get to here, the resource already exists, so we can update it.
+
+	obj.SetResourceVersion(existingObj.GetResourceVersion())
+	if err := s.client.Update(ctx, obj); err != nil {
+		return &svcv1alpha1.CreateOrUpdateResourceResult{
+			Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
+				Error: fmt.Errorf("update resource: %w", err).Error(),
+			},
+		}, err
 	}
+	updatedManifest, err := sigyaml.Marshal(obj)
+	if err != nil {
+		return &svcv1alpha1.CreateOrUpdateResourceResult{
+			Result: &svcv1alpha1.CreateOrUpdateResourceResult_Error{
+				Error: fmt.Errorf("marshal updated manifest: %w", err).Error(),
+			},
+		}, err
+	}
+	return &svcv1alpha1.CreateOrUpdateResourceResult{
+		Result: &svcv1alpha1.CreateOrUpdateResourceResult_UpdatedResourceManifest{
+			UpdatedResourceManifest: updatedManifest,
+		},
+	}, nil
 }

--- a/internal/api/create_resource_v1alpha1.go
+++ b/internal/api/create_resource_v1alpha1.go
@@ -3,9 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"connectrpc.com/connect"
+	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigyaml "sigs.k8s.io/yaml"
 
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -20,14 +24,18 @@ func (s *server) CreateResource(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parse manifest: %w", err))
 	}
 	resources := append(projects, otherResources...)
-	res := make([]*svcv1alpha1.CreateResourceResult, 0, len(resources))
+	results := make([]*svcv1alpha1.CreateResourceResult, 0, len(resources))
 	for _, r := range resources {
 		resource := r // Avoid implicit memory aliasing
-		res = append(res, s.createResource(ctx, &resource))
+		result, err := s.createResource(ctx, &resource)
+		if err != nil && len(resources) == 1 {
+			return nil, err
+		}
+		results = append(results, result)
 	}
 	return &connect.Response[svcv1alpha1.CreateResourceResponse]{
 		Msg: &svcv1alpha1.CreateResourceResponse{
-			Results: res,
+			Results: results,
 		},
 	}, nil
 }
@@ -35,26 +43,58 @@ func (s *server) CreateResource(
 func (s *server) createResource(
 	ctx context.Context,
 	obj *unstructured.Unstructured,
-) *svcv1alpha1.CreateResourceResult {
-	if err := s.client.Create(ctx, obj); err != nil {
+) (*svcv1alpha1.CreateResourceResult, error) {
+	// Note: We don't blindly attempt creating the resource because many resource
+	// types have defaulting and/or validating webhooks and what we do not want is
+	// for some error from a webhook to obscure the fact that the resource already
+	// exists.
+	existingObj := obj.DeepCopy()
+	err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), existingObj)
+	if err == nil {
+		// Whoops! This resource already exists. Make the error look just like we'd
+		// gotten it from directly calling s.client.Create.
+		err := kubeerr.NewAlreadyExists(
+			schema.GroupResource{
+				Group:    existingObj.GetObjectKind().GroupVersionKind().Group,
+				Resource: strings.ToLower(existingObj.GetKind()),
+			},
+			existingObj.GetName(),
+		)
 		return &svcv1alpha1.CreateResourceResult{
 			Result: &svcv1alpha1.CreateResourceResult_Error{
 				Error: fmt.Errorf("create resource: %w", err).Error(),
 			},
-		}
+		}, err
+	}
+	if !kubeerr.IsNotFound(err) {
+		return &svcv1alpha1.CreateResourceResult{
+			Result: &svcv1alpha1.CreateResourceResult_Error{
+				Error: fmt.Errorf("get resource: %w", err).Error(),
+			},
+		}, err
 	}
 
+	// If we get to here, the resource does not already exists, so we can create
+	// it.
+
+	if err = s.client.Create(ctx, obj); err != nil {
+		return &svcv1alpha1.CreateResourceResult{
+			Result: &svcv1alpha1.CreateResourceResult_Error{
+				Error: fmt.Errorf("create resource: %w", err).Error(),
+			},
+		}, err
+	}
 	createdManifest, err := sigyaml.Marshal(obj)
 	if err != nil {
 		return &svcv1alpha1.CreateResourceResult{
 			Result: &svcv1alpha1.CreateResourceResult_Error{
 				Error: fmt.Errorf("marshal created manifest: %w", err).Error(),
 			},
-		}
+		}, err
 	}
 	return &svcv1alpha1.CreateResourceResult{
 		Result: &svcv1alpha1.CreateResourceResult_CreatedResourceManifest{
 			CreatedResourceManifest: createdManifest,
 		},
-	}
+	}, nil
 }


### PR DESCRIPTION
Fixes #1648 

The create, update, and "create or update" endpoints tend to always return results that appear error-free unless closely inspected. This is because each line item in the response indicates success or failure for a single resource.

I'm a little iffy on what status code we should be returning for a request where creates or updates succeeded and others failed -- and we can debate that separately.

What this PR does is revamps the error-handling so that _at least_ in the case of a _single_ resource being created/updated, when an issue is encountered creating/updating that one resource, the issue with that one create/update will dictate the return code for the entire request.

This PR also updates the create process to explicitly check for existence before creating or updating using a get.

It would be tempting to just _do_ a create and let it fail if the resource exists, or just _do_ the update and let it fail if the resource does _not_ exist, but given that several of our resource types have defaulting and/or mutating webhooks, an attempt to create a resource that already exists or update a resource that doesn't exist could have those more serious problems obscured by comparatively less serious issues found by the webhooks.

