### PR TITLE
chore: minor test cleanup

### DIFF
--- a/internal/api/dex/proxy_test.go
+++ b/internal/api/dex/proxy_test.go
@@ -59,9 +59,8 @@ func TestNewProxy(t *testing.T) {
 				}
 			},
 			assertions: func(t *testing.T, _ *httputil.ReverseProxy, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error reading CA cert file")
-				require.Contains(t, err.Error(), "/bogus/path")
+				require.ErrorContains(t, err, "error reading CA cert file")
+				require.ErrorContains(t, err, "/bogus/path")
 			},
 		},
 		{
@@ -75,8 +74,7 @@ func TestNewProxy(t *testing.T) {
 				return cfg
 			},
 			assertions: func(t *testing.T, _ *httputil.ReverseProxy, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error building CA cert pool")
+				require.ErrorContains(t, err, "error building CA cert pool")
 			},
 		},
 		{

--- a/internal/api/kubernetes/client_test.go
+++ b/internal/api/kubernetes/client_test.go
@@ -187,8 +187,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      getOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 
@@ -242,8 +241,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      deleteOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 
@@ -261,8 +259,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      updateOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 
@@ -280,8 +277,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      patchOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 
@@ -317,8 +313,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      updateStatusOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 
@@ -336,8 +331,7 @@ func TestAllClientOperations(t *testing.T) {
 			op:      patchStatusOp,
 			allowed: true,
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 

--- a/internal/api/query_freights_v1alpha1_test.go
+++ b/internal/api/query_freights_v1alpha1_test.go
@@ -56,8 +56,7 @@ func TestQueryFreight(t *testing.T) {
 				_ *connect.Response[svcv1alpha1.QueryFreightResponse],
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -204,8 +203,7 @@ func TestQueryFreight(t *testing.T) {
 				_ *connect.Response[svcv1alpha1.QueryFreightResponse],
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -437,13 +435,10 @@ func TestGetAvailableFreightForStage(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error listing Freight verified in Stages upstream from Stage",
+				require.ErrorContains(
+					t, err, "error listing Freight verified in Stages upstream from Stage",
 				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -472,13 +467,8 @@ func TestGetAvailableFreightForStage(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error listing Freight approved for Stage",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight approved for Stage")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -558,9 +548,8 @@ func TestGetFreightFromWarehouse(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error listing Freight for Warehouse")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight for Warehouse")
 			},
 		},
 		{
@@ -624,13 +613,8 @@ func TestGetVerifiedFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error listing Freight verified in Stage",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight verified in Stage")
 			},
 		},
 		{

--- a/internal/api/update_freight_alias_v1alpha1_test.go
+++ b/internal/api/update_freight_alias_v1alpha1_test.go
@@ -96,8 +96,7 @@ func TestUpdateFreightAlias(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -25,8 +25,7 @@ func TestLoadCLIConfig(t *testing.T) {
 				return getTestConfigPath()
 			},
 			assertions: func(t *testing.T, _ CLIConfig, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "no configuration file was found")
+				require.ErrorContains(t, err, "no configuration file was found")
 			},
 		},
 		{
@@ -38,8 +37,7 @@ func TestLoadCLIConfig(t *testing.T) {
 				return configPath
 			},
 			assertions: func(t *testing.T, _ CLIConfig, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing configuration file")
+				require.ErrorContains(t, err, "error parsing configuration file")
 			},
 		},
 		{

--- a/internal/controller/management/namespaces/namespaces_test.go
+++ b/internal/controller/management/namespaces/namespaces_test.go
@@ -68,8 +68,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ ctrl.Result, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -185,9 +184,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ ctrl.Result, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error deleting Project")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error deleting Project")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -220,9 +218,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ ctrl.Result, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error removing finalizer")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error removing finalizer")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/management/projects/projects_test.go
+++ b/internal/controller/management/projects/projects_test.go
@@ -74,8 +74,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ ctrl.Result, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -130,8 +129,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ ctrl.Result, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -189,8 +187,7 @@ func TestSyncProject(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 				// Still initializing because retry could succeed
 				require.Equal(t, kargoapi.ProjectPhaseInitializing, status.Phase)
 			},
@@ -208,8 +205,7 @@ func TestSyncProject(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went very wrong")
+				require.ErrorContains(t, err, "something went very wrong")
 				// Failed because retry cannot possibly succeed
 				require.Equal(
 					t,
@@ -235,8 +231,7 @@ func TestSyncProject(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 				// Still initializing because retry could succeed
 				require.Equal(t, kargoapi.ProjectPhaseInitializing, status.Phase)
 			},
@@ -304,9 +299,8 @@ func TestEnsureNamespace(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error getting namespace")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error getting namespace")
 				// Phase wasn't changed
 				require.Equal(t, kargoapi.ProjectPhaseInitializing, status.Phase)
 			},
@@ -342,9 +336,8 @@ func TestEnsureNamespace(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error updating namespace")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating namespace")
+				require.ErrorContains(t, err, "something went wrong")
 				// Phase wasn't changed
 				require.Equal(t, kargoapi.ProjectPhaseInitializing, status.Phase)
 			},
@@ -403,8 +396,7 @@ func TestEnsureNamespace(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "failed to initialize Project")
+				require.ErrorContains(t, err, "failed to initialize Project")
 				// Phase reflects the unrecoverable failure
 				require.Equal(t, status.Phase, kargoapi.ProjectPhaseInitializationFailed)
 			},
