### PR TITLE
fix: do not check project namespaces for sas when operating on cluster-scoped resources

### DIFF
--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -667,16 +667,18 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 		if userInfo.Subject != "" {
 			var namespacesToCheck []string
 			if key.Namespace != "" {
-				namespacesToCheck = make([]string, 0, len(globalServiceAccountNamespaces)+1)
+				// This is written the way it is to keep key.Namespace as the first
+				// element in the slice, so it is checked first, because this is where
+				// there is the highest likelihood of finding a ServiceAccount with
+				// the required permissions.
+				namespacesToCheck = make([]string, 0, 1+len(globalServiceAccountNamespaces))
 				namespacesToCheck = append(namespacesToCheck, key.Namespace)
 				namespacesToCheck = append(namespacesToCheck, globalServiceAccountNamespaces...)
 			} else {
-				namespacesToCheck = make([]string, len(userInfo.ServiceAccountsByNamespace))
-				var i int
-				for ns := range userInfo.ServiceAccountsByNamespace {
-					namespacesToCheck[i] = ns
-					i++
-				}
+				// Check ONLY globalServiceAccountNamespaces. i.e. We will NOT check
+				// project namespaces to find suitable ServiceAccounts for dealing with
+				// cluster-scoped resources.
+				namespacesToCheck = globalServiceAccountNamespaces
 			}
 			for _, namespaceToCheck := range namespacesToCheck {
 				serviceAccountsToCheck := userInfo.ServiceAccountsByNamespace[namespaceToCheck]


### PR DESCRIPTION
Happened to notice today that when our authorizing client wrapper tries to find a ServiceAccount that the SSO user is entitled to use, and which _also_ has suitable permissions for the resource + operation in question, it checks all Project namespaces for such ServiceAccounts _when the resource in question is cluster-scoped._

Although a ServiceAccount living in some Project namespace _could_ have ClusterRoleBindings that give it access to cluster-scoped resources, I believe users would find it surprising for anything that goes on within a Project namespace to have ramifications _beyond_ that namespace.

This PR narrows the subset of SAs (to which the user is federated with) that will be considered for operations on cluster-scoped resources. It will _only_ consider SAs within the so-called "global ServiceAccount namespaces."