### PR TITLE
fix(webhook): sync shard field and label in only one direction

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -937,12 +937,9 @@ message StageList {
 message StageSpec {
   // Shard is the name of the shard that this Stage belongs to. This is an
   // optional field. If not specified, the Stage will belong to the default
-  // shard. A defaulting webhook will sync this field with the value of the
-  // kargo.akuity.io/shard label. When the shard label is not present or differs
-  // from the value of this field, the defaulting webhook will set the label to
-  // the value of this field. If the shard label is present and this field is
-  // empty, the defaulting webhook will set the value of this field to the value
-  // of the shard label.
+  // shard. A defaulting webhook will sync the value of the
+  // kargo.akuity.io/shard label with the value of this field. When this field
+  // is empty, the webhook will ensure that label is absent.
   optional string shard = 4;
 
   // Subscriptions describes the Stage's sources of Freight. This is a required

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -142,12 +142,9 @@ func (s *Stage) GetStatus() *StageStatus {
 type StageSpec struct {
 	// Shard is the name of the shard that this Stage belongs to. This is an
 	// optional field. If not specified, the Stage will belong to the default
-	// shard. A defaulting webhook will sync this field with the value of the
-	// kargo.akuity.io/shard label. When the shard label is not present or differs
-	// from the value of this field, the defaulting webhook will set the label to
-	// the value of this field. If the shard label is present and this field is
-	// empty, the defaulting webhook will set the value of this field to the value
-	// of the shard label.
+	// shard. A defaulting webhook will sync the value of the
+	// kargo.akuity.io/shard label with the value of this field. When this field
+	// is empty, the webhook will ensure that label is absent.
 	Shard string `json:"shard,omitempty" protobuf:"bytes,4,opt,name=shard"`
 	// Subscriptions describes the Stage's sources of Freight. This is a required
 	// field.

--- a/charts/kargo/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/crds/kargo.akuity.io_stages.yaml
@@ -461,12 +461,9 @@ spec:
                 description: |-
                   Shard is the name of the shard that this Stage belongs to. This is an
                   optional field. If not specified, the Stage will belong to the default
-                  shard. A defaulting webhook will sync this field with the value of the
-                  kargo.akuity.io/shard label. When the shard label is not present or differs
-                  from the value of this field, the defaulting webhook will set the label to
-                  the value of this field. If the shard label is present and this field is
-                  empty, the defaulting webhook will set the value of this field to the value
-                  of the shard label.
+                  shard. A defaulting webhook will sync the value of the
+                  kargo.akuity.io/shard label with the value of this field. When this field
+                  is empty, the webhook will ensure that label is absent.
                 type: string
               subscriptions:
                 description: |-

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -62,14 +62,14 @@ func newWebhook(kubeClient client.Client) *webhook {
 func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
 	stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
 
-	// Sync the convenience shard field with the shard label
+	// Sync the shard label to the convenience shard field
 	if stage.Spec.Shard != "" {
 		if stage.Labels == nil {
 			stage.Labels = make(map[string]string, 1)
 		}
 		stage.Labels[kargoapi.ShardLabelKey] = stage.Spec.Shard
-	} else if stage.Labels[kargoapi.ShardLabelKey] != "" {
-		stage.Spec.Shard = stage.Labels[kargoapi.ShardLabelKey]
+	} else {
+		delete(stage.Labels, kargoapi.ShardLabelKey)
 	}
 
 	return nil

--- a/internal/webhook/stage/webhook_test.go
+++ b/internal/webhook/stage/webhook_test.go
@@ -47,7 +47,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 		{
-			name:      "sync shard label to shard field",
+			name:      "sync shard label to non-empty shard field",
 			operation: admissionv1.Create,
 			stage: &kargoapi.Stage{
 				Spec: &kargoapi.StageSpec{
@@ -56,12 +56,12 @@ func TestDefault(t *testing.T) {
 			},
 			assertions: func(t *testing.T, stage *kargoapi.Stage, err error) {
 				require.NoError(t, err)
-				require.Equal(t, testShardName, stage.Labels[kargoapi.ShardLabelKey])
 				require.Equal(t, testShardName, stage.Spec.Shard)
+				require.Equal(t, testShardName, stage.Labels[kargoapi.ShardLabelKey])
 			},
 		},
 		{
-			name:      "sync shard field to shard label",
+			name:      "sync shard label to empty shard field",
 			operation: admissionv1.Create,
 			stage: &kargoapi.Stage{
 				ObjectMeta: metav1.ObjectMeta{
@@ -73,8 +73,9 @@ func TestDefault(t *testing.T) {
 			},
 			assertions: func(t *testing.T, stage *kargoapi.Stage, err error) {
 				require.NoError(t, err)
-				require.Equal(t, testShardName, stage.Labels[kargoapi.ShardLabelKey])
-				require.Equal(t, testShardName, stage.Spec.Shard)
+				require.Empty(t, stage.Spec.Shard)
+				_, ok := stage.Labels[kargoapi.ShardLabelKey]
+				require.False(t, ok)
 			},
 		},
 	}

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -343,7 +343,7 @@
           "type": "object"
         },
         "shard": {
-          "description": "Shard is the name of the shard that this Stage belongs to. This is an\noptional field. If not specified, the Stage will belong to the default\nshard. A defaulting webhook will sync this field with the value of the\nkargo.akuity.io/shard label. When the shard label is not present or differs\nfrom the value of this field, the defaulting webhook will set the label to\nthe value of this field. If the shard label is present and this field is\nempty, the defaulting webhook will set the value of this field to the value\nof the shard label.",
+          "description": "Shard is the name of the shard that this Stage belongs to. This is an\noptional field. If not specified, the Stage will belong to the default\nshard. A defaulting webhook will sync the value of the\nkargo.akuity.io/shard label with the value of this field. When this field\nis empty, the webhook will ensure that label is absent.",
           "type": "string"
         },
         "subscriptions": {

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -3108,12 +3108,9 @@ export class StageSpec extends Message<StageSpec> {
   /**
    * Shard is the name of the shard that this Stage belongs to. This is an
    * optional field. If not specified, the Stage will belong to the default
-   * shard. A defaulting webhook will sync this field with the value of the
-   * kargo.akuity.io/shard label. When the shard label is not present or differs
-   * from the value of this field, the defaulting webhook will set the label to
-   * the value of this field. If the shard label is present and this field is
-   * empty, the defaulting webhook will set the value of this field to the value
-   * of the shard label.
+   * shard. A defaulting webhook will sync the value of the
+   * kargo.akuity.io/shard label with the value of this field. When this field
+   * is empty, the webhook will ensure that label is absent.
    *
    * @generated from field: optional string shard = 4;
    */


### PR DESCRIPTION
Fixes #1699

#1683 has also received a complementary change.