@@ -466,9 +458,8 @@ func TestEnsureNamespace(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error creating namespace")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error creating namespace")
 				// Phase wasn't changed
 				require.Equal(t, kargoapi.ProjectPhaseInitializing, status.Phase)
 			},
@@ -533,9 +524,8 @@ func TestEnsureSecretPermissions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error creating role binding")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error creating role binding")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/argocd_test.go
+++ b/internal/controller/promotion/argocd_test.go
@@ -89,11 +89,8 @@ func TestArgoCDPromote(t *testing.T) {
 				_ kargoapi.FreightReference,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"Argo CD integration is disabled on this controller",
+				require.ErrorContains(
+					t, err, "Argo CD integration is disabled on this controller",
 				)
 			},
 		},
@@ -682,9 +679,8 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error finding Argo CD Application")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error finding Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -699,8 +695,7 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "unable to find Argo CD Application")
+				require.ErrorContains(t, err, "unable to find Argo CD Application")
 			},
 		},
 		{
@@ -725,8 +720,7 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				Namespace: "fake-namespace",
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "does not permit mutation by")
+				require.ErrorContains(t, err, "does not permit mutation by")
 			},
 		},
 		{
@@ -768,13 +762,8 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error updating source of Argo CD Application",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating source of Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -818,13 +807,8 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error updating source(s) of Argo CD Application",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating source(s) of Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -859,13 +843,8 @@ func TestArgoCDDoSingleUpdate(t *testing.T) {
 				Namespace: "fake-namespace",
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error patching Argo CD Application",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error patching Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/composite_test.go
+++ b/internal/controller/promotion/composite_test.go
@@ -75,13 +75,8 @@ func TestCompositePromote(t *testing.T) {
 				_ kargoapi.FreightReference,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error executing fake promotion mechanism",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error executing fake promotion mechanism")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/git_test.go
+++ b/internal/controller/promotion/git_test.go
@@ -394,12 +394,7 @@ func TestGetReadRef(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ string, _ int, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"because it will form a subscription loop",
-				)
+				require.ErrorContains(t, err, "because it will form a subscription loop")
 			},
 		},
 		{
@@ -449,9 +444,8 @@ func TestGetRepoCredentials(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *git.RepoCredentials, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error obtaining credentials")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error obtaining credentials")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/helm_test.go
+++ b/internal/controller/promotion/helm_test.go
@@ -100,9 +100,8 @@ func TestHelmerApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error updating values in file")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating values in file")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -126,13 +125,8 @@ func TestHelmerApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error preparing changes to affected Chart.yaml files",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error preparing changes to affected Chart.yaml files")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -163,13 +157,8 @@ func TestHelmerApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error updating dependencies for chart",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating dependencies for chart")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -200,13 +189,8 @@ func TestHelmerApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error updating dependencies for chart",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating dependencies for chart")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/kustomize_test.go
+++ b/internal/controller/promotion/kustomize_test.go
@@ -91,9 +91,8 @@ func TestKustomizerApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error updating image")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error updating image")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/promotion/render_test.go
+++ b/internal/controller/promotion/render_test.go
@@ -95,9 +95,8 @@ func TestKargoRenderApply(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []string, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error rendering manifests via Kargo Render")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error rendering manifests via Kargo Render")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -117,9 +117,8 @@ func TestSyncControlFlowStage(t *testing.T) {
 				newStatus kargoapi.StageStatus,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Freight from Warehouse")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight from Warehouse")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 
