### PR TITLE
chore(warehouse): enrich discovery logs

### DIFF
--- a/internal/controller/warehouses/helm_test.go
+++ b/internal/controller/warehouses/helm_test.go
@@ -131,7 +131,7 @@ func TestDiscoverCharts(t *testing.T) {
 				{Chart: &kargoapi.ChartSubscription{}},
 			},
 			assertions: func(t *testing.T, results []kargoapi.ChartDiscoveryResult, err error) {
-				require.ErrorContains(t, err, "error discovering latest suitable chart versions")
+				require.ErrorContains(t, err, "error discovering latest chart versions")
 				require.ErrorContains(t, err, "something went wrong")
 				require.Empty(t, results)
 			},
@@ -156,7 +156,7 @@ func TestDiscoverCharts(t *testing.T) {
 				}},
 			},
 			assertions: func(t *testing.T, results []kargoapi.ChartDiscoveryResult, err error) {
-				require.ErrorContains(t, err, "error discovering latest suitable chart versions for chart")
+				require.ErrorContains(t, err, "error discovering latest chart versions for chart")
 				require.ErrorContains(t, err, "something went wrong")
 				require.Empty(t, results)
 			},

--- a/internal/image/newest_build_selector.go
+++ b/internal/image/newest_build_selector.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -97,13 +98,14 @@ func (n *newestBuildSelector) Select(ctx context.Context) ([]Image, error) {
 			continue
 		}
 
-		logger.WithFields(log.Fields{
-			"tag":    image.Tag,
-			"digest": image.Digest,
-		}).Trace("discovered image")
-
 		discoveredImage.Tag = image.Tag
 		discoveredImages = append(discoveredImages, *discoveredImage)
+
+		logger.WithFields(log.Fields{
+			"tag":       discoveredImage.Tag,
+			"digest":    discoveredImage.Digest,
+			"createdAt": discoveredImage.CreatedAt.Format(time.RFC3339),
+		}).Trace("discovered image")
 	}
 
 	if len(discoveredImages) == 0 {


### PR DESCRIPTION
Related to #1984

This brings the logging for Git and Helm artifact discovery up to the same level as what was already done for container images. Providing much richer data on trace level, and more structured information at the debug level.