### PR TITLE
always pass credentials to kargo render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.38 as back-end-dev
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.39 as back-end-dev
 
 USER root
 
@@ -103,7 +103,7 @@ CMD ["pnpm", "dev"]
 # - the official image we publish
 # - purposefully last so that it is the default target when building
 ####################################################################################################
-FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.38 as final
+FROM ghcr.io/akuity/kargo-render:v0.1.0-rc.39 as final
 
 USER root
 

--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -43,6 +43,7 @@ type gitMechanism struct {
 		readRef string,
 		writeBranch string,
 		repo git.Repo,
+		repoCreds git.RepoCredentials,
 	) (string, error)
 	applyConfigManagementFn func(
 		update kargoapi.GitRepoUpdate,
@@ -50,6 +51,7 @@ type gitMechanism struct {
 		sourceCommit string,
 		homeDir string,
 		workingDir string,
+		repoCreds git.RepoCredentials,
 	) ([]string, error)
 }
 
@@ -67,6 +69,7 @@ func newGitMechanism(
 		sourceCommit string,
 		homeDir string,
 		workingDir string,
+		repoCreds git.RepoCredentials,
 	) ([]string, error),
 ) Mechanism {
 	g := &gitMechanism{
@@ -182,6 +185,7 @@ func (g *gitMechanism) doSingleUpdate(
 		readRef,
 		commitBranch,
 		repo,
+		*creds,
 	)
 	if err != nil {
 		return nil, newFreight, err
@@ -288,6 +292,7 @@ func (g *gitMechanism) gitCommit(
 	readRef string,
 	writeBranch string,
 	repo git.Repo,
+	repoCreds git.RepoCredentials,
 ) (string, error) {
 	var err error
 	// If readRef is non-empty, check out the specified commit or branch,
@@ -311,6 +316,7 @@ func (g *gitMechanism) gitCommit(
 			sourceCommitID,
 			repo.HomeDir(),
 			repo.WorkingDir(),
+			repoCreds,
 		); err != nil {
 			return "", err
 		}

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -28,6 +28,7 @@ func TestNewGitMechanism(t *testing.T) {
 			kargoapi.GitRepoUpdate,
 			kargoapi.FreightReference,
 			string, string, string,
+			git.RepoCredentials,
 		) ([]string, error) {
 			return nil, nil
 		},
@@ -237,6 +238,7 @@ func TestGitDoSingleUpdate(t *testing.T) {
 					string,
 					string,
 					git.Repo,
+					git.RepoCredentials,
 				) (string, error) {
 					return "", errors.New("something went wrong")
 				},
@@ -275,6 +277,7 @@ func TestGitDoSingleUpdate(t *testing.T) {
 					string,
 					string,
 					git.Repo,
+					git.RepoCredentials,
 				) (string, error) {
 					return "fake-commit-id", nil
 				},

--- a/internal/controller/promotion/helm.go
+++ b/internal/controller/promotion/helm.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/helm"
 	libYAML "github.com/akuity/kargo/internal/yaml"
@@ -67,6 +68,7 @@ func (h *helmer) apply(
 	_ string, // TODO: sourceCommit would be a nice addition to the commit message
 	homeDir string,
 	workingDir string,
+	_ git.RepoCredentials,
 ) ([]string, error) {
 	// Image updates
 	changesByFile, imageChangeSummary :=

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 )
 
@@ -255,6 +256,7 @@ func TestHelmerApply(t *testing.T) {
 				"",
 				"",
 				"",
+				git.RepoCredentials{},
 			)
 			testCase.assertions(t, changes, err)
 		})

--- a/internal/controller/promotion/kustomize.go
+++ b/internal/controller/promotion/kustomize.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/kustomize"
 )
@@ -50,6 +51,7 @@ func (k *kustomizer) apply(
 	_ string, // TODO: sourceCommit would be a nice addition to the commit message
 	_ string,
 	workingDir string,
+	_ git.RepoCredentials,
 ) ([]string, error) {
 	changeSummary := make([]string, 0, len(update.Kustomize.Images))
 	for _, imgUpdate := range update.Kustomize.Images {

--- a/internal/controller/promotion/kustomize_test.go
+++ b/internal/controller/promotion/kustomize_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 )
 
@@ -169,6 +170,7 @@ func TestKustomizerApply(t *testing.T) {
 				"",
 				"",
 				"",
+				git.RepoCredentials{},
 			)
 			testCase.assertions(t, changes, err)
 		})

--- a/internal/controller/promotion/render.go
+++ b/internal/controller/promotion/render.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	render "github.com/akuity/kargo/internal/kargo-render"
 )
@@ -52,6 +53,7 @@ func (r *renderer) apply(
 	sourceCommit string,
 	_ string,
 	workingDir string,
+	repoCreds git.RepoCredentials,
 ) ([]string, error) {
 	images := make([]string, 0, len(newFreight.Images))
 	if len(update.Render.Images) == 0 {
@@ -97,6 +99,7 @@ func (r *renderer) apply(
 		Images:       images,
 		LocalInPath:  workingDir,
 		LocalOutPath: writeDir,
+		RepoCreds:    repoCreds,
 	}
 
 	if err = r.renderManifestsFn(req); err != nil {

--- a/internal/controller/promotion/render_test.go
+++ b/internal/controller/promotion/render_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	render "github.com/akuity/kargo/internal/kargo-render"
 )
@@ -219,6 +220,7 @@ func TestKargoRenderApply(t *testing.T) {
 				testSourceCommitID,
 				"", // Home directory is not used by this implementation
 				testWorkDir,
+				git.RepoCredentials{},
 			)
 			testCase.assertions(t, changes, testWorkDir, err)
 		})


### PR DESCRIPTION
Prior to #1674 we _did_ always pass credentials to Kargo Render. We stopped because Kargo proper now handles all the checking out and committing -- or so I thought...

I had forgotten that Kargo Render will, even if given a local repo that is already checked out to the correct source commit, check if the target branch exists remotely and attempt to pull from it. It does this because it wants up-to-date metadata from the target branch, if it exists.

