### PR TITLE
fix(ui): freight contents corner radius cut off

### DIFF
--- a/ui/src/features/freightline/freight-contents.tsx
+++ b/ui/src/features/freightline/freight-contents.tsx
@@ -20,7 +20,7 @@ export const FreightContents = (props: {
     } & React.PropsWithChildren
   ) => (
     <Tooltip
-      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-20 max-w-20 overflow-x-hidden ${
+      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-full overflow-x-hidden ${
         promoting && highlighted ? 'bg-transparent' : ''
       }`}
       overlay={props.overlay}

--- a/ui/src/features/freightline/stage-indicators.tsx
+++ b/ui/src/features/freightline/stage-indicators.tsx
@@ -32,7 +32,7 @@ export const StageIndicators = (props: { stages: Stage[]; faded?: boolean }) => 
   return (props.stages || []).length > 0 ? (
     <div
       className={`flex flex-col align-center h-full justify-center flex-shrink mr-2`}
-      style={{ width: '80px' }}
+      style={{ width: '20px' }}
     >
       {(props.stages || []).map((s) => (
         <StageIndicator


### PR DESCRIPTION
Difficult to see because of the lack of contrast, so it wasn't noticed until I worked on changing the freightline to light mode #1955.

Before:
![CleanShot 2024-05-04 at 16 09 36@2x](https://github.com/akuity/kargo/assets/6250584/9821df6e-dc5e-445d-b469-73035589895a)

After: 
![CleanShot 2024-05-04 at 16 09 45@2x](https://github.com/akuity/kargo/assets/6250584/51c32566-e446-46bf-b2ca-a7aa82e462c0)

