### PR TITLE
chore: update scripts and quickstart for v0.5.0-rc.3

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -166,7 +166,7 @@ To download the Kargo CLI:
 ```shell
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch=amd64
-curl -L -o kargo https://github.com/akuity/kargo/releases/download/v0.5.0-rc.2/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}
+curl -L -o kargo https://github.com/akuity/kargo/releases/download/v0.5.0-rc.3/kargo-$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}
 chmod +x kargo
 ```
 
@@ -179,7 +179,7 @@ value of your `PATH` environment variable.
 To download the Kargo CLI:
 
 ```shell
-Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/download/v0.5.0-rc.2/kargo-windows-amd64.exe -OutFile kargo.exe
+Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/download/v0.5.0-rc.3/kargo-windows-amd64.exe -OutFile kargo.exe
 ```
 
 Then move `kargo.exe` to a location in your file system that is included in the value

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -35,7 +35,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
-  --version 0.5.0-rc.2 \
+  --version 0.5.0-rc.3 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -42,7 +42,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
-  --version 0.5.0-rc.2 \
+  --version 0.5.0-rc.3 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -56,7 +56,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
-  --version 0.5.0-rc.2 \
+  --version 0.5.0-rc.3 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \


### PR DESCRIPTION
v0.5.0-rc.3 is on its way out the door as we speak.

This PR will make it easier for non-engineers to validate the quickstart using https://main.kargo.akuity.io/quickstart

This is a follow-up to #1740 and can be rolled back at a later date.