### PR TITLE
fix(ui): bring back empty freight label

### DIFF
--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -120,6 +120,7 @@ export const StageNode = ({
               {(currentFreight || []).map((freight) => (
                 <FreightLabel freight={freight} showContents={true} key={freight?.metadata?.name} />
               ))}
+              {currentFreight?.length === 0 && <FreightLabel />}
               {stage?.status?.lastPromotion?.finishedAt && (
                 <>
                   <div


### PR DESCRIPTION
Empty label was missing with new multi pipelines logic:

![CleanShot 2024-07-09 at 09 52 31@2x](https://github.com/akuity/kargo/assets/6250584/d3041bac-471d-4ad3-aa80-8d44a3ff37f4)
