### PR TITLE
fix: allow obtaining diff paths for root commit

### DIFF
--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -409,7 +409,7 @@ func (r *repo) HasDiffs() (bool, error) {
 }
 
 func (r *repo) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(r.buildGitCommand("show", "--pretty=\"\"", "--name-only", commitID))
+	resBytes, err := libExec.Exec(r.buildGitCommand("show", `--pretty=""`, "--name-only", commitID))
 	if err != nil {
 		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}

--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -409,7 +409,7 @@ func (r *repo) HasDiffs() (bool, error) {
 }
 
 func (r *repo) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(r.buildGitCommand("show", `--pretty=""`, "--name-only", commitID))
+	resBytes, err := libExec.Exec(r.buildGitCommand("show", "--pretty=", "--name-only", commitID))
 	if err != nil {
 		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}

--- a/internal/controller/git/git.go
+++ b/internal/controller/git/git.go
@@ -409,9 +409,9 @@ func (r *repo) HasDiffs() (bool, error) {
 }
 
 func (r *repo) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(r.buildGitCommand("diff", "--name-only", commitID+"^", commitID))
+	resBytes, err := libExec.Exec(r.buildGitCommand("show", "--pretty=\"\"", "--name-only", commitID))
 	if err != nil {
-		return nil, fmt.Errorf("error getting diffs for commit %q: %w", commitID, err)
+		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}
 	var paths []string
 	scanner := bufio.NewScanner(bytes.NewReader(resBytes))


### PR DESCRIPTION
The previous approach was inherited from when there was a need to be able to obtain the diff paths for a range of commits. With the refactoring in v0.7.0, however, this is no longer a requirement.

Because of this, we can switch to `git show` to obtain the diff paths for a specific commit. Using `--name-only` to print the paths, while further supplying `--pretty=""` to omit any other commit (message) data. Effectively yielding the same output as the previous command, except that it now also works for root commits.

Fixes: #2140 