### PR TITLE
feat: track actor who triggered reverification

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -13,6 +13,7 @@ const (
 	AnnotationKeyOIDCSubjects = "rbac.kargo.akuity.io/sub"
 
 	AnnotationKeyEventActor               = "event.kargo.akuity.io/actor"
+	AnnotationKeyEventReverifyActor       = "event.kargo.akuity.io/reverify-actor"
 	AnnotationKeyEventProject             = "event.kargo.akuity.io/project"
 	AnnotationKeyEventPromotionName       = "event.kargo.akuity.io/promotion-name"
 	AnnotationKeyEventPromotionCreateTime = "event.kargo.akuity.io/promotion-create-time"

--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -5,15 +5,15 @@ const (
 
 	AnnotationKeyRefresh = "kargo.akuity.io/refresh"
 
-	AnnotationKeyReverify = "kargo.akuity.io/reverify"
-	AnnotationKeyAbort    = "kargo.akuity.io/abort"
+	AnnotationKeyReverify      = "kargo.akuity.io/reverify"
+	AnnotationKeyReverifyActor = "kargo.akuity.io/reverify-actor"
+	AnnotationKeyAbort         = "kargo.akuity.io/abort"
 
 	AnnotationKeyOIDCEmails   = "rbac.kargo.akuity.io/email"
 	AnnotationKeyOIDCGroups   = "rbac.kargo.akuity.io/groups"
 	AnnotationKeyOIDCSubjects = "rbac.kargo.akuity.io/sub"
 
 	AnnotationKeyEventActor               = "event.kargo.akuity.io/actor"
-	AnnotationKeyEventReverifyActor       = "event.kargo.akuity.io/reverify-actor"
 	AnnotationKeyEventProject             = "event.kargo.akuity.io/project"
 	AnnotationKeyEventPromotionName       = "event.kargo.akuity.io/promotion-name"
 	AnnotationKeyEventPromotionCreateTime = "event.kargo.akuity.io/promotion-create-time"

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -2,9 +2,11 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -32,35 +34,48 @@ func AddFinalizer(ctx context.Context, c client.Client, obj client.Object) error
 }
 
 func ClearAnnotations(ctx context.Context, c client.Client, obj client.Object, keys ...string) error {
-	if len(keys) == 0 {
-		return nil
+	kvs := make(map[string]*string, len(keys))
+	for _, k := range keys {
+		kvs[k] = nil
 	}
-
-	patchBytes := []byte(`{"metadata":{"annotations":{`)
-	for i, key := range keys {
-		if i > 0 {
-			patchBytes = append(patchBytes, ',')
-		}
-		patchBytes = append(patchBytes, fmt.Sprintf(`"%s":null`, key)...)
-	}
-	patchBytes = append(patchBytes, "}}}"...)
-	patch := client.RawPatch(types.MergePatchType, patchBytes)
-	if err := c.Patch(ctx, obj, patch); err != nil {
-		return fmt.Errorf("patch annotation: %w", err)
-	}
-	return nil
+	return patchAnnotations(ctx, c, obj, kvs)
 }
 
 func patchAnnotation(ctx context.Context, c client.Client, obj client.Object, key, value string) error {
-	patchBytes := []byte(
-		fmt.Sprintf(
-			`{"metadata":{"annotations":{"%s":"%s"}}}`,
-			key,
-			value,
-		),
-	)
-	patch := client.RawPatch(types.MergePatchType, patchBytes)
-	if err := c.Patch(ctx, obj, patch); err != nil {
+	return patchAnnotations(ctx, c, obj, map[string]*string{
+		key: ptr.To(value),
+	})
+}
+
+func patchAnnotations(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+	kvs map[string]*string,
+) error {
+	type objectMeta struct {
+		Annotations map[string]*string `json:"annotations"`
+	}
+	type patch struct {
+		ObjectMeta objectMeta `json:"metadata"`
+	}
+	if len(kvs) == 0 {
+		// Do nothing if there are no kv pairs to patch.
+		return nil
+	}
+	data, err := json.Marshal(patch{
+		ObjectMeta: objectMeta{
+			Annotations: kvs,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal patch data: %w", err)
+	}
+	if err := c.Patch(
+		ctx,
+		obj,
+		client.RawPatch(types.MergePatchType, data),
+	); err != nil {
 		return fmt.Errorf("patch annotation: %w", err)
 	}
 	return nil

--- a/api/v1alpha1/helpers_test.go
+++ b/api/v1alpha1/helpers_test.go
@@ -52,7 +52,6 @@ func TestClearAnnotations(t *testing.T) {
 	scheme := k8sruntime.NewScheme()
 	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
 
-	t.Parallel()
 	newFakeClient := func(obj ...client.Object) client.Client {
 		return fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -164,6 +163,7 @@ func TestClearAnnotations(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := ClearAnnotations(context.TODO(), tc.client, tc.obj, tc.keys...)
 			tc.assertions(t, tc.obj, err)
 		})
@@ -174,7 +174,6 @@ func Test_patchAnnotation(t *testing.T) {
 	scheme := k8sruntime.NewScheme()
 	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
 
-	t.Parallel()
 	newFakeClient := func(obj ...client.Object) client.Client {
 		return fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -240,6 +239,7 @@ func Test_patchAnnotation(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			err := patchAnnotation(context.Background(), tc.client, tc.obj, tc.key, tc.value)
 			if tc.errExpected {
 				require.Error(t, err)

--- a/api/v1alpha1/stage_helpers.go
+++ b/api/v1alpha1/stage_helpers.go
@@ -8,7 +8,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/akuity/kargo/internal/api/user"
 )
 
 // GetStage returns a pointer to the Stage resource specified by the
@@ -84,7 +87,14 @@ func ReverifyStageFreight(
 		return fmt.Errorf("stage verification info has no ID")
 	}
 
-	return patchAnnotation(ctx, c, stage, AnnotationKeyReverify, curFreight.VerificationInfo.ID)
+	kvs := map[string]*string{
+		AnnotationKeyReverify: ptr.To(curFreight.VerificationInfo.ID),
+	}
+	// Put actor information to track on the controller side
+	if u, ok := user.InfoFromContext(ctx); ok {
+		kvs[AnnotationKeyEventReverifyActor] = ptr.To(FormatEventUserActor(u))
+	}
+	return patchAnnotations(ctx, c, stage, kvs)
 }
 
 // AbortStageFreightVerification forces aborting the verification of the

--- a/api/v1alpha1/stage_helpers.go
+++ b/api/v1alpha1/stage_helpers.go
@@ -92,7 +92,7 @@ func ReverifyStageFreight(
 	}
 	// Put actor information to track on the controller side
 	if u, ok := user.InfoFromContext(ctx); ok {
-		kvs[AnnotationKeyEventReverifyActor] = ptr.To(FormatEventUserActor(u))
+		kvs[AnnotationKeyReverifyActor] = ptr.To(FormatEventUserActor(u))
 	}
 	return patchAnnotations(ctx, c, stage, kvs)
 }

--- a/cmd/controlplane/webhooks.go
+++ b/cmd/controlplane/webhooks.go
@@ -120,7 +120,7 @@ func (o *webhooksServerOptions) run(ctx context.Context) error {
 	if err = promotion.SetupWebhookWithManager(webhookCfg, mgr); err != nil {
 		return fmt.Errorf("setup Promotion webhook: %w", err)
 	}
-	if err = stage.SetupWebhookWithManager(mgr); err != nil {
+	if err = stage.SetupWebhookWithManager(webhookCfg, mgr); err != nil {
 		return fmt.Errorf("setup Stage webhook: %w", err)
 	}
 	if err = warehouse.SetupWebhookWithManager(mgr); err != nil {

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -319,7 +319,7 @@ func SetupReconcilerWithManager(
 			Annotations: []string{
 				kargoapi.AnnotationKeyRefresh,
 				kargoapi.AnnotationKeyReverify,
-				kargoapi.AnnotationKeyEventReverifyActor,
+				kargoapi.AnnotationKeyReverifyActor,
 				kargoapi.AnnotationKeyAbort,
 			},
 		}).
@@ -559,7 +559,7 @@ func (r *reconciler) Reconcile(
 		stage,
 		kargoapi.AnnotationKeyRefresh,
 		kargoapi.AnnotationKeyReverify,
-		kargoapi.AnnotationKeyEventReverifyActor,
+		kargoapi.AnnotationKeyReverifyActor,
 		kargoapi.AnnotationKeyAbort,
 	)
 	if clearErr != nil {
@@ -675,6 +675,7 @@ func (r *reconciler) syncControlFlowStage(
 				&kargoapi.VerificationInfo{
 					Phase: kargoapi.VerificationPhaseSuccessful,
 				},
+				nil, // Explicitly pass `nil` here since there is no associated AnalysisRun
 			)
 		}
 	}
@@ -869,6 +870,22 @@ func (r *reconciler) syncNormalStage(
 				}
 			}
 
+			var ar *rollouts.AnalysisRun
+			if vi.HasAnalysisRun() {
+				var err error
+				ar, err = r.getAnalysisRunFn(
+					ctx,
+					r.kargoClient,
+					types.NamespacedName{
+						Namespace: vi.AnalysisRun.Namespace,
+						Name:      vi.AnalysisRun.Name,
+					},
+				)
+				if err != nil {
+					return status, fmt.Errorf("get analysisRun: %w", err)
+				}
+			}
+
 			fr, err := r.getFreightFn(
 				ctx,
 				r.kargoClient,
@@ -881,7 +898,7 @@ func (r *reconciler) syncNormalStage(
 				return status, fmt.Errorf("get freight: %w", err)
 			}
 			if fr != nil {
-				r.recordFreightVerificationEvent(stage, fr, vi)
+				r.recordFreightVerificationEvent(stage, fr, vi, ar)
 			}
 		}
 	}
@@ -1494,6 +1511,7 @@ func (r *reconciler) recordFreightVerificationEvent(
 	s *kargoapi.Stage,
 	fr *kargoapi.Freight,
 	vi *kargoapi.VerificationInfo,
+	ar *rollouts.AnalysisRun,
 ) {
 	annotations := map[string]string{
 		kargoapi.AnnotationKeyEventActor:        kargoapi.FormatEventControllerActor(r.cfg.Name()),
@@ -1502,14 +1520,24 @@ func (r *reconciler) recordFreightVerificationEvent(
 		kargoapi.AnnotationKeyEventFreightAlias: fr.Alias,
 		kargoapi.AnnotationKeyEventFreightName:  fr.Name,
 	}
-	if _, ok := s.Annotations[kargoapi.AnnotationKeyReverify]; ok {
-		// Set Actor as a reverify actor if present
-		if actor, ok := s.Annotations[kargoapi.AnnotationKeyEventReverifyActor]; ok {
+	if ar != nil {
+		annotations[kargoapi.AnnotationKeyEventAnalysisRunName] = ar.Name
+	}
+
+	// If the verification is manually triggered (e.g. reverify),
+	// override the actor if the Stage or AnalysisRun knows about them.
+	{
+		// Check if the stage has reverify actor annotation
+		if actor, ok := s.Annotations[kargoapi.AnnotationKeyReverifyActor]; ok {
 			annotations[kargoapi.AnnotationKeyEventActor] = actor
 		}
-	}
-	if vi.AnalysisRun != nil {
-		annotations[kargoapi.AnnotationKeyEventAnalysisRunName] = vi.AnalysisRun.Name
+
+		// Or if the analysis run has it, then set it as the actor
+		if ar != nil {
+			if actor, ok := ar.Annotations[kargoapi.AnnotationKeyReverifyActor]; ok {
+				annotations[kargoapi.AnnotationKeyEventActor] = actor
+			}
+		}
 	}
 
 	reason := kargoapi.EventReasonFreightVerificationUnknown

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -319,6 +319,7 @@ func SetupReconcilerWithManager(
 			Annotations: []string{
 				kargoapi.AnnotationKeyRefresh,
 				kargoapi.AnnotationKeyReverify,
+				kargoapi.AnnotationKeyEventReverifyActor,
 				kargoapi.AnnotationKeyAbort,
 			},
 		}).
@@ -558,6 +559,7 @@ func (r *reconciler) Reconcile(
 		stage,
 		kargoapi.AnnotationKeyRefresh,
 		kargoapi.AnnotationKeyReverify,
+		kargoapi.AnnotationKeyEventReverifyActor,
 		kargoapi.AnnotationKeyAbort,
 	)
 	if clearErr != nil {
@@ -1499,6 +1501,11 @@ func (r *reconciler) recordFreightVerificationEvent(
 		kargoapi.AnnotationKeyEventStageName:    s.Namespace,
 		kargoapi.AnnotationKeyEventFreightAlias: fr.Alias,
 		kargoapi.AnnotationKeyEventFreightName:  fr.Name,
+	}
+	if _, ok := s.Annotations[kargoapi.AnnotationKeyReverify]; ok {
+		if actor, ok := s.Annotations[kargoapi.AnnotationKeyEventReverifyActor]; ok {
+			annotations[kargoapi.AnnotationKeyEventReverifyActor] = actor
+		}
 	}
 	if vi.AnalysisRun != nil {
 		annotations[kargoapi.AnnotationKeyEventAnalysisRunName] = vi.AnalysisRun.Name

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1503,8 +1503,9 @@ func (r *reconciler) recordFreightVerificationEvent(
 		kargoapi.AnnotationKeyEventFreightName:  fr.Name,
 	}
 	if _, ok := s.Annotations[kargoapi.AnnotationKeyReverify]; ok {
+		// Set Actor as a reverify actor if present
 		if actor, ok := s.Annotations[kargoapi.AnnotationKeyEventReverifyActor]; ok {
-			annotations[kargoapi.AnnotationKeyEventReverifyActor] = actor
+			annotations[kargoapi.AnnotationKeyEventActor] = actor
 		}
 	}
 	if vi.AnalysisRun != nil {

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -777,6 +777,13 @@ func TestSyncNormalStage(t *testing.T) {
 			reconciler: &reconciler{
 				hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 				appHealth:                  &mockAppHealthEvaluator{},
+				getAnalysisRunFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*rollouts.AnalysisRun, error) {
+					return &rollouts.AnalysisRun{}, nil
+				},
 				getFreightFn: func(
 					context.Context,
 					client.Client,
@@ -855,6 +862,17 @@ func TestSyncNormalStage(t *testing.T) {
 			reconciler: &reconciler{
 				hasNonTerminalPromotionsFn: noNonTerminalPromotionsFn,
 				appHealth:                  &mockAppHealthEvaluator{},
+				getAnalysisRunFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*rollouts.AnalysisRun, error) {
+					return &rollouts.AnalysisRun{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "fake-analysis-run",
+						},
+					}, nil
+				},
 				getFreightFn: func(
 					context.Context,
 					client.Client,
@@ -1551,6 +1569,18 @@ func TestSyncNormalStage(t *testing.T) {
 					Health: &kargoapi.Health{
 						Status: kargoapi.HealthStateHealthy,
 					},
+				},
+				getAnalysisRunFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*rollouts.AnalysisRun, error) {
+					return &rollouts.AnalysisRun{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-namespace",
+							Name:      "fake-analysis-run",
+						},
+					}, nil
 				},
 				getVerificationInfoFn: func(
 					context.Context,

--- a/internal/controller/stages/verification.go
+++ b/internal/controller/stages/verification.go
@@ -366,7 +366,7 @@ func (r *reconciler) buildAnalysisRun(
 	}
 	// Kargo will add up to three labels of its own, so size the map accordingly
 	lbls := make(map[string]string, numLabels+4)
-	annotations := make(map[string]string, numAnnotations)
+	annotations := make(map[string]string, numAnnotations+1)
 	if stage.Spec.Verification.AnalysisRunMetadata != nil {
 		for k, v := range stage.Spec.Verification.AnalysisRunMetadata.Labels {
 			lbls[k] = v
@@ -377,9 +377,16 @@ func (r *reconciler) buildAnalysisRun(
 	}
 	lbls[kargoapi.StageLabelKey] = stage.Name
 	lbls[kargoapi.FreightLabelKey] = stage.Status.CurrentFreight.Name
-	// Add Promotion name if the AnalysisRun is triggered by Promotion.
+
+	// Check if the AnalysisRun is triggered manually (e.g. reverification).
 	// We can determine it by checking existence of Reverify key in annotations.
-	if _, ok := stage.GetAnnotations()[kargoapi.AnnotationKeyReverify]; !ok {
+	if _, ok := stage.GetAnnotations()[kargoapi.AnnotationKeyReverify]; ok {
+		// Add Actor who triggered the reverification to the annotations (if exists).
+		if actor, ok := stage.GetAnnotations()[kargoapi.AnnotationKeyReverifyActor]; ok {
+			annotations[kargoapi.AnnotationKeyReverifyActor] = actor
+		}
+	} else {
+		// Add Promotion name if the AnalysisRun is triggered by Promotion.
 		if stage.Status.LastPromotion != nil {
 			lbls[kargoapi.PromotionLabelKey] = stage.Status.LastPromotion.Name
 		}

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -115,9 +115,7 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 			}
 		} else {
 			// Ensure actor annotation is not set when not reverifying
-			if _, ok := stage.Annotations[kargoapi.AnnotationKeyEventReverifyActor]; ok {
-				delete(stage.Annotations, kargoapi.AnnotationKeyEventReverifyActor)
-			}
+			delete(stage.Annotations, kargoapi.AnnotationKeyEventReverifyActor)
 		}
 	}
 	return nil

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -7,10 +7,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	libWebhook "github.com/akuity/kargo/internal/webhook"
@@ -28,6 +29,14 @@ type webhook struct {
 
 	// The following behaviors are overridable for testing purposes:
 
+	admissionRequestFromContextFn func(context.Context) (admission.Request, error)
+
+	getStageFn func(
+		context.Context,
+		client.Client,
+		types.NamespacedName,
+	) (*kargoapi.Stage, error)
+
 	validateProjectFn func(
 		context.Context,
 		client.Client,
@@ -38,10 +47,15 @@ type webhook struct {
 	validateCreateOrUpdateFn func(*kargoapi.Stage) (admission.Warnings, error)
 
 	validateSpecFn func(*field.Path, *kargoapi.StageSpec) field.ErrorList
+
+	isRequestFromKargoControlplaneFn libWebhook.IsRequestFromKargoControlplaneFn
 }
 
-func SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := newWebhook(mgr.GetClient())
+func SetupWebhookWithManager(
+	cfg libWebhook.Config,
+	mgr ctrl.Manager,
+) error {
+	w := newWebhook(cfg, mgr.GetClient())
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&kargoapi.Stage{}).
 		WithDefaulter(w).
@@ -49,17 +63,24 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-func newWebhook(kubeClient client.Client) *webhook {
+func newWebhook(
+	cfg libWebhook.Config,
+	kubeClient client.Client,
+) *webhook {
 	w := &webhook{
 		client: kubeClient,
 	}
+	w.admissionRequestFromContextFn = admission.RequestFromContext
+	w.getStageFn = kargoapi.GetStage
 	w.validateProjectFn = libWebhook.ValidateProject
 	w.validateCreateOrUpdateFn = w.validateCreateOrUpdate
 	w.validateSpecFn = w.validateSpec
+	w.isRequestFromKargoControlplaneFn =
+		libWebhook.IsRequestFromKargoControlplane(cfg.ControlplaneUserRegex)
 	return w
 }
 
-func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
+func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 	stage := obj.(*kargoapi.Stage) // nolint: forcetypeassert
 
 	// Sync the shard label to the convenience shard field
@@ -72,6 +93,33 @@ func (w *webhook) Default(_ context.Context, obj runtime.Object) error {
 		delete(stage.Labels, kargoapi.ShardLabelKey)
 	}
 
+	req, err := w.admissionRequestFromContextFn(ctx)
+	if err != nil {
+		return fmt.Errorf("get admission request from context: %w", err)
+	}
+	if !w.isRequestFromKargoControlplaneFn(req) {
+		// Set actor information to annotation when reverification is requested
+		// to allow controllers to track who triggered it.
+		if id, ok := stage.Annotations[kargoapi.AnnotationKeyReverify]; ok {
+			oldStage, err := kargoapi.GetStage(ctx, w.client, types.NamespacedName{
+				Namespace: stage.Namespace,
+				Name:      stage.Name,
+			})
+			if err != nil {
+				return fmt.Errorf("get old stage: %w", err)
+			}
+			if oldStage == nil ||
+				(oldStage != nil && oldStage.Annotations[kargoapi.AnnotationKeyReverify] != id) {
+				stage.Annotations[kargoapi.AnnotationKeyEventReverifyActor] =
+					kargoapi.FormatEventKubernetesUserActor(req.UserInfo)
+			}
+		} else {
+			// Ensure actor annotation is not set when not reverifying
+			if _, ok := stage.Annotations[kargoapi.AnnotationKeyEventReverifyActor]; ok {
+				delete(stage.Annotations, kargoapi.AnnotationKeyEventReverifyActor)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/webhook/stage/webhook_test.go
+++ b/internal/webhook/stage/webhook_test.go
@@ -15,15 +15,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libWebhook "github.com/akuity/kargo/internal/webhook"
 )
 
 func TestNewWebhook(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
-	w := newWebhook(kubeClient)
+	w := newWebhook(
+		libWebhook.Config{},
+		kubeClient,
+	)
 	// Assert that all overridable behaviors were initialized to a default:
+	require.NotNil(t, w.admissionRequestFromContextFn)
+	require.NotNil(t, w.getStageFn)
 	require.NotNil(t, w.validateProjectFn)
 	require.NotNil(t, w.validateCreateOrUpdateFn)
 	require.NotNil(t, w.validateSpecFn)
+	require.NotNil(t, w.isRequestFromKargoControlplaneFn)
 }
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
> Part of #1231 

This PR sets actor information on Stage and AnalysisRun to allow controller to track who triggered (re-)Verification.

If the Stage or AnalysisRun has re-verify actor annotation, the controller will override the actor information with the given actor when emitting `FreightVerification` events.