### PR TITLE
refactor: use normalized URLs in constructing freight id

### DIFF
--- a/api/v1alpha1/freight_types.go
+++ b/api/v1alpha1/freight_types.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/akuity/kargo/internal/git"
+	"github.com/akuity/kargo/internal/helm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,12 +67,12 @@ func (f *Freight) GenerateID() string {
 			// Freight for the new tag.
 			artifacts = append(
 				artifacts,
-				fmt.Sprintf("%s:%s:%s", commit.RepoURL, commit.Tag, commit.ID),
+				fmt.Sprintf("%s:%s:%s", git.NormalizeURL(commit.RepoURL), commit.Tag, commit.ID),
 			)
 		} else {
 			artifacts = append(
 				artifacts,
-				fmt.Sprintf("%s:%s", commit.RepoURL, commit.ID),
+				fmt.Sprintf("%s:%s", git.NormalizeURL(commit.RepoURL), commit.ID),
 			)
 		}
 	}
@@ -92,7 +94,7 @@ func (f *Freight) GenerateID() string {
 			fmt.Sprintf(
 				"%s:%s",
 				// path.Join accounts for the possibility that chart.Name is empty
-				path.Join(chart.RepoURL, chart.Name),
+				path.Join(helm.NormalizeChartRepositoryURL(chart.RepoURL), chart.Name),
 				chart.Version,
 			),
 		)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalizeGitURL(t *testing.T) {
+func TestNormalizeURL(t *testing.T) {
 	testCases := map[string]string{
 		// Anything we can't normalize should be returned as-is
 		"https://not a url":                      "https://not a url",


### PR DESCRIPTION
Follow-up to #1854.

I've realized that we should use normalized URLs when constructing Freight IDs.

This way, if someone updates a subscription in a Warehouse to use a new URL that is semantically equivalent to the old URL, we won't end up with a new piece of Freight just because of that.