### PR TITLE
fix(controller): make pull request-based promotions honor cert ignore option

### DIFF
--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -231,7 +231,7 @@ func (g *gitMechanism) doSingleUpdate(
 
 	newStatus := promo.Status.DeepCopy()
 	if update.PullRequest != nil {
-		gpClient, err := newGitProvider(update.RepoURL, update.PullRequest, creds)
+		gpClient, err := newGitProvider(update, creds)
 		if err != nil {
 			return nil, newFreight, err
 		}

--- a/internal/gitprovider/gitprovider.go
+++ b/internal/gitprovider/gitprovider.go
@@ -4,6 +4,19 @@ import (
 	"context"
 )
 
+// GitProviderOptions contains the options for a GitProvider.
+type GitProviderOptions struct { // nolint: revive
+	// Name specifies which Git provider to use when that information cannot be
+	// inferred from the repository URL.
+	Name string
+	// Token is the access token used to authenticate against the Git provider's
+	// API.
+	Token string
+	// InsecureSkipTLSVerify specifies whether certificate verification errors
+	// should be ignored when connecting to the Git provider's API.
+	InsecureSkipTLSVerify bool
+}
+
 // GitProviderService is an abstracted interface for a git providers (GitHub, GitLab, BitBucket)
 // when interacting against a single git repository (e.g. managing pull requests).
 type GitProviderService interface { // nolint: revive

--- a/internal/gitprovider/registry.go
+++ b/internal/gitprovider/registry.go
@@ -12,7 +12,7 @@ type ProviderRegistration struct {
 	// for the provider to handle (e.g. github.com is the domain name)
 	Predicate func(repoURL string) bool
 	// NewService instantiates the git provider
-	NewService func(repoURL, token string) (GitProviderService, error)
+	NewService func(repoURL string, opts *GitProviderOptions) (GitProviderService, error)
 }
 
 var (
@@ -20,21 +20,21 @@ var (
 	registeredProviders = map[string]ProviderRegistration{}
 )
 
-// NewGitProviderServiceFromName returns a git provider service by it's registered name
-func NewGitProviderServiceFromName(name, repoURL, token string) (GitProviderService, error) {
-	if reg, ok := registeredProviders[name]; ok {
-		return reg.NewService(repoURL, token)
+// NewGitProviderService returns an implementation of the GitProviderService
+// interface.
+func NewGitProviderService(repoURL string, opts *GitProviderOptions) (GitProviderService, error) {
+	if opts == nil {
+		opts = &GitProviderOptions{}
 	}
-	return nil, fmt.Errorf("No registered providers with name %q", name)
-}
-
-// NewGitProviderServiceFromURL iterates all registered providers and instantiates the
-// appropriate GitProvider service implementation (GitHub, GitLab, BitBucket)
-// based on inference of the repo URL.
-func NewGitProviderServiceFromURL(repoURL, token string) (GitProviderService, error) {
+	if opts.Name != "" {
+		if reg, found := registeredProviders[opts.Name]; found {
+			return reg.NewService(repoURL, opts)
+		}
+		return nil, fmt.Errorf("No registered providers with name %q", opts.Name)
+	}
 	for _, reg := range registeredProviders {
 		if reg.Predicate(repoURL) {
-			return reg.NewService(repoURL, token)
+			return reg.NewService(repoURL, opts)
 		}
 	}
 	return nil, fmt.Errorf("No registered providers for %s", repoURL)


### PR DESCRIPTION
Follow up to #2158, #2145, #1274

The last remaining difficulty I have been able to detect with PR-based promotions to repositories in self-hosted GitHub Enterprise or GitLab is that the `insecureSkipTLSVerify` option available at the pull request level is not honored by the clients used by the relevant GitProviders.

This PR fixes that.

And with this PR, I can also confirm Kargo working e2e with an actual instance of GHE Server.