### PR TITLE
chore: change labels used by feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,9 @@
 name: Feature Request
 about: Propose an enhancement for consideration by the maintainers
 title: ''
-labels: 'kind/feature-request'
+labels:
+- 'kind/proposal'
+- 'kind/enhancement'
 assignees: ''
 ---
 


### PR DESCRIPTION
@jessesuen we discussed this quite some time ago.

To refresh:

There was some confusion over the `kind/feature-request` vs `kind/enhancement` labels.

I had intended that the former be, as it says, _a request_, while the latter is _more than a request_ -- something we're committed to doing.

We agreed this wasn't very intuitive and that we would change the template to add both `kind/enhancement` _and_ `kind/proposal` and that maintainers can simply drop `kind/proposal` when we've agreed that a feature is worth implementing. 

Well... here it is. Sorry for the delay.

After this is merged, I'll update outstanding `kind/feature-request` to be `kind/proposal` + `kind/enhancement` instead.