### PR TITLE
fix(chart): add AnalysisRun permissions for users

### DIFF
--- a/charts/kargo/templates/users/cluster-roles.yaml
+++ b/charts/kargo/templates/users/cluster-roles.yaml
@@ -64,6 +64,14 @@ rules:
   - analysistemplates
   verbs:
   - "*"
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,6 +114,14 @@ rules:
   - argoproj.io
   resources:
   - analysistemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
   verbs:
   - get
   - list


### PR DESCRIPTION
Without these being present on the roles, it appears that the get functionalities in the UI for AnalysisRuns do not work as expected.