### PR TITLE
feat(ui): extend IntOrString to support JsonValue

### DIFF
--- a/ui/hack/generate-proto-extensions.mjs
+++ b/ui/hack/generate-proto-extensions.mjs
@@ -3,6 +3,36 @@
  */
 import { Project } from 'ts-morph';
 
+const formatCodeSettings = { indentSize: 2, convertTabsToSpaces: true };
+
+function overrideFromJson(classDecl, bodyText) {
+  classDecl.getInstanceMethod('fromJson')?.remove();
+  classDecl
+    .addMethod({
+      hasOverrideKeyword: true,
+      name: 'fromJson',
+      parameters: [
+        { name: 'json', type: 'JsonValue' },
+        { name: 'options?', type: 'Partial<JsonReadOptions>' }
+      ],
+      returnType: 'this'
+    })
+    .setBodyText(bodyText);
+}
+
+
+function overrideToJson(classDecl, bodyText) {
+  classDecl.getInstanceMethod('toJson')?.remove();
+  classDecl
+    .addMethod({
+      hasOverrideKeyword: true,
+      name: 'toJson',
+      parameters: [{ name: 'options?', type: 'Partial<JsonWriteOptions>' }],
+      returnType: 'JsonValue'
+    })
+    .setBodyText(bodyText);
+}
+
 /**
  * Extends metav1.Time class to compatible with generic `Timestamp` message.
  * Extended methods sources are from `bufbuild/protobuf-es`.
@@ -25,17 +55,9 @@ function extendTime(src) {
 
   // Extend Time class
   const time = src.getClassOrThrow('Time');
+
   // Override fromJson()
-  time.getInstanceMethod('fromJson')?.remove();
-  time.addMethod({
-    hasOverrideKeyword: true,
-    name: 'fromJson',
-    parameters: [
-      { name: 'json', type: 'JsonValue' },
-      { name: 'options?', type: 'Partial<JsonReadOptions>' }
-    ],
-    returnType: 'this'
-  }).setBodyText(`if (typeof json !== "string") {
+  overrideFromJson(time, `if (typeof json !== "string") {
     throw new Error(\`cannot decode google.protobuf.Timestamp from JSON: \${proto.json.debug(json)}\`);
   }
   const matches = json.match(/^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(?:Z|\\.([0-9]{3,9})Z|([+-][0-9][0-9]:[0-9][0-9]))$/);
@@ -58,13 +80,7 @@ function extendTime(src) {
 `);
 
   // Override toJson()
-  time.getInstanceMethod('toJson')?.remove();
-  time.addMethod({
-    hasOverrideKeyword: true,
-    name: 'toJson',
-    parameters: [{ name: 'options?', type: 'Partial<JsonWriteOptions>' }],
-    returnType: 'JsonValue'
-  }).setBodyText(`const ms = Number(this.seconds) * 1000;
+  overrideToJson(time, `const ms = Number(this.seconds) * 1000;
   if (ms < Date.parse("0001-01-01T00:00:00Z") || ms > Date.parse("9999-12-31T23:59:59Z")) {
     throw new Error(\`cannot encode google.protobuf.Timestamp to JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive\`);
   }
@@ -97,12 +113,14 @@ function extendTime(src) {
 
   // fromDate()
   time.getStaticMethod('fromDate')?.remove();
-  time.addMethod({
-    isStatic: true,
-    name: 'fromDate',
-    parameters: [{ name: 'date', type: 'Date' }],
-    returnType: 'Time'
-  }).setBodyText(`const ms = date.getTime();
+  time
+    .addMethod({
+      isStatic: true,
+      name: 'fromDate',
+      parameters: [{ name: 'date', type: 'Date' }],
+      returnType: 'Time'
+    })
+    .setBodyText(`const ms = date.getTime();
   return new Time({
     seconds: protoInt64.parse(Math.floor(ms / 1000)),
     nanos: (ms % 1000) * 1000000,
@@ -120,6 +138,96 @@ function extendTime(src) {
     .setBodyText(`return Time.fromDate(new Date())`);
 }
 
+/**
+ * Extends intstr.IntOrString class to compatible with Golang implementation.
+ *
+ * @param {SourceFile} src Generated source file.
+ */
+function extendIntOrString(src) {
+  // Extend IntOrString class
+  const intOrString = src.getClassOrThrow('IntOrString');
+
+  // Define constants
+  const classConstants = [
+    {
+      name: 'TYPE_INT',
+      isStatic: true,
+      isReadonly: true,
+      initializer: 'BigInt(0)'
+    },
+    {
+      name: 'TYPE_STRING',
+      isStatic: true,
+      isReadonly: true,
+      initializer: 'BigInt(1)'
+    },
+    {
+      name: 'MAX_INT32',
+      isStatic: true,
+      isReadonly: true,
+      initializer: '2147483647'
+    },
+    {
+      name: 'MIN_INT32',
+      isStatic: true,
+      isReadonly: true,
+      initializer: '-2147483648'
+    },
+  ];
+  classConstants
+    .forEach((c) => {
+      intOrString.getStaticProperty(c.name)?.remove();
+      intOrString.addProperty(c);
+    });
+
+  // Override fromJson()
+  overrideFromJson(intOrString, `if (json === null) {
+  return this;
+}
+switch (typeof json) {
+  case "string":
+    this.type = IntOrString.TYPE_STRING;
+    this.strVal = json;
+    return this;
+  case "number":
+    if (!this.isInt32(json)) {
+      throw new Error(\`value is not an Int32: \${proto.json.debug(json)}\`);
+    }
+    this.type = IntOrString.TYPE_INT;
+    this.intVal = json;
+    return this;
+  default:
+    throw new Error(\`cannot decode \${IntOrString.typeName} from JSON: \${proto.json.debug(json)}\`);
+}`);
+
+  // Override toJson()
+  overrideToJson(intOrString, `if (this.type === IntOrString.TYPE_STRING) {
+  return this.strVal;
+}
+if (this.type === IntOrString.TYPE_INT) {
+  if (!this.intVal) {
+    return null;
+  } else if (!this.isInt32(this.intVal)) {
+    throw new Error(\`value is not an Int32: \${this.intVal}\`);
+  }
+  return this.intVal;
+}
+return null;`);
+
+  // Add helper methods
+  // isInt32()
+  intOrString.getInstanceMethod('isInt32')?.remove();
+  intOrString
+    .addMethod({
+      name: 'isInt32',
+      parameters: [{ name: 'value', type: 'number' }],
+      returnType: 'boolean'
+    })
+    .setBodyText(`return Number.isInteger(value) &&
+  IntOrString.MIN_INT32 <= value &&
+  value <= IntOrString.MAX_INT32;`);
+}
+
 async function main() {
   const project = new Project({
     tsConfigFilePath: 'tsconfig.json'
@@ -129,8 +237,14 @@ async function main() {
     './src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb.ts'
   );
   extendTime(metaV1);
+  metaV1.formatText(formatCodeSettings);
 
-  metaV1.formatText({ indentSize: 2, convertTabsToSpaces: true });
+  const intstr = project.getSourceFileOrThrow(
+    './src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb.ts'
+  )
+  extendIntOrString(intstr);
+  intstr.formatText(formatCodeSettings)
+
   await project.save();
 }
 

--- a/ui/src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb.ts
+++ b/ui/src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb.ts
@@ -113,3 +113,4 @@ export class IntOrString extends Message<IntOrString> {
       value <= IntOrString.MAX_INT32;
   }
 }
+

--- a/ui/src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb.ts
+++ b/ui/src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb.ts
@@ -65,5 +65,51 @@ export class IntOrString extends Message<IntOrString> {
   static equals(a: IntOrString | PlainMessage<IntOrString> | undefined, b: IntOrString | PlainMessage<IntOrString> | undefined): boolean {
     return proto2.util.equals(IntOrString, a, b);
   }
-}
 
+  static readonly TYPE_INT = BigInt(0);
+  static readonly TYPE_STRING = BigInt(1);
+  static readonly MAX_INT32 = 2147483647;
+  static readonly MIN_INT32 = -2147483648;
+
+  override fromJson(json: JsonValue, options?: Partial<JsonReadOptions>): this {
+    if (json === null) {
+      return this;
+    }
+    switch (typeof json) {
+      case "string":
+        this.type = IntOrString.TYPE_STRING;
+        this.strVal = json;
+        return this;
+      case "number":
+        if (!this.isInt32(json)) {
+          throw new Error(`value is not an Int32: ${proto.json.debug(json)}`);
+        }
+        this.type = IntOrString.TYPE_INT;
+        this.intVal = json;
+        return this;
+      default:
+        throw new Error(`cannot decode ${IntOrString.typeName} from JSON: ${proto.json.debug(json)}`);
+    }
+  }
+
+  override toJson(options?: Partial<JsonWriteOptions>): JsonValue {
+    if (this.type === IntOrString.TYPE_STRING) {
+      return this.strVal;
+    }
+    if (this.type === IntOrString.TYPE_INT) {
+      if (!this.intVal) {
+        return null;
+      } else if (!this.isInt32(this.intVal)) {
+        throw new Error(`value is not an Int32: ${this.intVal}`);
+      }
+      return this.intVal;
+    }
+    return null;
+  }
+
+  isInt32(value: number): boolean {
+    return Number.isInteger(value) &&
+      IntOrString.MIN_INT32 <= value &&
+      value <= IntOrString.MAX_INT32;
+  }
+}

