### PR TITLE
fix(api): fix bug in kargo role update logic

### DIFF
--- a/internal/api/rbac/roles.go
+++ b/internal/api/rbac/roles.go
@@ -565,9 +565,9 @@ func (r *rolesDatabase) Update(
 		return nil, err
 	}
 
-	amendClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCSubjects, kargoRole.Subs)
-	amendClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCEmails, kargoRole.Emails)
-	amendClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCGroups, kargoRole.Groups)
+	replaceClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCSubjects, kargoRole.Subs)
+	replaceClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCEmails, kargoRole.Emails)
+	replaceClaimAnnotation(sa, rbacapi.AnnotationKeyOIDCGroups, kargoRole.Groups)
 	if err = r.client.Update(ctx, sa); err != nil {
 		return nil, fmt.Errorf(
 			"error updating ServiceAccount %q in namespace %q: %w", kargoRole.Name, kargoRole.Namespace, err,
@@ -671,6 +671,15 @@ func RoleToResources(
 	rb := buildNewRoleBinding(kargoRole.Namespace, kargoRole.Name)
 
 	return sa, role, rb, nil
+}
+
+func replaceClaimAnnotation(sa *corev1.ServiceAccount, key string, values []string) {
+	slices.Sort(values)
+	values = slices.Compact(values)
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
+	sa.Annotations[key] = strings.Join(values, ",")
 }
 
 func amendClaimAnnotation(sa *corev1.ServiceAccount, key string, values []string) {

--- a/internal/api/rbac/roles_test.go
+++ b/internal/api/rbac/roles_test.go
@@ -893,7 +893,11 @@ func TestUpdate(t *testing.T) {
 
 	t.Run("success with updated ServiceAccount and Role", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			managedServiceAccount(nil),
+			managedServiceAccount(map[string]string{
+				rbacapi.AnnotationKeyOIDCSubjects: "foo-sub,bar-sub",
+				rbacapi.AnnotationKeyOIDCEmails:   "foo-email,bar-email",
+				rbacapi.AnnotationKeyOIDCGroups:   "foo-group,bar-group",
+			}),
 			managedRole([]rbacv1.PolicyRule{{
 				APIGroups: []string{kargoapi.GroupVersion.Group},
 				Resources: []string{"promotions"},
@@ -909,9 +913,9 @@ func TestUpdate(t *testing.T) {
 					Namespace: testProject,
 					Name:      testKargoRoleName,
 				},
-				Subs:   []string{"foo-sub", "bar-sub"},
-				Emails: []string{"foo-email", "bar-email"},
-				Groups: []string{"foo-group", "bar-group"},
+				Subs:   []string{"foo-sub"},
+				Emails: []string{"foo-email"},
+				Groups: []string{"foo-group"},
 				Rules: []rbacv1.PolicyRule{{
 					APIGroups: []string{kargoapi.GroupVersion.Group},
 					Resources: []string{"stages", "promotions"},
@@ -928,9 +932,9 @@ func TestUpdate(t *testing.T) {
 			t,
 			map[string]string{
 				rbacapi.AnnotationKeyManaged:      rbacapi.AnnotationValueTrue,
-				rbacapi.AnnotationKeyOIDCSubjects: "bar-sub,foo-sub",
-				rbacapi.AnnotationKeyOIDCEmails:   "bar-email,foo-email",
-				rbacapi.AnnotationKeyOIDCGroups:   "bar-group,foo-group",
+				rbacapi.AnnotationKeyOIDCSubjects: "foo-sub",
+				rbacapi.AnnotationKeyOIDCEmails:   "foo-email",
+				rbacapi.AnnotationKeyOIDCGroups:   "foo-group",
 			},
 			sa.Annotations,
 		)


### PR DESCRIPTION
Fixes a bug @rbreeze found just now where wholesale update of a "Kargo Role" could add to claim annotations on the underlying ServiceAccount, but couldn't remove values from them.

I also updated a test case to surface the issue and prove it's fixed.