### PR TITLE
fix(api): use Unstructured to return raw response

### DIFF
--- a/internal/api/get_analysisrun_v1alpha1.go
+++ b/internal/api/get_analysisrun_v1alpha1.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	rolloutsapi "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -32,32 +36,50 @@ func (s *server) GetAnalysisRun(
 		return nil, err
 	}
 
-	ar, err := s.getAnalysisRunFn(ctx, s.client, types.NamespacedName{
+	// Get the AnalysisRun from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": rolloutsapi.GroupVersion.String(),
+			"kind":       "AnalysisRun",
+		},
+	}
+	if err := s.client.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
-	})
-	if err != nil {
+	}, &u); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			err = fmt.Errorf("AnalysisRun %q not found in namespace %q", name, namespace)
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
 		return nil, err
 	}
-	if ar == nil {
-		err = fmt.Errorf("AnalysisRun %q not found in namespace %q", name, namespace)
-		return nil, connect.NewError(connect.CodeNotFound, err)
-	}
 
-	obj, raw, err := objectOrRaw(ar, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if raw != nil {
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetAnalysisRunResponse{
 			Result: &svcv1alpha1.GetAnalysisRunResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		ar := rolloutsapi.AnalysisRun{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &ar); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&ar, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetAnalysisRunResponse{
+			Result: &svcv1alpha1.GetAnalysisRunResponse_AnalysisRun{
+				AnalysisRun: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetAnalysisRunResponse{
-		Result: &svcv1alpha1.GetAnalysisRunResponse_AnalysisRun{
-			AnalysisRun: obj,
-		},
-	}), nil
 }

--- a/internal/api/get_analysistemplate_v1alpha1.go
+++ b/internal/api/get_analysistemplate_v1alpha1.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	rolloutsapi "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -36,32 +40,50 @@ func (s *server) GetAnalysisTemplate(
 		return nil, err
 	}
 
-	at, err := s.getAnalysisTemplateFn(ctx, s.client, types.NamespacedName{
+	// Get the AnalysisTemplate from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": rolloutsapi.GroupVersion.String(),
+			"kind":       "AnalysisTemplate",
+		},
+	}
+	if err := s.client.Get(ctx, types.NamespacedName{
 		Namespace: project,
 		Name:      name,
-	})
-	if err != nil {
+	}, &u); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			err = fmt.Errorf("AnalysisTemplate %q not found in namespace %q", name, project)
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
 		return nil, err
 	}
-	if at == nil {
-		err = fmt.Errorf("AnalysisTemplate %q not found in namespace %q", name, project)
-		return nil, connect.NewError(connect.CodeNotFound, err)
-	}
 
-	obj, raw, err := objectOrRaw(at, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if raw != nil {
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
 			Result: &svcv1alpha1.GetAnalysisTemplateResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		at := rolloutsapi.AnalysisTemplate{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &at); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&at, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
+			Result: &svcv1alpha1.GetAnalysisTemplateResponse_AnalysisTemplate{
+				AnalysisTemplate: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
-		Result: &svcv1alpha1.GetAnalysisTemplateResponse_AnalysisTemplate{
-			AnalysisTemplate: obj,
-		},
-	}), nil
 }

--- a/internal/api/get_freight_v1alpha1.go
+++ b/internal/api/get_freight_v1alpha1.go
@@ -6,7 +6,12 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -32,39 +37,78 @@ func (s *server) GetFreight(
 		return nil, err
 	}
 
-	freight, err := s.getFreightByNameOrAliasFn(
-		ctx,
-		s.client,
-		project,
-		name,
-		alias,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get freight: %w", err)
-	}
-	if freight == nil {
-		if name != "" {
-			err = fmt.Errorf("freight %q not found in namespace %q", name, project)
-		} else {
-			err = fmt.Errorf("freight with alias %q not found in namespace %q", alias, project)
-		}
-		return nil, connect.NewError(connect.CodeNotFound, err)
+	// Get the Freight from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": kargoapi.GroupVersion.String(),
+			"kind":       "Freight",
+		},
 	}
 
-	obj, raw, err := objectOrRaw(freight, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+	switch {
+	case alias != "":
+		ul := unstructured.UnstructuredList{
+			Object: map[string]any{
+				"apiVersion": kargoapi.GroupVersion.String(),
+				"kind":       "FreightList",
+			},
+		}
+		if err := s.client.List(
+			ctx,
+			&ul,
+			client.InNamespace(project),
+			client.MatchingLabels{
+				kargoapi.AliasLabelKey: alias,
+			},
+		); err != nil {
+			return nil, err
+		}
+		if len(ul.Items) == 0 {
+			return nil, connect.NewError(
+				connect.CodeNotFound,
+				fmt.Errorf("Freight with alias %q not found in namespace %q", alias, project),
+			)
+		}
+		u = ul.Items[0]
+	default:
+		if err := s.client.Get(ctx, types.NamespacedName{
+			Namespace: project,
+			Name:      name,
+		}, &u); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				err = fmt.Errorf("Freight %q not found in namespace %q", name, project)
+				return nil, connect.NewError(connect.CodeNotFound, err)
+			}
+			return nil, err
+		}
 	}
