### PR TITLE
feat(controller): allow use of multi sources apps

### DIFF
--- a/internal/argocd/health.go
+++ b/internal/argocd/health.go
@@ -160,19 +160,6 @@ func (h *applicationHealth) GetApplicationHealth(
 		}
 	}
 
-	// TODO: We should re-evaluate this soon. It may have been fixed in recent
-	//       versions.
-	// TODO(hidde): Do we have an upstream reference for this?
-	if len(app.Spec.Sources) > 0 {
-		err := fmt.Errorf(
-			"bugs in Argo CD currently prevent a comprehensive assessment of "+
-				"the health of multi-source Application %q in namespace %q",
-			key.Name,
-			key.Namespace,
-		)
-		return kargoapi.HealthStateUnknown, healthStatus, syncStatus, err
-	}
-
 	// Check for any error conditions. If these are found, the application is
 	// considered unhealthy as they may indicate a problem which can result in
 	// e.g. the health status result to become unreliable.

--- a/internal/argocd/health_test.go
+++ b/internal/argocd/health_test.go
@@ -399,56 +399,6 @@ func TestApplicationHealth_GetApplicationHealth(t *testing.T) {
 			},
 		},
 		{
-			name: "error on multiple app sources",
-			key:  types.NamespacedName{Namespace: "fake-namespace", Name: "fake-name"},
-			stage: &kargoapi.Stage{
-				Spec: testStageSpec,
-			},
-			application: &argocd.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fake-namespace",
-					Name:      "fake-name",
-				},
-				Spec: argocd.ApplicationSpec{
-					Sources: argocd.ApplicationSources{
-						{},
-						{},
-					},
-				},
-				Status: argocd.ApplicationStatus{
-					Health: argocd.HealthStatus{
-						Status:  argocd.HealthStatusHealthy,
-						Message: "fake-message",
-					},
-					Sync: argocd.SyncStatus{
-						Status:    argocd.SyncStatusCodeSynced,
-						Revision:  "fake-revision",
-						Revisions: []string{"fake-revision1", "fake-revision2"},
-					},
-				},
-			},
-			assertions: func(
-				t *testing.T,
-				state kargoapi.HealthState,
-				healthStatus kargoapi.ArgoCDAppHealthStatus,
-				syncStatus kargoapi.ArgoCDAppSyncStatus,
-				err error,
-			) {
-				require.ErrorContains(t, err, "bugs in Argo CD currently prevent a comprehensive assessment")
-
-				require.Equal(t, kargoapi.HealthStateUnknown, state)
-				require.Equal(t, kargoapi.ArgoCDAppHealthStatus{
-					Status:  kargoapi.ArgoCDAppHealthStateHealthy,
-					Message: "fake-message",
-				}, healthStatus)
-				require.Equal(t, kargoapi.ArgoCDAppSyncStatus{
-					Status:    kargoapi.ArgoCDAppSyncStateSynced,
-					Revision:  "fake-revision",
-					Revisions: []string{"fake-revision1", "fake-revision2"},
-				}, syncStatus)
-			},
-		},
-		{
 			name: "Application with error conditions yields Unhealthy state",
 			key:  types.NamespacedName{Namespace: "fake-namespace", Name: "fake-name"},
 			stage: &kargoapi.Stage{


### PR DESCRIPTION
Possibly fixes #1399

We're currently using Kargo with multi sources apps in ArgoCD. Because of that, we've noticed that the health status of our ArgoCD applications in Kargo are set to status unknown, and the verification is continuously spinning due to this following code :

```
TODO: We should re-evaluate this soon. It may have been fixed in recent
	//       versions.
	// TODO(hidde): Do we have an upstream reference for this?
	if len(app.Spec.Sources) > 0 {
		err := fmt.Errorf(
			"bugs in Argo CD currently prevent a comprehensive assessment of "+
				"the health of multi-source Application %q in namespace %q",
			key.Name,
			key.Namespace,
		)
		return kargoapi.HealthStateUnknown, healthStatus, syncStatus, err
	}
```

We're using Kargo 0.6.0 and ArgoCD 2.11.2 (both on latest versions available).
We forked the project to remove this test and managed to get our multi sources apps to work.
Here's an ArgoCD application example:

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    kargo.akuity.io/authorized-stage: kargo-test:test
  name: test
  namespace: argocd
spec:
  project: test
  sources:
    - repoURL: test
      chart: test/test
      targetRevision: 1.0.0
      helm:
        valueFiles:
          - $values/test/values.yaml
    - repoURL: https://github.com/test
      targetRevision: main
      ref: values
  destination:
    name: test
    namespace: test
```

Results inside Kargo:

![image](https://github.com/akuity/kargo/assets/19993116/96ce47bd-6270-42d3-aef9-7826cd8d9e13)

The issue seems to be fixed in ArgoCD, maybe one of these:
https://github.com/search?q=repo%3Aargoproj%2Fargo-cd+multi+sources&type=commits