### PR TITLE
fix(ui): provide initialization value to `metav1.Time` properties

### DIFF
--- a/ui/src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb.ts
+++ b/ui/src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb.ts
@@ -2856,7 +2856,7 @@ export class Time extends Message<Time> {
    *
    * @generated from field: optional int64 seconds = 1;
    */
-  seconds?: bigint;
+  seconds?: bigint = protoInt64.zero;
 
   /**
    * Non-negative fractions of a second at nanosecond resolution. Negative
@@ -2866,7 +2866,7 @@ export class Time extends Message<Time> {
    *
    * @generated from field: optional int32 nanos = 2;
    */
-  nanos?: number;
+  nanos?: number = 0;
 
   constructor(data?: PartialMessage<Time>) {
     super();
@@ -2920,6 +2920,11 @@ export class Time extends Message<Time> {
   }
 
   override toJson(options?: Partial<JsonWriteOptions>): JsonValue {
+    // Return null if the value of both `seconds` and `nanos` 
+    // are zero to behave identically with metav1.Time implementation in Go.
+    if ((!this.seconds || this.seconds === 0) && (!this.nanos || this.nanos === 0)) {
+      return null;
+    }
     const ms = Number(this.seconds) * 1000;
     if (ms < Date.parse("0001-01-01T00:00:00Z") || ms > Date.parse("9999-12-31T23:59:59Z")) {
       throw new Error(`cannot encode google.protobuf.Timestamp to JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive`);
@@ -2938,11 +2943,7 @@ export class Time extends Message<Time> {
         z = "." + nanosStr + "Z";
       }
     }
-    try {
-      return new Date(ms).toISOString().replace(".000Z", z);
-    } catch {
-      return undefined;
-    }
+    return new Date(ms).toISOString().replace(".000Z", z);
   }
 
   toDate(): Date {

--- a/ui/tests/api/apimachinery.spec.ts
+++ b/ui/tests/api/apimachinery.spec.ts
@@ -1,25 +1,34 @@
-import { Timestamp } from '@bufbuild/protobuf';
 import { describe, expect, test } from 'vitest';
 
+import { Time } from '../../src/gen/k8s.io/apimachinery/pkg/apis/meta/v1/generated_pb';
 import { IntOrString } from '../../src/gen/k8s.io/apimachinery/pkg/util/intstr/generated_pb';
 
 describe('metav1.Time', () => {
+  test('fromBinary with empty value', () => {
+    const time = Time.fromBinary(new Uint8Array());
+    expect(time).toBeDefined();
+    expect(time.seconds).toBe(BigInt(0));
+    expect(time.nanos).toBe(0);
+  });
   test('fromJson', () => {
-    const time = Timestamp.fromJson('2023-05-30T00:00:00Z');
+    const time = Time.fromJson('2023-05-30T00:00:00Z');
     expect(time).toBeDefined();
     expect(time.seconds).toBe(BigInt(1685404800));
     expect(time.nanos).toBe(0);
   });
-
   test('toJson', () => {
-    const time = new Timestamp({seconds: BigInt(1685404800), nanos: 0});
+    const time = new Time({seconds: BigInt(1685404800), nanos: 0});
     expect(time.toJson()).toBe('2023-05-30T00:00:00Z');
-    expect(time.toJsonString()).toBe('"2023-05-30T00:00:00Z"');
   });
-
+  // Make sure that the generated code behaves identically to metav1.Time implementation in Go.
+  test('toJson with empty value', () => {
+    const time = new Time({});
+    expect(time.toDate()).toStrictEqual(new Date(0))
+    expect(time.toJson()).toBeNull();
+  });
   test('toDate', () => {
     const date = new Date('2023-05-30T00:00:00Z');
-    const time = new Timestamp({seconds: BigInt(1685404800), nanos: 0});
+    const time = new Time({seconds: BigInt(1685404800), nanos: 0});
     expect(time.toDate().getTime()).toBe(date.getTime());
   });
 });


### PR DESCRIPTION
Fixes https://github.com/akuity/kargo/issues/1783

UI fails to render `metav1.Time` because properties are omitted during deserialization. However, those omitted number properties should be treated as `zero` by the protobuf speiciation (https://protobuf.dev/programming-guides/proto2/#optional).

This commit narrows down the fix provided in https://github.com/akuity/kargo/issues/1783 by ensuring omitted (undefined) properties to be treated as `zero` by providing initialization value to the properties. Also make sure to `metav1.Time` to be serialized to `null` when the both of properties are `zero` (or undefined) - same as the Go implementation.