### PR TITLE
fix(webhooks): label sync logic in webhooks

### DIFF
--- a/internal/webhook/warehouse/webhook.go
+++ b/internal/webhook/warehouse/webhook.go
@@ -65,14 +65,14 @@ func newWebhook(kubeClient client.Client) *webhook {
 func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
 	warehouse := obj.(*kargoapi.Warehouse) // nolint: forcetypeassert
 
-	// Sync the convenience shard field with the shard label
+	// Sync the shard label to the convenience shard field
 	if warehouse.Spec.Shard != "" {
 		if warehouse.Labels == nil {
 			warehouse.Labels = make(map[string]string, 1)
 		}
 		warehouse.Labels[kargoapi.ShardLabelKey] = warehouse.Spec.Shard
-	} else if warehouse.Labels[kargoapi.ShardLabelKey] != "" {
-		warehouse.Spec.Shard = warehouse.Labels[kargoapi.ShardLabelKey]
+	} else {
+		delete(warehouse.Labels, kargoapi.ShardLabelKey)
 	}
 
 	return nil

--- a/internal/webhook/warehouse/webhook_test.go
+++ b/internal/webhook/warehouse/webhook_test.go
@@ -40,7 +40,7 @@ func TestDefault(t *testing.T) {
 		require.Empty(t, warehouse.Spec.Shard)
 	})
 
-	t.Run("sync shard label to shard field", func(t *testing.T) {
+	t.Run("sync shard label to non-empty shard field", func(t *testing.T) {
 		warehouse := &kargoapi.Warehouse{
 			Spec: &kargoapi.WarehouseSpec{
 				Shard: testShardName,
@@ -48,25 +48,24 @@ func TestDefault(t *testing.T) {
 		}
 		err := w.Default(context.Background(), warehouse)
 		require.NoError(t, err)
-		require.Equal(t, testShardName, warehouse.Labels[kargoapi.ShardLabelKey])
 		require.Equal(t, testShardName, warehouse.Spec.Shard)
+		require.Equal(t, testShardName, warehouse.Labels[kargoapi.ShardLabelKey])
 	})
 
-	t.Run("sync shard field to shard label", func(t *testing.T) {
+	t.Run("sync shard label to empty shard field", func(t *testing.T) {
 		warehouse := &kargoapi.Warehouse{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					kargoapi.ShardLabelKey: testShardName,
 				},
 			},
-			Spec: &kargoapi.WarehouseSpec{
-				Shard: testShardName,
-			},
+			Spec: &kargoapi.WarehouseSpec{},
 		}
 		err := w.Default(context.Background(), warehouse)
 		require.NoError(t, err)
-		require.Equal(t, testShardName, warehouse.Labels[kargoapi.ShardLabelKey])
-		require.Equal(t, testShardName, warehouse.Spec.Shard)
+		require.Empty(t, warehouse.Spec.Shard)
+		_, ok := warehouse.Labels[kargoapi.ShardLabelKey]
+		require.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
Similar to #1699/#1701, this PR updates logic in webhooks to sync only one-way between important labels and their corresponding "convenience fields." This removes the surprising behavior that clearing such a field has no effect.