### PR TITLE
feat: use config value if no address passed to login command

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -50,7 +50,7 @@ func NewRootCommand(cfg clicfg.CLIConfig) *cobra.Command {
 	cmd.AddCommand(delete.NewCommand(cfg, streams))
 	cmd.AddCommand(get.NewCommand(cfg, streams))
 	cmd.AddCommand(grant.NewCommand(cfg, streams))
-	cmd.AddCommand(login.NewCommand())
+	cmd.AddCommand(login.NewCommand(cfg))
 	cmd.AddCommand(logout.NewCommand())
 	cmd.AddCommand(refresh.NewCommand(cfg))
 	cmd.AddCommand(revoke.NewCommand(cfg, streams))

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -38,6 +38,7 @@ const defaultRandStringCharSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 var assets embed.FS
 
 type loginOptions struct {
+	Config        libConfig.CLIConfig
 	InsecureTLS   bool
 	UseAdmin      bool
 	UseKubeconfig bool
@@ -47,12 +48,16 @@ type loginOptions struct {
 	ServerAddress string
 }
 
-func NewCommand() *cobra.Command {
-	cmdOpts := &loginOptions{}
+func NewCommand(
+	cfg libConfig.CLIConfig,
+) *cobra.Command {
+	cmdOpts := &loginOptions{
+		Config: cfg,
+	}
 
 	cmd := &cobra.Command{
-		Use:   "login SERVER_ADDRESS (--admin | --kubeconfig | --sso)",
-		Args:  option.ExactArgs(1),
+		Use:   "login [SERVER_ADDRESS] (--admin | --kubeconfig | --sso)",
+		Args:  option.MaximumNArgs(1),
 		Short: "Log in to a Kargo API server",
 		Example: templates.Example(`
 # Log in using SSO
@@ -108,7 +113,11 @@ func (o *loginOptions) addFlags(cmd *cobra.Command) {
 
 // complete sets the options from the command arguments.
 func (o *loginOptions) complete(args []string) {
-	o.ServerAddress = strings.TrimSpace(args[0])
+	// Use the API address in config as a default address
+	o.ServerAddress = o.Config.APIAddress
+	if len(args) == 1 {
+		o.ServerAddress = strings.TrimSpace(args[0])
+	}
 }
 
 // validate performs validation of the options. If the options are invalid, an

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -63,6 +63,9 @@ func NewCommand(
 # Log in using SSO
 kargo login https://kargo.example.com --sso
 
+# Last logged in address will be used if the server address is not provided
+kargo login --sso
+
 # Log in using the admin user
 kargo login https://kargo.example.com --admin
 

--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -63,7 +63,7 @@ func NewCommand(
 # Log in using SSO
 kargo login https://kargo.example.com --sso
 
-# Last logged in address will be used if the server address is not provided
+# Log in (again) using the last used server address
 kargo login --sso
 
 # Log in using the admin user

--- a/internal/cli/option/option.go
+++ b/internal/cli/option/option.go
@@ -18,6 +18,18 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	}
 }
 
+// MaximumNArgs is a wrapper around cobra.MaximumNArgs to additionally print usage string
+func MaximumNArgs(n int) cobra.PositionalArgs {
+	maxNArgs := cobra.MaximumNArgs(n)
+	return func(cmd *cobra.Command, args []string) error {
+		if err := maxNArgs(cmd, args); err != nil {
+			_, _ = fmt.Fprintf(cmd.OutOrStderr(), "%s\n", cmd.UsageString())
+			return err
+		}
+		return nil
+	}
+}
+
 // MinimumNArgs is a wrapper around cobra.MinimumNArgs to additionally print usage string
 func MinimumNArgs(n int) cobra.PositionalArgs {
 	minNArgs := cobra.MinimumNArgs(n)


### PR DESCRIPTION
Fixes https://github.com/akuity/kargo/issues/1974

This commit uses the address in config if no address is passed to the login command.