### PR TITLE
fix(devx): Disable vcs stamping when running in docker container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,9 +170,13 @@ codegen-ui:
 # that is pre-loaded with required tools.                                      #
 ################################################################################
 
+# Prevents issues with vcs stamping within docker containers. 
+GOFLAGS="-buildvcs=false"
+
 DOCKER_CMD := $(CONTAINER_RUNTIME) run \
 	-it \
 	--rm \
+	-e GOFLAGS=$(GOFLAGS) \
 	-v gomodcache:/home/user/gocache \
 	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/kargo \
 	-v /workspaces/kargo/ui/node_modules \


### PR DESCRIPTION
Fixes #1789

I put this at the top level to pass to all hack commands so it covers both the hack-test-unit and hack-build-cli commands (and any future commands that may be affected).