### PR TITLE
fix(cli): remove duplicate `create project` cmd

### DIFF
--- a/internal/cli/cmd/create/create.go
+++ b/internal/cli/cmd/create/create.go
@@ -68,7 +68,6 @@ kargo create project my-project
 	// Register subcommands.
 	cmd.AddCommand(newCredentialsCommand(cfg, streams))
 	cmd.AddCommand(newProjectCommand(cfg, streams))
-	cmd.AddCommand(newProjectCommand(cfg, streams))
 
 	return cmd
 }


### PR DESCRIPTION
The interesting thing is that this became apparent due to Bash auto-completion showing odd behavior, as it would complete `kargo create project` with the short description added `(Create a project)`.