### PR TITLE
refactor(controller): support multi-Freight health checks 

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -675,6 +676,27 @@ func (f *FreightCollection) UpdateOrPush(freight ...FreightReference) {
 	for _, i := range freight {
 		f.Freight[i.Origin.String()] = i
 	}
+}
+
+// References returns a slice of FreightReference objects from the
+// FreightCollection. The slice is ordered by the origin of the
+// FreightReference objects.
+func (f *FreightCollection) References() []FreightReference {
+	if f == nil || len(f.Freight) == 0 {
+		return nil
+	}
+
+	var origins []string
+	for o, _ := range f.Freight {
+		origins = append(origins, o)
+	}
+	slices.Sort(origins)
+
+	var refs []FreightReference
+	for _, o := range origins {
+		refs = append(refs, f.Freight[o])
+	}
+	return refs
 }
 
 // FreightHistory is a linear list of FreightCollection items. The list is

--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -124,6 +124,73 @@ func TestFreightCollectionUpdateOrPush(t *testing.T) {
 	}
 }
 
+func TestFreightCollectionReferences(t *testing.T) {
+	fooOrigin := FreightOrigin{
+		Kind: FreightOriginKindWarehouse,
+		Name: "foo",
+	}
+	barOrigin := FreightOrigin{
+		Kind: FreightOriginKindWarehouse,
+		Name: "bar",
+	}
+	bazOrigin := FreightOrigin{
+		Kind: FreightOriginKindWarehouse,
+		Name: "baz",
+	}
+
+	testCases := []struct {
+		name           string
+		freight        FreightCollection
+		expectedResult []FreightReference
+	}{
+		{
+			name: "freight is nil",
+			freight: FreightCollection{
+				Freight: nil,
+			},
+			expectedResult: nil,
+		},
+		{
+			name: "freight is empty",
+			freight: FreightCollection{
+				Freight: map[string]FreightReference{},
+			},
+		},
+		{
+			name: "freight has one element",
+			freight: FreightCollection{
+				Freight: map[string]FreightReference{
+					fooOrigin.String(): {Origin: fooOrigin},
+				},
+			},
+			expectedResult: []FreightReference{{Origin: fooOrigin}},
+		},
+		{
+			name: "freight has multiple elements",
+			freight: FreightCollection{
+				Freight: map[string]FreightReference{
+					fooOrigin.String(): {Origin: fooOrigin},
+					barOrigin.String(): {Origin: barOrigin},
+					bazOrigin.String(): {Origin: bazOrigin},
+				},
+			},
+			expectedResult: []FreightReference{
+				{Origin: barOrigin},
+				{Origin: bazOrigin},
+				{Origin: fooOrigin},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Run the test multiple times to ensure the result is consistent.
+			for i := 0; i < 100; i++ {
+				require.Equal(t, testCase.expectedResult, testCase.freight.References())
+			}
+		})
+	}
+}
+
 func TestFreightHistoryCurrent(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/internal/argocd/health_test.go
+++ b/internal/argocd/health_test.go
@@ -24,7 +24,7 @@ func TestApplicationHealth_EvaluateHealth(t *testing.T) {
 	testCases := []struct {
 		name         string
 		applications []client.Object
-		freight      kargoapi.FreightReference
+		freight      []kargoapi.FreightReference
 		updates      []kargoapi.ArgoCDAppUpdate
 		assertions   func(*testing.T, *kargoapi.Health)
 	}{
@@ -59,12 +59,14 @@ func TestApplicationHealth_EvaluateHealth(t *testing.T) {
 					},
 				},
 			},
-			freight: kargoapi.FreightReference{
-				Charts: []kargoapi.Chart{
-					{
-						RepoURL: "https://example.com",
-						Name:    "fake-chart",
-						Version: "v1.2.3",
+			freight: []kargoapi.FreightReference{
+				{
+					Charts: []kargoapi.Chart{
+						{
+							RepoURL: "https://example.com",
+							Name:    "fake-chart",
+							Version: "v1.2.3",
+						},
 					},
 				},
 			},
@@ -250,7 +252,7 @@ func TestApplicationHealth_EvaluateHealth(t *testing.T) {
 
 	t.Run("Argo CD integration disabled", func(t *testing.T) {
 		h := &applicationHealth{}
-		health := h.EvaluateHealth(context.TODO(), kargoapi.FreightReference{}, []kargoapi.ArgoCDAppUpdate{{}})
+		health := h.EvaluateHealth(context.TODO(), nil, []kargoapi.ArgoCDAppUpdate{{}})
 		require.NotNil(t, health)
 		require.Equal(t, kargoapi.HealthStateUnknown, health.Status)
 		require.Len(t, health.Issues, 1)
@@ -267,7 +269,7 @@ func TestApplicationHealth_GetApplicationHealth(t *testing.T) {
 		application *argocd.Application
 		interceptor interceptor.Funcs
 		key         types.NamespacedName
-		freight     kargoapi.FreightReference
+		freight     []kargoapi.FreightReference
 		assertions  func(
 			*testing.T,
 			kargoapi.HealthState,
@@ -445,11 +447,13 @@ func TestApplicationHealth_GetApplicationHealth(t *testing.T) {
 					},
 				},
 			},
-			freight: kargoapi.FreightReference{
-				Commits: []kargoapi.GitCommit{
-					{
-						RepoURL: "https://example.com/universe/42",
-						ID:      "other-fake-revision",
+			freight: []kargoapi.FreightReference{
+				{
+					Commits: []kargoapi.GitCommit{
+						{
+							RepoURL: "https://example.com/universe/42",
+							ID:      "other-fake-revision",
+						},
 					},
 				},
 			},
@@ -537,11 +541,13 @@ func TestApplicationHealth_GetApplicationHealth(t *testing.T) {
 					},
 				},
 			},
-			freight: kargoapi.FreightReference{
-				Commits: []kargoapi.GitCommit{
-					{
-						RepoURL: "https://example.com/universe/42",
-						ID:      "fake-revision",
+			freight: []kargoapi.FreightReference{
+				{
+					Commits: []kargoapi.GitCommit{
+						{
+							RepoURL: "https://example.com/universe/42",
+							ID:      "fake-revision",
+						},
 					},
 				},
 			},

--- a/internal/controller/stages/health_test.go
+++ b/internal/controller/stages/health_test.go
@@ -12,7 +12,7 @@ type mockAppHealthEvaluator struct {
 
 func (m *mockAppHealthEvaluator) EvaluateHealth(
 	context.Context,
-	kargoapi.FreightReference,
+	[]kargoapi.FreightReference,
 	[]kargoapi.ArgoCDAppUpdate,
 ) *kargoapi.Health {
 	return m.Health

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -666,23 +666,17 @@ func (r *reconciler) syncNormalStage(
 			"Stage has no current Freight; no health checks or verification to perform",
 		)
 	} else {
-		// TODO: This loop for checking health is currently incorrect. The health of
-		// the last piece of Freight assessed "wins," so this only functions
-		// correctly for Stages that have one pipeline.
-		for _, freight := range currentFC.Freight {
-			freightLogger := logger.WithValues("freight", freight.Name)
-			// Always check the health of the Argo CD Applications associated with the
-			// Stage. This is regardless of the phase of the Stage, as the health of the
-			// Argo CD Applications is always relevant.
-			if status.Health = r.appHealth.EvaluateHealth(
-				ctx,
-				freight,
-				stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
-			); status.Health != nil {
-				freightLogger.WithValues("health", status.Health.Status).Debug("Stage health assessed")
-			} else {
-				freightLogger.Debug("Stage health deemed not applicable")
-			}
+		// Always check the health of the Argo CD Applications associated with the
+		// Stage. This is regardless of the phase of the Stage, as the health of the
+		// Argo CD Applications is always relevant.
+		if status.Health = r.appHealth.EvaluateHealth(
+			ctx,
+			currentFC.References(),
+			stage.Spec.PromotionMechanisms.ArgoCDAppUpdates,
+		); status.Health != nil {
+			logger.WithValues("health", status.Health.Status).Debug("Stage health assessed")
+		} else {
+			logger.Debug("Stage health deemed not applicable")
 		}
 
 		// currentVI is VerificationInfo of the currentFC


### PR DESCRIPTION
This is the most elegant way I could think of to enable support for multi-Freight health checks.

It works by determining which Freight element from a `FreightCombination` applies to the Application, leveraging the existing logic to determine the desired revision (based on source matching of the Freight against the Application data).

For each match, the further "revision health" is assessed, which will either return early in case of an "unhealthy" state or allow it to continue when it passes for all applicable Freight.