### PR TITLE
feat: set promotion actor to the annotation

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -23,6 +23,8 @@ const (
 
 	AnnotationKeyDescription = "kargo.akuity.io/description"
 
+	AnnotationKeyPromoteActor = "kargo.akuity.io/promote-actor"
+
 	AnnotationKeyOIDCEmails   = "rbac.kargo.akuity.io/email"
 	AnnotationKeyOIDCGroups   = "rbac.kargo.akuity.io/groups"
 	AnnotationKeyOIDCSubjects = "rbac.kargo.akuity.io/sub"

--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -3,6 +3,10 @@ package v1alpha1
 import "encoding/json"
 
 const (
+	// AnnotationKeyCreateActor is an annotation key that can be injected to a resource
+	// by the Kargo controlplane to indicate the actor that created the resource.
+	AnnotationKeyCreateActor = "kargo.akuity.io/create-actor"
+
 	// AnnotationKeyRefresh is an annotation key that can be set on a resource
 	// to trigger a refresh of the resource by the controller. The value of the
 	// annotation is interpreted as a token, and any change to the value of the
@@ -22,8 +26,6 @@ const (
 	AnnotationKeyAbort = "kargo.akuity.io/abort"
 
 	AnnotationKeyDescription = "kargo.akuity.io/description"
-
-	AnnotationKeyPromoteActor = "kargo.akuity.io/promote-actor"
 
 	AnnotationKeyOIDCEmails   = "rbac.kargo.akuity.io/email"
 	AnnotationKeyOIDCGroups   = "rbac.kargo.akuity.io/groups"

--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -93,9 +93,16 @@ func NewPromotionEventAnnotations(
 		AnnotationKeyEventStageName:           p.Spec.Stage,
 		AnnotationKeyEventPromotionCreateTime: p.GetCreationTimestamp().Format(time.RFC3339),
 	}
+
 	if actor != "" {
 		annotations[AnnotationKeyEventActor] = actor
 	}
+	// All Promotion-related events are emitted after the promotion was created.
+	// Therefore, if the promotion knows who triggered it, set them as an actor.
+	if promoteActor, ok := p.Annotations[AnnotationKeyPromoteActor]; ok {
+		annotations[AnnotationKeyEventActor] = promoteActor
+	}
+
 	if f != nil {
 		annotations[AnnotationKeyEventFreightCreateTime] = f.CreationTimestamp.Format(time.RFC3339)
 		annotations[AnnotationKeyEventFreightAlias] = f.Alias

--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -99,7 +99,7 @@ func NewPromotionEventAnnotations(
 	}
 	// All Promotion-related events are emitted after the promotion was created.
 	// Therefore, if the promotion knows who triggered it, set them as an actor.
-	if promoteActor, ok := p.Annotations[AnnotationKeyPromoteActor]; ok {
+	if promoteActor, ok := p.Annotations[AnnotationKeyCreateActor]; ok {
 		annotations[AnnotationKeyEventActor] = promoteActor
 	}
 

--- a/internal/api/promote_to_stage_subscribers_v1alpha1.go
+++ b/internal/api/promote_to_stage_subscribers_v1alpha1.go
@@ -133,7 +133,7 @@ func (s *server) PromoteToStageSubscribers(
 	promoteErrs := make([]error, 0, len(subscribers))
 	createdPromos := make([]*kargoapi.Promotion, 0, len(subscribers))
 	for _, subscriber := range subscribers {
-		newPromo := kargo.NewPromotion(subscriber, freight.Name)
+		newPromo := kargo.NewPromotion(ctx, subscriber, freight.Name)
 		if subscriber.Spec.PromotionMechanisms == nil {
 			// Avoid creating a Promotion if the subscriber has no
 			// PromotionMechanisms, and is a "control flow" Stage.

--- a/internal/api/promote_to_stage_v1alpha1.go
+++ b/internal/api/promote_to_stage_v1alpha1.go
@@ -118,7 +118,7 @@ func (s *server) PromoteToStage(
 		return nil, err
 	}
 
-	promotion := kargo.NewPromotion(*stage, freight.Name)
+	promotion := kargo.NewPromotion(ctx, *stage, freight.Name)
 	if err := s.createPromotionFn(ctx, &promotion); err != nil {
 		return nil, fmt.Errorf("create promotion: %w", err)
 	}

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -989,7 +989,7 @@ func (r *reconciler) syncNormalStage(
 
 	logger.Debug("auto-promotion will proceed")
 
-	promo := kargo.NewPromotion(*stage, latestFreight.Name)
+	promo := kargo.NewPromotion(ctx, *stage, latestFreight.Name)
 	if err :=
 		r.createPromotionFn(ctx, &promo); err != nil {
 		return status, fmt.Errorf(

--- a/internal/kargo/kargo.go
+++ b/internal/kargo/kargo.go
@@ -41,7 +41,7 @@ func NewPromotion(
 	annotations := make(map[string]string, 1)
 	// Put actor information to track on the controller side
 	if u, ok := user.InfoFromContext(ctx); ok {
-		annotations[kargoapi.AnnotationKeyPromoteActor] = kargoapi.FormatEventUserActor(u)
+		annotations[kargoapi.AnnotationKeyCreateActor] = kargoapi.FormatEventUserActor(u)
 	}
 
 	// ulid.Make() is pseudo-random, not crypto-random, but we don't care.

--- a/internal/kargo/kargo_test.go
+++ b/internal/kargo/kargo_test.go
@@ -1,6 +1,7 @@
 package kargo
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -64,7 +65,7 @@ func TestNewPromotion(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			promo := NewPromotion(tc.stage, tc.freight)
+			promo := NewPromotion(context.TODO(), tc.stage, tc.freight)
 			require.Equal(t, tc.freight, promo.Spec.Freight)
 			require.Equal(t, tc.stage.Name, promo.Spec.Stage)
 			require.Equal(t, tc.freight, promo.Spec.Freight)

--- a/internal/webhook/promotion/webhook.go
+++ b/internal/webhook/promotion/webhook.go
@@ -142,15 +142,15 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 		// Set actor as an admission request's user info when the promotion is created
 		// to allow controllers to track who created it.
 		if !w.isRequestFromKargoControlplaneFn(req) {
-			promo.Annotations[kargoapi.AnnotationKeyPromoteActor] =
+			promo.Annotations[kargoapi.AnnotationKeyCreateActor] =
 				kargoapi.FormatEventKubernetesUserActor(req.UserInfo)
 		}
 	} else if req.Operation == admissionv1.Update {
 		// Ensure actor annotation immutability
-		if oldActor, ok := oldPromo.Annotations[kargoapi.AnnotationKeyPromoteActor]; ok {
-			promo.Annotations[kargoapi.AnnotationKeyPromoteActor] = oldActor
+		if oldActor, ok := oldPromo.Annotations[kargoapi.AnnotationKeyCreateActor]; ok {
+			promo.Annotations[kargoapi.AnnotationKeyCreateActor] = oldActor
 		} else {
-			delete(promo.Annotations, kargoapi.AnnotationKeyPromoteActor)
+			delete(promo.Annotations, kargoapi.AnnotationKeyCreateActor)
 		}
 	}
 

--- a/internal/webhook/promotion/webhook_test.go
+++ b/internal/webhook/promotion/webhook_test.go
@@ -27,6 +27,7 @@ func TestNewWebhook(t *testing.T) {
 	w := newWebhook(
 		libWebhook.Config{},
 		kubeClient,
+		admission.NewDecoder(kubeClient.Scheme()),
 		&fakeevent.EventRecorder{},
 	)
 	// Assert that all overridable behaviors were initialized to a default:
@@ -48,6 +49,9 @@ func TestDefault(t *testing.T) {
 		{
 			name: "error getting stage",
 			webhook: &webhook{
+				admissionRequestFromContextFn: func(context.Context) (admission.Request, error) {
+					return admission.Request{}, nil
+				},
 				getStageFn: func(
 					context.Context,
 					client.Client,
@@ -64,6 +68,9 @@ func TestDefault(t *testing.T) {
 		{
 			name: "stage not found",
 			webhook: &webhook{
+				admissionRequestFromContextFn: func(context.Context) (admission.Request, error) {
+					return admission.Request{}, nil
+				},
 				getStageFn: func(
 					context.Context,
 					client.Client,
@@ -80,6 +87,9 @@ func TestDefault(t *testing.T) {
 		{
 			name: "stage without promotion mechanisms",
 			webhook: &webhook{
+				admissionRequestFromContextFn: func(context.Context) (admission.Request, error) {
+					return admission.Request{}, nil
+				},
 				getStageFn: func(
 					context.Context,
 					client.Client,
@@ -98,6 +108,9 @@ func TestDefault(t *testing.T) {
 		{
 			name: "success",
 			webhook: &webhook{
+				admissionRequestFromContextFn: func(context.Context) (admission.Request, error) {
+					return admission.Request{}, nil
+				},
 				getStageFn: func(
 					context.Context,
 					client.Client,


### PR DESCRIPTION
This PR allows to controller to track who triggered Promotion by the actor information set by API / Webhook when the Promotion is created.