### PR TITLE
fix(build): pin pnpm version and update to 9.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,16 @@
 ####################################################################################################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.2 AS ui-builder
 
-RUN npm install --global pnpm@9.0.2
+ARG PNPM_VERSION=9.0.3
+RUN npm install --global pnpm@${PNPM_VERSION}
+
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
-ARG VERSION
 
 RUN pnpm install
-
 COPY ["ui/", "."]
 
+ARG VERSION
 RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 
 ####################################################################################################
@@ -106,7 +107,8 @@ CMD ["/usr/local/bin/kargo"]
 ####################################################################################################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.2 AS ui-dev
 
-RUN npm install --global pnpm@9.0.2
+ARG PNPM_VERSION=9.0.3
+RUN npm install --global pnpm@${PNPM_VERSION}
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ####################################################################################################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:20.12.2 AS ui-builder
 
-RUN npm install --global pnpm
+RUN npm install --global pnpm@9.0.2
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
 ARG VERSION

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,7 @@ ARG GOLANGCI_LINT_VERSION=1.57.2
 ARG HELM_VERSION=v3.12.3
 ARG NODE_MAJOR=20
 ARG PROTOC_VERSION=25.3
+ARG PNPM_VERSION=9.0.3
 
 RUN apt update && apt install -y ca-certificates curl gnupg unzip \
     && export PROTOC_REL=protoc-${PROTOC_VERSION}-linux-$([ $(uname -m) = "aarch64" ] && echo "aarch" || echo "x86")_64.zip \
@@ -28,7 +29,7 @@ RUN apt update && apt install -y ca-certificates curl gnupg unzip \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update && apt-get install nodejs -y
 
-RUN npm install --global pnpm@9.0.2
+RUN npm install --global pnpm@${PNPM_VERSION}
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "vitest": "^0.34.6",
     "zx": "^7.2.3"
   },
-  "packageManager": "pnpm@9.0.2",
+  "packageManager": "pnpm@9.0.3",
   "dependencies": {
     "@bufbuild/protobuf": "1.8.0",
     "@connectrpc/connect": "1.4.0",


### PR DESCRIPTION
This unblocks the CI from merge failures, see e.g. https://github.com/akuity/kargo/actions/runs/8812620833/job/24188756463