### PR TITLE
feat(cli): add --no-headers flag to all get commands.

### DIFF
--- a/internal/cli/cmd/get/credentials.go
+++ b/internal/cli/cmd/get/credentials.go
@@ -30,6 +30,8 @@ type getCredentialsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -85,6 +87,8 @@ kargo get credentials my-credentials`),
 // addFlags adds the flags for the get credentials options to the provided
 // command.
 func (o *getCredentialsOptions) addFlags(cmd *cobra.Command) {
+	o.getOptions.addFlags(cmd)
+
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 
@@ -129,7 +133,7 @@ func (o *getCredentialsOptions) run(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("list credentials: %w", err)
 		}
-		return printObjects(resp.Msg.GetCredentials(), o.PrintFlags, o.IOStreams)
+		return printObjects(resp.Msg.GetCredentials(), o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*corev1.Secret, 0, len(o.Names))
@@ -151,7 +155,7 @@ func (o *getCredentialsOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetCredentials())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print stages: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/credentials.go
+++ b/internal/cli/cmd/get/credentials.go
@@ -30,7 +30,7 @@ type getCredentialsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -42,7 +42,7 @@ type getCredentialsOptions struct {
 func newGetCredentialsCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
 ) *cobra.Command {
 	cmdOpts := &getCredentialsOptions{
 		Config:     cfg,

--- a/internal/cli/cmd/get/credentials.go
+++ b/internal/cli/cmd/get/credentials.go
@@ -39,10 +39,15 @@ type getCredentialsOptions struct {
 	Names   []string
 }
 
-func newGetCredentialsCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {
+func newGetCredentialsCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+	getOptions getOptions,
+) *cobra.Command {
 	cmdOpts := &getCredentialsOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 
@@ -87,8 +92,6 @@ kargo get credentials my-credentials`),
 // addFlags adds the flags for the get credentials options to the provided
 // command.
 func (o *getCredentialsOptions) addFlags(cmd *cobra.Command) {
-	o.getOptions.addFlags(cmd)
-
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -27,7 +27,7 @@ type getFreightOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -40,7 +40,8 @@ type getFreightOptions struct {
 func newGetFreightCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
+
 ) *cobra.Command {
 	cmdOpts := &getFreightOptions{
 		Config:     cfg,

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -27,6 +27,8 @@ type getFreightOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -91,6 +93,8 @@ kargo get freight --alias=wonky-wombat
 
 // addFlags adds the flags for the get freight options to the provided command.
 func (o *getFreightOptions) addFlags(cmd *cobra.Command) {
+	o.getOptions.addFlags(cmd)
+
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 
@@ -136,7 +140,7 @@ func (o *getFreightOptions) run(ctx context.Context) error {
 		// We didn't specify any groupBy, so there should be one group with an
 		// empty key
 		freight := resp.Msg.GetGroups()[""]
-		return printObjects(freight.Freight, o.PrintFlags, o.IOStreams)
+		return printObjects(freight.Freight, o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*kargoapi.Freight, 0, len(o.Names)+len(o.Aliases))
@@ -174,7 +178,7 @@ func (o *getFreightOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetFreight())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print freight: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/freight.go
+++ b/internal/cli/cmd/get/freight.go
@@ -37,10 +37,15 @@ type getFreightOptions struct {
 	Aliases []string
 }
 
-func newGetFreightCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {
+func newGetFreightCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+	getOptions getOptions,
+) *cobra.Command {
 	cmdOpts := &getFreightOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 
@@ -93,8 +98,6 @@ kargo get freight --alias=wonky-wombat
 
 // addFlags adds the flags for the get freight options to the provided command.
 func (o *getFreightOptions) addFlags(cmd *cobra.Command) {
-	o.getOptions.addFlags(cmd)
-
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -38,7 +38,7 @@ kargo get promotions --project=my-project --stage=my-stage
 `),
 	}
 
-	cmdOpts := getOptions{}
+	cmdOpts := &getOptions{}
 
 	cmdOpts.addFlags(cmd)
 

--- a/internal/cli/cmd/get/get.go
+++ b/internal/cli/cmd/get/get.go
@@ -38,17 +38,17 @@ kargo get promotions --project=my-project --stage=my-stage
 `),
 	}
 
-	cmdOpts := &getOptions{}
-
-	// Register subcommands.
-	cmd.AddCommand(newGetCredentialsCommand(cfg, streams))
-	cmd.AddCommand(newGetFreightCommand(cfg, streams))
-	cmd.AddCommand(newGetProjectsCommand(cfg, streams))
-	cmd.AddCommand(newGetPromotionsCommand(cfg, streams))
-	cmd.AddCommand(newGetStagesCommand(cfg, streams))
-	cmd.AddCommand(newGetWarehousesCommand(cfg, streams))
+	cmdOpts := getOptions{}
 
 	cmdOpts.addFlags(cmd)
+
+	// Register subcommands.
+	cmd.AddCommand(newGetCredentialsCommand(cfg, streams, cmdOpts))
+	cmd.AddCommand(newGetFreightCommand(cfg, streams, cmdOpts))
+	cmd.AddCommand(newGetProjectsCommand(cfg, streams, cmdOpts))
+	cmd.AddCommand(newGetPromotionsCommand(cfg, streams, cmdOpts))
+	cmd.AddCommand(newGetStagesCommand(cfg, streams, cmdOpts))
+	cmd.AddCommand(newGetWarehousesCommand(cfg, streams, cmdOpts))
 
 	return cmd
 }

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -27,6 +27,8 @@ type getProjectsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -72,6 +74,8 @@ kargo get project my-project
 
 // addFlags adds the flags for the get projects options to the provided command.
 func (o *getProjectsOptions) addFlags(cmd *cobra.Command) {
+	o.getOptions.addFlags(cmd)
+
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 }
@@ -96,7 +100,7 @@ func (o *getProjectsOptions) run(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("list projects: %w", err)
 		}
-		return printObjects(resp.Msg.GetProjects(), o.PrintFlags, o.IOStreams)
+		return printObjects(resp.Msg.GetProjects(), o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*kargoapi.Project, 0, len(o.Names))
@@ -117,7 +121,7 @@ func (o *getProjectsOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetProject())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print projects: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -27,7 +27,7 @@ type getProjectsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -38,7 +38,7 @@ type getProjectsOptions struct {
 func newGetProjectsCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
 ) *cobra.Command {
 	cmdOpts := &getProjectsOptions{
 		Config:     cfg,

--- a/internal/cli/cmd/get/projects.go
+++ b/internal/cli/cmd/get/projects.go
@@ -35,10 +35,15 @@ type getProjectsOptions struct {
 	Names []string
 }
 
-func newGetProjectsCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {
+func newGetProjectsCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+	getOptions getOptions,
+) *cobra.Command {
 	cmdOpts := &getProjectsOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 
@@ -74,8 +79,6 @@ kargo get project my-project
 
 // addFlags adds the flags for the get projects options to the provided command.
 func (o *getProjectsOptions) addFlags(cmd *cobra.Command) {
-	o.getOptions.addFlags(cmd)
-
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 }

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -38,10 +38,15 @@ type getPromotionsOptions struct {
 	Names   []string
 }
 
-func newGetPromotionsCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {
+func newGetPromotionsCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+	getOptions getOptions,
+) *cobra.Command {
 	cmdOpts := &getPromotionsOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 
@@ -96,8 +101,6 @@ kargo get promotion abc1234
 
 // addFlags adds the flags for the get promotions options to the provided command.
 func (o *getPromotionsOptions) addFlags(cmd *cobra.Command) {
-	o.getOptions.addFlags(cmd)
-
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -28,7 +28,7 @@ type getPromotionsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -41,7 +41,7 @@ type getPromotionsOptions struct {
 func newGetPromotionsCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
 ) *cobra.Command {
 	cmdOpts := &getPromotionsOptions{
 		Config:     cfg,

--- a/internal/cli/cmd/get/promotions.go
+++ b/internal/cli/cmd/get/promotions.go
@@ -28,6 +28,8 @@ type getPromotionsOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -94,6 +96,8 @@ kargo get promotion abc1234
 
 // addFlags adds the flags for the get promotions options to the provided command.
 func (o *getPromotionsOptions) addFlags(cmd *cobra.Command) {
+	o.getOptions.addFlags(cmd)
+
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 
@@ -141,7 +145,7 @@ func (o *getPromotionsOptions) run(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("list promotions: %w", err)
 		}
-		return printObjects(resp.Msg.GetPromotions(), o.PrintFlags, o.IOStreams)
+		return printObjects(resp.Msg.GetPromotions(), o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*kargoapi.Promotion, 0, len(o.Names))
@@ -163,7 +167,7 @@ func (o *getPromotionsOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetPromotion())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print promotions: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -28,6 +28,8 @@ type getStagesOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -86,6 +88,8 @@ kargo get stage qa
 
 // addFlags adds the flags for the get stages options to the provided command.
 func (o *getStagesOptions) addFlags(cmd *cobra.Command) {
+	o.getOptions.addFlags(cmd)
+
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 
@@ -128,7 +132,7 @@ func (o *getStagesOptions) run(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("list stages: %w", err)
 		}
-		return printObjects(resp.Msg.GetStages(), o.PrintFlags, o.IOStreams)
+		return printObjects(resp.Msg.GetStages(), o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*kargoapi.Stage, 0, len(o.Names))
@@ -150,7 +154,7 @@ func (o *getStagesOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetStage())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print stages: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -28,7 +28,7 @@ type getStagesOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -40,7 +40,7 @@ type getStagesOptions struct {
 func newGetStagesCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
 ) *cobra.Command {
 	cmdOpts := &getStagesOptions{
 		Config:     cfg,

--- a/internal/cli/cmd/get/stages.go
+++ b/internal/cli/cmd/get/stages.go
@@ -37,10 +37,15 @@ type getStagesOptions struct {
 	Names   []string
 }
 
-func newGetStagesCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {
+func newGetStagesCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+	getOptions getOptions,
+) *cobra.Command {
 	cmdOpts := &getStagesOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 
@@ -88,8 +93,6 @@ kargo get stage qa
 
 // addFlags adds the flags for the get stages options to the provided command.
 func (o *getStagesOptions) addFlags(cmd *cobra.Command) {
-	o.getOptions.addFlags(cmd)
-
 	o.ClientOptions.AddFlags(cmd.PersistentFlags())
 	o.PrintFlags.AddFlags(cmd)
 

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -40,10 +40,12 @@ type getWarehousesOptions struct {
 func newGetWarehousesCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
+	getOptions getOptions,
 ) *cobra.Command {
 	cmdOpts := &getWarehousesOptions{
 		Config:     cfg,
 		IOStreams:  streams,
+		getOptions: getOptions,
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(kubernetes.GetScheme()),
 	}
 

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -28,6 +28,8 @@ type getWarehousesOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
+	getOptions
+
 	Config        config.CLIConfig
 	ClientOptions client.Options
 
@@ -132,7 +134,7 @@ func (o *getWarehousesOptions) run(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("list warehouses: %w", err)
 		}
-		return printObjects(resp.Msg.GetWarehouses(), o.PrintFlags, o.IOStreams)
+		return printObjects(resp.Msg.GetWarehouses(), o.PrintFlags, o.IOStreams, o.NoHeaders)
 	}
 
 	res := make([]*kargoapi.Warehouse, 0, len(o.Names))
@@ -154,7 +156,7 @@ func (o *getWarehousesOptions) run(ctx context.Context) error {
 		res = append(res, resp.Msg.GetWarehouse())
 	}
 
-	if err = printObjects(res, o.PrintFlags, o.IOStreams); err != nil {
+	if err = printObjects(res, o.PrintFlags, o.IOStreams, o.NoHeaders); err != nil {
 		return fmt.Errorf("print warehouses: %w", err)
 	}
 	return errors.Join(errs...)

--- a/internal/cli/cmd/get/warehouse.go
+++ b/internal/cli/cmd/get/warehouse.go
@@ -28,7 +28,7 @@ type getWarehousesOptions struct {
 	genericiooptions.IOStreams
 	*genericclioptions.PrintFlags
 
-	getOptions
+	*getOptions
 
 	Config        config.CLIConfig
 	ClientOptions client.Options
@@ -40,7 +40,7 @@ type getWarehousesOptions struct {
 func newGetWarehousesCommand(
 	cfg config.CLIConfig,
 	streams genericiooptions.IOStreams,
-	getOptions getOptions,
+	getOptions *getOptions,
 ) *cobra.Command {
 	cmdOpts := &getWarehousesOptions{
 		Config:     cfg,

--- a/internal/cli/option/flag.go
+++ b/internal/cli/option/flag.go
@@ -44,6 +44,9 @@ const (
 	// NewAliasFlag is the flag name for the new-alias flag.
 	NewAliasFlag = "new-alias"
 
+	// NoHeadersFlag is the flag name for the no-headers flag.
+	NoHeadersFlag = "no-headers"
+
 	// OldAliasFlag is the flag name for the old-alias flag.
 	OldAliasFlag = "old-alias"
 
@@ -149,7 +152,12 @@ func NewAlias(fs *pflag.FlagSet, stage *string, usage string) {
 
 // NoHeaders adds the NoHeadersFlag to the provided flag set.
 func NoHeaders(fs *pflag.FlagSet, noHeaders *bool) {
-	fs.BoolVar(noHeaders, "no-headers", false, "Don't print headers when printing resource tables")
+	fs.BoolVar(
+		noHeaders,
+		NoHeadersFlag,
+		false,
+		"When using the default output format, don't print headers (default print headers).",
+	)
 }
 
 // OldAlias adds the OldAliasFlag to the provided flag set.

--- a/internal/cli/option/flag.go
+++ b/internal/cli/option/flag.go
@@ -147,6 +147,11 @@ func NewAlias(fs *pflag.FlagSet, stage *string, usage string) {
 	fs.StringVar(stage, NewAliasFlag, "", usage)
 }
 
+// NoHeaders adds the NoHeadersFlag to the provided flag set.
+func NoHeaders(fs *pflag.FlagSet, noHeaders *bool) {
+	fs.BoolVar(noHeaders, "no-headers", false, "Don't print headers when printing resource tables")
+}
+
 // OldAlias adds the OldAliasFlag to the provided flag set.
 func OldAlias(fs *pflag.FlagSet, stage *string, usage string) {
 	fs.StringVar(stage, OldAliasFlag, "", usage)


### PR DESCRIPTION
Fixes #1751

So I hope this way of solving it is okay, please be critical because I haven't worked much on cobra before.

I've added the flag to the options pacakge just to keep it clean, I believe we have done that for all flags as far as I can tell.

I set the --no-headers flag as a persistent flag on the get (root) command using the same options pattern.

In the options structs of all subcommands I have embedded the getOptions (kept it unexported for now), so that we can easily add more get options to all subcommands. **Struct embedding felt natural here to me as we are using it across all get commands, but happy to amend that if needed** just means we get o.getOptions.NoHeaders instead of o.NoHeaders in a few places.

For the printTable function I ended up just adding a no headers bool as well, the alternative would have been being able to pass the whole printoptions struct, but it would have meant a bunch of if statements on every subcommand, plus I don't see the use currently for that considering we are only specifying one print option.

Note: I haven't doen the tests yet because I wanted to make sure the implementation is alright first. Although I'm note sure if there are any tests for these aspects of the CLI.

```
webstradev@Eriks-MacBook-Pro kargo % kargo get project
NAME         PHASE   AGE
my-project   Ready   26h
webstradev@Eriks-MacBook-Pro kargo % kargo get project --no-headers
my-project   Ready   26h
webstradev@Eriks-MacBook-Pro kargo % 
```

Closes #1751

Let me know what you think!