### PR TITLE
fix: change placement of freightline tooltips

### DIFF
--- a/ui/src/features/common/freight-label.tsx
+++ b/ui/src/features/common/freight-label.tsx
@@ -37,6 +37,7 @@ export const FreightLabel = ({ freight }: { freight?: Freight }) => {
     >
       {alias || id ? (
         <Tooltip
+          placement='right'
           title={
             <>
               <div className='uppercase text-xs w-full text-center font-semibold text-gray-400'>


### PR DESCRIPTION
Using `placement='bottom'` does not work immediately and would likely require fiddling with CSS for an hour or two... but `placement='right'` works with a one line change. I'd prefer bottom placement but it's not worth the refactoring

Fixes #1773

![CleanShot 2024-04-08 at 08 27 32@2x](https://github.com/akuity/kargo/assets/6250584/723d971d-a210-4a34-a555-44b3ada58d92)
