### PR TITLE
feat(chart)!: manage CRDs as part of release

### DIFF
--- a/charts/kargo/README.md
+++ b/charts/kargo/README.md
@@ -21,9 +21,10 @@
 
 ### CRDs
 
-| Name           | Description                                                                                                                                   | Value  |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `crds.install` | Indicates if CRDs should be managed as part of the Helm release. If set to `false`, the CRDs are only installed if they do not already exist. | `true` |
+| Name           | Description                                                                                                                                                                        | Value  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `crds.install` | Indicates if Custom Resource Definitions should be installed and upgraded as part of the release. If set to `false`, the CRDs will only be installed if they do not already exist. | `true` |
+| `crds.keep`    | Indicates if Custom Resource Definitions should be kept when a release is uninstalled.                                                                                             | `true` |
 
 ### KubeConfigs
 

--- a/charts/kargo/README.md
+++ b/charts/kargo/README.md
@@ -19,6 +19,12 @@
 | `rbac.installClusterRoles`        | Indicates if `ClusterRoles` should be installed.        | `true` |
 | `rbac.installClusterRoleBindings` | Indicates if `ClusterRoleBindings` should be installed. | `true` |
 
+### CRDs
+
+| Name           | Description                                                                                                                                   | Value  |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `crds.install` | Indicates if CRDs should be managed as part of the Helm release. If set to `false`, the CRDs are only installed if they do not already exist. | `true` |
+
 ### KubeConfigs
 
 Optionally point to Kubernetes Secrets containing kubeconfig for:

--- a/charts/kargo/templates/crds.yaml
+++ b/charts/kargo/templates/crds.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.crds.install -}}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+{{- end }}
+{{- end }}

--- a/charts/kargo/templates/crds.yaml
+++ b/charts/kargo/templates/crds.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.crds.install -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
+{{- $manifest := $.Files.Get $path | fromYaml }}
+{{- if $.Values.crds.keep }}
+{{- $newAnnotations := dict "helm.sh/resource-policy" "keep" | merge $manifest.metadata.annotations }}
+{{- $_ := set $manifest.metadata "annotations" $newAnnotations }}
+{{- end }}
+{{- $manifest | toYaml  }}
+{{- print "\n---\n" }}
 {{- end }}
 {{- end }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -22,6 +22,11 @@ rbac:
   ## @param rbac.installClusterRoleBindings Indicates if `ClusterRoleBindings` should be installed.
   installClusterRoleBindings: true
 
+## @section CRDs
+crds:
+  ## @param crds.install Indicates if CRDs should be managed as part of the Helm release. If set to `false`, the CRDs are only installed if they do not already exist.
+  install: true
+
 ## @section KubeConfigs
 ## @descriptionStart
 ## Optionally point to Kubernetes Secrets containing kubeconfig for:

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -24,8 +24,10 @@ rbac:
 
 ## @section CRDs
 crds:
-  ## @param crds.install Indicates if CRDs should be managed as part of the Helm release. If set to `false`, the CRDs are only installed if they do not already exist.
+  ## @param crds.install Indicates if Custom Resource Definitions should be installed and upgraded as part of the release. If set to `false`, the CRDs will only be installed if they do not already exist.
   install: true
+  ## @param crds.keep Indicates if Custom Resource Definitions should be kept when a release is uninstalled.
+  keep: true
 
 ## @section KubeConfigs
 ## @descriptionStart

--- a/hack/tilt/values.dev.yaml
+++ b/hack/tilt/values.dev.yaml
@@ -21,6 +21,8 @@ api:
         enabled: false
 controller:
   logLevel: DEBUG
+crds:
+  install: false
 managementController:
   logLevel: DEBUG
 webhooksServer:


### PR DESCRIPTION
This introduces a new change to the chart which allows the Custom Resource Definitions to be managed as part of the release, effectively allowing upgrades. Which is not possible with [Helm's built-in Custom Resource Definition management](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds).

The behavior can be opted-out of by setting `crds.create` to `false`, causing them to be excluded from the Helm release manifests which effectively causes a fallback to Helm's default behavior.

With this change, existing installations will have to adopt the Custom Resource Definitions by configuring the following annotations and label on the resources:

```sh
RELEASE=<Helm release name>
NAMESPACE=<Helm release namespace>

for name in $(kubectl get crds -o name | grep kargo.akuity.io); do
   echo "Adopting $name"
   kubectl annotate $name meta.helm.sh/release-name=$RELEASE
   kubectl annotate $name meta.helm.sh/release-namespace=$NAMESPACE
   kubectl label $name app.kubernetes.io/managed-by=Helm
done
```