### PR TITLE
refactor(docs): don't use dockerhub in the quickstart or concepts doc

### DIFF
--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -288,7 +288,7 @@ spec:
       writeBranch: stages/test
       kustomize:
         images:
-        - image: nginx
+        - image: public.ecr.aws/nginx/nginx
           path: stages/test
     argoCDAppUpdates:
     - appName: kargo-demo-test
@@ -415,8 +415,9 @@ status:
   phase: Steady
   currentFreight:
     images:
-    - repoURL: nginx
-      tag: 1.25.3
+    - digest: sha256:b2487a28589657b318e0d63110056e11564e73b9fd3ec4c4afba5542f9d07d46
+      repoURL: public.ecr.aws/nginx/nginx
+      tag: 1.27.0
     commits:
     - repoURL: https://github.com/example/kargo-demo.git
       id: 1234abc
@@ -450,8 +451,9 @@ status:
     - repoURL: https://github.com/example/kargo-demo.git
       id: 1234abc
     images:
-      - repoURL: nginx
-        tag: 1.25.3
+      - digest: sha256:b2487a28589657b318e0d63110056e11564e73b9fd3ec4c4afba5542f9d07d46
+        repoURL: public.ecr.aws/nginx/nginx
+        tag: 1.27.0
     name: 47b33c0c92b54439e5eb7fb80ecc83f8626fe390
     warehouse: my-warehouse
     verificationInfo:
@@ -509,8 +511,9 @@ metadata:
     kargo.akuity.io/alias: fruitful-ferret
 alias: fruitful-ferret
 images:
-- repoURL: nginx
-  tag: 1.25.3
+- digest: sha256:b2487a28589657b318e0d63110056e11564e73b9fd3ec4c4afba5542f9d07d46
+  repoURL: public.ecr.aws/nginx/nginx
+  tag: 1.27.0
 commits:
 - repoURL: https://github.com/example/kargo-demo.git
   id: 1234abc
@@ -548,8 +551,8 @@ metadata:
 spec:
   subscriptions:
   - image:
-      repoURL: nginx
-      semverConstraint: ^1.24.0
+      repoURL: public.ecr.aws/nginx/nginx
+      semverConstraint: ^1.26.0
   - git:
       repoURL: https://github.com/example/kargo-demo.git
 ```

--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -335,8 +335,9 @@ the previous section.
     spec:
       subscriptions:
       - image:
-          repoURL: nginx
-          semverConstraint: ^1.24.0
+          repoURL: public.ecr.aws/nginx/nginx
+          semverConstraint: ^1.26.0
+          discoveryLimit: 5
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -352,7 +353,7 @@ the previous section.
           writeBranch: stage/test
           kustomize:
             images:
-            - image: nginx
+            - image: public.ecr.aws/nginx/nginx
               path: stages/test
         argoCDAppUpdates:
         - appName: kargo-demo-test
@@ -373,7 +374,7 @@ the previous section.
           writeBranch: stage/uat
           kustomize:
             images:
-            - image: nginx
+            - image: public.ecr.aws/nginx/nginx
               path: stages/uat
         argoCDAppUpdates:
         - appName: kargo-demo-uat
@@ -394,7 +395,7 @@ the previous section.
           writeBranch: stage/prod
           kustomize:
             images:
-            - image: nginx
+            - image: public.ecr.aws/nginx/nginx
               path: stages/prod
         argoCDAppUpdates:
         - appName: kargo-demo-prod
@@ -434,8 +435,9 @@ the previous section.
     uat                                       NotApplicable   20s
     ```
 
-1. Our `Warehouse`, which subscribes to the `nginx` image repository, also
-   should have already produced `Freight`:
+1. After a few seconds, our `Warehouse`, which subscribes to the
+   `public.ecr.aws/nginx/nginx` container image, also should have already
+   produced `Freight`:
 
     ```shell
     kargo get freight --project kargo-demo
@@ -458,7 +460,7 @@ the previous section.
       * Helm charts (from chart repositories)
 
     This introductory example has `Freight` that references only a specific
-    version of the `nginx` container image.
+    version of the `public.ecr.aws/nginx/nginx` container image.
     :::
 
 1. We'll use it later, so save the ID of the `Freight` to an environment
@@ -534,9 +536,9 @@ the previous section.
             "id": "f5f87aa23c9e97f43eb83dd63768ee41f5ba3766",
             "images": [
                 {
-                    "digest": "sha256:2bdc49f2f8ae8d8dc50ed00f2ee56d00385c6f8bc8a8b320d0a294d9e3b49026",
-                    "repoURL": "nginx",
-                    "tag": "1.25.3"
+                    "digest": "sha256:b2487a28589657b318e0d63110056e11564e73b9fd3ec4c4afba5542f9d07d46",
+                    "repoURL": "public.ecr.aws/nginx/nginx",
+                    "tag": "1.27.0"
                 }
             ],
         },
@@ -546,9 +548,9 @@ the previous section.
                 "id": "f5f87aa23c9e97f43eb83dd63768ee41f5ba3766",
                 "images": [
                     {
-                        "digest": "sha256:2bdc49f2f8ae8d8dc50ed00f2ee56d00385c6f8bc8a8b320d0a294d9e3b49026",
-                        "repoURL": "nginx",
-                        "tag": "1.25.3"
+                        "digest": "sha256:b2487a28589657b318e0d63110056e11564e73b9fd3ec4c4afba5542f9d07d46",
+                        "repoURL": "public.ecr.aws/nginx/nginx",
+                        "tag": "1.27.0"
                     }
                 ],
             }

--- a/ui/src/features/project/pipelines/utils/stage-yaml-example.ts
+++ b/ui/src/features/project/pipelines/utils/stage-yaml-example.ts
@@ -14,7 +14,7 @@ spec:
       writeBranch: main
       kustomize:
         images:
-        - image: nginx
+        - image: public.ecr.aws/nginx/nginx
           path: stages/prod
     argoCDAppUpdates:
     - appName: kargo-demo-prod


### PR DESCRIPTION
Partially addresses #1966

Long-term, I'd like if the quickstart perhaps transitioned to using forks of the https://github.com/akuity/guestbook-deploy repo, but this PR is an interim step that at least eliminates the quickstart's dependency on Docker Hub, thereby dramatically reducing the possibility that any one run through the quickstart fails due to rate-limiting.

fwiw, I have been able to run discovery (with a limit of 20) on the Nginx repo in ECR 10x without being rate-limited, so no one should really encounter rate limits with the Warehouse discovery limit set to 5 and performing discovery on its regular schedule.

This should not be merged immediately after approval because it requires corresponding changes to the [akuity/kargo-demo](https://github.com/akuity/kargo-demo) repo.