### PR TITLE
fix(ui): when serializing resources as json, interpret zero value timestamps as undefined

### DIFF
--- a/ui/hack/generate-proto-extensions.mjs
+++ b/ui/hack/generate-proto-extensions.mjs
@@ -98,7 +98,11 @@ function extendTime(src) {
       z = "." + nanosStr + "Z";
     }
   }
-  return new Date(ms).toISOString().replace(".000Z", z);
+  try {
+    return new Date(ms).toISOString().replace(".000Z", z);
+  } catch {
+    return undefined;
+  }
 `);
 
   // Add helper methods

--- a/ui/src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb.ts
+++ b/ui/src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb.ts
@@ -2938,7 +2938,11 @@ export class Time extends Message<Time> {
         z = "." + nanosStr + "Z";
       }
     }
-    return new Date(ms).toISOString().replace(".000Z", z);
+    try {
+      return new Date(ms).toISOString().replace(".000Z", z);
+    } catch {
+      return undefined;
+    }
   }
 
   toDate(): Date {


### PR DESCRIPTION
Fixes #1783 

When serializing resources as JSON, this change will interpret zero value timestamps (i.e. `{seconds: 0, nanos: 0}`) as `undefined` instead of throwing a parsing error.

@rpelczar this solves the problem that we were debugging together earlier.

@hoon I think you'd be the best person to review this. 🙏 