### PR TITLE
chore: release chores 0.4

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -52,7 +52,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -71,7 +71,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -83,7 +83,7 @@ just for this quickstart using
 [kind](https://kind.sigs.k8s.io/#installation-and-usage).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/kind.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/kind.sh | sh
 ```
 
 :::info
@@ -101,7 +101,7 @@ Docker, Docker Desktop, or OrbStack), you can easily launch a disposable cluster
 just for this quickstart using [k3d](https://k3d.io).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/k3d.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/k3d.sh | sh
 ```
 
 :::info
@@ -166,7 +166,7 @@ To download the Kargo CLI:
 ```shell
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch=amd64
-curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}
+curl -L -o kargo https://github.com/akuity/kargo/releases/download/v0.4.5/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}
 chmod +x kargo
 ```
 
@@ -179,7 +179,7 @@ value of your `PATH` environment variable.
 To download the Kargo CLI:
 
 ```shell
-Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/download/v0.4.5/kargo-windows-amd64.exe -OutFile kargo.exe
 ```
 
 Then move `kargo.exe` to a location in your file system that is included in the value
@@ -649,7 +649,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>
@@ -667,7 +667,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-0.4/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -34,6 +34,7 @@ helm install argo-rollouts argo-rollouts \
 
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.4.5 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -41,6 +41,7 @@ helm install argo-rollouts argo-rollouts \
 
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.4.5 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -55,6 +55,7 @@ helm install argo-rollouts argo-rollouts \
 
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.4.5 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \


### PR DESCRIPTION
This PR locks the docs in `release-0.4` (which are the current production docs) into v0.4.5 of the chart and quickstart scripts from the `release-0.4` branch.

This will keep what are now the production docs working correctly even as we begin to tackle v0.5.0-specific release chores in `main`.