### PR TITLE
refactor: use go-logr/logr with log/slog backend

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -102,7 +102,7 @@ func NewPromotionEventAnnotations(
 		if len(f.Commits) > 0 {
 			data, err := json.Marshal(f.Commits)
 			if err != nil {
-				log.WithError(err).Error("marshal freight commits in JSON")
+				log.Error(err, "marshal freight commits in JSON")
 			} else {
 				annotations[AnnotationKeyEventFreightCommits] = string(data)
 			}
@@ -110,7 +110,7 @@ func NewPromotionEventAnnotations(
 		if len(f.Images) > 0 {
 			data, err := json.Marshal(f.Images)
 			if err != nil {
-				log.WithError(err).Error("marshal freight images in JSON")
+				log.Error(err, "marshal freight images in JSON")
 			} else {
 				annotations[AnnotationKeyEventFreightImages] = string(data)
 			}
@@ -118,7 +118,7 @@ func NewPromotionEventAnnotations(
 		if len(f.Charts) > 0 {
 			data, err := json.Marshal(f.Charts)
 			if err != nil {
-				log.WithError(err).Error("marshal freight charts in JSON")
+				log.Error(err, "marshal freight charts in JSON")
 			} else {
 				annotations[AnnotationKeyEventFreightCharts] = string(data)
 			}

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +22,7 @@ import (
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 )
@@ -32,12 +33,12 @@ type apiOptions struct {
 	Host string
 	Port string
 
-	Logger *log.Logger
+	Logger logr.Logger
 }
 
 func newAPICommand() *cobra.Command {
 	cmdOpts := &apiOptions{
-		Logger: log.StandardLogger(),
+		Logger: logging.LoggerFromContext(context.Background()),
 	}
 
 	cmd := &cobra.Command{
@@ -64,10 +65,10 @@ func (o *apiOptions) complete() {
 
 func (o *apiOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
-	o.Logger.WithFields(log.Fields{
-		"version": version.Version,
-		"commit":  version.GitCommit,
-	}).Info("Starting Kargo API Server")
+	o.Logger.WithValues(
+		"version", version.Version,
+		"commit", version.GitCommit,
+	).Info("Starting Kargo API Server")
 
 	cfg := config.ServerConfigFromEnv()
 
@@ -84,7 +85,7 @@ func (o *apiOptions) run(ctx context.Context) error {
 	case !cfg.RolloutsIntegrationEnabled:
 		o.Logger.Info("Argo Rollouts integration is disabled")
 	case !argoRolloutsExists(ctx, clientCfg):
-		o.Logger.Warn(
+		o.Logger.Info(
 			"Argo Rollouts integration was enabled, but no Argo Rollouts " +
 				"CRDs were found. Proceeding without Argo Rollouts integration.",
 		)
@@ -97,11 +98,11 @@ func (o *apiOptions) run(ctx context.Context) error {
 		o.Logger.Info("admin account is enabled")
 	}
 	if cfg.OIDCConfig != nil {
-		o.Logger.WithFields(log.Fields{
-			"issuerURL":   cfg.OIDCConfig.IssuerURL,
-			"clientID":    cfg.OIDCConfig.ClientID,
-			"cliClientID": cfg.OIDCConfig.CLIClientID,
-		}).Info("SSO via OpenID Connect is enabled")
+		o.Logger.WithValues(
+			"issuerURL", cfg.OIDCConfig.IssuerURL,
+			"clientID", cfg.OIDCConfig.ClientID,
+			"cliClientID", cfg.OIDCConfig.CLIClientID,
+		).Info("SSO via OpenID Connect is enabled")
 	}
 
 	srv := api.NewServer(cfg, kubeClient, internalClient, recorder)

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -38,7 +38,7 @@ type apiOptions struct {
 
 func newAPICommand() *cobra.Command {
 	cmdOpts := &apiOptions{
-		Logger: logging.LoggerFromContext(context.Background()),
+		Logger: logging.DefaultLogger(),
 	}
 
 	cmd := &cobra.Command{

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -65,10 +65,11 @@ func (o *apiOptions) complete() {
 
 func (o *apiOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
-	o.Logger.WithValues(
+	o.Logger.Info(
+		"Starting Kargo API Server",
 		"version", version.Version,
 		"commit", version.GitCommit,
-	).Info("Starting Kargo API Server")
+	)
 
 	cfg := config.ServerConfigFromEnv()
 
@@ -98,11 +99,12 @@ func (o *apiOptions) run(ctx context.Context) error {
 		o.Logger.Info("admin account is enabled")
 	}
 	if cfg.OIDCConfig != nil {
-		o.Logger.WithValues(
+		o.Logger.Info(
+			"SSO via OpenID Connect is enabled",
 			"issuerURL", cfg.OIDCConfig.IssuerURL,
 			"clientID", cfg.OIDCConfig.ClientID,
 			"cliClientID", cfg.OIDCConfig.CLIClientID,
-		).Info("SSO via OpenID Connect is enabled")
+		)
 	}
 
 	srv := api.NewServer(cfg, kubeClient, internalClient, recorder)

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -76,14 +76,11 @@ func (o *controllerOptions) complete() {
 func (o *controllerOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
 
-	startupLogEntry := o.Logger.WithValues(
-		"version", version.Version,
-		"commit", version.GitCommit,
-	)
+	keyVals := []any{"version", version.Version, "commit", version.GitCommit}
 	if o.ShardName != "" {
-		startupLogEntry = startupLogEntry.WithValues("shard", o.ShardName)
+		keyVals = append(keyVals, "shard", o.ShardName)
 	}
-	startupLogEntry.Info("Starting Kargo Controller")
+	o.Logger.Info("Starting Kargo Controller")
 
 	promotionsReconcilerCfg := promotions.ReconcilerConfigFromEnv()
 	stagesReconcilerCfg := stages.ReconcilerConfigFromEnv()

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,6 +25,7 @@ import (
 	"github.com/akuity/kargo/internal/controller/stages"
 	"github.com/akuity/kargo/internal/controller/warehouses"
 	"github.com/akuity/kargo/internal/credentials"
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	"github.com/akuity/kargo/internal/types"
 	versionpkg "github.com/akuity/kargo/internal/version"

--- a/cmd/controlplane/garbage_collector.go
+++ b/cmd/controlplane/garbage_collector.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +16,7 @@ import (
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/garbage"
 	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 )

--- a/cmd/controlplane/garbage_collector.go
+++ b/cmd/controlplane/garbage_collector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,12 +25,12 @@ import (
 type garbageCollectorOptions struct {
 	KubeConfig string
 
-	Logger *log.Logger
+	Logger logr.Logger
 }
 
 func newGarbageCollectorCommand() *cobra.Command {
 	cmdOpts := &garbageCollectorOptions{
-		Logger: log.StandardLogger(),
+		Logger: logging.DefaultLogger(),
 	}
 
 	cmd := &cobra.Command{
@@ -54,10 +55,11 @@ func (o *garbageCollectorOptions) complete() {
 func (o *garbageCollectorOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
 
-	o.Logger.WithFields(log.Fields{
-		"version": version.Version,
-		"commit":  version.GitCommit,
-	}).Info("Starting Kargo Garbage Collector")
+	o.Logger.Info(
+		"Starting Kargo Garbage Collector",
+		"version", version.Version,
+		"commit", version.GitCommit,
+	)
 
 	mgr, err := o.setupManager(ctx)
 	if err != nil {

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	ctx := signals.SetupSignalHandler()
 	if err := Execute(ctx); err != nil {
-		logging.LoggerFromContext(ctx).Error(err)
+		logging.LoggerFromContext(ctx).Error(err, "couldn't execute command")
 		os.Exit(1)
 	}
 }

--- a/cmd/controlplane/management_controller.go
+++ b/cmd/controlplane/management_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -24,12 +25,12 @@ import (
 type managementControllerOptions struct {
 	KubeConfig string
 
-	Logger *log.Logger
+	Logger logr.Logger
 }
 
 func newManagementControllerCommand() *cobra.Command {
 	cmdOpts := &managementControllerOptions{
-		Logger: log.StandardLogger(),
+		Logger: logging.DefaultLogger(),
 	}
 
 	cmd := &cobra.Command{
@@ -54,10 +55,11 @@ func (o *managementControllerOptions) complete() {
 func (o *managementControllerOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
 
-	o.Logger.WithFields(log.Fields{
-		"version": version.Version,
-		"commit":  version.GitCommit,
-	}).Info("Starting Kargo Management Controller")
+	o.Logger.Info(
+		"Starting Kargo Management Controller",
+		"version", version.Version,
+		"commit", version.GitCommit,
+	)
 
 	kargoMgr, err := o.setupManager(ctx)
 	if err != nil {

--- a/cmd/controlplane/management_controller.go
+++ b/cmd/controlplane/management_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -17,6 +16,7 @@ import (
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/controller/management/namespaces"
 	"github.com/akuity/kargo/internal/controller/management/projects"
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 )

--- a/cmd/controlplane/webhooks.go
+++ b/cmd/controlplane/webhooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,12 +31,12 @@ import (
 type webhooksServerOptions struct {
 	KubeConfig string
 
-	Logger *log.Logger
+	Logger logr.Logger
 }
 
 func newWebhooksServerCommand() *cobra.Command {
 	cmdOpts := &webhooksServerOptions{
-		Logger: log.StandardLogger(),
+		Logger: logging.DefaultLogger(),
 	}
 
 	cmd := &cobra.Command{
@@ -59,10 +60,11 @@ func (o *webhooksServerOptions) complete() {
 
 func (o *webhooksServerOptions) run(ctx context.Context) error {
 	version := versionpkg.GetVersion()
-	o.Logger.WithFields(log.Fields{
-		"version": version.Version,
-		"commit":  version.GitCommit,
-	}).Info("Starting Kargo Webhooks Server")
+	o.Logger.Info(
+		"Starting Kargo Webhooks Server",
+		"version", version.Version,
+		"commit", version.GitCommit,
+	)
 
 	webhookCfg := libWebhook.ConfigFromEnv()
 

--- a/cmd/controlplane/webhooks.go
+++ b/cmd/controlplane/webhooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +16,7 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
 	libWebhook "github.com/akuity/kargo/internal/webhook"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/adrg/xdg v0.4.0
 	github.com/bacongobbler/browser v1.1.0
-	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -28,7 +27,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.10.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
@@ -56,7 +54,10 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-require github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+require (
+	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+)
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
@@ -82,7 +83,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bombsimon/logrusr/v4 v4.1.0 h1:uZNPbwusB0eUXlO8hIUwStE6Lr5bLN6IgYgG+75kuh4=
-github.com/bombsimon/logrusr/v4 v4.1.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -578,7 +578,7 @@ func GetRestConfig(ctx context.Context, path string) (*rest.Config, error) {
 	// is empty, but will issue a warning that we can suppress by checking for
 	// that condition ourselves and calling rest.InClusterConfig() directly.
 	if path == "" {
-		logger.Debug("loading in-cluster REST config")
+		logger.V(1).Info("loading in-cluster REST config")
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
 			return cfg, fmt.Errorf("error loading in-cluster REST config: %w", err)
@@ -586,7 +586,7 @@ func GetRestConfig(ctx context.Context, path string) (*rest.Config, error) {
 		return cfg, nil
 	}
 
-	logger.WithField("path", path).Debug("loading REST config from path")
+	logger.WithValues("path", path).V(1).Info("loading REST config from path")
 	cfg, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
 		return cfg, fmt.Errorf("error loading REST config from %q: %w", path, err)

--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -586,7 +586,7 @@ func GetRestConfig(ctx context.Context, path string) (*rest.Config, error) {
 		return cfg, nil
 	}
 
-	logger.WithValues("path", path).V(1).Info("loading REST config from path")
+	logger.V(1).Info("loading REST config from path", "path", path)
 	cfg, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
 		return cfg, fmt.Errorf("error loading REST config from %q: %w", path, err)

--- a/internal/api/option/log.go
+++ b/internal/api/option/log.go
@@ -53,15 +53,18 @@ func (i *logInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		fields := map[string]any{
 			"connect.duration": time.Since(start).String(),
 		}
-		level := slog.LevelInfo
 		if err != nil {
-			level = slog.LevelError
 			fields["connect.code"] = connect.CodeOf(err).String()
+			logging.
+				LoggerFromContext(ctx).
+				WithValues(fields).
+				Error(err, "finished unary call")
+			return res, err
 		}
 		logging.
 			LoggerFromContext(ctx).
 			WithValues(fields).
-			V(int(level)).Info("finished unary call")
+			Info("finished unary call")
 		return res, err
 	}
 }
@@ -85,15 +88,18 @@ func (i *logInterceptor) WrapStreamingHandler(
 		fields := map[string]any{
 			"connect.duration": time.Since(start),
 		}
-		level := slog.LevelInfo
 		if err != nil {
-			level = slog.LevelInfo
 			fields["connect.code"] = connect.CodeOf(err).String()
+			logging.
+				LoggerFromContext(ctx).
+				WithValues(fields).
+				Error(err, "finished streaming call")
+			return err
 		}
+
 		logging.
 			LoggerFromContext(ctx).
 			WithValues(fields).
-			V(int(level)).
 			Info("finished streaming call")
 		return err
 	}

--- a/internal/api/option/log.go
+++ b/internal/api/option/log.go
@@ -2,7 +2,6 @@ package option
 
 import (
 	"context"
-	"log/slog"
 	"path"
 	"time"
 

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	log "github.com/sirupsen/logrus"
 	libClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/internal/api/config"
@@ -33,7 +32,7 @@ func NewHandlerOption(
 		connect.WithInterceptors(interceptors...),
 		connect.WithRecover(
 			func(ctx context.Context, _ connect.Spec, _ http.Header, r any) error {
-				logging.LoggerFromContext(ctx).Log(log.ErrorLevel, takeStacktrace(defaultStackLength, 3))
+				logging.LoggerFromContext(ctx).Error(nil, takeStacktrace(defaultStackLength, 3))
 				return connect.NewError(
 					connect.CodeInternal, fmt.Errorf("panic: %v", r))
 			}),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,7 +11,6 @@ import (
 
 	"connectrpc.com/grpchealth"
 	"github.com/rs/cors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -232,9 +231,9 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 		}
 	}()
 
-	log.WithFields(logrus.Fields{
-		"tls": s.cfg.TLSConfig != nil,
-	}).Infof("Server is listening on %q", l.Addr().String())
+	log.WithValues(
+		"tls", s.cfg.TLSConfig != nil,
+	).Info("Server is listening", "port", l.Addr().String())
 
 	select {
 	case <-ctx.Done():

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -231,9 +231,11 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 		}
 	}()
 
-	log.WithValues(
+	log.Info(
+		"Server is listening",
+		"bindAddress", l.Addr().String(),
 		"tls", s.cfg.TLSConfig != nil,
-	).Info("Server is listening", "bindAddress", l.Addr().String())
+	)
 
 	select {
 	case <-ctx.Done():

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -233,7 +233,7 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 
 	log.WithValues(
 		"tls", s.cfg.TLSConfig != nil,
-	).Info("Server is listening", "port", l.Addr().String())
+	).Info("Server is listening", "bindAddress", l.Addr().String())
 
 	select {
 	case <-ctx.Done():

--- a/internal/controller/management/namespaces/namespaces.go
+++ b/internal/controller/management/namespaces/namespaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -81,11 +80,11 @@ func (r *reconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
-	logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
-		"project": req.NamespacedName.Name,
-	})
+	logger := logging.LoggerFromContext(ctx).WithValues(
+		"project", req.NamespacedName.Name,
+	)
 	ctx = logging.ContextWithLogger(ctx, logger)
-	logger.Debug("reconciling Namespace")
+	logger.V(1).Info("reconciling Namespace")
 
 	// Find the Namespace
 	ns := &corev1.Namespace{}
@@ -99,12 +98,12 @@ func (r *reconciler) Reconcile(
 	if ns.DeletionTimestamp == nil {
 		return ctrl.Result{}, nil
 	}
-	logger.Debug("Namespace is being deleted")
+	logger.V(1).Info("Namespace is being deleted")
 
 	if !controllerutil.ContainsFinalizer(ns, kargoapi.FinalizerName) {
 		return ctrl.Result{}, nil
 	}
-	logger.Debug("Namespace needs finalizing")
+	logger.V(1).Info("Namespace needs finalizing")
 
 	// Ignore not found errors to keep this idempotent.
 	if err := client.IgnoreNotFound(
@@ -124,6 +123,6 @@ func (r *reconciler) Reconcile(
 			return ctrl.Result{}, fmt.Errorf("error removing finalizer: %w", err)
 		}
 	}
-	logger.Debug("done reconciling Namespace")
+	logger.V(1).Info("done reconciling Namespace")
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/promotion/argocd.go
+++ b/internal/controller/promotion/argocd.go
@@ -213,8 +213,7 @@ func (a *argoCDMechanism) doSingleUpdate(
 	); err != nil {
 		return fmt.Errorf("error patching Argo CD Application %q: %w", app.Name, err)
 	}
-	logging.LoggerFromContext(ctx).WithValues("app", app.Name).
-		V(1).Info("patched Argo CD Application")
+	logging.LoggerFromContext(ctx).V(1).Info("patched Argo CD Application", "app", app.Name)
 	return nil
 }
 

--- a/internal/controller/promotion/argocd.go
+++ b/internal/controller/promotion/argocd.go
@@ -91,7 +91,7 @@ func (a *argoCDMechanism) Promote(
 	}
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Debug("executing Argo CD-based promotion mechanisms")
+	logger.V(1).Info("executing Argo CD-based promotion mechanisms")
 
 	for _, update := range updates {
 		if err := a.doSingleUpdateFn(
@@ -104,7 +104,7 @@ func (a *argoCDMechanism) Promote(
 		}
 	}
 
-	logger.Debug("done executing Argo CD-based promotion mechanisms")
+	logger.V(1).Info("done executing Argo CD-based promotion mechanisms")
 
 	return promo.Status.WithPhase(kargoapi.PromotionPhaseSucceeded), newFreight, nil
 }
@@ -213,8 +213,8 @@ func (a *argoCDMechanism) doSingleUpdate(
 	); err != nil {
 		return fmt.Errorf("error patching Argo CD Application %q: %w", app.Name, err)
 	}
-	logging.LoggerFromContext(ctx).WithField("app", app.Name).
-		Debug("patched Argo CD Application")
+	logging.LoggerFromContext(ctx).WithValues("app", app.Name).
+		V(1).Info("patched Argo CD Application")
 	return nil
 }
 

--- a/internal/controller/promotion/composite.go
+++ b/internal/controller/promotion/composite.go
@@ -54,7 +54,7 @@ func (c *compositeMechanism) Promote(
 	newFreight = *newFreight.DeepCopy()
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Debugf("executing %s", c.name)
+	logger.V(1).Info("executing", "name", c.name)
 
 	for _, childMechanism := range c.childMechanisms {
 		var err error
@@ -76,7 +76,7 @@ func (c *compositeMechanism) Promote(
 		}
 	}
 
-	logger.Debug("done executing promotion mechanisms. aggregated status: ", newStatus.Phase)
+	logger.V(1).Info("done executing promotion mechanisms", "aggregated status", newStatus.Phase)
 
 	return newStatus, newFreight, nil
 }

--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -106,7 +106,7 @@ func (g *gitMechanism) Promote(
 	newFreight = *newFreight.DeepCopy()
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Debugf("executing %s", g.name)
+	logger.V(1).Info("executing", "name", g.name)
 
 	for _, update := range updates {
 		var err error
@@ -122,7 +122,7 @@ func (g *gitMechanism) Promote(
 		newStatus = aggregateGitPromoStatus(newStatus, *otherStatus)
 	}
 
-	logger.Debugf("done executing %s", g.name)
+	logger.V(1).Info("done executing", "name", g.name)
 
 	return newStatus, newFreight, nil
 }
@@ -267,12 +267,12 @@ func getRepoCredentialsFn(
 		if err != nil {
 			return nil, fmt.Errorf("error obtaining credentials for git repo %q: %w", repoURL, err)
 		}
-		logger := logging.LoggerFromContext(ctx).WithField("repo", repoURL)
+		logger := logging.LoggerFromContext(ctx).WithValues("repo", repoURL)
 		if !ok {
-			logger.Debug("found no credentials for git repo")
+			logger.V(1).Info("found no credentials for git repo")
 			return nil, nil
 		}
-		logger.Debug("obtained credentials for git repo")
+		logger.V(1).Info("obtained credentials for git repo")
 		return &git.RepoCredentials{
 			Username:      creds.Username,
 			Password:      creds.Password,

--- a/internal/controller/promotions/promoqueues.go
+++ b/internal/controller/promotions/promoqueues.go
@@ -67,20 +67,22 @@ func (pqs *promoQueues) initializeQueues(ctx context.Context, promos kargoapi.Pr
 			continue
 		}
 		pq.Push(&promo)
-		logger.WithValues(
+		logger.V(1).Info(
+			"pushed Promotion onto Stage-specific Promotion queue",
 			"promotion", promo.Name,
 			"namespace", promo.Namespace,
 			"stage", promo.Spec.Stage,
 			"phase", promo.Status.Phase,
-		).V(1).Info("pushed Promotion onto Stage-specific Promotion queue")
+		)
 	}
 	if logger.V(1).Enabled() {
 		for stage, pq := range pqs.pendingPromoQueuesByStage {
-			logger.WithValues(
+			logger.V(1).Info(
+				"Stage-specific Promotion queue initialized",
 				"stage", stage.Name,
 				"namespace", stage.Namespace,
 				"depth", pq.Depth(),
-			).V(1).Info("Stage-specific Promotion queue initialized")
+			)
 		}
 	}
 }
@@ -141,11 +143,13 @@ func (pqs *promoQueues) conclude(ctx context.Context, stageKey types.NamespacedN
 	pqs.promoQueuesByStageMu.RLock()
 	defer pqs.promoQueuesByStageMu.RUnlock()
 	if pqs.activePromoByStage[stageKey] == promoName {
-		logger := logging.LoggerFromContext(ctx).WithValues(
+		logger := logging.LoggerFromContext(ctx)
+
+		delete(pqs.activePromoByStage, stageKey)
+		logger.V(1).Info(
+			"conclude promo",
 			"namespace", stageKey.Namespace,
 			"promotion", promoName,
 		)
-		delete(pqs.activePromoByStage, stageKey)
-		logger.V(1).Info("conclude promo")
 	}
 }

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -172,12 +172,12 @@ func (r *reconciler) Reconcile(
 	req ctrl.Request,
 ) (ctrl.Result, error) {
 	logger := logging.LoggerFromContext(ctx).
-		WithFields(log.Fields{
-			"namespace": req.NamespacedName.Namespace,
-			"promotion": req.NamespacedName.Name,
-		})
+		WithValues(
+			"namespace", req.NamespacedName.Namespace,
+			"promotion", req.NamespacedName.Name,
+		)
 	ctx = logging.ContextWithLogger(ctx, logger)
-	logger.Debug("reconciling Promotion")
+	logger.V(1).Info("reconciling Promotion")
 
 	// Note that initialization occurs here because we basically know that the
 	// controller runtime client's cache is ready at this point. We cannot attempt
@@ -410,7 +410,7 @@ func (r *reconciler) promote(
 		)
 	}
 
-	logger = logger.WithField("targetFreight", targetFreight.Name)
+	logger = logger.WithValues("targetFreight", targetFreight.Name)
 
 	targetFreightRef := kargoapi.FreightReference{
 		Name:      targetFreight.Name,
@@ -462,7 +462,7 @@ func (r *reconciler) promote(
 					); err != nil {
 						// Log the error, but don't let failure to initiate re-verification
 						// prevent the promotion from succeeding.
-						logger.Errorf("error triggering re-verification: %s", err)
+						logger.Error(err, "error triggering re-verification")
 					}
 				} else if stage.Spec.PromotionMechanisms != nil {
 					status.CurrentFreight = &nextFreight

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -133,11 +133,12 @@ func (e *EnqueueHighestPriorityPromotionHandler) enqueueNext(
 				},
 			},
 		)
-		e.logger.WithValues(
+		e.logger.V(1).Info(
+			"enqueued promo",
 			"promotion", promo.Name,
 			"namespace", promo.Namespace,
 			"stage", promo.Spec.Stage,
-		).V(1).Info("enqueued promo")
+		)
 		return
 	}
 }

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -743,8 +743,10 @@ func (r *reconciler) syncNormalStage(
 			*status.CurrentFreight,
 			stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
 		); status.Health != nil {
-			freightLogger.WithValues("health", status.Health.Status).
-				Debug("Stage health assessed")
+			freightLoggerV(1).Info(
+				"Stage health assessed",
+				"health", status.Health.Status,
+			)
 		} else {
 			freightLogger.V(1).Info("Stage health deemed not applicable")
 		}
@@ -1026,7 +1028,7 @@ func (r *reconciler) syncNormalStage(
 		promo.Spec.Stage,
 	)
 
-	logger.WithValues("promotion", promo.Name).V(1).Info("created Promotion resource")
+	logger.V(1).Info("created Promotion resource", "promotion", promo.Name)
 
 	return status, nil
 }
@@ -1300,8 +1302,11 @@ func (r *reconciler) isAutoPromotionPermitted(
 	}
 	for _, policy := range project.Spec.PromotionPolicies {
 		if policy.Stage == stageName {
-			logger.WithValues("autoPromotionEnabled", policy.AutoPromotionEnabled).
-				V(1).Info("found PromotionPolicy associated with the Stage")
+			logger.V(1).Info(
+				"found PromotionPolicy associated with the Stage",
+				"autoPromotionEnabled", policy.AutoPromotionEnabled,
+			)
+
 			return policy.AutoPromotionEnabled, nil
 		}
 	}
@@ -1330,8 +1335,10 @@ func (r *reconciler) getLatestAvailableFreight(
 			)
 		}
 		if latestFreight == nil {
-			logger.WithValues("warehouse", stage.Spec.Subscriptions.Warehouse).
-				V(1).Info("no Freight found from Warehouse")
+			logger.V(1).Info(
+				"no Freight found from Warehouse",
+				"warehouse", stage.Spec.Subscriptions.Warehouse,
+			)
 		}
 		return latestFreight, nil
 	}

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	corev1 "k8s.io/api/core/v1"
@@ -743,7 +744,7 @@ func (r *reconciler) syncNormalStage(
 			*status.CurrentFreight,
 			stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
 		); status.Health != nil {
-			freightLoggerV(1).Info(
+			freightLogger.V(1).Info(
 				"Stage health assessed",
 				"health", status.Health.Status,
 			)
@@ -787,7 +788,7 @@ func (r *reconciler) syncNormalStage(
 			if status.Phase == kargoapi.StagePhaseVerifying || status.Phase == kargoapi.StagePhaseNotApplicable {
 				if !status.CurrentFreight.VerificationInfo.HasAnalysisRun() {
 					if status.Health == nil || status.Health.Status == kargoapi.HealthStateHealthy {
-						logger.V(1).Debug("starting verification")
+						logger.V(1).Info("starting verification")
 						var err error
 						if status.CurrentFreight.VerificationInfo, err = r.startVerificationFn(
 							ctx,
@@ -800,7 +801,7 @@ func (r *reconciler) syncNormalStage(
 						}
 					}
 				} else {
-					logger.V(1).Debug("checking verification results")
+					logger.V(1).Info("checking verification results")
 					var err error
 					if status.CurrentFreight.VerificationInfo, err = r.getVerificationInfoFn(
 						ctx,

--- a/internal/controller/stages/verification.go
+++ b/internal/controller/stages/verification.go
@@ -86,7 +86,7 @@ func (r *reconciler) startVerification(
 				return analysisRuns.Items[j].CreationTimestamp.Before(&analysisRuns.Items[i].CreationTimestamp)
 			})
 
-			logger.Debug("AnalysisRun already exists for Freight")
+			logger.V(1).Info("AnalysisRun already exists for Freight")
 			latestAnalysisRun := analysisRuns.Items[0]
 			return &kargoapi.VerificationInfo{
 				ID:         uuid.NewString(),

--- a/internal/controller/stages/watches.go
+++ b/internal/controller/stages/watches.go
@@ -92,7 +92,7 @@ func (v *verifiedFreightEventHandler) Update(
 			},
 		); err != nil {
 			logger.Error(
-				nil,
+				err,
 				"Failed list Stages downstream from Stage",
 				"stage", evt.ObjectOld,
 				"namespace", newFreight.Namespace,

--- a/internal/controller/stages/watches.go
+++ b/internal/controller/stages/watches.go
@@ -112,10 +112,11 @@ func (v *verifiedFreightEventHandler) Update(
 				},
 			},
 		)
-		logger.WithValues(
+		logger.V(1).Info(
+			"enqueued downstream Stage for reconciliation",
 			"namespace", newFreight.Namespace,
 			"stage", downStreamStage,
-		).V(1).Info("enqueued downstream Stage for reconciliation")
+		)
 	}
 }
 
@@ -194,10 +195,11 @@ func (a *approvedFreightEventHandler) Update(
 				},
 			},
 		)
-		logger.WithValues(
+		logger.V(1).Info(
+			"enqueued Stage for reconciliation",
 			"namespace", newFreight.Namespace,
 			"stage", stage,
-		).V(1).Info("enqueued Stage for reconciliation")
+		)
 	}
 }
 
@@ -258,10 +260,11 @@ func (c *createdFreightEventHandler) Create(
 				},
 			},
 		)
-		logger.WithValues(
+		logger.V(1).Info(
+			"enqueued Stage for reconciliation",
 			"namespace", freight.Namespace,
 			"stage", stage.Name,
-		).V(1).Info("enqueued Stage for reconciliation")
+		)
 	}
 }
 
@@ -367,11 +370,12 @@ func (u *updatedArgoCDAppHandler) Update(
 					},
 				},
 			)
-			logger.WithValues(
+			logger.V(1).Info(
+				"enqueued Stage for reconciliation",
 				"namespace", stage.Namespace,
 				"stage", stage.Name,
 				"app", e.ObjectNew.GetName(),
-			).V(1).Info("enqueued Stage for reconciliation")
+			)
 		}
 	}
 }
@@ -480,11 +484,12 @@ func (p *phaseChangedAnalysisRunHandler) Update(
 					},
 				},
 			)
-			logger.WithValues(
+			logger.V(1).Info(
+				"enqueued Stage for reconciliation",
 				"namespace", stage.Namespace,
 				"stage", stage.Name,
 				"analysisRun", e.ObjectNew.GetName(),
-			).V(1).Info("enqueued Stage for reconciliation")
+			)
 		}
 	}
 }

--- a/internal/controller/warehouses/git.go
+++ b/internal/controller/warehouses/git.go
@@ -80,8 +80,7 @@ func (r *reconciler) selectCommits(
 				err,
 			)
 		}
-		logger.WithValues("commit", gm.Commit).
-			V(1).Info("found latest commit from repo")
+		logger.V(1).Info("found latest commit from repo", "commit", gm.Commit)
 		latestCommits = append(
 			latestCommits,
 			kargoapi.GitCommit{

--- a/internal/controller/warehouses/git.go
+++ b/internal/controller/warehouses/git.go
@@ -48,7 +48,7 @@ func (r *reconciler) selectCommits(
 			continue
 		}
 		sub := s.Git
-		logger := logging.LoggerFromContext(ctx).WithField("repo", sub.RepoURL)
+		logger := logging.LoggerFromContext(ctx).WithValues("repo", sub.RepoURL)
 		creds, ok, err :=
 			r.credentialsDB.Get(ctx, namespace, credentials.TypeGit, sub.RepoURL)
 		if err != nil {
@@ -65,9 +65,9 @@ func (r *reconciler) selectCommits(
 				Password:      creds.Password,
 				SSHPrivateKey: creds.SSHPrivateKey,
 			}
-			logger.Debug("obtained credentials for git repo")
+			logger.V(1).Info("obtained credentials for git repo")
 		} else {
-			logger.Debug("found no credentials for git repo")
+			logger.V(1).Info("found no credentials for git repo")
 		}
 
 		baseCommit := repoCommitMappings[sub.RepoURL+"#"+sub.Branch]
@@ -80,8 +80,8 @@ func (r *reconciler) selectCommits(
 				err,
 			)
 		}
-		logger.WithField("commit", gm.Commit).
-			Debug("found latest commit from repo")
+		logger.WithValues("commit", gm.Commit).
+			V(1).Info("found latest commit from repo")
 		latestCommits = append(
 			latestCommits,
 			kargoapi.GitCommit{
@@ -105,7 +105,7 @@ func (r *reconciler) selectCommitMeta(
 	creds *git.RepoCredentials,
 	baseCommit string,
 ) (*gitMeta, error) {
-	logger := logging.LoggerFromContext(ctx).WithField("repo", sub.RepoURL)
+	logger := logging.LoggerFromContext(ctx).WithValues("repo", sub.RepoURL)
 	if creds == nil {
 		creds = &git.RepoCredentials{}
 	}
@@ -142,7 +142,7 @@ func (r *reconciler) selectCommitMeta(
 	msg, err := repo.CommitMessage(selectedCommit)
 	if err != nil {
 		// This is best effort, so just log the error
-		logger.Warnf("failed to get message from commit %q: %v", selectedCommit, err)
+		logger.Error(err, "failed to get message from commit", "commit", selectedCommit, err)
 	}
 	return &gitMeta{
 		Commit: selectedCommit,

--- a/internal/controller/warehouses/helm.go
+++ b/internal/controller/warehouses/helm.go
@@ -87,8 +87,10 @@ func (r *reconciler) selectCharts(
 				sub.RepoURL,
 			)
 		}
-		logger.WithValues("version", vers).
-			V(1).Info("found latest suitable chart version")
+		logger.V(1).Info(
+			"found latest suitable chart version",
+			"version", vers,
+		)
 
 		charts = append(
 			charts,

--- a/internal/controller/warehouses/helm.go
+++ b/internal/controller/warehouses/helm.go
@@ -24,9 +24,9 @@ func (r *reconciler) selectCharts(
 
 		sub := s.Chart
 
-		logger := logging.LoggerFromContext(ctx).WithField("repoURL", sub.RepoURL)
+		logger := logging.LoggerFromContext(ctx).WithValues("repoURL", sub.RepoURL)
 		if sub.Name != "" {
-			logger = logger.WithField("chart", sub.Name)
+			logger = logger.WithValues("chart", sub.Name)
 		}
 
 		creds, ok, err :=
@@ -45,9 +45,9 @@ func (r *reconciler) selectCharts(
 				Username: creds.Username,
 				Password: creds.Password,
 			}
-			logger.Debug("obtained credentials for chart repo")
+			logger.V(1).Info("obtained credentials for chart repo")
 		} else {
-			logger.Debug("found no credentials for chart repo")
+			logger.V(1).Info("found no credentials for chart repo")
 		}
 
 		vers, err := r.selectChartVersionFn(
@@ -74,7 +74,7 @@ func (r *reconciler) selectCharts(
 		}
 
 		if vers == "" {
-			logger.Error("found no suitable chart version")
+			logger.Error(nil, "found no suitable chart version")
 			if sub.Name == "" {
 				return nil, fmt.Errorf(
 					"found no suitable version of chart in repository %q",
@@ -87,8 +87,8 @@ func (r *reconciler) selectCharts(
 				sub.RepoURL,
 			)
 		}
-		logger.WithField("version", vers).
-			Debug("found latest suitable chart version")
+		logger.WithValues("version", vers).
+			V(1).Info("found latest suitable chart version")
 
 		charts = append(
 			charts,

--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/git"
@@ -27,7 +25,7 @@ func (r *reconciler) selectImages(
 
 		sub := s.Image
 
-		logger := logging.LoggerFromContext(ctx).WithField("repo", sub.RepoURL)
+		logger := logging.LoggerFromContext(ctx).WithValues("repo", sub.RepoURL)
 
 		creds, ok, err :=
 			r.credentialsDB.Get(ctx, namespace, credentials.TypeImage, sub.RepoURL)
@@ -44,9 +42,9 @@ func (r *reconciler) selectImages(
 				Username: creds.Username,
 				Password: creds.Password,
 			}
-			logger.Debug("obtained credentials for image repo")
+			logger.V(1).Info("obtained credentials for image repo")
 		} else {
-			logger.Debug("found no credentials for image repo")
+			logger.V(1).Info("found no credentials for image repo")
 		}
 
 		tag, digest, err := r.getImageRefsFn(ctx, *sub, regCreds)
@@ -66,10 +64,10 @@ func (r *reconciler) selectImages(
 				Digest:     digest,
 			},
 		)
-		logger.WithFields(log.Fields{
-			"tag":    tag,
-			"digest": digest,
-		}).Debug("found latest suitable image")
+		logger.WithValues(
+			"tag", tag,
+			"digest", digest,
+		).V(1).Info("found latest suitable image")
 	}
 	return imgs, nil
 }

--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -64,10 +64,11 @@ func (r *reconciler) selectImages(
 				Digest:     digest,
 			},
 		)
-		logger.WithValues(
+		logger.V(1).Info(
+			"found latest suitable image",
 			"tag", tag,
 			"digest", digest,
-		).V(1).Info("found latest suitable image")
+		)
 	}
 	return imgs, nil
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/kelseyhightower/envconfig"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -110,8 +109,8 @@ func (k *kubernetesDatabase) Get(
 	// If we are dealing with an insecure HTTP endpoint (of any type),
 	// refuse to return any credentials
 	if strings.HasPrefix(repoURL, "http://") {
-		logger := logging.LoggerFromContext(ctx).WithField("repoURL", repoURL)
-		logger.Warnf("refused to get credentials for insecure HTTP endpoint")
+		logger := logging.LoggerFromContext(ctx).WithValues("repoURL", repoURL)
+		logger.Info("refused to get credentials for insecure HTTP endpoint")
 		return creds, false, nil
 	}
 
@@ -220,10 +219,10 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 		}
 		regex, err := regexp.Compile(string(patternBytes))
 		if err != nil {
-			logger.WithFields(log.Fields{
-				"namespace": namespace,
-				"secret":    secret.Name,
-			}).Warn("failed to compile regex for credential secret")
+			logger.WithValues(
+				"namespace", namespace,
+				"secret", secret.Name,
+			).Info("failed to compile regex for credential secret")
 			continue
 		}
 		if regex.MatchString(repoURL) {

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -109,8 +109,11 @@ func (k *kubernetesDatabase) Get(
 	// If we are dealing with an insecure HTTP endpoint (of any type),
 	// refuse to return any credentials
 	if strings.HasPrefix(repoURL, "http://") {
-		logger := logging.LoggerFromContext(ctx).WithValues("repoURL", repoURL)
-		logger.Info("refused to get credentials for insecure HTTP endpoint")
+		logger := logging.LoggerFromContext(ctx)
+		logger.Info(
+			"refused to get credentials for insecure HTTP endpoint",
+			"repoURL", repoURL,
+		)
 		return creds, false, nil
 	}
 
@@ -219,10 +222,11 @@ func (k *kubernetesDatabase) getCredentialsSecret(
 		}
 		regex, err := regexp.Compile(string(patternBytes))
 		if err != nil {
-			logger.WithValues(
+			logger.Info(
+				"failed to compile regex for credential secret",
 				"namespace", namespace,
 				"secret", secret.Name,
-			).Info("failed to compile regex for credential secret")
+			)
 			continue
 		}
 		if regex.MatchString(repoURL) {

--- a/internal/garbage/freight.go
+++ b/internal/garbage/freight.go
@@ -102,7 +102,7 @@ func (c *collector) cleanWarehouseFreight(
 				kubeclient.StagesByFreightIndexField: f.Name,
 			},
 		); err != nil {
-			logger.WithValues("freight", f).Error(err, "error listing Stages using Freight")
+			logger.Error(err, "error listing Stages using Freight", "freight", f)
 			return fmt.Errorf(
 				"error listing Stages in Project %q using Freight %q: %w",
 				project,

--- a/internal/garbage/projects.go
+++ b/internal/garbage/projects.go
@@ -23,16 +23,16 @@ func (c *collector) cleanProjects(
 			if !ok {
 				return // Channel was closed
 			}
-			projectLogger := logger.WithField("project", project)
+			projectLogger := logger.WithValues("project", project)
 			if err := c.cleanProjectFn(ctx, project); err != nil {
-				projectLogger.Errorf("error cleaning Project: %s", err)
+				projectLogger.Error(err, "error cleaning Project")
 				select {
 				case errCh <- struct{}{}:
 				case <-ctx.Done():
 					return
 				}
 			} else {
-				projectLogger.Debug("cleaned Project")
+				projectLogger.V(1).Info("cleaned Project")
 			}
 		case <-ctx.Done():
 			return

--- a/internal/image/digest_selector.go
+++ b/internal/image/digest_selector.go
@@ -69,10 +69,11 @@ func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
 			)
 			return nil, nil
 		}
-		logger.WithValues(
+		logger.V(2).Info(
+			"found image",
 			"tag", image.Tag,
 			"digest", image.Digest.String(),
-		).V(2).Info("found image")
+		)
 		return image, nil
 	}
 

--- a/internal/image/digest_selector.go
+++ b/internal/image/digest_selector.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/akuity/kargo/internal/logging"
 )
 
@@ -36,13 +34,13 @@ func newDigestSelector(
 
 // Select implements the Selector interface.
 func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
-	logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
-		"registry":            d.repoClient.registry.name,
-		"image":               d.repoClient.image,
-		"selectionStrategy":   SelectionStrategyDigest,
-		"platformConstrained": d.platform != nil,
-	})
-	logger.Trace("selecting image")
+	logger := logging.LoggerFromContext(ctx).WithValues(
+		"registry", d.repoClient.registry.name,
+		"image", d.repoClient.image,
+		"selectionStrategy", SelectionStrategyDigest,
+		"platformConstrained", d.platform != nil,
+	)
+	logger.V(2).Info("selecting image")
 
 	ctx = logging.ContextWithLogger(ctx, logger)
 
@@ -51,10 +49,10 @@ func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
 		return nil, fmt.Errorf("error listing tags: %w", err)
 	}
 	if len(tags) == 0 {
-		logger.Trace("found no tags")
+		logger.V(2).Info("found no tags")
 		return nil, nil
 	}
-	logger.Trace("got all tags")
+	logger.V(2).Info("got all tags")
 
 	for _, tag := range tags {
 		if tag != d.constraint {
@@ -65,19 +63,19 @@ func (d *digestSelector) Select(ctx context.Context) (*Image, error) {
 			return nil, fmt.Errorf("error retrieving image with tag %q: %w", tag, err)
 		}
 		if image == nil {
-			logger.Tracef(
-				"image with tag %q was found, but did not match platform constraint",
-				tag,
+			logger.V(2).Info(
+				"image was found, but did not match platform constraint",
+				"tag", tag,
 			)
 			return nil, nil
 		}
-		logger.WithFields(log.Fields{
-			"tag":    image.Tag,
-			"digest": image.Digest.String(),
-		}).Trace("found image")
+		logger.WithValues(
+			"tag", image.Tag,
+			"digest", image.Digest.String(),
+		).V(2).Info("found image")
 		return image, nil
 	}
 
-	logger.Trace("no images matched criteria")
+	logger.V(2).Info("no images matched criteria")
 	return nil, nil
 }

--- a/internal/image/lexical_selector.go
+++ b/internal/image/lexical_selector.go
@@ -87,10 +87,11 @@ func (l *lexicalSelector) Select(ctx context.Context) (*Image, error) {
 		return nil, nil
 	}
 
-	logger.WithValues(
+	logger.V(2).Info(
+		"found image",
 		"tag", image.Tag,
 		"digest", image.Digest.String(),
-	).V(2).Info("found image")
+	)
 	return image, nil
 }
 

--- a/internal/image/newest_build_selector.go
+++ b/internal/image/newest_build_selector.go
@@ -87,10 +87,11 @@ func (n *newestBuildSelector) Select(ctx context.Context) (*Image, error) {
 
 	if n.platform == nil {
 		image := images[0]
-		logger.WithValues(
+		logger.V(2).Info(
+			"found image",
 			"tag", image.Tag,
 			"digest", image.Digest.String(),
-		).V(2).Info("found image")
+		)
 		return &image, nil
 	}
 
@@ -109,10 +110,11 @@ func (n *newestBuildSelector) Select(ctx context.Context) (*Image, error) {
 	}
 	image.Tag = tag
 
-	logger.WithValues(
+	logger.V(2).Info(
+		"found image",
 		"tag", image.Tag,
 		"digest", image.Digest.String(),
-	).V(2).Info("found image")
+	)
 	return image, nil
 }
 

--- a/internal/image/repository_client.go
+++ b/internal/image/repository_client.go
@@ -244,7 +244,7 @@ var getChallengeManager = func(
 // getTags retrieves a list of all tags from the repository.
 func (r *repositoryClient) getTags(ctx context.Context) ([]string, error) {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Trace("retrieving tags for image")
+	logger.V(2).Info("retrieving tags for image")
 	tagSvc := r.repo.Tags(ctx)
 	tags, err := tagSvc.All(ctx)
 	if err != nil {
@@ -282,14 +282,14 @@ func (r *repositoryClient) getImageByDigest(
 	platform *platformConstraint,
 ) (*Image, error) {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("retrieving image for manifest %s", d)
+	logger.V(2).Info("retrieving image for manifest", "digest", d)
 
 	if entry, exists := r.registry.imageCache.Get(d.String()); exists {
 		image := entry.(Image) // nolint: forcetypeassert
 		return &image, nil
 	}
 
-	logger.Tracef("image for manifest %s NOT found in cache", d)
+	logger.V(2).Info("image for manifest NOT found in cache", "digest", d)
 
 	manifest, err := r.getManifestByDigestFn(ctx, d)
 	if err != nil {
@@ -303,7 +303,7 @@ func (r *repositoryClient) getImageByDigest(
 	if image != nil {
 		// Cache the image
 		r.registry.imageCache.Set(d.String(), *image, cache.DefaultExpiration)
-		logger.Tracef("cached image for manifest %s", d)
+		logger.V(2).Info("cached image for manifest", "digest", d)
 	}
 
 	return image, nil
@@ -315,7 +315,7 @@ func (r *repositoryClient) getManifestByTag(
 	tag string,
 ) (distribution.Manifest, error) {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("retrieving manifest for tag %q from repository", tag)
+	logger.V(2).Info("retrieving manifest from repository", "tag", tag)
 	manifestSvc, err := r.repo.Manifests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting manifest service: %w", err)
@@ -338,7 +338,7 @@ func (r *repositoryClient) getManifestByDigest(
 	d digest.Digest,
 ) (distribution.Manifest, error) {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("retrieving manifest for digest %q from repository", d.String())
+	logger.V(2).Info("retrieving manifest from repository", "digest", d.String())
 	manifestSvc, err := r.repo.Manifests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting manifest service: %w", err)
@@ -399,7 +399,7 @@ func (r *repositoryClient) extractImageFromV1Manifest(
 	digest := digest.FromBytes(manifestBytes)
 
 	logger := logging.LoggerFromContext(context.Background())
-	logger.Tracef("extracting image from V1 manifest %s", digest)
+	logger.V(2).Info("extracting image from V1 manifest", "digest", digest)
 
 	if len(manifest.History) == 0 {
 		return nil, fmt.Errorf("no history information found in V1 manifest %s", digest)
@@ -449,7 +449,7 @@ func (r *repositoryClient) extractImageFromV2Manifest(
 	digest := digest.FromBytes(manifestBytes)
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("extracting image from V2 manifest %s", digest)
+	logger.V(2).Info("extracting image from V2 manifest", "digest", digest)
 
 	// This referenced config object has platform information and creation
 	// timestamp
@@ -509,7 +509,7 @@ func (r *repositoryClient) extractImageFromOCIManifest(
 	digest := digest.FromBytes(manifestBytes)
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("extracting image from OCI manifest %s", digest)
+	logger.V(2).Info("extracting image from OCI manifest", "digest", digest)
 
 	// This referenced config object has platform information and creation
 	// timestamp
@@ -577,9 +577,9 @@ func (r *repositoryClient) extractImageFromCollection(
 	digest := digest.FromBytes(manifestBytes)
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef(
-		"extracting image from V2 manifest list or OCI index %s",
-		digest,
+	logger.V(2).Info(
+		"extracting image from V2 manifest list or OCI index",
+		"digest", digest,
 	)
 
 	refs := make([]distribution.Descriptor, 0, len(collection.References()))
@@ -688,7 +688,7 @@ func (r *repositoryClient) getBlob(
 	digest digest.Digest,
 ) ([]byte, error) {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Tracef("retrieving blob for digest %q", digest.String())
+	logger.V(2).Info("retrieving blob for digest", "digest", digest.String())
 	return r.repo.Blobs(ctx).Get(ctx, digest)
 }
 

--- a/internal/image/selector_docker_hub_test.go
+++ b/internal/image/selector_docker_hub_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/internal/logging"
@@ -28,7 +27,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logging.LoggerFromContext(ctx)
-	logger.Logger.SetLevel(log.TraceLevel)
+	logging.SetLevel(logging.LevelTrace)
 	ctx = logging.ContextWithLogger(ctx, logger)
 
 	t.Run("digest strategy miss", func(t *testing.T) {

--- a/internal/image/selector_ghcr_test.go
+++ b/internal/image/selector_ghcr_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/internal/logging"
@@ -23,7 +22,7 @@ func TestSelectImageGHCR(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logging.LoggerFromContext(ctx)
-	logger.Logger.SetLevel(log.TraceLevel)
+	logging.SetLevel(logging.LevelTrace)
 	ctx = logging.ContextWithLogger(ctx, logger)
 
 	t.Run("digest strategy", func(t *testing.T) {

--- a/internal/image/semver_selector.go
+++ b/internal/image/semver_selector.go
@@ -112,10 +112,11 @@ func (s *semVerSelector) Select(ctx context.Context) (*Image, error) {
 		return nil, nil
 	}
 
-	logger.WithValues(
+	logger.V(2).Info(
+		"found image",
 		"tag", image.Tag,
 		"digest", image.Digest.String(),
-	).V(2).Info("found image")
+	)
 	return image, nil
 }
 

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -79,6 +79,12 @@ func init() {
 	runtimelog.SetLogger(globalLogger)
 }
 
+// DefaultLogger returns a logr.Logger with slog as the backend. It writes to
+// stderr and is hardcoded to Info level.
+func DefaultLogger() logr.Logger {
+	return logr.FromSlogHandler(slog.NewTextHandler(os.Stderr, nil))
+}
+
 // ContextWithLogger returns a context.Context that has been augmented with
 // the provided logr.Logger.
 func ContextWithLogger(ctx context.Context, logger logr.Logger) context.Context {

--- a/internal/logging/context_test.go
+++ b/internal/logging/context_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContextWithLogger(t *testing.T) {
-	testLogger := log.New().WithFields(nil)
+	testLogger := logr.New(nil)
 	ctx := ContextWithLogger(context.Background(), testLogger)
-	require.Same(t, testLogger, ctx.Value(loggerContextKey{}))
+	require.Equal(t, testLogger, ctx.Value(loggerContextKey{}))
 }
 
 func TestLoggerFromContext(t *testing.T) {
@@ -19,10 +19,11 @@ func TestLoggerFromContext(t *testing.T) {
 	// This should give us the global logger if one was never explicitly added to
 	// the context.
 	require.NotNil(t, logger)
-	require.IsType(t, &log.Entry{}, logger)
-	require.Equal(t, log.InfoLevel, logger.Logger.Level)
+	require.IsType(t, logr.Logger{}, logger)
+	require.Equal(t, true, logger.V(0).Enabled())  // INFO level enabled
+	require.Equal(t, false, logger.V(1).Enabled()) // DEBUG level disabled
 
-	testLogger := log.New().WithFields(nil)
+	testLogger := logr.New(nil)
 	ctx := context.WithValue(context.Background(), loggerContextKey{}, testLogger)
-	require.Same(t, testLogger, LoggerFromContext(ctx))
+	require.Equal(t, testLogger, LoggerFromContext(ctx))
 }

--- a/internal/os/env.go
+++ b/internal/os/env.go
@@ -29,3 +29,5 @@ func GetEnvInt(key string, defaultValue int) int {
 	}
 	return int(value)
 }
+
+var Stderr = os.Stderr

--- a/internal/webhook/promotion/webhook.go
+++ b/internal/webhook/promotion/webhook.go
@@ -238,7 +238,7 @@ func (w *webhook) authorize(
 
 	req, err := w.admissionRequestFromContextFn(ctx)
 	if err != nil {
-		logger.Error(err)
+		logger.Error(err, "")
 		return apierrors.NewForbidden(
 			promotionGroupResource,
 			promo.Name,
@@ -264,7 +264,7 @@ func (w *webhook) authorize(
 		},
 	}
 	if err := w.createSubjectAccessReviewFn(ctx, accessReview); err != nil {
-		logger.Error(err)
+		logger.Error(err, "")
 		return apierrors.NewForbidden(
 			promotionGroupResource,
 			promo.Name,


### PR DESCRIPTION
Addresses #1419

This PR standardises on the `go-logr/logr` interface with `log/slog` as the actual logging implementation.

# Level names

There's a little bit of logic on top of the `globalLogger` to achieve clearer `level` field names in log messages. By default `logr` negates the `V()` for `slog`, effectively achieving:

| logr    | slog      |
| --------| ----------|
| V(1)    | -1        |
| V(2)    | -2        |
| ...     | ...       |
| V(4)    | -4 (DEBUG)|

In practice, this means that the following logs:

```go
log.Info("0")
log.V(1).Info("", "slog-level", "1")
log.V(2).Info("", "slog-level", "2")
log.V(3).Info("", "slog-level", "3")
log.V(4).Info("", "slog-level", "4")
```

result in the following log output:

```sh
time=2006-01-02T15:04:05.000-07:00 level=INFO msg=0
time=2006-01-02T15:04:05.000-07:00 level=DEBUG+3 msg="" slog-level=1
time=2006-01-02T15:04:05.000-07:00 level=DEBUG+2 msg="" slog-level=2
time=2006-01-02T15:04:05.000-07:00 level=DEBUG+1 msg="" slog-level=3
time=2006-01-02T15:04:05.000-07:00 level=DEBUG msg="" slog-level=4
```

Using `ReplaceAttr` from `slog.HandlerOptions` allows us to modify it, getting rid of the `+{number}` bit from `level` field. The same logs achieve the following output:

```sh
time=2006-01-02T15:04:05.000-07:00 level=INFO msg=0
time=2006-01-02T15:04:05.000-07:00 level=DEBUG msg="" slog-level=1
time=2006-01-02T15:04:05.000-07:00 level=TRACE msg="" slog-level=2
time=2006-01-02T15:04:05.000-07:00 level=TRACE msg="" slog-level=3
time=2006-01-02T15:04:05.000-07:00 level=TRACE msg="" slog-level=4
```

Currently the lowest defined level is `LevelTrace` at `V(2)` or `slog.Level(-2)`, meaning that any logs with a higher `logr` level will never be shown.

# Warning level

Since `logr` maps to `slog.Level()` by negating the `V()` field, it's impossible to log at warning level. I've added PR comments to highlight instances of `log.Warn` and tried to replace them with what made sense to me.