### PR TITLE
chore(api): remove redundant setter from Promotion

### DIFF
--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -112,13 +112,6 @@ func (p *PromotionStatus) WithPhase(phase PromotionPhase) *PromotionStatus {
 	return status
 }
 
-// WithFreight returns a copy of PromotionStatus with the given freight
-func (p *PromotionStatus) WithFreight(freight *FreightReference) *PromotionStatus {
-	status := p.DeepCopy()
-	status.Freight = freight
-	return status
-}
-
 // +kubebuilder:object:root=true
 
 // PromotionList contains a list of Promotion

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -457,7 +457,7 @@ func (r *reconciler) promote(
 	if err != nil {
 		return nil, err
 	}
-	newStatus = newStatus.WithFreight(&nextFreight)
+	newStatus.Freight = &nextFreight
 
 	logger.Debugf("promotion %s", newStatus.Phase)
 


### PR DESCRIPTION
Follow up on https://github.com/akuity/kargo/pull/1721

I also debated with myself about the suggestion to make the Promotion mechanism(s) responsible for setting the Freight in the Status. In the end, I decided against it partly because it would make the composite mechanism more difficult to understand. As for any mechanism other than the first, the new Freight reference input would have to be taken from the Status.