### PR TITLE
feat(ui): display freight contents in freight details page

### DIFF
--- a/ui/src/features/freight/freight-details.tsx
+++ b/ui/src/features/freight/freight-details.tsx
@@ -64,7 +64,7 @@ export const FreightDetails = ({ freight }: { freight?: Freight }) => {
                   children: (
                     <>
                       <div className='mb-4'>
-                        <div className='font-semibold mb-2 text-xs'>CONTENTS</div>
+                        <div className='font-semibold mb-2 text-xs'>ARTIFACTS</div>
                         <FreightContents freight={freight} highlighted={true} horizontal={true} />
                       </div>
                       <FreightStatusList freight={freight} />

--- a/ui/src/features/freight/freight-details.tsx
+++ b/ui/src/features/freight/freight-details.tsx
@@ -11,6 +11,7 @@ import { Freight } from '@ui/gen/v1alpha1/generated_pb';
 import { Description } from '../common/description';
 import { ManifestPreview } from '../common/manifest-preview';
 import { getAlias } from '../common/utils';
+import { FreightContents } from '../freightline/freight-contents';
 
 import { FreightStatusList } from './freight-status-list';
 
@@ -60,7 +61,15 @@ export const FreightDetails = ({ freight }: { freight?: Freight }) => {
                   key: '1',
                   label: 'Details',
                   icon: <FontAwesomeIcon icon={faInfoCircle} />,
-                  children: <FreightStatusList freight={freight} />
+                  children: (
+                    <>
+                      <div className='mb-4'>
+                        <div className='font-semibold mb-2 text-xs'>CONTENTS</div>
+                        <FreightContents freight={freight} highlighted={true} horizontal={true} />
+                      </div>
+                      <FreightStatusList freight={freight} />
+                    </>
+                  )
                 },
                 {
                   key: '2',

--- a/ui/src/features/freightline/freight-contents.tsx
+++ b/ui/src/features/freightline/freight-contents.tsx
@@ -2,11 +2,17 @@ import { faDocker, faGit } from '@fortawesome/free-brands-svg-icons';
 import { IconDefinition, faAnchor } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tooltip } from 'antd';
+import classNames from 'classnames';
 
 import { Freight, GitCommit } from '@ui/gen/v1alpha1/generated_pb';
+import { urlForImage } from '@ui/utils/url';
 
-export const FreightContents = (props: { freight?: Freight; highlighted: boolean }) => {
-  const { freight, highlighted } = props;
+export const FreightContents = (props: {
+  freight?: Freight;
+  highlighted: boolean;
+  horizontal?: boolean;
+}) => {
+  const { freight, highlighted, horizontal } = props;
 
   const FreightContentItem = (
     props: {
@@ -16,27 +22,46 @@ export const FreightContents = (props: { freight?: Freight; highlighted: boolean
     } & React.PropsWithChildren
   ) => (
     <Tooltip
-      className={`flex items-center my-1 flex-col bg-neutral-300 rounded p-1 w-full overflow-x-hidden`}
+      className={classNames(
+        'min-w-0 flex items-center justify-center my-1 bg-neutral-300 rounded',
+        {
+          'flex-col p-1 w-full': !horizontal,
+          'mr-2 p-2 max-w-60 flex-shrink': horizontal
+        }
+      )}
       overlay={props.overlay}
       title={props.title}
     >
-      <FontAwesomeIcon icon={props.icon} className={`px-1 text-lg mb-2`} />
+      <FontAwesomeIcon
+        icon={props.icon}
+        className={classNames('px-1 text-lg', {
+          'mb-2': !horizontal,
+          'mr-2': horizontal
+        })}
+      />
       {props.children}
     </Tooltip>
   );
 
+  const linkClass = `${highlighted ? 'text-blue-600' : 'text-gray-400'} hover:text-blue-500 underline hover:underline max-w-full truncate`;
+
   return (
     <div
-      className={`flex flex-col justify-start items-center font-mono text-xs flex-shrink min-w-min w-20 overflow-y-auto max-h-full ${
-        highlighted ? 'text-gray-700 hover:text-gray-800' : 'text-gray-400 hover:text-gray-500'
-      }`}
+      className={classNames(
+        'flex justify-start items-center font-mono text-xs flex-shrink max-h-full max-w-full',
+        {
+          'text-gray-700 hover:text-gray-800': highlighted,
+          'text-gray-400 hover:text-gray-500': !highlighted,
+          'flex-col w-20 overflow-y-auto': !horizontal
+        }
+      )}
     >
       {(freight?.commits || []).map((c) => (
         <FreightContentItem key={c.id} overlay={<CommitInfo commit={c} />} icon={faGit}>
           <a
             href={`${c.repoURL?.replace('.git', '')}/commit/${c.id}`}
             target='_blank'
-            className={`${highlighted ? 'text-blue-200' : 'text-gray-500'} hover:text-blue-300`}
+            className={linkClass}
           >
             {c.tag && c.tag.length > 12
               ? c.tag.substring(0, 12) + '...'
@@ -50,7 +75,10 @@ export const FreightContents = (props: { freight?: Freight; highlighted: boolean
           title={`${i.repoURL}:${i.tag}`}
           icon={faDocker}
         >
-          <div>{i.tag}</div>
+          <a href={urlForImage(i.repoURL || '')} target='_blank' className={linkClass}>
+            {props.horizontal && i.repoURL + ':'}
+            {i.tag}
+          </a>
         </FreightContentItem>
       ))}
       {(freight?.charts || []).map((c) => (

--- a/ui/src/features/freightline/freight-item.tsx
+++ b/ui/src/features/freightline/freight-item.tsx
@@ -39,7 +39,7 @@ export const FreightItem = ({
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
     >
-      <div className='flex w-full h-full mb-1 items-center justify-center overflow-hidden'>
+      <div className='flex w-full h-full mb-1 items-center justify-center max-w-full truncate'>
         {children}
       </div>
       <div className='mt-auto w-full'>

--- a/ui/src/features/freightline/freightline.module.less
+++ b/ui/src/features/freightline/freightline.module.less
@@ -12,6 +12,7 @@
   flex-direction: column;
   align-items: center;
   flex-shrink: 0;
+  min-width: 0;
 }
 
 .promotable {


### PR DESCRIPTION
<img width="624" alt="Screenshot 2024-05-08 at 17 28 16" src="https://github.com/akuity/kargo/assets/6250584/b53e2878-b185-4b81-809f-9105b5ba9ab6">

Also adds links to Freight Details in Promotions table, and a tooltip showing the Freight alias (related to #1822):
<img width="1298" alt="Screenshot 2024-05-08 at 17 28 05" src="https://github.com/akuity/kargo/assets/6250584/bf95f3f4-5162-4b57-a874-753b535fbafa">
