### PR TITLE
refactor: small bit of cleanup after role mgmt feature

### DIFF
--- a/internal/controller/management/projects/projects.go
+++ b/internal/controller/management/projects/projects.go
@@ -83,7 +83,7 @@ type reconciler struct {
 		...client.UpdateOption,
 	) error
 
-	ensureSecretPermissionsFn func(context.Context, *kargoapi.Project) error
+	ensureProjectAdminPermissionsFn func(context.Context, *kargoapi.Project) error
 
 	createRoleBindingFn func(
 		context.Context,
@@ -124,7 +124,7 @@ func newReconciler(kubeClient client.Client, cfg ReconcilerConfig) *reconciler {
 	r.getNamespaceFn = r.client.Get
 	r.createNamespaceFn = r.client.Create
 	r.updateNamespaceFn = r.client.Update
-	r.ensureSecretPermissionsFn = r.ensureSecretPermissions
+	r.ensureProjectAdminPermissionsFn = r.ensureProjectAdminPermissions
 	r.createRoleBindingFn = r.client.Create
 	return r
 }
@@ -199,7 +199,7 @@ func (r *reconciler) syncProject(
 		return status, fmt.Errorf("error ensuring namespace: %w", err)
 	}
 
-	if err = r.ensureSecretPermissionsFn(ctx, project); err != nil {
+	if err = r.ensureProjectAdminPermissionsFn(ctx, project); err != nil {
 		return status, fmt.Errorf("error ensuring secret permissions: %w", err)
 	}
 
@@ -288,11 +288,11 @@ func (r *reconciler) ensureNamespace(
 	return status, nil
 }
 
-func (r *reconciler) ensureSecretPermissions(
+func (r *reconciler) ensureProjectAdminPermissions(
 	ctx context.Context,
 	project *kargoapi.Project,
 ) error {
-	const roleBindingName = "kargo-api-server-project-admin"
+	const roleBindingName = "kargo-project-admin"
 
 	logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
 		"project":     project.Name,

--- a/internal/controller/management/projects/projects_test.go
+++ b/internal/controller/management/projects/projects_test.go
@@ -30,7 +30,7 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, r.getNamespaceFn)
 	require.NotNil(t, r.createNamespaceFn)
 	require.NotNil(t, r.updateNamespaceFn)
-	require.NotNil(t, r.ensureSecretPermissionsFn)
+	require.NotNil(t, r.ensureProjectAdminPermissionsFn)
 	require.NotNil(t, r.createRoleBindingFn)
 }
 
@@ -223,7 +223,7 @@ func TestSyncProject(t *testing.T) {
 				) (kargoapi.ProjectStatus, error) {
 					return *project.Status.DeepCopy(), nil
 				},
-				ensureSecretPermissionsFn: func(
+				ensureProjectAdminPermissionsFn: func(
 					context.Context,
 					*kargoapi.Project,
 				) error {
@@ -245,7 +245,7 @@ func TestSyncProject(t *testing.T) {
 				) (kargoapi.ProjectStatus, error) {
 					return *project.Status.DeepCopy(), nil
 				},
-				ensureSecretPermissionsFn: func(
+				ensureProjectAdminPermissionsFn: func(
 					context.Context,
 					*kargoapi.Project,
 				) error {
@@ -563,7 +563,7 @@ func TestEnsureSecretPermissions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				t,
-				testCase.reconciler.ensureSecretPermissions(
+				testCase.reconciler.ensureProjectAdminPermissions(
 					context.Background(),
 					&kargoapi.Project{},
 				),

--- a/internal/webhook/project/webhook.go
+++ b/internal/webhook/project/webhook.go
@@ -53,7 +53,7 @@ type webhook struct {
 
 	ensureNamespaceFn func(context.Context, *kargoapi.Project) error
 
-	ensureSecretPermissionsFn func(
+	ensureProjectAdminPermissionsFn func(
 		context.Context,
 		*kargoapi.Project,
 	) error
@@ -92,7 +92,7 @@ func newWebhook(kubeClient client.Client, cfg WebhookConfig) *webhook {
 	}
 	w.validateSpecFn = w.validateSpec
 	w.ensureNamespaceFn = w.ensureNamespace
-	w.ensureSecretPermissionsFn = w.ensureSecretPermissions
+	w.ensureProjectAdminPermissionsFn = w.ensureProjectAdminPermissions
 	w.getNamespaceFn = kubeClient.Get
 	w.createNamespaceFn = kubeClient.Create
 	w.createRoleBindingFn = kubeClient.Create
@@ -132,7 +132,7 @@ func (w *webhook) ValidateCreate(
 	// Kargo API server carte blanche access to all secrets in the cluster. We do
 	// this synchronously because Secrets are likely to follow the Project in a
 	// manifest.
-	return nil, w.ensureSecretPermissionsFn(ctx, project)
+	return nil, w.ensureProjectAdminPermissionsFn(ctx, project)
 }
 
 func (w *webhook) ValidateUpdate(
@@ -273,11 +273,11 @@ func (w *webhook) ensureNamespace(
 	return nil
 }
 
-func (w *webhook) ensureSecretPermissions(
+func (w *webhook) ensureProjectAdminPermissions(
 	ctx context.Context,
 	project *kargoapi.Project,
 ) error {
-	const roleBindingName = "kargo-api-server-project-admin"
+	const roleBindingName = "kargo-project-admin"
 
 	logger := logging.LoggerFromContext(ctx).WithFields(log.Fields{
 		"project":     project.Name,

--- a/internal/webhook/project/webhook_test.go
+++ b/internal/webhook/project/webhook_test.go
@@ -31,7 +31,7 @@ func TestNewWebhook(t *testing.T) {
 	require.Equal(t, testCfg, w.cfg)
 	require.NotNil(t, w.validateSpecFn)
 	require.NotNil(t, w.ensureNamespaceFn)
-	require.NotNil(t, w.ensureSecretPermissionsFn)
+	require.NotNil(t, w.ensureProjectAdminPermissionsFn)
 	require.NotNil(t, w.getNamespaceFn)
 	require.NotNil(t, w.createNamespaceFn)
 	require.NotNil(t, w.createRoleBindingFn)
@@ -428,7 +428,7 @@ func TestEnsureSecretPermissions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				t,
-				testCase.webhook.ensureSecretPermissions(
+				testCase.webhook.ensureProjectAdminPermissions(
 					ctx,
 					&kargoapi.Project{
 						ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR changes the names of a few functions and RoleBindings to better reflect what they actually do as of #1906.

Note that changing the RoleBinding name used for _new_ Projects doesn't hurt old Projects in any way. Nevertheless, I _will_ make the Project upgrade reconciler (headed for the `release-0.6` branch only) tidy this up just for consistency.