### PR TITLE
fix: pass environment variables to sub processes

### DIFF
--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -556,12 +556,8 @@ func (r *repo) setupAuth(repoCreds RepoCredentials) error {
 
 func (r *repo) buildCommand(arg ...string) *exec.Cmd {
 	cmd := exec.Command("git", arg...)
-	homeEnvVar := fmt.Sprintf("HOME=%s", r.homeDir)
-	if cmd.Env == nil {
-		cmd.Env = []string{homeEnvVar}
-	} else {
-		cmd.Env = append(cmd.Env, homeEnvVar)
-	}
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", r.homeDir))
 	if r.insecureSkipTLSVerify {
 		cmd.Env = append(cmd.Env, "GIT_SSL_NO_VERIFY=true")
 	}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -199,12 +200,8 @@ func getLatestVersion(versions []string, constraintStr string) (string, error) {
 
 func UpdateChartDependencies(homePath, chartPath string) error {
 	cmd := exec.Command("helm", "dependency", "update", chartPath)
-	homeEnvVar := fmt.Sprintf("HOME=%s", homePath)
-	if cmd.Env == nil {
-		cmd.Env = []string{homeEnvVar}
-	} else {
-		cmd.Env = append(cmd.Env, homeEnvVar)
-	}
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", homePath))
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf("error running `helm dependency update` for chart at %q: %w", chartPath, err)
 	}

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -1,6 +1,7 @@
 package kustomize
 
 import (
+	"os"
 	"os/exec"
 
 	libExec "github.com/akuity/kargo/internal/exec"
@@ -22,6 +23,7 @@ func buildSetImageCmd(dir, fqImageRef string) *exec.Cmd {
 		"image",
 		fqImageRef,
 	)
+	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Dir = dir
 	return cmd
 }


### PR DESCRIPTION
This PR allows sub processes to have access to the parent environment variables (usually set on the container).

For example, certain environments use an HTTP_PROXY to forward traffic. In order to support this use-case, Kargo needs to forward the container's environment variables to the sub processes.

The updated processes are `git`, `helm` and `kustomize`. `kargo-render` is already passing the `os.Environ()` down to the sub process (see [here](https://github.com/akuity/kargo/blob/2d9101eebdbe4ddb1b121f2cdbe885a42721e1c4/internal/kargo-render/render.go#L73-L77))

Let me know if you'd like me to create an issue for this also.