### PR TITLE
fix(ui): correctly display AnalysisRun YAML

### DIFF
--- a/ui/src/features/stage/analysis-run-modal.tsx
+++ b/ui/src/features/stage/analysis-run-modal.tsx
@@ -32,7 +32,7 @@ export const AnalysisRunModal = ({ visible, hide, name }: Props) => {
       {isLoading ? (
         <LoadingState />
       ) : (
-        <YamlEditor value={yaml.stringify(data?.analysisRun?.toJson())} height='500px' disabled />
+        <YamlEditor value={yaml.stringify(data?.result?.value?.toJson())} height='500px' disabled />
       )}
     </Modal>
   );


### PR DESCRIPTION
Follow up to #1827.

Ensures the modal actually displays the YAML, even if it does not make use of the raw response API option yet.