### PR TITLE
chore: clarify optionality

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -1334,6 +1334,7 @@ message WarehouseSpec {
   // treated as if its value were "Automatic".
   //
   // +kubebuilder:default=Automatic
+  // +kubebuilder:validation:Optional
   optional string freightCreationPolicy = 3;
 
   // Subscriptions describes sources of artifacts to be included in Freight

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -69,6 +69,7 @@ type WarehouseSpec struct {
 	// treated as if its value were "Automatic".
 	//
 	// +kubebuilder:default=Automatic
+	// +kubebuilder:validation:Optional
 	FreightCreationPolicy FreightCreationPolicy `json:"freightCreationPolicy" protobuf:"bytes,3,opt,name=freightCreationPolicy"`
 	// Subscriptions describes sources of artifacts to be included in Freight
 	// produced by this Warehouse.

--- a/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
@@ -344,7 +344,6 @@ spec:
                 minItems: 1
                 type: array
             required:
-            - freightCreationPolicy
             - interval
             - subscriptions
             type: object

--- a/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
@@ -214,7 +214,6 @@
         }
       },
       "required": [
-        "freightCreationPolicy",
         "interval",
         "subscriptions"
       ],

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -4297,6 +4297,7 @@ export class WarehouseSpec extends Message<WarehouseSpec> {
    * treated as if its value were "Automatic".
    *
    * +kubebuilder:default=Automatic
+   * +kubebuilder:validation:Optional
    *
    * @generated from field: optional string freightCreationPolicy = 3;
    */


### PR DESCRIPTION
In the CRD docs `freightCreationPolicy` is required, even though strictly speaking if not specified it will be set to `Automatic`.