@@ -157,13 +156,10 @@ func TestSyncControlFlowStage(t *testing.T) {
 				newStatus kargoapi.StageStatus,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting all Freight verified in Stages upstream from Stage",
+				require.ErrorContains(
+					t, err, "error getting all Freight verified in Stages upstream from Stage",
 				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 
@@ -209,9 +205,8 @@ func TestSyncControlFlowStage(t *testing.T) {
 				newStatus kargoapi.StageStatus,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error marking Freight")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error marking Freight")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 
@@ -999,9 +994,8 @@ func TestSyncNormalStage(t *testing.T) {
 				newStatus kargoapi.StageStatus,
 				err error,
 			) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error marking Freight")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error marking Freight")
 				// Since no verification process was defined and the Stage is healthy,
 				// the Stage should have transitioned to a Steady phase.
 				require.Equal(t, kargoapi.StagePhaseSteady, newStatus.Phase)
@@ -1068,13 +1062,8 @@ func TestSyncNormalStage(t *testing.T) {
 					event.Annotations[kargoapi.AnnotationKeyEventVerificationFinishTime],
 				)
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error checking if auto-promotion is permitted",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error checking if auto-promotion is permitted")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1201,13 +1190,8 @@ func TestSyncNormalStage(t *testing.T) {
 					event.Annotations[kargoapi.AnnotationKeyEventVerificationFinishTime],
 				)
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error finding latest Freight for Stage",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error finding latest Freight for Stage")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1485,9 +1469,8 @@ func TestSyncNormalStage(t *testing.T) {
 					event.Annotations[kargoapi.AnnotationKeyEventVerificationFinishTime],
 				)
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error creating Promotion of Stage")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error creating Promotion of Stage")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1813,9 +1796,8 @@ func TestSyncStageDelete(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, initialStatus, newStatus kargoapi.StageStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error clearing verifications for Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error clearing verifications for Stage")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1831,9 +1813,8 @@ func TestSyncStageDelete(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, initialStatus, newStatus kargoapi.StageStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error clearing approvals for Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error clearing approvals for Stage")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1848,9 +1829,8 @@ func TestSyncStageDelete(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, initialStatus, newStatus kargoapi.StageStatus, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error clearing AnalysisRuns for Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error clearing AnalysisRuns for Stage")
+				require.ErrorContains(t, err, "something went wrong")
 				// Status should be returned unchanged
 				require.Equal(t, initialStatus, newStatus)
 			},
@@ -1904,9 +1884,8 @@ func TestClearVerification(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Freight verified in Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight verified in Stage")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -1935,9 +1914,8 @@ func TestClearVerification(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error patching status of Freight")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error patching status of Freight")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -2001,9 +1979,8 @@ func TestClearApprovals(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Freight approved for Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight approved for Stage")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -2032,9 +2009,8 @@ func TestClearApprovals(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error patching status of Freight")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error patching status of Freight")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -2098,8 +2074,7 @@ func TestHasNonTerminalPromotions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ bool, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -2171,10 +2146,9 @@ func TestVerifyFreightInStage(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, updated bool, err error) {
-				require.Error(t, err)
 				require.False(t, updated)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error finding Freight")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error finding Freight")
 			},
 		},
 		{
@@ -2189,9 +2163,8 @@ func TestVerifyFreightInStage(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, updated bool, err error) {
-				require.Error(t, err)
 				require.False(t, updated)
-				require.Contains(t, err.Error(), "found no Freight")
+				require.ErrorContains(t, err, "found no Freight")
 			},
 		},
 		{
@@ -2235,8 +2208,7 @@ func TestVerifyFreightInStage(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, updated bool, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 				require.False(t, updated)
 			},
 		},
@@ -2295,9 +2267,8 @@ func TestIsAutoPromotionPermitted(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, allowed bool, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error finding Project")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error finding Project")
 				require.False(t, allowed)
 			},
 		},
@@ -2313,9 +2284,8 @@ func TestIsAutoPromotionPermitted(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, allowed bool, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "Project")
-				require.Contains(t, err.Error(), "not found")
+				require.ErrorContains(t, err, "Project")
+				require.ErrorContains(t, err, "not found")
 				require.False(t, allowed)
 			},
 		},
