### PR TITLE
feat: add Promotion name to freight verification event if possible

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1545,6 +1545,9 @@ func (r *reconciler) recordFreightVerificationEvent(
 	}
 	if ar != nil {
 		annotations[kargoapi.AnnotationKeyEventAnalysisRunName] = ar.Name
+		if promoName, ok := ar.Labels[kargoapi.PromotionLabelKey]; ok {
+			annotations[kargoapi.AnnotationKeyEventPromotionName] = promoName
+		}
 	}
 
 	// If the verification is manually triggered (e.g. reverify),


### PR DESCRIPTION
This PR allows client to know if the freight verification is triggered by Promotion or not, by checking the existence of `Promotion` name in event annotations.