### PR TITLE
chore: minor ui linting cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,12 +57,8 @@ jobs:
         node-version: "20.12.2"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
-    - name: Install nodejs dependencies
-      run: pnpm install --dev
-      working-directory: ./ui
     - name: Run linter
-      run: pnpm run lint
-      working-directory: ./ui
+      run: make lint-ui
 
   lint-go:
     runs-on: ubuntu-latest
@@ -162,7 +158,7 @@ jobs:
       run: git diff --exit-code -- .
 
   build-image:
-    needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
+    needs: [test-unit, lint-go, lint-charts, lint-proto, lint-ui, check-codegen]
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU
@@ -178,7 +174,7 @@ jobs:
         cache-to: type=gha,mode=max
 
   build-cli:
-    needs: [test-unit, lint-go, lint-charts, lint-proto, check-codegen]
+    needs: [test-unit, lint-go, lint-charts, lint-proto, lint-ui, check-codegen]
     runs-on: ubuntu-latest
     container:
       image: golang:1.22.3-bookworm

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 ################################################################################
 
 .PHONY: lint
-lint: lint-go lint-proto lint-charts
+lint: lint-go lint-proto lint-charts lint-ui
 
 .PHONY: lint-go
 lint-go:
@@ -75,6 +75,11 @@ lint-charts:
 	cd charts/kargo && \
 	helm dep up && \
 	helm lint .
+
+.PHONY: lint-ui
+lint-ui:
+	pnpm --dir=ui install --dev
+	pnpm --dir=ui run lint
 
 .PHONY: test-unit
 test-unit:
@@ -200,6 +205,10 @@ hack-lint-proto: hack-build-dev-tools
 .PHONY: hack-lint-charts
 hack-lint-charts: hack-build-dev-tools
 	$(DOCKER_CMD) make lint-charts
+
+.PHONY: hack-lint-ui
+hack-lint-ui: hack-build-dev-tools
+	$(DOCKER_CMD) make lint-ui
 
 .PHONY: hack-test-unit
 hack-test-unit: hack-build-dev-tools


### PR DESCRIPTION
Minor changes:

1. Make it convenient to run UI linting with make: `make lint-ui`
2. Make it convenient to run UI linting in a container (as similar as possible to CI): `make hack-lint-ui`
3. Make `make lint`/`make hack-lint` include UI linting with all the other linting it already does
4. Make second "stage" of CI jobs (the "expensive" ones) depend on successful completion of the `lint-ui` job (along with all the other faster/cheaper ones)