### PR TITLE
fix(chart): dex additional volumes indentation

### DIFF
--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -100,7 +100,7 @@ spec:
               - key: config.yaml
                 path: config.yaml
       {{- if .Values.api.oidc.dex.volumes }}
-        {{- toYaml .Values.api.oidc.dex.volumes | nindent 8 }}
+        {{- toYaml .Values.api.oidc.dex.volumes | nindent 6 }}
       {{- end }}
       {{- with .Values.api.oidc.dex.nodeSelector | default .Values.global.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Chart render fails with additional dex volumes added, using example in values.yaml results in error due to volume formatting.
```
    volumes:
      - name: config
        projected:
          sources:
          - secret:
              name: kargo-dex-server-cert
              items:
              - key: tls.crt
                path: tls.crt
              - key: tls.key
                path: tls.key
          - secret:
              name: kargo-dex-server
              items:
              - key: config.yaml
                path: config.yaml
        - name: google-json
          secret:
            defaultMode: 420
            secretName: kargo-google-groups-json
```