### PR TITLE
feat(ui): convert to dark theme

### DIFF
--- a/ui/src/config/themeConfig.ts
+++ b/ui/src/config/themeConfig.ts
@@ -1,19 +1,21 @@
+import { theme } from 'antd';
 import { ThemeConfig } from 'antd/es/config-provider';
 import { MapToken } from 'antd/es/theme/interface';
 
 export const token: Partial<MapToken> = {
-  colorPrimary: '#30476c',
+  colorPrimary: '#4c9bff',
   fontSizeHeading1: 28,
   fontSizeHeading2: 24,
   fontSizeHeading3: 20,
   fontSizeHeading4: 18,
   fontSizeHeading5: 14,
-  colorText: '#454545',
+  colorText: '#fff',
   borderRadius: 8,
   fontFamily: 'Poppins, sans-serif'
 };
 
 export const themeConfig: ThemeConfig = {
   // ...token,
-  token
+  token,
+  algorithm: theme.darkAlgorithm
 };

--- a/ui/src/features/common/code-editor/yaml-editor-lazy.tsx
+++ b/ui/src/features/common/code-editor/yaml-editor-lazy.tsx
@@ -123,7 +123,7 @@ const YamlEditor: FC<YamlEditorProps> = (props) => {
         )}
       </Flex>
       <div
-        style={{ border: '1px solid #d9d9d9', height, overflow: 'hidden' }}
+        style={{ border: '1px solid #424242', height, overflow: 'hidden' }}
         className={className}
       >
         <Editor
