### PR TITLE
feat: make pr-based promotions work with kargo render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.35 as back-end-dev
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.37 as back-end-dev
 
 USER root
 
@@ -103,7 +103,7 @@ CMD ["pnpm", "dev"]
 # - the official image we publish
 # - purposefully last so that it is the default target when building
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.35 as final
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.37 as final
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.37 as back-end-dev
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.38 as back-end-dev
 
 USER root
 
@@ -103,7 +103,7 @@ CMD ["pnpm", "dev"]
 # - the official image we publish
 # - purposefully last so that it is the default target when building
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.37 as final
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.38 as final
 
 USER root
 

--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -30,6 +30,12 @@ type RepoCredentials struct {
 	Password string `json:"password,omitempty"`
 }
 
+// CommitOptions represents options for committing changes to a git repository.
+type CommitOptions struct {
+	// AllowEmpty indicates whether an empty commit should be allowed.
+	AllowEmpty bool
+}
+
 // Repo is an interface for interacting with a git repository.
 type Repo interface {
 	// AddAll stages pending changes for commit.
@@ -46,7 +52,7 @@ type Repo interface {
 	// Checkout checks out the specified branch.
 	Checkout(branch string) error
 	// Commit commits staged changes to the current branch.
-	Commit(message string) error
+	Commit(message string, opts *CommitOptions) error
 	// CreateChildBranch creates a new branch that is a child of the current
 	// branch.
 	CreateChildBranch(branch string) error
@@ -162,7 +168,7 @@ func (r *repo) AddAllAndCommit(message string) error {
 	if err := r.AddAll(); err != nil {
 		return err
 	}
-	return r.Commit(message)
+	return r.Commit(message, nil)
 }
 
 func (r *repo) Clean() error {
@@ -226,8 +232,16 @@ func (r *repo) Checkout(branch string) error {
 	return nil
 }
 
-func (r *repo) Commit(message string) error {
-	if _, err := libExec.Exec(r.buildCommand("commit", "-m", message)); err != nil {
+func (r *repo) Commit(message string, opts *CommitOptions) error {
+	if opts == nil {
+		opts = &CommitOptions{}
+	}
+	cmdTokens := []string{"commit", "-m", message}
+	if opts.AllowEmpty {
+		cmdTokens = append(cmdTokens, "--allow-empty")
+	}
+
+	if _, err := libExec.Exec(r.buildCommand(cmdTokens...)); err != nil {
 		return fmt.Errorf("error committing changes to branch %q: %w", r.currentBranch, err)
 	}
 	return nil

--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -141,7 +141,7 @@ func Clone(
 	repoCreds RepoCredentials,
 	opts *CloneOptions,
 ) (Repo, error) {
-	homeDir, err := os.MkdirTemp("", "")
+	homeDir, err := os.MkdirTemp("", "repo-")
 	if err != nil {
 		return nil, fmt.Errorf("error creating home directory for repo %q: %w", repoURL, err)
 	}

--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -45,6 +45,7 @@ type gitMechanism struct {
 	applyConfigManagementFn func(
 		update kargoapi.GitRepoUpdate,
 		newFreight kargoapi.FreightReference,
+		sourceCommit string,
 		homeDir string,
 		workingDir string,
 	) ([]string, error)
@@ -61,6 +62,7 @@ func newGitMechanism(
 	applyConfigManagementFn func(
 		update kargoapi.GitRepoUpdate,
 		newFreight kargoapi.FreightReference,
+		sourceCommit string,
 		homeDir string,
 		workingDir string,
 	) ([]string, error),
@@ -294,11 +296,17 @@ func (g *gitMechanism) gitCommit(
 		}
 	}
 
+	sourceCommitID, err := repo.LastCommitID()
+	if err != nil {
+		return "", err // TODO: Wrap this
+	}
+
 	var changes []string
 	if g.applyConfigManagementFn != nil {
 		if changes, err = g.applyConfigManagementFn(
 			update,
 			newFreight,
+			sourceCommitID,
 			repo.HomeDir(),
 			repo.WorkingDir(),
 		); err != nil {

--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -13,6 +13,8 @@ import (
 	"github.com/akuity/kargo/internal/logging"
 )
 
+const tmpPrefix = "repo-scrap-"
+
 // gitMechanism is an implementation of the Mechanism interface that uses Git to
 // update configuration in a repository. It is easily configured to support
 // different types of configuration management tools.
@@ -318,7 +320,7 @@ func (g *gitMechanism) gitCommit(
 	// Sometimes we don't write to the same branch we read from...
 	if readRef != writeBranch {
 		var tempDir string
-		tempDir, err = os.MkdirTemp("", "")
+		tempDir, err = os.MkdirTemp("", tmpPrefix)
 		if err != nil {
 			return "", fmt.Errorf("error creating temp directory for pending changes: %w", err)
 		}

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -470,7 +470,7 @@ func TestMoveRepoContents(t *testing.T) {
 	const subdirCount = 50
 	const fileCount = 50
 	// Create dummy repo dir
-	srcDir, err := createDummyRepoDir(subdirCount, fileCount)
+	srcDir, err := createDummyRepoDir(t, subdirCount, fileCount)
 	defer os.RemoveAll(srcDir)
 	require.NoError(t, err)
 	// Double-check the setup
@@ -478,8 +478,7 @@ func TestMoveRepoContents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dirEntries, subdirCount+fileCount+1)
 	// Create destination dir
-	destDir, err := os.MkdirTemp("", "")
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 	require.NoError(t, err)
 	// Move
 	err = moveRepoContents(srcDir, destDir)
@@ -503,7 +502,7 @@ func TestDeleteRepoContents(t *testing.T) {
 	const subdirCount = 50
 	const fileCount = 50
 	// Create dummy repo dir
-	dir, err := createDummyRepoDir(subdirCount, fileCount)
+	dir, err := createDummyRepoDir(t, subdirCount, fileCount)
 	defer os.RemoveAll(dir)
 	require.NoError(t, err)
 	// Double-check the setup
@@ -584,19 +583,16 @@ func TestBuildCommitMessage(t *testing.T) {
 	}
 }
 
-func createDummyRepoDir(dirCount, fileCount int) (string, error) {
+func createDummyRepoDir(t *testing.T, dirCount, fileCount int) (string, error) {
 	// Create a directory
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return dir, err
-	}
+	dir := t.TempDir()
 	// Add a dummy .git/ subdir
-	if err = os.Mkdir(filepath.Join(dir, ".git"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0755); err != nil {
 		return dir, err
 	}
 	// Add some dummy dirs
 	for i := 0; i < dirCount; i++ {
-		if err = os.Mkdir(
+		if err := os.Mkdir(
 			filepath.Join(dir, fmt.Sprintf("dir-%d", i)),
 			0755,
 		); err != nil {

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -24,7 +24,11 @@ func TestNewGitMechanism(t *testing.T) {
 		func([]kargoapi.GitRepoUpdate) []kargoapi.GitRepoUpdate {
 			return nil
 		},
-		func(kargoapi.GitRepoUpdate, kargoapi.FreightReference, string, string) ([]string, error) {
+		func(
+			kargoapi.GitRepoUpdate,
+			kargoapi.FreightReference,
+			string, string, string,
+		) ([]string, error) {
 			return nil, nil
 		},
 	)

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -471,7 +471,6 @@ func TestMoveRepoContents(t *testing.T) {
 	const fileCount = 50
 	// Create dummy repo dir
 	srcDir, err := createDummyRepoDir(t, subdirCount, fileCount)
-	defer os.RemoveAll(srcDir)
 	require.NoError(t, err)
 	// Double-check the setup
 	dirEntries, err := os.ReadDir(srcDir)

--- a/internal/controller/promotion/helm.go
+++ b/internal/controller/promotion/helm.go
@@ -64,6 +64,7 @@ type helmer struct {
 func (h *helmer) apply(
 	update kargoapi.GitRepoUpdate,
 	newFreight kargoapi.FreightReference,
+	_ string, // TODO: sourceCommit would be a nice addition to the commit message
 	homeDir string,
 	workingDir string,
 ) ([]string, error) {

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -346,7 +346,6 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 func TestBuildChartDependencyChanges(t *testing.T) {
 	// Set up a couple of fake Chart.yaml files
 	testDir := t.TempDir()
-	defer os.RemoveAll(testDir)
 
 	testChartsDir := filepath.Join(testDir, "charts")
 	err := os.Mkdir(testChartsDir, 0755)

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -345,12 +345,11 @@ func TestBuildValuesFilesChanges(t *testing.T) {
 
 func TestBuildChartDependencyChanges(t *testing.T) {
 	// Set up a couple of fake Chart.yaml files
-	testDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 	defer os.RemoveAll(testDir)
 
 	testChartsDir := filepath.Join(testDir, "charts")
-	err = os.Mkdir(testChartsDir, 0755)
+	err := os.Mkdir(testChartsDir, 0755)
 	require.NoError(t, err)
 
 	testFooChartDir := filepath.Join(testChartsDir, "foo")

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -254,6 +254,7 @@ func TestHelmerApply(t *testing.T) {
 				kargoapi.FreightReference{}, // The way the tests are structured, this value doesn't matter
 				"",
 				"",
+				"",
 			)
 			testCase.assertions(t, changes, err)
 		})

--- a/internal/controller/promotion/kustomize.go
+++ b/internal/controller/promotion/kustomize.go
@@ -47,6 +47,7 @@ type kustomizer struct {
 func (k *kustomizer) apply(
 	update kargoapi.GitRepoUpdate,
 	newFreight kargoapi.FreightReference,
+	_ string, // TODO: sourceCommit would be a nice addition to the commit message
 	_ string,
 	workingDir string,
 ) ([]string, error) {

--- a/internal/controller/promotion/kustomize_test.go
+++ b/internal/controller/promotion/kustomize_test.go
@@ -168,6 +168,7 @@ func TestKustomizerApply(t *testing.T) {
 				},
 				"",
 				"",
+				"",
 			)
 			testCase.assertions(t, changes, err)
 		})

--- a/internal/controller/promotion/render.go
+++ b/internal/controller/promotion/render.go
@@ -85,7 +85,7 @@ func (r *renderer) apply(
 
 	sort.StringSlice(images).Sort()
 
-	tempDir, err := os.MkdirTemp("", "")
+	tempDir, err := os.MkdirTemp("", tmpPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("error creating temporary directory: %w", err)
 	}

--- a/internal/controller/promotion/render.go
+++ b/internal/controller/promotion/render.go
@@ -1,136 +1,58 @@
 package promotion
 
 import (
-	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
-	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	render "github.com/akuity/kargo/internal/kargo-render"
-	"github.com/akuity/kargo/internal/logging"
 )
 
-// kargoRenderMechanism is an implementation of the Mechanism interface that
-// uses Kargo Render to update configuration in a Git repository.
-type kargoRenderMechanism struct {
-	// Overridable behaviors:
-	doSingleUpdateFn func(
-		ctx context.Context,
-		promo *kargoapi.Promotion,
-		update kargoapi.GitRepoUpdate,
-		newFreight kargoapi.FreightReference,
-	) (kargoapi.FreightReference, error)
-	getReadRefFn func(
-		update kargoapi.GitRepoUpdate,
-		commits []kargoapi.GitCommit,
-	) (string, int, error)
-	getCredentialsFn func(
-		ctx context.Context,
-		namespace string,
-		credType credentials.Type,
-		repo string,
-	) (credentials.Credentials, bool, error)
-	renderManifestsFn func(render.Request) (render.Response, error)
-}
-
-// newKargoRenderMechanism returns an implementation of the Mechanism interface
-// that uses Kargo Render to update configuration in a Git repository.
+// newKargoRenderMechanism returns a gitMechanism that only only selects and
+// performs updates that involve Kargo Render.
 func newKargoRenderMechanism(
 	credentialsDB credentials.Database,
 ) Mechanism {
-	b := &kargoRenderMechanism{}
-	b.doSingleUpdateFn = b.doSingleUpdate
-	b.getReadRefFn = getReadRef
-	b.getCredentialsFn = credentialsDB.Get
-	// TODO: KR: Refactor this
-	b.renderManifestsFn = render.RenderManifests
-	return b
+	return newGitMechanism(
+		"Kargo Render promotion mechanism",
+		credentialsDB,
+		selectKargoRenderUpdates,
+		(&renderer{
+			renderManifestsFn: render.RenderManifests,
+		}).apply,
+	)
 }
 
-// GetName implements the Mechanism interface.
-func (*kargoRenderMechanism) GetName() string {
-	return "Kargo Render promotion mechanisms"
-}
-
-// Promote implements the Mechanism interface.
-func (b *kargoRenderMechanism) Promote(
-	ctx context.Context,
-	stage *kargoapi.Stage,
-	promo *kargoapi.Promotion,
-	newFreight kargoapi.FreightReference,
-) (*kargoapi.PromotionStatus, kargoapi.FreightReference, error) {
-	updates := make([]kargoapi.GitRepoUpdate, 0, len(stage.Spec.PromotionMechanisms.GitRepoUpdates))
-	for _, update := range stage.Spec.PromotionMechanisms.GitRepoUpdates {
-		if update.Render != nil {
-			updates = append(updates, update)
-		}
-	}
-
-	if len(updates) == 0 {
-		return promo.Status.WithPhase(kargoapi.PromotionPhaseSucceeded), newFreight, nil
-	}
-
-	newFreight = *newFreight.DeepCopy()
-
-	logger := logging.LoggerFromContext(ctx)
-	logger.Debug("executing Kargo Render-based promotion mechanisms")
-
-	for _, update := range updates {
-		var err error
-		if newFreight, err = b.doSingleUpdateFn(
-			ctx,
-			promo,
-			update,
-			newFreight,
-		); err != nil {
-			return nil, newFreight, err
-		}
-	}
-
-	logger.Debug("done executing Kargo Render-based promotion mechanisms")
-
-	return promo.Status.WithPhase(kargoapi.PromotionPhaseSucceeded), newFreight, nil
-}
-
-// doSingleUpdateFn updates configuration in a single Git repository using
+// selectKargoRenderUpdates returns a subset of the given updates that involve
 // Kargo Render.
-func (b *kargoRenderMechanism) doSingleUpdate(
-	ctx context.Context,
-	promo *kargoapi.Promotion,
+func selectKargoRenderUpdates(updates []kargoapi.GitRepoUpdate) []kargoapi.GitRepoUpdate {
+	selectedUpdates := make([]kargoapi.GitRepoUpdate, 0, len(updates))
+	for _, update := range updates {
+		if update.Render != nil {
+			selectedUpdates = append(selectedUpdates, update)
+		}
+	}
+	return selectedUpdates
+}
+
+// renderer is a helper struct whose sole purpose is to close over several
+// other functions that are used in the implementation of the apply() function.
+type renderer struct {
+	renderManifestsFn func(req render.Request) error
+}
+
+// apply uses Kargo Render to carry out the provided update in the specified
+// working directory.
+func (r *renderer) apply(
 	update kargoapi.GitRepoUpdate,
 	newFreight kargoapi.FreightReference,
-) (kargoapi.FreightReference, error) {
-	logger := logging.LoggerFromContext(ctx).WithField("repo", update.RepoURL)
-
-	readRef, commitIndex, err := b.getReadRefFn(update, newFreight.Commits)
-	if err != nil {
-		return newFreight, err
-	}
-
-	creds, ok, err := b.getCredentialsFn(
-		ctx,
-		promo.Namespace,
-		credentials.TypeGit,
-		update.RepoURL,
-	)
-	if err != nil {
-		return newFreight, fmt.Errorf(
-			"error obtaining credentials for git repo %q: %w",
-			update.RepoURL,
-			err,
-		)
-	}
-	repoCreds := git.RepoCredentials{}
-	if ok {
-		repoCreds.Username = creds.Username
-		repoCreds.Password = creds.Password
-		repoCreds.SSHPrivateKey = creds.SSHPrivateKey
-		logger.Debug("obtained credentials for git repo")
-	} else {
-		logger.Debug("found no credentials for git repo")
-	}
-
+	sourceCommit string,
+	_ string,
+	workingDir string,
+) ([]string, error) {
 	images := make([]string, 0, len(newFreight.Images))
 	if len(update.Render.Images) == 0 {
 		// When no explicit image updates are specified, we will pass all images
@@ -161,37 +83,47 @@ func (b *kargoRenderMechanism) doSingleUpdate(
 		}
 	}
 
+	sort.StringSlice(images).Sort()
+
+	tempDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+	writeDir := filepath.Join(tempDir, "rendered-manifests")
+
 	req := render.Request{
-		RepoURL:      update.RepoURL,
-		RepoCreds:    repoCreds,
-		Ref:          readRef,
-		Images:       images,
 		TargetBranch: update.WriteBranch,
+		Images:       images,
+		LocalInPath:  workingDir,
+		LocalOutPath: writeDir,
 	}
 
-	res, err := b.renderManifestsFn(req)
-	if err != nil {
-		return newFreight, fmt.Errorf(
-			"error rendering manifests for git repo %q via Kargo Render: %w",
-			update.RepoURL,
-			err,
+	if err = r.renderManifestsFn(req); err != nil {
+		return nil, fmt.Errorf("error rendering manifests via Kargo Render: %w", err)
+	}
+
+	if err = deleteRepoContents(workingDir); err != nil {
+		return nil,
+			fmt.Errorf("error overwriting working directory with rendered manifests: %w", err)
+	}
+
+	if err = moveRepoContents(writeDir, workingDir); err != nil {
+		return nil,
+			fmt.Errorf("error overwriting working directory with rendered manifests: %w", err)
+	}
+
+	changeSummary := make([]string, 0, len(images)+1)
+	changeSummary = append(
+		changeSummary,
+		fmt.Sprintf("rendered manifests from commit %s", sourceCommit[:7]),
+	)
+	for _, image := range images {
+		changeSummary = append(
+			changeSummary,
+			fmt.Sprintf("updated manifests to use image %s", image),
 		)
 	}
-	switch res.ActionTaken {
-	case render.ActionTakenPushedDirectly:
-		logger.WithField("commit", res.CommitID).
-			Debug("pushed new commit to repo via Kargo Render")
-		if commitIndex > -1 {
-			newFreight.Commits[commitIndex].HealthCheckCommit = res.CommitID
-		}
-	case render.ActionTakenNone:
-		logger.Debug("Kargo Render made no changes to repo")
-		if commitIndex > -1 {
-			newFreight.Commits[commitIndex].HealthCheckCommit = res.CommitID
-		}
-	default:
-		// TODO: Not sure yet how to handle PRs.
-	}
 
-	return newFreight, nil
+	return changeSummary, nil
 }


### PR DESCRIPTION
Fixes #1330

~~Depends on https://github.com/akuity/kargo-render/pull/268~~

This PR:

* Upgrades us to Kargo Render v0.1.0-rc.38, which has three important, new features:
    * Can take input from a local repository instead of a remote repository
    * Can write output to a local path instead of a branch in a remote repository
    * Does not refuse to manage an existing branch that lacks Kargo Render metadata, _as long as the branch is 100% empty_
* Fixes a bug in Kargo's existing PR-based promotions where the base branch is assumed to exist
    * We now create it if it doesn't
* Make Kargo Render promotion mechanism behave much more like the Helm and Kustomize-based ones:
    * Points Kargo Render at the path of the already-cloned repo, which will already be sitting on the desired commit

Taken together, these remove the limitation of Kargo Render and PR-based promotions not working together.