### PR TITLE
fix(ui): freightline contents background renders text unreadable

### DIFF
--- a/ui/src/features/freightline/freight-contents.tsx
+++ b/ui/src/features/freightline/freight-contents.tsx
@@ -16,7 +16,7 @@ export const FreightContents = (props: { freight?: Freight; highlighted: boolean
     } & React.PropsWithChildren
   ) => (
     <Tooltip
-      className={`flex items-center my-1 flex-col bg-neutral-800 rounded p-1 w-full overflow-x-hidden`}
+      className={`flex items-center my-1 flex-col bg-neutral-300 rounded p-1 w-full overflow-x-hidden`}
       overlay={props.overlay}
       title={props.title}
     >

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -833,7 +833,7 @@ export const Pipelines = () => {
                             fullFreightById[node.data?.status?.currentFreight?.name || '']
                           }
                           hasNoSubscribers={
-                            (subscribersByStage[node?.data?.metadata?.name || ''] || []).length <= 0
+                            (subscribersByStage[node?.data?.metadata?.name || ''] || []).length <= 1
                           }
                           onPromoteClick={(type: FreightlineAction) => {
                             if (promotingStage?.metadata?.name === node.data?.metadata?.name) {


### PR DESCRIPTION
Was due to bad merge conflict resolution. Before and after (size difference is due to screenshot):

<img width="164" alt="Screenshot 2024-05-06 at 14 29 21" src="https://github.com/akuity/kargo/assets/6250584/c5e7e54a-6a4c-4b43-ba46-2bd8ed571200">
<img width="174" alt="Screenshot 2024-05-06 at 14 29 12" src="https://github.com/akuity/kargo/assets/6250584/e03a63fd-8fb0-4331-a7a4-760b579feb47">
