### PR TITLE
fix: pass version info to UI during build -- release-0.5 edition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,13 @@ FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.0 AS ui-builder
 RUN npm install --global pnpm
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
+ARG VERSION
 
 RUN pnpm install
 
 COPY ["ui/", "."]
 
-RUN NODE_ENV='production' pnpm run build
+RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 
 ####################################################################################################
 # tools


### PR DESCRIPTION
This PR backports #1802 to the `release-0.5` branch.