### PR TITLE
feat(controller): fully support eks pod identity for ecr access

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -98,6 +98,7 @@ func (o *controllerOptions) run(ctx context.Context) error {
 	}
 
 	credentialsDB := credentials.NewKubernetesDatabase(
+		ctx,
 		kargoMgr.GetClient(),
 		credentials.KubernetesDatabaseConfigFromEnv(),
 	)

--- a/internal/controller/promotion/root_test.go
+++ b/internal/controller/promotion/root_test.go
@@ -14,7 +14,11 @@ import (
 func TestNewMechanisms(t *testing.T) {
 	promoMechs := NewMechanisms(
 		fake.NewClientBuilder().Build(),
-		credentials.NewKubernetesDatabase(nil, credentials.KubernetesDatabaseConfig{}),
+		credentials.NewKubernetesDatabase(
+			context.Background(),
+			nil,
+			credentials.KubernetesDatabaseConfig{},
+		),
 	)
 	require.IsType(t, &compositeMechanism{}, promoMechs)
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -95,13 +95,14 @@ func KubernetesDatabaseConfigFromEnv() KubernetesDatabaseConfig {
 // Database interface that utilizes a Kubernetes controller runtime client to
 // retrieve Credentials stored in Kubernetes Secrets.
 func NewKubernetesDatabase(
+	ctx context.Context,
 	kargoClient client.Client,
 	cfg KubernetesDatabaseConfig,
 ) Database {
 	return &kubernetesDatabase{
 		kargoClient:          kargoClient,
 		ecrAccessKeyHelper:   ecr.NewAccessKeyCredentialHelper(),
-		ecrPodIdentityHelper: ecr.NewPodIdentityCredentialHelper(),
+		ecrPodIdentityHelper: ecr.NewPodIdentityCredentialHelper(ctx),
 		gcpHelper:            gcp.NewCredentialHelper(),
 		cfg:                  cfg,
 	}

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -18,7 +18,7 @@ func TestNewKubernetesDatabase(t *testing.T) {
 	testCfg := KubernetesDatabaseConfig{
 		GlobalCredentialsNamespaces: []string{"fake-namespace"},
 	}
-	d := NewKubernetesDatabase(testClient, testCfg)
+	d := NewKubernetesDatabase(context.Background(), testClient, testCfg)
 	require.NotNil(t, d)
 	k, ok := d.(*kubernetesDatabase)
 	require.True(t, ok)
@@ -195,6 +195,7 @@ func TestGet(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			creds, found, err := NewKubernetesDatabase(
+				context.Background(),
 				fake.NewClientBuilder().WithObjects(testCase.secrets...).Build(),
 				KubernetesDatabaseConfig{
 					GlobalCredentialsNamespaces: []string{testGlobalNamespace},

--- a/internal/credentials/ecr/pod_identity.go
+++ b/internal/credentials/ecr/pod_identity.go
@@ -18,7 +18,7 @@ import (
 	"github.com/akuity/kargo/internal/logging"
 )
 
-var ecrURLRegex = regexp.MustCompile(`^([0-9]{12})\.dkr\.ecr\.(.+)\.amazonaws\.com`)
+var ecrURLRegex = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr\.(.+)\.amazonaws\.com`)
 
 // PodIdentityCredentialHelper is an interface for components that can obtain a
 // username and password for ECR using EKS Pod Identity.
@@ -31,13 +31,14 @@ type PodIdentityCredentialHelper interface {
 }
 
 type podIdentityCredentialHelper struct {
+	awsAccountID string
+
 	tokenCache *cache.Cache
 
 	// The following behaviors are overridable for testing purposes:
 
 	getAuthTokenFn func(
 		ctx context.Context,
-		accountID string,
 		region string,
 		project string,
 	) (string, error)
@@ -46,9 +47,35 @@ type podIdentityCredentialHelper struct {
 // NewPodIdentityCredentialHelper returns an implementation of the
 // PodIdentityCredentialHelper interface that utilizes a cache to avoid
 // unnecessary calls to AWS.
-func NewPodIdentityCredentialHelper() PodIdentityCredentialHelper {
-
+func NewPodIdentityCredentialHelper(ctx context.Context) PodIdentityCredentialHelper {
+	logger := logging.LoggerFromContext(ctx)
+	var awsAccountID string
+	if os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") == "" {
+		logger.Info("AWS_CONTAINER_CREDENTIALS_FULL_URI not set; assuming EKS Pod Identity is not in use")
+	} else {
+		logger.Info("EKS Pod Identity appears to be in use")
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			logger.Error(
+				"error loading AWS config; EKS Pod Identity integration will be disabled: %w",
+				err,
+			)
+		} else {
+			stsSvc := sts.NewFromConfig(cfg)
+			res, err := stsSvc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+			if err != nil {
+				logger.Error(
+					"error getting caller identity; EKS Pod Identity integration will be disabled: %w",
+					err,
+				)
+			} else {
+				logger.WithField("account", *res.Account).Debug("got AWS account ID")
+				awsAccountID = *res.Account
+			}
+		}
+	}
 	p := &podIdentityCredentialHelper{
+		awsAccountID: awsAccountID,
 		tokenCache: cache.New(
 			// Tokens live for 12 hours. We'll hang on to them for 10.
 			10*time.Hour, // Default ttl for each entry
@@ -65,24 +92,17 @@ func (p *podIdentityCredentialHelper) GetUsernameAndPassword(
 	repoURL string,
 	project string,
 ) (string, string, error) {
-	if os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") == "" {
+	if p.awsAccountID == "" {
 		// Don't even try if it looks like EKS Pod Identity isn't set up for this
 		// controller.
 		return "", "", nil
 	}
 
 	matches := ecrURLRegex.FindStringSubmatch(repoURL)
-	if len(matches) != 3 { // This doesn't look like an ECR URL
+	if len(matches) != 2 { // This doesn't look like an ECR URL
 		return "", "", nil
 	}
-	// TODO: We actually might not want to get the account ID from the repoURL
-	// because the account ID in the repoURL may be for a different account from
-	// the one containing the Kargo controller's IAM role and the Project-specific
-	// IAM roles it assumes. (Access across accounts IS possible. It is just not
-	// clear to me yet where else I can get the correct account ID from without
-	// requiring it to be explicitly configured at install-time.)
-	accountID := matches[1]
-	region := matches[2]
+	region := matches[1]
 
 	cacheKey := p.tokenCacheKey(region, project)
 
@@ -90,7 +110,7 @@ func (p *podIdentityCredentialHelper) GetUsernameAndPassword(
 		return decodeAuthToken(entry.(string)) // nolint: forcetypeassert
 	}
 
-	encodedToken, err := p.getAuthTokenFn(ctx, accountID, region, project)
+	encodedToken, err := p.getAuthTokenFn(ctx, region, project)
 	if err != nil {
 		// This might mean the controller's IAM role isn't authorized to assume the
 		// project-specific IAM role, or that the project-specific IAM role doesn't
@@ -120,7 +140,6 @@ func (p *podIdentityCredentialHelper) tokenCacheKey(region, project string) stri
 // token.
 func (p *podIdentityCredentialHelper) getAuthToken(
 	ctx context.Context,
-	accountID string,
 	region string,
 	project string,
 ) (string, error) {
@@ -134,7 +153,7 @@ func (p *podIdentityCredentialHelper) getAuthToken(
 		Region: region,
 		Credentials: stscreds.NewAssumeRoleProvider(
 			sts.NewFromConfig(cfg),
-			fmt.Sprintf("arn:aws:iam::%s:role/kargo-project-%s", accountID, project),
+			fmt.Sprintf("arn:aws:iam::%s:role/kargo-project-%s", p.awsAccountID, project),
 		),
 	})
 	output, err := ecrSvc.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})

--- a/internal/credentials/ecr/pod_identity.go
+++ b/internal/credentials/ecr/pod_identity.go
@@ -121,7 +121,7 @@ func (p *podIdentityCredentialHelper) GetUsernameAndPassword(
 	}
 
 	// Cache the encoded token
-	p.tokenCache.Set(project, encodedToken, cache.DefaultExpiration)
+	p.tokenCache.Set(cacheKey, encodedToken, cache.DefaultExpiration)
 
 	return decodeAuthToken(encodedToken)
 }

--- a/internal/credentials/ecr/pod_identity_test.go
+++ b/internal/credentials/ecr/pod_identity_test.go
@@ -1,0 +1,132 @@
+package ecr
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPodIdentityCredentialHelper(t *testing.T) {
+	// Without env var AWS_CONTAINER_CREDENTIALS_FULL_URI set, we expect not to
+	// be making any calls out to AWS.
+	h := NewPodIdentityCredentialHelper(context.Background())
+	require.NotNil(t, h)
+	p, ok := h.(*podIdentityCredentialHelper)
+	require.True(t, ok)
+	require.Empty(t, p.awsAccountID)
+	require.NotNil(t, p.tokenCache)
+	require.NotNil(t, p.getAuthTokenFn)
+}
+
+func TestPodIdentityCredentialHelper(t *testing.T) {
+	const (
+		testAWSAccountID = "123456789012"
+		testRegion       = "fake-region"
+		testProject      = "fake-project"
+		testUsername     = "fake-username"
+		testPassword     = "fake-password"
+	)
+	testRepoURL := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", testAWSAccountID, testRegion)
+	testToken := fmt.Sprintf("%s:%s", testUsername, testPassword)
+	testEncodedToken := base64.StdEncoding.EncodeToString([]byte(testToken))
+
+	warmTokenCache := cache.New(0, 0)
+	warmTokenCache.Set(
+		(&podIdentityCredentialHelper{}).tokenCacheKey(testRegion, testProject),
+		testEncodedToken,
+		cache.DefaultExpiration,
+	)
+
+	testCases := []struct {
+		name       string
+		repoURL    string
+		helper     PodIdentityCredentialHelper
+		assertions func(t *testing.T, username, password string, c *cache.Cache, err error)
+	}{
+		{
+			name:    "EKS Pod Identity not in use",
+			repoURL: testRepoURL,
+			helper:  &podIdentityCredentialHelper{},
+			assertions: func(t *testing.T, username, password string, _ *cache.Cache, err error) {
+				require.NoError(t, err)
+				require.Empty(t, username)
+				require.Empty(t, password)
+			},
+		},
+		{
+			name:    "repo URL does not match ECR URL regex",
+			repoURL: "ghcr.io/fake-org/fake-repo",
+			helper: &podIdentityCredentialHelper{
+				awsAccountID: testAWSAccountID,
+			},
+			assertions: func(t *testing.T, username, password string, _ *cache.Cache, err error) {
+				require.NoError(t, err)
+				require.Empty(t, username)
+				require.Empty(t, password)
+			},
+		},
+		{
+			name:    "cache hit",
+			repoURL: testRepoURL,
+			helper: &podIdentityCredentialHelper{
+				awsAccountID: testAWSAccountID,
+				tokenCache:   warmTokenCache,
+			},
+			assertions: func(t *testing.T, username, password string, _ *cache.Cache, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testUsername, username)
+				require.Equal(t, testPassword, password)
+			},
+		},
+		{
+			name:    "cache miss; error getting auth token",
+			repoURL: testRepoURL,
+			helper: &podIdentityCredentialHelper{
+				awsAccountID: testAWSAccountID,
+				tokenCache:   cache.New(0, 0),
+				getAuthTokenFn: func(context.Context, string, string) (string, error) {
+					return "", fmt.Errorf("something went wrong")
+				},
+			},
+			assertions: func(t *testing.T, _, _ string, _ *cache.Cache, err error) {
+				require.ErrorContains(t, err, "error getting ECR auth token")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name:    "cache miss; success",
+			repoURL: testRepoURL,
+			helper: &podIdentityCredentialHelper{
+				awsAccountID: testAWSAccountID,
+				tokenCache:   cache.New(0, 0),
+				getAuthTokenFn: func(context.Context, string, string) (string, error) {
+					return testEncodedToken, nil
+				},
+			},
+			assertions: func(t *testing.T, username, password string, c *cache.Cache, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testUsername, username)
+				require.Equal(t, testPassword, password)
+				_, found := c.Get(
+					(&podIdentityCredentialHelper{}).tokenCacheKey(testRegion, testProject),
+				)
+				require.True(t, found)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			username, password, err := testCase.helper.GetUsernameAndPassword(
+				context.Background(),
+				testCase.repoURL,
+				testProject,
+			)
+			cache := testCase.helper.(*podIdentityCredentialHelper).tokenCache // nolint: forcetypeassert
+			testCase.assertions(t, username, password, cache, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1885 

This is a follow-up to #2059, which accidentally addressed a large portion of #1885.

This adds unit tests to our `ecr` package, improves existing ones, fixes a cache bug, and improves how we determine the AWS account ID, which we need for calculating the ARN of the roles to be assumed by the Kargo controller.