### PR TITLE
chore(docs): update documentation for v0.5.0

### DIFF
--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -170,7 +170,7 @@ For each `Stage`, the Kargo controller will periodically check for `Freight`
 resources that are newly qualified for promotion to that `Stage`.
 
 For any `Stage` subscribed directly to a `Warehouse`, _any_ new `Freight`
-resource from that `Warehouse` is tacitly consider to have been _verified_
+resource from that `Warehouse` is tacitly considered to have been _verified_
 upstream, and is therefore immediately qualified for promotion to such a
 `Stage`.
 
@@ -404,7 +404,7 @@ A `Stage` resource's `status` field records:
 * History of `Freight` that has been deployed to the `Stage`. (From most to
   least recent.)
 
-* The health status any any associated Argo CD `Application` resources.
+* The health status of any associated Argo CD `Application` resources.
 
 * The status of any in-progress of completed verification processes.
 
@@ -414,18 +414,27 @@ For example:
 status:
   phase: Steady
   currentFreight:
-    id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
     images:
     - repoURL: nginx
       tag: 1.25.3
     commits:
     - repoURL: https://github.com/example/kargo-demo.git
       id: 1234abc
-    verificationResult:
+    name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
+    verificationInfo:
       analysisRun:
         namespace: kargo-demo
         name: test.ab85b188-0ad5-43d9-a36d-ddcf63666183.47b33c0
         phase: Successful
+      id: 69219d8d-cf5e-414e-8ee9-7d3e3a7c3f15
+      phase: Successful
+    verificationHistory:
+    - analysisRun:
+        namespace: kargo-demo
+        name: test.ab85b188-0ad5-43d9-a36d-ddcf63666183.47b33c0
+        phase: Successful
+      id: 69219d8d-cf5e-414e-8ee9-7d3e3a7c3f15
+      phase: Successful
   health:
     argoCDApps:
     - healthStatus:
@@ -437,18 +446,21 @@ status:
         status: Synced
     status: Healthy
   history:
-  - id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
-    images:
-    - repoURL: nginx
-      tag: 1.25.3
-    commits:
+  - commits:
     - repoURL: https://github.com/example/kargo-demo.git
       id: 1234abc
-    verificationResult:
+    images:
+      - repoURL: nginx
+        tag: 1.25.3
+    name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
+    warehouse: my-warehouse
+    verificationInfo:
       analysisRun:
         namespace: kargo-demo
         name: test.ab85b188-0ad5-43d9-a36d-ddcf63666183.47b33c0
         phase: Successful
+      id: 69219d8d-cf5e-414e-8ee9-7d3e3a7c3f15
+      phase: Successful
 ```
 
 ### `Freight` Resources
@@ -464,11 +476,16 @@ A single `Freight` resource references one or more versioned artifacts, such as:
 
 * Helm charts (from chart repositories)
 
-A `Freight` resource's `id` field _and_ `metadata.name` field are both (for now)
-set to the same value, which is a SHA1 hash of a canonical representation of the
-artifacts referenced by the `Freight` resource. (This is enforced by an
-admission webhook.) The `id` and `metadata.name` fields, therefore, are both
-"fingerprints," deterministically derived from the `Freight`'s contents.
+A `Freight` resource's `metadata.name` field is a SHA1 hash of a canonical
+representation of the artifacts referenced by the `Freight` resource. (This is
+enforced by an admission webhook.) The `metadata.name` field is therefore a
+"fingerprint", deterministically derived from the `Freight`'s contents.
+
+To provide a human-readable identifier for a `Freight` resource, a `Freight`
+resource has an `alias` field and `kargo.akuity.io/alias` label. This alias is
+a human-readable string that is unique within the `Project` to which the
+`Freight` belongs. While it can be set manually (and changed), by default,
+Kargo will automatically generate a unique alias for each `Freight` resource.
 
 A `Freight` resource's `status` field records a list of `Stage` resources in
 which the `Freight` has been _verified_ and a separate list of `Stage` resources
@@ -482,13 +499,16 @@ kind: Freight
 metadata:
   name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
   namespace: kargo-demo
-id: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
+  labels:
+    kargo.akuity.io/alias: fruitful-ferret
+alias: fruitful-ferret
 images:
 - repoURL: nginx
   tag: 1.25.3
 commits:
 - repoURL: https://github.com/example/kargo-demo.git
   id: 1234abc
+warehouse: my-warehouse
 status:
   verifiedIn:
     test: {}

--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -487,6 +487,12 @@ a human-readable string that is unique within the `Project` to which the
 `Freight` belongs. While it can be set manually (and changed), by default,
 Kargo will automatically generate a unique alias for each `Freight` resource.
 
+:::note
+For more information on aliases, refer to the [aliases](./30-how-to-guides/15-working-with-freight.md#aliases)
+and [updating aliases](./30-how-to-guides/15-working-with-freight.md#updating-aliases)
+sections of the "Working with Freight" how-to guide.
+:::
+
 A `Freight` resource's `status` field records a list of `Stage` resources in
 which the `Freight` has been _verified_ and a separate list of `Stage` resources
 for which the `Freight` has been manually _approved_.

--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -447,7 +447,7 @@ the previous section.
     Sample output:
 
     ```shell