@@ -2409,9 +2379,8 @@ func TestGetLatestAvailableFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error checking Warehouse")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error checking Warehouse")
 			},
 		},
 		{
@@ -2467,12 +2436,9 @@ func TestGetLatestAvailableFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error finding latest Freight verified in Stages upstream from Stage",
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(
+					t, err, "error finding latest Freight verified in Stages upstream from Stage",
 				)
 			},
 		},
@@ -2498,13 +2464,8 @@ func TestGetLatestAvailableFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error finding latest Freight approved for Stage",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error finding latest Freight approved for Stage")
 			},
 		},
 		{
@@ -2702,8 +2663,7 @@ func TestGetLatestFreightFromWarehouse(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -2791,13 +2751,8 @@ func TestGetAllVerifiedFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error listing Freight verified in Stage",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight verified in Stage")
 			},
 		},
 		{
@@ -2885,8 +2840,7 @@ func TestGetLatestVerifiedFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{

--- a/internal/controller/warehouses/git_test.go
+++ b/internal/controller/warehouses/git_test.go
@@ -37,13 +37,8 @@ func TestSelectCommits(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, commits []kargoapi.GitCommit, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error obtaining credentials for git repo",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error obtaining credentials for git repo")
+				require.ErrorContains(t, err, "something went wrong")
 				require.Empty(t, commits)
 			},
 		},
@@ -71,13 +66,8 @@ func TestSelectCommits(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, commits []kargoapi.GitCommit, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error determining latest commit ID of git repo",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error determining latest commit ID of git repo")
+				require.ErrorContains(t, err, "something went wrong")
 				require.Empty(t, commits)
 			},
 		},
@@ -152,8 +142,7 @@ func TestSelectCommitMeta(t *testing.T) {
 			},
 			reconciler: &reconciler{},
 			assertions: func(t *testing.T, _ *gitMeta, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error cloning git repo")
+				require.ErrorContains(t, err, "error cloning git repo")
 			},
 		},
 		{
@@ -201,13 +190,8 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error determining commit ID at head of branch",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error determining commit ID at head of branch")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -241,13 +225,10 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting diffs since commit \"sha\" in git repo \"\":",
+				require.ErrorContains(
+					t, err, `error getting diffs since commit "sha" in git repo "":`,
 				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -265,18 +246,10 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error checking includePaths/excludePaths match for commit",
+				require.ErrorContains(
+					t, err, "error checking includePaths/excludePaths match for commit",
 				)
-				require.Contains(
-					t,
-					err.Error(),
-					"error parsing regexp: missing closing ]",
-				)
-				require.Contains(t, err.Error(), "error parsing regexp: missing closing ]")
+				require.ErrorContains(t, err, "error parsing regexp: missing closing ]")
 			},
 		},
 		{
@@ -294,11 +267,10 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(
+				require.ErrorContains(
 					t,
-					err.Error(),
-					"commit \"fake-commit\" not applicable due to includePaths/excludePaths configuration for repo",
+					err,
+					`commit "fake-commit" not applicable due to includePaths/excludePaths configuration for repo`,
 				)
 			},
 		},
@@ -313,9 +285,8 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing tags from git repo")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing tags from git repo")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -330,8 +301,7 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error compiling regular expression")
+				require.ErrorContains(t, err, "error compiling regular expression")
 			},
 		},
 		{
@@ -346,8 +316,7 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "found no applicable tags in repo")
+				require.ErrorContains(t, err, "found no applicable tags in repo")
 			},
 		},
 		{
@@ -361,8 +330,7 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "unknown commit selection strategy")
+				require.ErrorContains(t, err, "unknown commit selection strategy")
 			},
 		},
 		{
@@ -379,9 +347,8 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error checking out tag")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error checking out tag")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -401,9 +368,8 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error determining commit ID of tag")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error determining commit ID of tag")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -462,8 +428,7 @@ func TestSelectCommitID(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing semver constraint")
+				require.ErrorContains(t, err, "error parsing semver constraint")
 			},
 		},
 		{
@@ -608,8 +573,7 @@ func TestSelectSemverTag(t *testing.T) {
 			constraint: "invalid",
 			tags:       nil,
 			assertions: func(t *testing.T, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing semver constraint")
+				require.ErrorContains(t, err, "error parsing semver constraint")
 			},
 		},
 		{
@@ -746,8 +710,7 @@ func TestMatchesPathsFilters(t *testing.T) {
 			excludePaths: []string{regexpPrefix + "nonexistent", regexpPrefix + ".*val.*", regexPrefix + "["},
 			diffs:        []string{"path1/values.yaml", "path2/_helpers.tpl"},
 			assertions: func(t *testing.T, _ bool, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing regexp: missing closing ]: `[`")
+				require.ErrorContains(t, err, "error parsing regexp: missing closing ]: `[`")
 			},
 		},
 		{

--- a/internal/controller/warehouses/helm_test.go
+++ b/internal/controller/warehouses/helm_test.go
@@ -39,13 +39,8 @@ func TestSelectCharts(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Chart, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error obtaining credentials for chart",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error obtaining credentials for chart")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -71,13 +66,8 @@ func TestSelectCharts(t *testing.T) {
 				return "", errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Chart, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error searching for latest version of chart",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error searching for latest version of chart")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -103,8 +93,7 @@ func TestSelectCharts(t *testing.T) {
 				return "", nil
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Chart, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "found no suitable version of chart")
+				require.ErrorContains(t, err, "found no suitable version of chart")
 			},
 		},
 