@@ -145,6 +145,7 @@ const YamlEditor: FC<YamlEditorProps> = (props) => {
           value={value}
           onChange={handleOnChange}
           onMount={handleEditorDidMount}
+          theme='vs-dark'
         />
 
         {placeholder && (

--- a/ui/src/features/common/form/multi-string-editor.tsx
+++ b/ui/src/features/common/form/multi-string-editor.tsx
@@ -44,11 +44,11 @@ export const MultiStringEditor = ({
   return (
     <div className={className}>
       <div className='flex items-center h-8'>
-        {label && <div className='text-xs uppercase font-semibold text-gray-500'>{label}</div>}
+        {label && <div className='text-xs uppercase font-semibold text-neutral-600'>{label}</div>}
         <div className='ml-auto flex items-center'>
           {values?.length > 1 && (
             <div
-              className='text-xs text-gray-400 cursor-pointer mr-2'
+              className='text-xs text-neutral-400 cursor-pointer mr-2'
               onClick={() => setValues([])}
             >
               Clear All
@@ -56,7 +56,7 @@ export const MultiStringEditor = ({
           )}
         </div>
       </div>
-      <div className='rounded bg-gray-100 p-2'>
+      <div className='rounded bg-neutral-800 p-2'>
         <div className='flex items-center mb-2 min-h-8 flex-wrap gap-2'>
           {(values || []).map((v, i) => (
             <_Tag
@@ -72,7 +72,7 @@ export const MultiStringEditor = ({
           ))}
 
           {(values || []).length === 0 && (
-            <div className='text-gray-400 text-sm mx-auto'>Type below to add values</div>
+            <div className='text-neutral-600 text-sm mx-auto'>Type below to add values</div>
           )}
         </div>
 

--- a/ui/src/features/common/layout/main-layout.module.less
+++ b/ui/src/features/common/layout/main-layout.module.less
@@ -34,6 +34,8 @@
   height: 100%;
   width: 100%;
   overflow: auto;
+  color: white;
+  @apply bg-neutral-950;
 }
 
 .logo {

--- a/ui/src/features/freightline/freight-contents.tsx
+++ b/ui/src/features/freightline/freight-contents.tsx
@@ -20,7 +20,7 @@ export const FreightContents = (props: {
     } & React.PropsWithChildren
   ) => (
     <Tooltip
-      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-20 max-w-20 overflow-x-hidden ${
+      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-full overflow-x-hidden ${
         promoting && highlighted ? 'bg-transparent' : ''
       }`}
       overlay={props.overlay}

--- a/ui/src/features/freightline/freightline.tsx
+++ b/ui/src/features/freightline/freightline.tsx
@@ -10,7 +10,10 @@ export const Freightline = ({
   children: React.ReactNode;
 }) => {
   return (
-    <div className='w-full py-3 flex flex-col overflow-hidden' style={{ backgroundColor: '#222' }}>
+    <div
+      className='w-full py-3 flex flex-col overflow-hidden'
+      style={{ backgroundColor: '#1c1c1c' }}
+    >
       <div className='flex h-44 w-full items-center px-1'>
         <div
           className='text-gray-500 text-sm font-semibold mb-2 w-min h-min'

--- a/ui/src/features/freightline/stage-indicators.tsx
+++ b/ui/src/features/freightline/stage-indicators.tsx
@@ -32,7 +32,7 @@ export const StageIndicators = (props: { stages: Stage[]; faded?: boolean }) => 
   return (props.stages || []).length > 0 ? (
     <div
       className={`flex flex-col align-center h-full justify-center flex-shrink mr-2`}
-      style={{ width: '80px' }}
+      style={{ width: '20px' }}
     >
       {(props.stages || []).map((s) => (
         <StageIndicator

--- a/ui/src/features/project/list/project-item/project-item.module.less
+++ b/ui/src/features/project/list/project-item/project-item.module.less
@@ -1,13 +1,13 @@
 .tile {
   padding: ~'@{sizeMD}px';
   border-radius: ~'@{borderRadiusLG}px';
-  box-shadow: 1px 1px #eee;
-  border: 1px solid @colorBorder;
+  box-shadow: 1px 1px #424242;
+  border: 1px solid #424242;
   text-decoration: none !important;
 }
 
 .title {
   font-size: 20px;
   font-weight: 600;
-  color: black;
+  color: white;
 }

--- a/ui/src/features/project/list/projects-list.tsx
+++ b/ui/src/features/project/list/projects-list.tsx
@@ -17,7 +17,7 @@ export const ProjectsList = () => {
   return (
     <div className={styles.list}>
       {data.projects.map((project) => (
-        <ProjectItem key={project.metadata?.name} name={project.metadata?.name} />
+        <ProjectItem key={project.metadata?.name} name={project.metadata?.name || ''} />
       ))}
     </div>
   );

--- a/ui/src/features/project/pipelines/images.tsx
+++ b/ui/src/features/project/pipelines/images.tsx
@@ -180,7 +180,7 @@ const Select = ({
   options: { label?: string; value: string }[];
 }) => (
   <select
-    className='block border-none w-full text-gray appearance-none p-2 bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-400'
+    className='block border-none w-full text-gray appearance-none p-2 bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-blue-400'
     value={value}
     onChange={(e) => onChange(e.target.value)}
   >

--- a/ui/src/features/project/pipelines/nodes/repo-node.module.less
+++ b/ui/src/features/project/pipelines/nodes/repo-node.module.less
@@ -1,5 +1,5 @@
 .node {
-  background-color: #ddd;
+  background-color: #484848;
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -8,7 +8,7 @@
 
   h3 {
     padding: 0.5em;
-    color: #333;
+    color: white;
     font-size: 15px;
     font-weight: 600;
     margin-left: 0.1em;
@@ -24,7 +24,7 @@
 }
 
 .body {
-  background-color: white;
+  background-color: black;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
   padding: 8px;
@@ -48,7 +48,7 @@
   max-width: 100%;
   padding-bottom: 0.25em;
   text-overflow: ellipsis;
-  color: black;
+  color: white;
   font-weight: 600;
   font-size: 14px;
   @apply font-mono items-center justify-center;

--- a/ui/src/features/project/pipelines/nodes/stage-node.module.less
+++ b/ui/src/features/project/pipelines/nodes/stage-node.module.less
@@ -16,7 +16,7 @@
     left: 2px;
     right: 2px;
     bottom: 2px;
-    background-color: white;
+    background-color: black;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     text-align: center;

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -919,7 +919,7 @@ export const Pipelines = () => {
             className='text-gray-300 text-sm'
             style={{
               width: '400px',
-              backgroundColor: '#222'
+              backgroundColor: '#1c1c1c'
             }}
           >
             <h3 className='bg-black px-6 pb-3 pt-4 flex items-center'>

--- a/ui/src/features/project/pipelines/project-details.module.less
+++ b/ui/src/features/project/pipelines/project-details.module.less
@@ -1,8 +1,8 @@
 .dag {
   position: relative;
   //   color: white;
-  --dot-bg: white;
-  --dot-color: #333;
+  --dot-bg: black;
+  --dot-color: #5e5e5e;
   --dot-size: 1px;
   --dot-space: 25px;
   @apply overflow-hidden flex-grow w-full;
@@ -13,4 +13,3 @@
       var(--dot-space) var(--dot-space),
     var(--dot-color);
 }
-

--- a/ui/src/features/project/roles/create-role.tsx
+++ b/ui/src/features/project/roles/create-role.tsx
@@ -104,7 +104,7 @@ export const CreateRole = ({ editing, onSuccess, project, hide }: Props) => {
             <Input {...field} type='text' placeholder='my-role' disabled={!!editing} />
           )}
         </FieldContainer>
-        <div className='text-lg font-semibold mb-4'>OIDC Bindings</div>
+        <div className='text-lg font-semibold mb-4 text-white'>OIDC Bindings</div>
         <div className='flex items-start gap-4'>
           {multiFields.map(({ name, placeholder, label }) => (
             <FieldContainer
@@ -127,7 +127,7 @@ export const CreateRole = ({ editing, onSuccess, project, hide }: Props) => {
         </div>
       </div>
       <div>
-        <div className='text-lg font-semibold mb-4'>Rules</div>
+        <div className='text-lg font-semibold mb-4 text-white'>Rules</div>
         <div className='flex gap-4'>
           <RulesTable rules={rules} setRules={setRules} />
           <RuleEditor onSuccess={(rule) => setRules([...rules, rule])} style={{ width: '600px' }} />

--- a/ui/src/features/project/roles/rule-editor.tsx
+++ b/ui/src/features/project/roles/rule-editor.tsx
@@ -64,16 +64,18 @@ export const RuleEditor = ({
 
   const _Select = (props: SelectProps & { label: string }) => (
     <div>
-      <div className='font-semibold text-xs text-gray-500 mb-2 mt-2'>{props.label}</div>
+      <div className='font-semibold text-xs text-neutral-500 mb-2 mt-2'>{props.label}</div>
       <Select {...props} className='w-full' mode='tags' />
     </div>
   );
 
   return (
     <div style={style} className='-mt-7'>
-      <div className='mx-auto font-semibold mb-2 text-gray-500 text-center text-sm'>NEW RULE</div>
+      <div className='mx-auto font-semibold mb-2 text-neutral-600 text-center text-sm'>
+        NEW RULE
+      </div>
 
-      <div className='rounded-md p-3 border-2 border-gray-100 border-solid'>
+      <div className='rounded-md p-3 border-2 border-neutral-700 border-solid'>
         <div className='w-full'>
           <FieldContainer control={control} name='verbs' className='w-full'>
             {({ field }) => (

--- a/ui/src/pages/login/login.module.less
+++ b/ui/src/pages/login/login.module.less
@@ -1,39 +1,34 @@
 .container {
-    min-height: 100vh;
-    background: linear-gradient(
-      177deg,
-      rgb(29, 50, 82) 0%,
-      rgb(29, 52, 81) 50%,
-      rgb(19, 36, 64) 77%,
-      rgb(10, 23, 49) 100%
-    );
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: ~'@{sizeMD}px';
-    gap: 40px;
+  min-height: 100vh;
+  background: black;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: ~'@{sizeMD}px';
+  gap: 40px;
 }
 
 .box {
-    max-width: 100%;
-    width: 360px;
-    background-color: @colorBgBase;;
-    padding: ~'@{sizeLG}px';
-    border-radius: ~'@{borderRadiusLG}px';
+  max-width: 100%;
+  width: 360px;
+  background-color: black;
+  border: 2px solid #333;
+  padding: ~'@{sizeLG}px';
+  border-radius: ~'@{borderRadiusLG}px';
 }
 
 .logo {
-    display: flex;
-    flex-direction: column;
-    color: @colorWhite;
-    align-items: center;
-    gap: 15px;
-    font-size: 24px;
-    font-weight: 600;
-    margin-top: -100px;
+  display: flex;
+  flex-direction: column;
+  color: white;
+  align-items: center;
+  gap: 15px;
+  font-size: 24px;
+  font-weight: 600;
+  margin-top: -100px;
 
-    img {
-        width: 70px;
-    }
+  img {
+    width: 70px;
+  }
 }

--- a/ui/src/pages/project.tsx
+++ b/ui/src/pages/project.tsx
@@ -74,7 +74,7 @@ export const Project = ({ tab = 'pipelines' }: { tab?: ProjectTab }) => {
       <div className='p-6'>
         <div className='flex items-center'>
           <div className='mr-auto'>
-            <div className='font-semibold mb-1 text-xs text-gray-600'>PROJECT</div>
+            <div className='font-semibold mb-1 text-xs text-zinc-500'>PROJECT</div>
             <div className='text-2xl font-semibold'>{name}</div>
           </div>
           <ProjectSettings />


### PR DESCRIPTION
The UI is currently somewhere in between light and dark with the Freightline and Images Table. This PR goes all the way to dark theme.

This PR does _not_ implement a light/dark toggle, it simply switches to full dark mode for the sake of simplicity.

Below are a few screenshots of a sample of UI views. Feedback is welcome!

![CleanShot 2024-05-04 at 14 44 54@2x](https://github.com/akuity/kargo/assets/6250584/0ce355c4-448c-487d-8f83-6f21d0133307)
![CleanShot 2024-05-04 at 14 45 18@2x](https://github.com/akuity/kargo/assets/6250584/53035802-31c8-4e59-b8c0-c91b713a37e2)
![CleanShot 2024-05-04 at 14 45 31@2x](https://github.com/akuity/kargo/assets/6250584/8730e130-3814-4dff-9f7f-c4fbc85a9f8d)
![CleanShot 2024-05-04 at 14 46 06@2x](https://github.com/akuity/kargo/assets/6250584/f82d9d05-f446-40d2-b2d7-26b23cb4680a)
![CleanShot 2024-05-04 at 14 45 40@2x](https://github.com/akuity/kargo/assets/6250584/47087264-f23f-4455-9505-81b943ec25cd)
![CleanShot 2024-05-04 at 14 51 09@2x](https://github.com/akuity/kargo/assets/6250584/3e8b2608-d54d-49d8-a213-1fdb3a79de58)
