### PR TITLE
feat(ui): ability to collapse old freight in freightline

### DIFF
--- a/ui/src/features/freightline/freight-item.tsx
+++ b/ui/src/features/freightline/freight-item.tsx
@@ -14,7 +14,8 @@ export const FreightItem = ({
   mode,
   empty,
   highlighted,
-  onHover
+  onHover,
+  hideLabel
 }: {
   freight?: Freight;
   children: React.ReactNode;
@@ -23,6 +24,7 @@ export const FreightItem = ({
   empty: boolean;
   highlighted?: boolean;
   onHover: (hovering: boolean) => void;
+  hideLabel?: boolean;
 }) => {
   return (
     <div
@@ -49,7 +51,7 @@ export const FreightItem = ({
             mode === FreightMode.Confirming ? 'text-black' : 'text-gray-400'
           }`}
         >
-          <FreightLabel freight={freight} breakOnHyphen={true} />
+          {!hideLabel && <FreightLabel freight={freight} breakOnHyphen={true} />}
         </div>
       </div>
     </div>

--- a/ui/src/features/freightline/freightline-header.tsx
+++ b/ui/src/features/freightline/freightline-header.tsx
@@ -1,6 +1,8 @@
 import {
   faBullseye,
   faCircleCheck,
+  faCompress,
+  faExpand,
   faQuestionCircle,
   faTimeline,
   faTools,
@@ -24,7 +26,9 @@ export const FreightlineHeader = ({
   downstreamSubs,
   selectedWarehouse,
   setSelectedWarehouse,
-  warehouses
+  warehouses,
+  collapsed,
+  setCollapsed
 }: {
   promotingStage?: string;
   action?: FreightlineAction;
@@ -33,6 +37,8 @@ export const FreightlineHeader = ({
   selectedWarehouse: string;
   setSelectedWarehouse: (warehouse: string) => void;
   warehouses: { [key: string]: Warehouse };
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
 }) => {
   const stageColorMap = useContext(ColorContext);
   const { name: projectName } = useParams();
@@ -107,6 +113,13 @@ export const FreightlineHeader = ({
               <FontAwesomeIcon icon={faTimeline} className='mr-2' />
               FREIGHTLINE
             </div>
+            <Tooltip title={`${collapsed ? 'Expand' : 'Collapse'} old freight`}>
+              <Button
+                icon={<FontAwesomeIcon icon={collapsed ? faExpand : faCompress} />}
+                className='-mb-1 mr-2'
+                onClick={() => setCollapsed(!collapsed)}
+              />
+            </Tooltip>
             <Button
               icon={<FontAwesomeIcon icon={faTools} />}
               className='-mb-1 mr-2'

--- a/ui/src/features/freightline/freightline-header.tsx
+++ b/ui/src/features/freightline/freightline-header.tsx
@@ -28,7 +28,8 @@ export const FreightlineHeader = ({
   setSelectedWarehouse,
   warehouses,
   collapsed,
-  setCollapsed
+  setCollapsed,
+  collapsable
 }: {
   promotingStage?: string;
   action?: FreightlineAction;
@@ -39,6 +40,7 @@ export const FreightlineHeader = ({
   warehouses: { [key: string]: Warehouse };
   collapsed: boolean;
   setCollapsed: (collapsed: boolean) => void;
+  collapsable?: boolean;
 }) => {
   const stageColorMap = useContext(ColorContext);
   const { name: projectName } = useParams();
@@ -113,13 +115,15 @@ export const FreightlineHeader = ({
               <FontAwesomeIcon icon={faTimeline} className='mr-2' />
               FREIGHTLINE
             </div>
-            <Tooltip title={`${collapsed ? 'Expand' : 'Collapse'} old freight`}>
-              <Button
-                icon={<FontAwesomeIcon icon={collapsed ? faExpand : faCompress} />}
-                className='-mb-1 mr-2'
-                onClick={() => setCollapsed(!collapsed)}
-              />
-            </Tooltip>
+            {collapsable && (
+              <Tooltip title={`${collapsed ? 'Expand' : 'Collapse'} old freight`}>
+                <Button
+                  icon={<FontAwesomeIcon icon={collapsed ? faExpand : faCompress} />}
+                  className='-mb-1 mr-2'
+                  onClick={() => setCollapsed(!collapsed)}
+                />
+              </Tooltip>
+            )}
             <Button
               icon={<FontAwesomeIcon icon={faTools} />}
               className='-mb-1 mr-2'

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -97,6 +97,7 @@ export const Pipelines = () => {
   );
 
   const [selectedWarehouse, setSelectedWarehouse] = React.useState('');
+  const [freightlineCollapsed, setFreightlineCollapsed] = React.useState(false);
 
   const warehouseMap = useMemo(() => {
     const map = {} as { [key: string]: Warehouse };
@@ -222,6 +223,8 @@ export const Pipelines = () => {
           selectedWarehouse={selectedWarehouse || ''}
           setSelectedWarehouse={setSelectedWarehouse}
           warehouses={warehouseMap}
+          collapsed={freightlineCollapsed}
+          setCollapsed={setFreightlineCollapsed}
         />
         <FreightlineWrapper>
           <Suspense
@@ -241,6 +244,8 @@ export const Pipelines = () => {
               state={state}
               promotionEligible={{}}
               stagesPerFreight={stagesPerFreight}
+              collapsed={freightlineCollapsed}
+              setCollapsed={setFreightlineCollapsed}
             />
           </Suspense>
         </FreightlineWrapper>

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -225,6 +225,12 @@ export const Pipelines = () => {
           warehouses={warehouseMap}
           collapsed={freightlineCollapsed}
           setCollapsed={setFreightlineCollapsed}
+          collapsable={
+            Object.keys(stagesPerFreight).reduce(
+              (acc, cur) => (cur?.length > 0 ? acc + stagesPerFreight[cur].length : acc),
+              0
+            ) > 0
+          }
         />
         <FreightlineWrapper>
           <Suspense


### PR DESCRIPTION
In many cases, Freightline are full of dozens or hundreds of old, unused freight that slows down the UI. This PR adds a toggle to hide all freight older than the oldest freight currently in use.

<img width="595" alt="Screenshot 2024-06-24 at 10 48 32" src="https://github.com/akuity/kargo/assets/6250584/2b30b539-6786-40da-88f5-c21be1f6217d">
<img width="885" alt="Screenshot 2024-06-24 at 10 48 22" src="https://github.com/akuity/kargo/assets/6250584/0551fdb2-48ce-4274-b444-598f38037cb6">