--- a/internal/controller/warehouses/images_test.go
+++ b/internal/controller/warehouses/images_test.go
@@ -41,13 +41,8 @@ func TestSelectImages(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting latest suitable image",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error getting latest suitable image")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 

--- a/internal/controller/warehouses/warehouses_test.go
+++ b/internal/controller/warehouses/warehouses_test.go
@@ -62,13 +62,8 @@ func TestSyncWarehouse(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting latest Freight from repos",
-				)
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error getting latest Freight from repos")
 			},
 		},
 
@@ -133,9 +128,8 @@ func TestSyncWarehouse(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error creating Freight")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error creating Freight")
 			},
 		},
 
@@ -195,9 +189,8 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error syncing git repo subscription")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error syncing git repo subscription")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -221,13 +214,8 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error syncing image repo subscriptions",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error syncing image repo subscriptions")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -258,13 +246,8 @@ func TestGetLatestFreightFromRepos(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error syncing chart repo subscriptions",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error syncing chart repo subscriptions")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -20,7 +20,8 @@ func TestExec(t *testing.T) {
 			// This command should fail, but ALSO produce some output
 			cmd: exec.Command("expr", "100", "/", "0"),
 			assertions: func(t *testing.T, _ []byte, err error) {
-				require.Error(t, err)
+				require.ErrorContains(t, err, "expr 100 / 0")
+				require.ErrorContains(t, err, "expr: division by zero")
 				var exitErr *ExitError
 				ok := errors.As(err, &exitErr)
 				require.True(t, ok)
@@ -28,8 +29,6 @@ func TestExec(t *testing.T) {
 				require.True(t, strings.HasSuffix(exitErr.Command, "expr 100 / 0"))
 				require.Equal(t, "expr: division by zero\n", string(exitErr.Output))
 				require.NotEmpty(t, exitErr.ExitCode)
-				require.Contains(t, err.Error(), "expr 100 / 0")
-				require.Contains(t, err.Error(), "expr: division by zero")
 			},
 		},
 		{

--- a/internal/garbage/collector_test.go
+++ b/internal/garbage/collector_test.go
@@ -58,12 +58,9 @@ func TestRun(t *testing.T) {
 				return errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(
-					t,
-					err.Error(),
-					"error listing projects; no garbage collection performed",
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(
+					t, err, "error listing projects; no garbage collection performed",
 				)
 			},
 		},

--- a/internal/garbage/freight_test.go
+++ b/internal/garbage/freight_test.go
@@ -31,9 +31,8 @@ func TestCleanProjectFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Warehouses in Project")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Warehouses in Project")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -54,11 +53,8 @@ func TestCleanProjectFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error cleaning Freight from one or more Warehouses",
+				require.ErrorContains(
+					t, err, "error cleaning Freight from one or more Warehouses",
 				)
 			},
 		},
@@ -115,9 +111,8 @@ func TestCleanWarehouseFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Freight from Warehouse")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Freight from Warehouse")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -166,9 +161,8 @@ func TestCleanWarehouseFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Stages in Project")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Stages in Project")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -217,11 +211,8 @@ func TestCleanWarehouseFreight(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error deleting one or more Freight from Warehouse",
+				require.ErrorContains(
+					t, err, "error deleting one or more Freight from Warehouse",
 				)
 			},
 		},

