### PR TITLE
feat(verification): improve transient error handling

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -738,6 +738,12 @@ type VerificationInfo struct {
 	AnalysisRun *AnalysisRunReference `json:"analysisRun,omitempty" protobuf:"bytes,3,opt,name=analysisRun"`
 }
 
+// HasAnalysisRun returns a bool indicating whether the VerificationInfo has an
+// associated AnalysisRun.
+func (v *VerificationInfo) HasAnalysisRun() bool {
+	return v != nil && v.AnalysisRun != nil
+}
+
 type VerificationInfoStack []VerificationInfo
 
 // UpdateOrPush updates the VerificationInfo with the same ID as the provided

--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVerificationInfo_HasAnalysisRun(t *testing.T) {
+	testCases := []struct {
+		name           string
+		info           *VerificationInfo
+		expectedResult bool
+	}{
+		{
+			name:           "VerificationInfo is nil",
+			info:           nil,
+			expectedResult: false,
+		},
+		{
+			name:           "AnalysisRun is nil",
+			info:           &VerificationInfo{},
+			expectedResult: false,
+		},
+		{
+			name: "AnalysisRun is not nil",
+			info: &VerificationInfo{
+				AnalysisRun: &AnalysisRunReference{},
+			},
+			expectedResult: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expectedResult, testCase.info.HasAnalysisRun())
+		})
+	}
+}
+
 func TestFreightReferenceStackUpdateOrPush(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/internal/kubeclient/errors.go
+++ b/internal/kubeclient/errors.go
@@ -1,0 +1,14 @@
+package kubeclient
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// IgnoreInvalid returns nil on Invalid errors.
+// All other values that are not Invalid errors or nil are returned unmodified.
+func IgnoreInvalid(err error) error {
+	if errors.IsInvalid(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/kubeclient/errors_test.go
+++ b/internal/kubeclient/errors_test.go
@@ -1,0 +1,49 @@
+package kubeclient
+
+import (
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestIgnoreInvalid(t *testing.T) {
+	testCases := []struct {
+		name    string
+		err     error
+		wantErr bool
+	}{
+		{
+			name:    "nil",
+			err:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "arbitrary error",
+			err:     errors.New("not invalid"),
+			wantErr: true,
+		},
+		{
+			name: "invalid",
+			err: apierrors.NewInvalid(
+				schema.GroupKind{
+					Group: kargoapi.GroupVersion.Group,
+					Kind:  "Freight",
+				},
+				"freight",
+				nil,
+			),
+			wantErr: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := IgnoreInvalid(testCase.err); (err != nil) != testCase.wantErr {
+				t.Errorf("IgnoreInvalid() error = %v, wantErr %v", err, testCase.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses (part of) #1640

This improves the handling of transient Kubernetes API errors which may occur during the verification step of a Stage's current Freight.

It does this by selectively returning errors which should be retried, causing the reconciler to not leave the `Verifying` phase and allowing it to retry the action it performed on the next reconciliation attempt.

To allow the reconciler to distinguish a creation error from a failed attempt to retrieve results, closer inspection is performed on the existence of an `AnalysisRun` reference in the `VerificationInfo`.