### PR TITLE
feat: add approved by column in the UI of the stage

### DIFF
--- a/ui/src/features/stage/promotions.tsx
+++ b/ui/src/features/stage/promotions.tsx
@@ -161,6 +161,14 @@ export const Promotions = () => {
       dataIndex: ['metadata', 'name']
     },
     {
+      title: 'Approved by',
+      render: (_, promotion) => {
+        const annotation = promotion.metadata?.annotations['kargo.akuity.io/create-actor'];
+        const email = annotation ? annotation.split(':')[1] : 'N/A';
+        return email;
+      }
+    },
+    {
       title: 'Freight',
       render: (_, promotion) => (
         <Tooltip


### PR DESCRIPTION
Hello,

It's will be nice to have approver informations inside the UI of the stage with all other informations we kept form promotions.

![image](https://github.com/akuity/kargo/assets/19993116/6ea118c0-6912-4336-b419-47faa65dc9e2)