--- a/internal/garbage/projects_test.go
+++ b/internal/garbage/projects_test.go
@@ -100,11 +100,10 @@ func TestCleanProject(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error cleaning Promotions in Project")
-				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error cleaning Freight in Project")
-				require.Contains(t, err.Error(), "something else went wrong")
+				require.ErrorContains(t, err, "error cleaning Promotions in Project")
+				require.ErrorContains(t, err, "something went wrong")
+				require.ErrorContains(t, err, "error cleaning Freight in Project")
+				require.ErrorContains(t, err, "something else went wrong")
 			},
 		},
 		{

--- a/internal/garbage/promotions_test.go
+++ b/internal/garbage/promotions_test.go
@@ -31,9 +31,8 @@ func TestCleanProjectPromotions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Stages in Project")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Stages in Project")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -55,12 +54,7 @@ func TestCleanProjectPromotions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error cleaning Promotions to one or more Stages",
-				)
+				require.ErrorContains(t, err, "error cleaning Promotions to one or more Stages")
 			},
 		},
 
@@ -118,9 +112,8 @@ func TestCleanStagePromotions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error listing Promotions to Stage")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error listing Promotions to Stage")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -188,12 +181,7 @@ func TestCleanStagePromotions(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error deleting one or more Promotions from Stage",
-				)
+				require.ErrorContains(t, err, "error deleting one or more Promotions from Stage")
 			},
 		},
 		{

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -49,8 +49,7 @@ func TestGetChartVersionsFromClassicRepo(t *testing.T) {
 			repoURL: fmt.Sprintf("%s/non-existent-repo", testServer.URL),
 			chart:   "fake-chart",
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "received unexpected HTTP 404")
+				require.ErrorContains(t, err, "received unexpected HTTP 404")
 			},
 		},
 		{
@@ -58,8 +57,7 @@ func TestGetChartVersionsFromClassicRepo(t *testing.T) {
 			repoURL: fmt.Sprintf("%s/bad-repo", testServer.URL),
 			chart:   "fake-chart",
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error unmarshaling repository index")
+				require.ErrorContains(t, err, "error unmarshaling repository index")
 			},
 		},
 		{
@@ -67,9 +65,8 @@ func TestGetChartVersionsFromClassicRepo(t *testing.T) {
 			repoURL: fmt.Sprintf("%s/fake-repo", testServer.URL),
 			chart:   "non-existent-chart",
 			assertions: func(t *testing.T, _ []string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "no versions of chart")
-				require.Contains(t, err.Error(), "found in repository index")
+				require.ErrorContains(t, err, "no versions of chart")
+				require.ErrorContains(t, err, "found in repository index")
 			},
 		},
 		{
@@ -126,8 +123,7 @@ func TestGetLatestVersion(t *testing.T) {
 			unsorted:   []string{"1.0.0"},
 			constraint: "invalid",
 			assertions: func(t *testing.T, _ string, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing constraint")
+				require.ErrorContains(t, err, "error parsing constraint")
 			},
 		},
 		{

--- a/internal/image/platform_constraint_test.go
+++ b/internal/image/platform_constraint_test.go
@@ -80,8 +80,7 @@ func TestParsePlatformConstraint(t *testing.T) {
 			name:        "invalid",
 			platformStr: "invalid",
 			assertions: func(t *testing.T, _ platformConstraint, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing platform constraint")
+				require.ErrorContains(t, err, "error parsing platform constraint")
 			},
 		},
 		{

--- a/internal/image/repository_client_test.go
+++ b/internal/image/repository_client_test.go
@@ -78,9 +78,8 @@ func TestGetImageByTag(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error retrieving manifest")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error retrieving manifest")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -103,13 +102,8 @@ func TestGetImageByTag(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error extracting image from manifest",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error extracting image from manifest")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -198,9 +192,8 @@ func TestGetImageByDigest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error retrieving manifest")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error retrieving manifest")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -223,13 +216,8 @@ func TestGetImageByDigest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error extracting image from manifest",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error extracting image from manifest")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -378,12 +366,7 @@ func TestExtractImageFromV1Manifest(t *testing.T) {
 			manifest: &schema1.SignedManifest{}, // nolint: staticcheck
 			client:   &repositoryClient{},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"no history information found in V1 manifest",
-				)
+				require.ErrorContains(t, err, "no history information found in V1 manifest")
 			},
 		},
 		{
@@ -399,8 +382,7 @@ func TestExtractImageFromV1Manifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error unmarshaling V1 manifest")
+				require.ErrorContains(t, err, "error unmarshaling V1 manifest")
 			},
 		},
 		{
@@ -437,8 +419,7 @@ func TestExtractImageFromV1Manifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing createdAt timestamp")
+				require.ErrorContains(t, err, "error parsing createdAt timestamp")
 			},
 		},
 		{
@@ -491,9 +472,8 @@ func TestExtractImageFromV2Manifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error fetching blob")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error fetching blob")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -504,8 +484,7 @@ func TestExtractImageFromV2Manifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error unmarshaling blob")
+				require.ErrorContains(t, err, "error unmarshaling blob")
 			},
 		},
 		{
@@ -532,8 +511,7 @@ func TestExtractImageFromV2Manifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing createdAt timestamp")
+				require.ErrorContains(t, err, "error parsing createdAt timestamp")
 			},
 		},
 		{
@@ -583,9 +561,8 @@ func TestExtractImageFromOCIManifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error fetching blob")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "error fetching blob")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -597,7 +574,7 @@ func TestExtractImageFromOCIManifest(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "error unmarshaling blob")
+				require.ErrorContains(t, err, "error unmarshaling blob")
 			},
 		},
 		{
@@ -636,8 +613,7 @@ func TestExtractImageFromOCIManifest(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing createdAt timestamp")
+				require.ErrorContains(t, err, "error parsing createdAt timestamp")
 			},
 		},
 		{
@@ -689,8 +665,7 @@ func TestExtractImageFromCollection(t *testing.T) {
 			collection: &manifestlist.DeserializedManifestList{},
 			client:     &repositoryClient{},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "empty V2 manifest list or OCI index")
+				require.ErrorContains(t, err, "empty V2 manifest list or OCI index")
 			},
 		},
 		{
@@ -744,11 +719,7 @@ func TestExtractImageFromCollection(t *testing.T) {
 			client: &repositoryClient{},
 			assertions: func(t *testing.T, _ *Image, err error) {
 				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"expected only one reference to match platform",
-				)
+				require.ErrorContains(t, err, "expected only one reference to match platform")
 			},
 		},
 		{
@@ -779,12 +750,7 @@ func TestExtractImageFromCollection(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting image from manifest",
-				)
+				require.ErrorContains(t, err, "error getting image from manifest")
 			},
 		},
 		{
@@ -815,9 +781,8 @@ func TestExtractImageFromCollection(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "expected manifest for digest")
-				require.Contains(t, err.Error(), "to match platform")
+				require.ErrorContains(t, err, "expected manifest for digest")
+				require.ErrorContains(t, err, "to match platform")
 			},
 		},
 		{
@@ -880,12 +845,7 @@ func TestExtractImageFromCollection(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting image from manifest",
-				)
+				require.ErrorContains(t, err, "error getting image from manifest")
 			},
 		},
 		{
@@ -912,8 +872,7 @@ func TestExtractImageFromCollection(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *Image, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "found no image for manifest")
+				require.ErrorContains(t, err, "found no image for manifest")
 			},
 		},
 		{

--- a/internal/image/selector_test.go
+++ b/internal/image/selector_test.go
@@ -35,8 +35,7 @@ func TestNewSelector(t *testing.T) {
 				AllowRegex: "(invalid", // Invalid regex due to unclosed parenthesis
 			},
 			assertions: func(t *testing.T, _ Selector, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error compiling regular expression")
+				require.ErrorContains(t, err, "error compiling regular expression")
 			},
 		},
 		{
@@ -46,8 +45,7 @@ func TestNewSelector(t *testing.T) {
 				Platform: "invalid",
 			},
 			assertions: func(t *testing.T, _ Selector, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing platform constraint")
+				require.ErrorContains(t, err, "error parsing platform constraint")
 			},
 		},
 		{
@@ -58,8 +56,7 @@ func TestNewSelector(t *testing.T) {
 				Constraint: "invalid", // Not a semver
 			},
 			assertions: func(t *testing.T, _ Selector, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "invalid image selection strategy")
+				require.ErrorContains(t, err, "invalid image selection strategy")
 			},
 		},
 		{

--- a/internal/image/semver_selector_test.go
+++ b/internal/image/semver_selector_test.go
@@ -23,8 +23,7 @@ func TestNewSemVerSelector(t *testing.T) {
 			name:       "invalid semver constraint",
 			constraint: "invalid",
 			assertions: func(t *testing.T, _ Selector, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error parsing semver constraint")
+				require.ErrorContains(t, err, "error parsing semver constraint")
 			},
 		},
 		{

--- a/internal/webhook/freight/webhook_test.go
+++ b/internal/webhook/freight/webhook_test.go
@@ -54,12 +54,7 @@ func TestDefault(t *testing.T) {
 			webhook: &webhook{},
 			freight: &kargoapi.Freight{},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error getting admission request from context",
-				)
+				require.ErrorContains(t, err, "error getting admission request from context")
 			},
 		},
 		{
@@ -86,9 +81,8 @@ func TestDefault(t *testing.T) {
 			},
 			freight: &kargoapi.Freight{},
 			assertions: func(t *testing.T, _ *kargoapi.Freight, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "get available freight alias")
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "get available freight alias")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -261,11 +255,8 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"freight must contain at least one commit, image, or chart",
+				require.ErrorContains(
+					t, err, "freight must contain at least one commit, image, or chart",
 				)
 			},
 		},
