### PR TITLE
fix: reduce scope of artifact registry access token

### DIFF
--- a/internal/credentials/gar/service_account_key.go
+++ b/internal/credentials/gar/service_account_key.go
@@ -102,7 +102,7 @@ func (s *serviceAccountKeyCredentialHelper) getAccessToken(
 	if err != nil {
 		return "", fmt.Errorf("error decoding service account key: %w", err)
 	}
-	config, err := google.JWTConfigFromJSON(decodedKey, "https://www.googleapis.com/auth/devstorage.read_write")
+	config, err := google.JWTConfigFromJSON(decodedKey, "https://www.googleapis.com/auth/devstorage.read_only")
 	if err != nil {
 		return "", fmt.Errorf("error parsing service account key: %w", err)
 	}


### PR DESCRIPTION
This isn't an especially serious flaw, as scopes only _limit_ a token's privileges and can not expand them beyond the associated service account's own privileges, but requesting read/write access when obtaining an access token for Artifact Registry is unnecessary as Kargo only ever _reads_ from container image repositories.