### PR TITLE
fix(controller): keep Stage history up-to-date

### DIFF
--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -6,113 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFreightReferenceStackEmpty(t *testing.T) {
-	testCases := []struct {
-		name           string
-		stack          FreightReferenceStack
-		expectedResult bool
-	}{
-		{
-			name:           "stack is nil",
-			stack:          nil,
-			expectedResult: true,
-		},
-		{
-			name:           "stack is empty",
-			stack:          FreightReferenceStack{},
-			expectedResult: true,
-		},
-		{
-			name:           "stack has items",
-			stack:          FreightReferenceStack{{Name: "foo"}},
-			expectedResult: false,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			require.Equal(t, testCase.expectedResult, testCase.stack.Empty())
-		})
-	}
-}
-
-func TestFreightReferenceStackPop(t *testing.T) {
-	testCases := []struct {
-		name            string
-		stack           FreightReferenceStack
-		expectedStack   FreightReferenceStack
-		expectedFreight FreightReference
-		expectedOK      bool
-	}{
-		{
-			name:            "stack is nil",
-			stack:           nil,
-			expectedStack:   nil,
-			expectedFreight: FreightReference{},
-			expectedOK:      false,
-		},
-		{
-			name:            "stack is empty",
-			stack:           FreightReferenceStack{},
-			expectedStack:   FreightReferenceStack{},
-			expectedFreight: FreightReference{},
-			expectedOK:      false,
-		},
-		{
-			name:            "stack has items",
-			stack:           FreightReferenceStack{{Name: "foo"}, {Name: "bar"}},
-			expectedStack:   FreightReferenceStack{{Name: "bar"}},
-			expectedFreight: FreightReference{Name: "foo"},
-			expectedOK:      true,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			freight, ok := testCase.stack.Pop()
-			require.Equal(t, testCase.expectedStack, testCase.stack)
-			require.Equal(t, testCase.expectedFreight, freight)
-			require.Equal(t, testCase.expectedOK, ok)
-		})
-	}
-}
-
-func TestFreightReferenceStackTop(t *testing.T) {
-	testCases := []struct {
-		name            string
-		stack           FreightReferenceStack
-		expectedFreight FreightReference
-		expectedOK      bool
-	}{
-		{
-			name:            "stack is nil",
-			stack:           nil,
-			expectedFreight: FreightReference{},
-			expectedOK:      false,
-		},
-		{
-			name:            "stack is empty",
-			stack:           FreightReferenceStack{},
-			expectedFreight: FreightReference{},
-			expectedOK:      false,
-		},
-		{
-			name:            "stack has items",
-			stack:           FreightReferenceStack{{Name: "foo"}, {Name: "bar"}},
-			expectedFreight: FreightReference{Name: "foo"},
-			expectedOK:      true,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			initialLen := len(testCase.stack)
-			freight, ok := testCase.stack.Top()
-			require.Len(t, testCase.stack, initialLen)
-			require.Equal(t, testCase.expectedFreight, freight)
-			require.Equal(t, testCase.expectedOK, ok)
-		})
-	}
-}
-
-func TestFreightReferenceStackPush(t *testing.T) {
+func TestFreightReferenceStackUpdateOrPush(t *testing.T) {
 	testCases := []struct {
 		name          string
 		stack         FreightReferenceStack
@@ -132,6 +26,17 @@ func TestFreightReferenceStackPush(t *testing.T) {
 			expectedStack: FreightReferenceStack{{Name: "bar"}, {Name: "foo"}},
 		},
 		{
+			name:       "initial stack has matching names",
+			stack:      FreightReferenceStack{{Name: "foo"}, {Name: "bar"}},
+			newFreight: []FreightReference{{Name: "bar", Warehouse: "update"}, {Name: "baz"}, {Name: "zab"}},
+			expectedStack: FreightReferenceStack{
+				{Name: "baz"},
+				{Name: "zab"},
+				{Name: "foo"},
+				{Name: "bar", Warehouse: "update"},
+			},
+		},
+		{
 			name: "initial stack is full",
 			stack: FreightReferenceStack{
 				{}, {}, {}, {}, {}, {}, {}, {}, {}, {},
@@ -144,7 +49,7 @@ func TestFreightReferenceStackPush(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testCase.stack.Push(testCase.newFreight...)
+			testCase.stack.UpdateOrPush(testCase.newFreight...)
 			require.Equal(t, testCase.expectedStack, testCase.stack)
 		})
 	}

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -368,7 +368,7 @@ func (r *reconciler) promote(
 			// control-flow stages in the first place)
 			if stage.Spec.PromotionMechanisms != nil {
 				status.CurrentFreight = &nextFreight
-				status.History.Push(nextFreight)
+				status.History.UpdateOrPush(nextFreight)
 			}
 		})
 		if err != nil {

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -717,6 +717,12 @@ func (r *reconciler) syncNormalStage(
 	} else {
 		freightLogger := logger.WithField("freight", status.CurrentFreight.Name)
 
+		// Push the latest state of the current Freight to the history at the
+		// end of each reconciliation loop.
+		defer func() {
+			status.History.UpdateOrPush(*status.CurrentFreight)
+		}()
+
 		// Check health
 		status.Health = r.checkHealthFn(
 			ctx,


### PR DESCRIPTION
This ensures that besides the initial push of a `FreightReference` to the history of a `Stage`, it is actually kept up-to-date with any new changes at the end of a reconciliation run. By doing this, we can provide the user with historical bookkeeping of verification information for the past `Freight` of a `Stage`.

Required to properly address #1694 