@@ -418,9 +409,8 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "is invalid")
-				require.Contains(t, err.Error(), "freight is immutable")
+				require.ErrorContains(t, err, "is invalid")
+				require.ErrorContains(t, err, "freight is immutable")
 			},
 		},
 
@@ -448,9 +438,8 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "is invalid")
-				require.Contains(t, err.Error(), "freight is immutable")
+				require.ErrorContains(t, err, "is invalid")
+				require.ErrorContains(t, err, "freight is immutable")
 			},
 		},
 		{

--- a/internal/webhook/promotion/webhook_test.go
+++ b/internal/webhook/promotion/webhook_test.go
@@ -61,8 +61,7 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Promotion, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -80,8 +79,7 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Promotion, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "could not find Stage")
+				require.ErrorContains(t, err, "could not find Stage")
 			},
 		},
 		{
@@ -99,8 +97,7 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, _ *kargoapi.Promotion, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "has no PromotionMechanisms")
+				require.ErrorContains(t, err, "has no PromotionMechanisms")
 			},
 		},
 		{
@@ -294,8 +291,7 @@ func TestValidateUpdate(t *testing.T) {
 				return errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 
@@ -320,9 +316,8 @@ func TestValidateUpdate(t *testing.T) {
 				return nil
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "\"fake-name\" is invalid")
-				require.Contains(t, err.Error(), "spec is immutable")
+				require.ErrorContains(t, err, `"fake-name" is invalid`)
+				require.ErrorContains(t, err, "spec is immutable")
 			},
 		},
 