-    NAME/ID                                    ALIAS              AGE
+    NAME                                       ALIAS              AGE
     f5f87aa23c9e97f43eb83dd63768ee41f5ba3766   mortal-dragonfly   35s
     ```
     :::info

--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -98,10 +98,9 @@ over its alias.
 :::
 
 :::note
-Some, but not all, Kargo CLI commands will accept `Freight` aliases as an
-alternative to `Freights` IDs.
-
-Eventually, all Kargo CLI commands will accept aliases as an alternative.
+Kargo CLI commands will accept `Freight` aliases as an alternative to a
+`Freight` name. Refer to the help text for the `kargo` command for more
+information.
 :::
 
 ### Updating Aliases

--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -25,38 +25,21 @@ visit the [concepts doc](../concepts).
 The remainder of this page describes features of freight that will enabled you
 to work more effectively.
 
-## IDs
+## Names
 
 Like all Kubernetes resources, Kargo `Freight` resources have a `metadata.name`
 field, which uniquely identifies each resource of that type within a given Kargo
 project (a specially labeled Kubernetes namespace). When a `Warehouse` produces
 a new `Freight` resource, it will compute a canonical representation of the
 artifacts referenced by that resource and use that, in turn, to compute a SHA-1
-hash. This becomes the value of both the resources's `metadata.name` _and_ `id`
-fields. The deterministic method of computing this value makes it a unique
-"fingerprint" of the collection of artifacts referenced by the `Freight`
-resource.
-
-:::info
-Why include the same information in two different fields?
-
-The Kargo team anticipates the possibility of someday permitting users to
-manually create their own `Freight` resources -- i.e. `Freight` resources not
-created by a `Warehouse`. In such a scenario, the value of the `metadata.name`
-field would be user-defined and would not be guaranteed to reflect the artifacts
-referenced by the resource.
-
-Because Kargo utilizes a
-[mutating admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook)
-to ensure that the value of the `id` field is _always_ set correctly, Kargo can
-rely on the value of that field to _always_ reflect the artifacts referenced by
-the resource, even when the `metadata.name` field does not.
-:::
+hash. This becomes the value of the `metadata.name` field. The deterministic
+method of computing this value makes it a unique "fingerprint" of the
+collection of artifacts referenced by the `Freight` resource.
 
 ## Aliases
 
-While the `id` field (and `metadata.name` field, for now) contain predictably
-computed SHA-1 hashes, such identifiers are, unarguably, not very user-friendly.
+While the `metadata.name` field contains a predictably computed SHA-1 hash,
+such identifiers are, unarguably, not very user-friendly.
 To make `Freight` resources easier for human users to identify, `Warehouse`s
 automatically generate a human-friendly alias for every `Freight` resource they
 produce and apply it as the value of the `Freight` resource's
@@ -73,12 +56,12 @@ by users.
 Why a label?
 
 Kubernetes enforces the immutability of the `metadata.name` field for all
-resources and a Kargo webhook enforces the immutability of the `id` field.
+resources.
 
 Kubernetes
 [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/),
-by contrast, are both mutable and indexed, which which makes them ideal for use
-as secondary identifiers.
+by contrast, are both mutable and indexed, which makes them ideal for use as
+secondary identifiers.
 :::
 
 When using the Kargo CLI to query for `Freight` resources, the `alias` field is
@@ -91,7 +74,7 @@ kargo get freight --project kargo-demo
 Sample output:
 
 ```shell
-NAME/ID                                    ALIAS              AGE
+NAME                                       ALIAS              AGE
 f5f87aa23c9e97f43eb83dd63768ee41f5ba3766   mortal-dragonfly   35s
 ```
 
@@ -110,12 +93,12 @@ f5f87aa23c9e97f43eb83dd63768ee41f5ba3766   mortal-dragonfly   35s
 
 :::info
 The Kargo UI, to make efficient use of screen real estate, displays aliases
-only, but a `Freight` resource's `id` can always be discovered by hovering over
-its alias.
+only, but a `Freight` resource's `name` can always be discovered by hovering
+over its alias.
 :::
 
 :::note
-Some, but not all, Kargo CLI commands will accepts `Freight` aliases as an
+Some, but not all, Kargo CLI commands will accept `Freight` aliases as an
 alternative to `Freights` IDs.
 
 Eventually, all Kargo CLI commands will accept aliases as an alternative.

--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -120,7 +120,21 @@ kargo update freight \
 ```
 
 This can also be accomplished via `kubectl` commands `apply`, `edit`, `patch`,
-etc.
+etc. by updating the `alias` field of the `Freight` resource.
+
+:::info
+The `alias` field is a convenient way to update the `Freight` resource's
+`kargo.akuity.io/alias` label, which causes a webhook to sync the field value
+to the label value. The precedence rules for syncing between the field and
+label values are as follows:
+
+- If the field has a non-empty value, the label will assume the field's value.
+- If the field has an empty value, the field will assume the label's value.
+  value.
+
+It's worth noting that removing an alias entirely requires clearing both the
+field and label values, but this is expected to be a rare occurrence.
+:::
 
 ## Manual Approvals
 

--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -130,7 +130,6 @@ label values are as follows:
 
 - If the field has a non-empty value, the label will assume the field's value.
 - If the field has an empty value, the field will assume the label's value.
-  value.
 
 It's worth noting that removing an alias entirely requires clearing both the
 field and label values, but this is expected to be a rare occurrence.


### PR DESCRIPTION
~~Fixes:~~ Partly addresses: #1656

- Remove mentions of `id` field for Freight.
- Change `verificationResult` to `verificationInfo`.
- Document newly introduced `verificationHistory` field.
- Document `alias` field and label for Freight.
- Small fixes of things I found along the way.
