### PR TITLE
fix: remediate errant use of deprecated fields

### DIFF
--- a/api/v1alpha1/stage_helpers_test.go
+++ b/api/v1alpha1/stage_helpers_test.go
@@ -247,7 +247,7 @@ func TestReverifyStageFreight(t *testing.T) {
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
-		require.ErrorContains(t, err, "stage has no existing verification info")
+		require.ErrorContains(t, err, "stage has no current verification info")
 	})
 
 	t.Run("missing verification info ID", func(t *testing.T) {
@@ -261,10 +261,9 @@ func TestReverifyStageFreight(t *testing.T) {
 					FreightHistory: FreightHistory{
 						{
 							Freight: map[string]FreightReference{
-								"fake-warehouse": {
-									VerificationInfo: &VerificationInfo{},
-								},
+								"fake-warehouse": {},
 							},
+							VerificationHistory: []VerificationInfo{{}},
 						},
 					},
 				},
@@ -289,12 +288,11 @@ func TestReverifyStageFreight(t *testing.T) {
 					FreightHistory: FreightHistory{
 						{
 							Freight: map[string]FreightReference{
-								"fake-warehouse": {
-									VerificationInfo: &VerificationInfo{
-										ID: "fake-id",
-									},
-								},
+								"fake-warehouse": {},
 							},
+							VerificationHistory: []VerificationInfo{{
+								ID: "fake-id",
+							}},
 						},
 					},
 				},
@@ -372,7 +370,7 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
-		require.ErrorContains(t, err, "stage has no existing verification info")
+		require.ErrorContains(t, err, "stage has no current verification info")
 	})
 
 	t.Run("missing verification info ID", func(t *testing.T) {
@@ -386,10 +384,9 @@ func TestAbortStageFreightVerification(t *testing.T) {
 					FreightHistory: FreightHistory{
 						{
 							Freight: map[string]FreightReference{
-								"fake-warehouse": {
-									VerificationInfo: &VerificationInfo{},
-								},
+								"fake-warehouse": {},
 							},
+							VerificationHistory: []VerificationInfo{{}},
 						},
 					},
 				},
@@ -414,13 +411,12 @@ func TestAbortStageFreightVerification(t *testing.T) {
 					FreightHistory: FreightHistory{
 						{
 							Freight: map[string]FreightReference{
-								"fake-warehouse": {
-									VerificationInfo: &VerificationInfo{
-										ID:    "fake-id",
-										Phase: VerificationPhaseError,
-									},
-								},
+								"fake-warehouse": {},
 							},
+							VerificationHistory: []VerificationInfo{{
+								ID:    "fake-id",
+								Phase: VerificationPhaseError,
+							}},
 						},
 					},
 				},
@@ -453,12 +449,11 @@ func TestAbortStageFreightVerification(t *testing.T) {
 					FreightHistory: FreightHistory{
 						{
 							Freight: map[string]FreightReference{
-								"fake-warehouse": {
-									VerificationInfo: &VerificationInfo{
-										ID: "fake-id",
-									},
-								},
+								"fake-warehouse": {},
 							},
+							VerificationHistory: []VerificationInfo{{
+								ID: "fake-id",
+							}},
 						},
 					},
 				},

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -694,6 +694,7 @@ func (r *reconciler) syncNormalStage(
 					if req, _ := kargoapi.ReverifyAnnotationValue(stage.GetAnnotations()); req.ForID(currentVI.ID) {
 						logger.Debug("rerunning verification")
 						status.Phase = kargoapi.StagePhaseVerifying
+						currentVI = &kargoapi.VerificationInfo{}
 					}
 				}
 			}

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -288,15 +288,15 @@ func TestSyncNormalStage(t *testing.T) {
 							Freight: map[string]kargoapi.FreightReference{
 								testOrigin.String(): {
 									Origin: testOrigin,
-									VerificationInfo: &kargoapi.VerificationInfo{
-										ID:    "fake-id",
-										Phase: kargoapi.VerificationPhaseFailed,
-										AnalysisRun: &kargoapi.AnalysisRunReference{
-											Name: "fake-analysis-run",
-										},
-									},
 								},
 							},
+							VerificationHistory: []kargoapi.VerificationInfo{{
+								ID:    "fake-id",
+								Phase: kargoapi.VerificationPhaseFailed,
+								AnalysisRun: &kargoapi.AnalysisRunReference{
+									Name: "fake-analysis-run",
+								},
+							}},
 						},
 					},
 				},
@@ -378,12 +378,6 @@ func TestSyncNormalStage(t *testing.T) {
 							Freight: map[string]kargoapi.FreightReference{
 								testOrigin.String(): {
 									Origin: testOrigin,
-									VerificationInfo: &kargoapi.VerificationInfo{
-										Phase: kargoapi.VerificationPhaseFailed,
-										AnalysisRun: &kargoapi.AnalysisRunReference{
-											Name: "fake-analysis-run",
-										},
-									},
 								},
 							},
 							VerificationHistory: []kargoapi.VerificationInfo{

--- a/internal/webhook/freight/webhook_test.go
+++ b/internal/webhook/freight/webhook_test.go
@@ -771,9 +771,9 @@ func TestValidateDelete(t *testing.T) {
 								Name: "fake-stage",
 							},
 							Status: kargoapi.StageStatus{
-								CurrentFreight: &kargoapi.FreightReference{
-									Name: "fake-id",
-								},
+								FreightHistory: kargoapi.FreightHistory{{
+									ID: "fake-id",
+								}},
 							},
 						},
 					}


### PR DESCRIPTION
This remediates some errant uses of newly deprecated fields and in doing so also happens to address some outstanding todos and fix some previously undetected bugs. (Abort verification and reverification were not working correctly in this feature branch.)