@@ -376,8 +371,7 @@ func TestValidateDelete(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "something went wrong")
+				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
 		{
@@ -424,11 +418,8 @@ func TestAuthorize(t *testing.T) {
 				return admission.Request{}, errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error retrieving admission request from context; refusing to",
+				require.ErrorContains(
+					t, err, "error retrieving admission request from context; refusing to",
 				)
 			},
 		},
@@ -447,8 +438,7 @@ func TestAuthorize(t *testing.T) {
 				return errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error creating SubjectAccessReview")
+				require.ErrorContains(t, err, "error creating SubjectAccessReview")
 			},
 		},
 		{
@@ -467,8 +457,7 @@ func TestAuthorize(t *testing.T) {
 				return nil
 			},
 			assertions: func(t *testing.T, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "is not permitted")
+				require.ErrorContains(t, err, "is not permitted")
 			},
 		},
 		{

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -24,8 +24,7 @@ characters:
 	affiliation: Light side
 `),
 			assertions: func(t *testing.T, bytes []byte, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error unmarshaling input")
+				require.ErrorContains(t, err, "error unmarshaling input")
 				require.Nil(t, bytes)
 			},
 		},


### PR DESCRIPTION
After a long session of more difficult coding, I wanted to zen out over something mindless...

This has been on my radar for a couple weeks. We haven't been taking advantage of `require.ErrorContains()` until now. It combines a check for a non-nil error with a check that the error message contains a particular fragment of text. This saves us a few lines of code here and there and makes the assertions just a tiny bit more expressive.

There are no functional changes in this PR.