### PR TITLE
fix(cli): restore ability to read manifests from stdin -- 0.4 edition

### DIFF
--- a/internal/cli/option/kubernetes.go
+++ b/internal/cli/option/kubernetes.go
@@ -14,6 +14,7 @@ import (
 func ReadManifests(filenames ...string) ([]byte, error) {
 	buildRes, err := cmdutil.NewFactory(&genericclioptions.ConfigFlags{}).
 		NewBuilder().
+		Local().
 		Unstructured().
 		FilenameParam(false, &resource.FilenameOptions{
 			Filenames: filenames,

--- a/internal/cli/option/kubernetes.go
+++ b/internal/cli/option/kubernetes.go
@@ -2,52 +2,43 @@ package option
 
 import (
 	"bytes"
-	"os"
-	"path"
-	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-// TODO: Test this
 func ReadManifests(filenames ...string) ([]byte, error) {
-	var allBytes [][]byte
-	for _, filename := range filenames {
-		var err error
-		if filename, err = filepath.Abs(filename); err != nil {
-			return nil, err
+	buildRes, err := cmdutil.NewFactory(&genericclioptions.ConfigFlags{}).
+		NewBuilder().
+		Unstructured().
+		FilenameParam(false, &resource.FilenameOptions{
+			Filenames: filenames,
+			Recursive: false,
+		}).
+		Flatten().
+		Do().
+		Infos()
+	if err != nil {
+		return nil, errors.Wrap(err, "build resources")
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	defer func() {
+		_ = enc.Close()
+	}()
+	for _, info := range buildRes {
+		u, ok := info.Object.(*unstructured.Unstructured)
+		if !ok {
+			return nil, errors.Errorf("expected *unstructured.Unstructured, got %T", info.Object)
 		}
-		fileInfo, err := os.Stat(filename)
-		if err != nil {
-			return nil, err
-		}
-		var fileBytes []byte
-		if fileInfo.IsDir() {
-			var dirEntries []os.DirEntry
-			if dirEntries, err = os.ReadDir(filename); err != nil {
-				return nil, err
-			}
-			dirFiles := make([]string, 0, len(dirEntries))
-			for _, dirEntry := range dirEntries {
-				dirFiles = append(dirFiles, path.Join(filename, dirEntry.Name()))
-			}
-			if fileBytes, err = ReadManifests(dirFiles...); err != nil {
-				return nil, err
-			}
-		} else {
-			// Check file extension
-			ext := filepath.Ext(filename)
-			if ext != ".yaml" && ext != ".yml" {
-				continue
-			}
-			if fileBytes, err = os.ReadFile(filename); err != nil {
-				return nil, err
-			}
-		}
-		if len(fileBytes) > 0 {
-			if fileBytes[len(fileBytes)-1] == '\n' {
-				fileBytes = fileBytes[:len(fileBytes)-1]
-			}
-			allBytes = append(allBytes, fileBytes)
+		if err := enc.Encode(&u.Object); err != nil {
+			return nil, errors.Wrap(err, "encode object")
 		}
 	}
-	return bytes.Join(allBytes, []byte("\n---\n")), nil
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Similar to #1715, but for v0.4.x. Reverts/replaces what was done in #1528