### PR TITLE
fix(cli): use stdout config from cmd in helpers

### DIFF
--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -11,7 +11,7 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	exactArgs := cobra.ExactArgs(n)
 	return func(cmd *cobra.Command, args []string) error {
 		if err := exactArgs(cmd, args); err != nil {
-			fmt.Println(cmd.UsageString())
+			_, _ = fmt.Fprintf(cmd.OutOrStderr(), "%s\n", cmd.UsageString())
 			return err
 		}
 		return nil
@@ -23,7 +23,7 @@ func MinimumNArgs(n int) cobra.PositionalArgs {
 	minNArgs := cobra.MinimumNArgs(n)
 	return func(cmd *cobra.Command, args []string) error {
 		if err := minNArgs(cmd, args); err != nil {
-			fmt.Println(cmd.UsageString())
+			_, _ = fmt.Fprintf(cmd.OutOrStderr(), "%s\n", cmd.UsageString())
 			return err
 		}
 		return nil
@@ -33,7 +33,7 @@ func MinimumNArgs(n int) cobra.PositionalArgs {
 // NoArgs is a wrapper around cobra.NoArgs to additionally print usage string
 func NoArgs(cmd *cobra.Command, args []string) error {
 	if err := cobra.NoArgs(cmd, args); err != nil {
-		fmt.Println(cmd.UsageString())
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "%s\n", cmd.UsageString())
 		return err
 	}
 	return nil


### PR DESCRIPTION
This caught my eye while reviewing #1906 