### PR TITLE
feat(devx): allow automated backporting of PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,45 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.repository_owner == 'akuity' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport/', github.event.label.name))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create backport PRs
+        uses: korthout/backport-action@v2
+        # xref: https://github.com/korthout/backport-action#inputs
+        with:
+          # Use token to allow workflows to be triggered for the created PR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Match labels with pattern `backport/<target-branch>`
+          label_pattern: '^backport\/([^ ]+)$'
+          # A bit shorter pull-request title than the default
+          pull_title: '[${target_branch}] ${pull_title}'
+          # Simpler PR description than default
+          pull_description: |-
+            Automated backport to `${target_branch}`, triggered by a label in #${pull_number}.
+          # Copy any labels (excluding those starting with "backport/") to the backport PR
+          copy_labels_pattern: '^(?!backport\/).*'
+          # Copy associated people to the backport PR
+          copy_assignees: true
+          copy_requested_reviewers: true
+          # Skip any merge commits in the source PR
+          merge_commits: 'skip'
+          # Automatically detect "squash and merge" instead of copying all
+          # commits from the source PR to the backport PR
+          experimental: >
+            {
+              "detect_merge_method": true
+            }


### PR DESCRIPTION
Fixes: #1935

If merged, pull requests can be backported automagically if labeled with `backport/<release-branch>`.