### PR TITLE
refactor: embed ui assets in binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,6 +181,26 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
+      with:
+        version: 8
+        run_install: false
+    - name: Install nodejs
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20.12.1"
+        cache: "pnpm"
+        cache-dependency-path: "**/pnpm-lock.yaml"
+    - name: Build UI
+      env:
+        VERSION: ${{ github.ref_name }}
+      working-directory: ./ui
+      run: |
+        pnpm install
+        NODE_ENV=production pnpm run build
+        rm -rf ../internal/api/ui
+        mv build ../internal/api/ui
     - name: Build CLI
       env:
         GOFLAGS: -buildvcs=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,7 +189,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: "20.12.1"
+        node-version: "20.12.2"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Build UI
@@ -230,10 +230,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.22.2-bookworm
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
     steps:
-    - name: Install awscli
-      run: |
-        apt update && apt install awscli -y
     - name: Checkout code
       uses: actions/checkout@v4
     - uses: actions/cache@v4
@@ -242,13 +243,38 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
+      with:
+        version: 8
+        run_install: false
+    - name: Install nodejs
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20.12.2"
+        cache: "pnpm"
+        cache-dependency-path: "**/pnpm-lock.yaml"
+    - name: Build UI
+      env:
+        VERSION: ${{ github.ref_name }}
+      working-directory: ./ui
+      run: |
+        pnpm install
+        NODE_ENV=production pnpm run build
+        rm -rf ../internal/api/ui
+        mv build ../internal/api/ui
     - name: Build CLI
       env:
         GOFLAGS: -buildvcs=false
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
         VERSION: ${{ needs.publish-image.outputs.unstable-version }}
         GIT_COMMIT: ${{ github.sha }}
         GIT_TREE_STATE: clean
-      run: make nightly-cli
+      run: make build-nightly-cli
+    - name: Install awscli
+      run: |
+        apt update && apt install awscli -y
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -259,7 +285,7 @@ jobs:
         CF_DISTRIBUTION_ID: ${{ secrets.CF_DISTRIBUTION_ID }}
         VERSION: ${{ needs.publish-image.outputs.unstable-version }}
       run: |
-        aws s3 sync "./bin/kargo-cli/${VERSION}" "s3://kargo-release/kargo-cli/${VERSION}"
+        aws s3 sync "./bin/kargo-cli/${VERSION}/${{ matrix.os }}/${{ matrix.arch }}" "s3://kargo-release/kargo-cli/${VERSION}/${{ matrix.os }}/${{ matrix.arch }}"
         printf "${VERSION}" > ./bin/kargo-cli/unstable.txt
         aws s3 cp ./bin/kargo-cli/unstable.txt s3://kargo-release/kargo-cli/unstable.txt
         aws cloudfront create-invalidation \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ####################################################################################################
 # ui-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.1 AS ui-builder
+FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.2 AS ui-builder
 
 RUN npm install --global pnpm
 WORKDIR /ui
@@ -88,7 +88,7 @@ CMD ["/usr/local/bin/kargo"]
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.1 AS ui-dev
+FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.2 AS ui-dev
 
 RUN npm install --global pnpm
 WORKDIR /ui

--- a/Makefile
+++ b/Makefile
@@ -115,20 +115,11 @@ build-cli:
 # Used for Nighty/Unstable builds                                              #
 ################################################################################
 
-.PHONY: kargo-all
-kargo-all:
+.PHONY: build-nightly-cli
+build-nightly-cli:
 	CGO_ENABLED=0 go build \
 		-ldflags "-w -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).buildDate=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT) -X $(VERSION_PACKAGE).gitTreeState=$(GIT_TREE_STATE)" \
-		-o bin/kargo-cli/${VERSION}/${GOOS}/${GOARCH}/${BIN_NAME} ./cmd/cli
-
-.PHONY: nightly-cli
-nightly-cli:
-	make BIN_NAME=kargo GOOS=darwin GOARCH=amd64 kargo-all
-	make BIN_NAME=kargo GOOS=darwin GOARCH=arm64 kargo-all
-	make BIN_NAME=kargo GOOS=linux GOARCH=amd64 kargo-all
-	make BIN_NAME=kargo GOOS=linux GOARCH=arm64 kargo-all
-	make BIN_NAME=kargo.exe GOOS=windows GOARCH=amd64 kargo-all
-	make BIN_NAME=kargo.exe GOOS=windows GOARCH=arm64 kargo-all
+		-o bin/kargo-cli/${VERSION}/${GOOS}/${GOARCH}/kargo$(shell [ ${GOOS} = windows ] && echo .exe) ./cmd/cli
 
 ################################################################################
 # Code generation: To be run after modifications to API types                  #

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -15,7 +15,6 @@ import (
 
 type StandardConfig struct {
 	GracefulShutdownTimeout time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT" default:"30s"`
-	UIDirectory             string        `envconfig:"UI_DIR" default:"./ui/build"`
 }
 
 type ServerConfig struct {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "vitest": "^0.34.6",
     "zx": "^7.2.3"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@9.0.2",
   "dependencies": {
     "@bufbuild/protobuf": "1.8.0",
     "@connectrpc/connect": "1.4.0",


### PR DESCRIPTION
This small change embeds all UI assets into the CLI and control plane binaries, constituting a minor step toward #1728, specifically the "It should allow the user to visit the UI in their browser" part.

Although it makes the server launched by the CLI capable of serving the UI, the UI still doesn't allow for the possibility of not needing to authn.

As I said... a minor step.

