### PR TITLE
fix(controller): populate warehouse field in new freight

### DIFF
--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -221,6 +221,7 @@ func (r *reconciler) syncWarehouse(
 		if err != nil {
 			return status, fmt.Errorf("failed to build Freight from latest artifacts: %w", err)
 		}
+		freight.Warehouse = warehouse.Name
 
 		if err = r.createFreightFn(ctx, freight); client.IgnoreAlreadyExists(err) != nil {
 			return status, fmt.Errorf(


### PR DESCRIPTION
Follow up to #1984.

Freight have always been indexed by the Warehouse that created them. This is important in determining a piece of Freight's eligibility for promotion to an Stage that's subscribed _directly_ to a Warehouse wherein all Freight from that Warehouse are implicitly qualified.

#1984 mistakenly did not set the Warehouse field on new Freight, which broke that index and, by extension, has made new Freight unavailable for promotion to "zero Stages."