### PR TITLE
fix(ui): freight contents overflowing horizontally

### DIFF
--- a/ui/src/features/freight-timeline/freight-contents.tsx
+++ b/ui/src/features/freight-timeline/freight-contents.tsx
@@ -59,7 +59,7 @@ export const FreightContents = (props: {
         {
           'text-gray-700 hover:text-gray-800': highlighted,
           'text-gray-400 hover:text-gray-500': !highlighted,
-          'flex-col w-20 overflow-y-auto': !horizontal
+          'flex-col w-20 overflow-y-auto flex-grow-0 flex-nowrap': !horizontal
         }
       )}
     >


### PR DESCRIPTION
Previosuly, with more than ~2 items in a piece of Freight, the Freight Timeline would overflow them with a vertical scrollbar (by design). A recent PR, which updated the `FreightContents` component for re-use elsewhere, accidentally broke this behavior. This PR restores it.