-	if raw != nil {
+
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetFreightResponse{
 			Result: &svcv1alpha1.GetFreightResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		f := kargoapi.Freight{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &f); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&f, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetFreightResponse{
+			Result: &svcv1alpha1.GetFreightResponse_Freight{
+				Freight: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetFreightResponse{
-		Result: &svcv1alpha1.GetFreightResponse_Freight{
-			Freight: obj,
-		},
-	}), nil
 }

--- a/internal/api/get_project_v1alpha1.go
+++ b/internal/api/get_project_v1alpha1.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -20,30 +22,47 @@ func (s *server) GetProject(
 		return nil, err
 	}
 
-	var project kargoapi.Project
-	if err := s.client.Get(
-		ctx, client.ObjectKey{
-			Name: name,
+	// Get the Project from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": kargoapi.GroupVersion.String(),
+			"kind":       "Project",
 		},
-		&project,
-	); err != nil {
-		return nil, fmt.Errorf("get project: %w", err)
+	}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: name}, &u); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			err = fmt.Errorf("Project %q not found", name)
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, err
 	}
 
-	obj, raw, err := objectOrRaw(&project, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if raw != nil {
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
 			Result: &svcv1alpha1.GetProjectResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		p := kargoapi.Project{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &p); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&p, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
+			Result: &svcv1alpha1.GetProjectResponse_Project{
+				Project: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
-		Result: &svcv1alpha1.GetProjectResponse_Project{
-			Project: obj,
-		},
-	}), nil
 }

--- a/internal/api/get_promotion_v1alpha1.go
+++ b/internal/api/get_promotion_v1alpha1.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -29,28 +31,50 @@ func (s *server) GetPromotion(
 		return nil, err
 	}
 
-	var promotion kargoapi.Promotion
+	// Get the Promotion from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": kargoapi.GroupVersion.String(),
+			"kind":       "Promotion",
+		},
+	}
 	if err := s.client.Get(ctx, client.ObjectKey{
-		Namespace: project,
 		Name:      name,
-	}, &promotion); err != nil {
-		return nil, fmt.Errorf("get promotion: %w", err)
+		Namespace: project,
+	}, &u); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			err = fmt.Errorf("Promotion %q not found in project %q", name, project)
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, err
 	}
 
-	obj, raw, err := objectOrRaw(&promotion, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if raw != nil {
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetPromotionResponse{
 			Result: &svcv1alpha1.GetPromotionResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		promotion := kargoapi.Promotion{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &promotion); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&promotion, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetPromotionResponse{
+			Result: &svcv1alpha1.GetPromotionResponse_Promotion{
+				Promotion: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetPromotionResponse{
-		Result: &svcv1alpha1.GetPromotionResponse_Promotion{
-			Promotion: obj,
-		},
-	}), nil
 }

--- a/internal/api/get_stage_v1alpha1.go
+++ b/internal/api/get_stage_v1alpha1.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -29,28 +31,50 @@ func (s *server) GetStage(
 		return nil, err
 	}
 
-	var stage kargoapi.Stage
+	// Get the Stage from the Kubernetes API as an unstructured object.
+	// Using an unstructured object allows us to return the object _as presented
+	// by the API_ if a raw format is requested.
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": kargoapi.GroupVersion.String(),
+			"kind":       "Stage",
+		},
+	}
 	if err := s.client.Get(ctx, client.ObjectKey{
-		Namespace: project,
 		Name:      name,
-	}, &stage); err != nil {
-		return nil, fmt.Errorf("get stage: %w", err)
+		Namespace: project,
+	}, &u); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			err = fmt.Errorf("Stage %q not found in project %q", name, project)
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, err
 	}
 
-	obj, raw, err := objectOrRaw(&stage, req.Msg.GetFormat())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	if raw != nil {
+	switch req.Msg.GetFormat() {
+	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
+		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		return connect.NewResponse(&svcv1alpha1.GetStageResponse{
 			Result: &svcv1alpha1.GetStageResponse_Raw{
 				Raw: raw,
 			},
 		}), nil
+	default:
+		stage := kargoapi.Stage{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &stage); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		obj, _, err := objectOrRaw(&stage, req.Msg.GetFormat())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&svcv1alpha1.GetStageResponse{
+			Result: &svcv1alpha1.GetStageResponse_Stage{
+				Stage: obj,
+			},
+		}), nil
 	}
-	return connect.NewResponse(&svcv1alpha1.GetStageResponse{
-		Result: &svcv1alpha1.GetStageResponse_Stage{
-			Stage: obj,
-		},
-	}), nil
 }


### PR DESCRIPTION
Fixes: #1899

This pull request ensures that the raw object data returned by the Kargo API matches the data from the Kubernetes API server. Which, unlike the JSON and YAML serializers, purges empty structures.