### PR TITLE
chore(deps): bump golang to 1.22 (everywhere)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  go: "1.20"
+  go: "1.22"
   build-tags:
     - dockerhub
     - ghcr

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/akuity/kargo
 
-go 1.21
+go 1.22
 
-toolchain go1.21.3
+toolchain go1.22.2
 
 require (
 	connectrpc.com/connect v1.16.0


### PR DESCRIPTION
closes #1790 

As @krancour said dependabot did most of the work yesterday but in golangci lint and the go module itself we were still on 1.20/1.21.