### PR TITLE
feat: inject reconcile target details to Promotion controller logger

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -164,7 +164,13 @@ func (r *reconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
-	logger := logging.LoggerFromContext(ctx)
+	logger := logging.LoggerFromContext(ctx).
+		WithFields(log.Fields{
+			"namespace": req.NamespacedName.Namespace,
+			"promotion": req.NamespacedName.Name,
+		})
+	ctx = logging.ContextWithLogger(ctx, logger)
+	logger.Debug("reconciling Promotion")
 
 	// Note that initialization occurs here because we basically know that the
 	// controller runtime client's cache is ready at this point. We cannot attempt

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -185,8 +185,6 @@ func (r *reconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("error initializing Promotion queues: %w", err)
 	}
 
-	ctx = logging.ContextWithLogger(ctx, logger)
-
 	// Find the Promotion
 	promo, err := kargoapi.GetPromotion(ctx, r.kargoClient, req.NamespacedName)
 	if err != nil {


### PR DESCRIPTION
This PR adds Promotion details (namespace and name) to logger to let controller log with contexts to track on.