--- a/ui/tests/api/apimachinery.spec.ts
+++ b/ui/tests/api/apimachinery.spec.ts
@@ -1,5 +1,7 @@
 import { Timestamp } from '@bufbuild/protobuf';
-import { test, describe, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
+
+import { IntOrString } from '../../src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb';
 
 describe('metav1.Time', () => {
   test('fromJson', () => {
@@ -10,13 +12,63 @@ describe('metav1.Time', () => {
   });
 
   test('toJson', () => {
-    const time = new Timestamp({ seconds: BigInt(1685404800), nanos: 0 });
+    const time = new Timestamp({seconds: BigInt(1685404800), nanos: 0});
+    expect(time.toJson()).toBe('2023-05-30T00:00:00Z');
     expect(time.toJsonString()).toBe('"2023-05-30T00:00:00Z"');
   });
 
   test('toDate', () => {
     const date = new Date('2023-05-30T00:00:00Z');
-    const time = new Timestamp({ seconds: BigInt(1685404800), nanos: 0 });
+    const time = new Timestamp({seconds: BigInt(1685404800), nanos: 0});
     expect(time.toDate().getTime()).toBe(date.getTime());
+  });
+});
+
+describe('intstr.IntOrString', () => {
+  test('fromJson - string', () => {
+    const intOrString = IntOrString.fromJson('32');
+    expect(intOrString).toBeDefined();
+    expect(intOrString.type).toBe(IntOrString.TYPE_STRING);
+    expect(intOrString.strVal).toBe('32');
+  });
+  test('fromJson - integer', () => {
+    const intOrString = IntOrString.fromJson(32);
+    expect(intOrString).toBeDefined();
+    expect(intOrString.type).toBe(IntOrString.TYPE_INT);
+    expect(intOrString.intVal).toBe(32);
+  });
+  test('fromJson - integer (bigger than Int32)', () => {
+    expect(() => IntOrString.fromJson(Number.MAX_SAFE_INTEGER)).toThrow();
+  });
+  test('fromJson - integer (smaller than Int32)', () => {
+    expect(() => IntOrString.fromJson(Number.MIN_SAFE_INTEGER)).toThrow();
+  });
+  test('toJson - string', () => {
+    const intOrString = new IntOrString({
+      type: IntOrString.TYPE_STRING,
+      strVal: '32'
+    });
+    expect(intOrString.toJson()).toBe('32');
+  });
+  test('toJson - integer', () => {
+    const intOrString = new IntOrString({
+      type: IntOrString.TYPE_INT,
+      intVal: 32
+    });
+    expect(intOrString.toJson()).toBe(32);
+  });
+  test('toJson - integer (bigger than Int32)', () => {
+    const intOrString = new IntOrString({
+      type: IntOrString.TYPE_INT,
+      intVal: IntOrString.MIN_INT32 - 1
+    });
+    expect(() => intOrString.toJson()).toThrow();
+  });
+  test('toJson - integer (smaller than Int32)', () => {
+    const intOrString = new IntOrString({
+      type: IntOrString.TYPE_INT,
+      intVal: IntOrString.MAX_INT32 + 1
+    });
+    expect(() => intOrString.toJson()).toThrow();
   });
 });


### PR DESCRIPTION
`intstr.IntOrString` relies on `gogo/protobuf` for JSON encoding/decoding, which is incompatible with the protobuf dependency used in our UI.

This commit extends `IntOrString` to encode/decode to/from JSON value to make compatible with
`gogo/protobuf`.

Related:
- https://github.com/akuity/kargo/issues/708
- https://github.com/akuity/kargo/pull/1515