### PR TITLE
chore: lock v0.6.x docs into v0.6.x scripts

### DIFF
--- a/docs/docs/20-quickstart.mdx
+++ b/docs/docs/20-quickstart.mdx
@@ -166,7 +166,7 @@ To download the Kargo CLI:
 ```shell
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch=amd64
-curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
+curl -L -o kargo https://github.com/akuity/kargo/releases/download/v0.6.0/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
 chmod +x kargo
 ```
 
@@ -179,7 +179,7 @@ value of your `PATH` environment variable.
 To download the Kargo CLI:
 
 ```shell
-Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/download/v0.6.0/kargo-windows-amd64.exe -OutFile kargo.exe
 ```
 
 Then move `kargo.exe` to a location in your file system that is included in the value


### PR DESCRIPTION
v0.6.x docs will soon be archived at https://release-0-6.kargo.akuity.io/, so this PR locks them into using the v0.6.0 CLI.

New production docs will be published from `release-0.7` after the v0.7.0 release.

Note: There would ordinarily be more changes in a PR of this nature, but it seems various other references to v0.6.0 in docs and scripts were already set prematurely at the time of the v0.6.0 release. We should avoid that in the future because by _not_ specifying exact versions, we would _naturally_ get the latest things and wouldn't need to update docs to reference every new patch release.