### PR TITLE
fix(webhook): compare to detect Freight mutations 

### DIFF
--- a/api/v1alpha1/freight_types.go
+++ b/api/v1alpha1/freight_types.go
@@ -136,6 +136,37 @@ type GitCommit struct {
 	Committer string `json:"committer,omitempty" protobuf:"bytes,8,opt,name=committer"`
 }
 
+// DeepEquals returns a bool indicating whether the receiver deep-equals the
+// provided GitCommit. I.e., all fields must be equal.
+func (g *GitCommit) DeepEquals(other *GitCommit) bool {
+	if g == nil && other == nil {
+		return true
+	}
+	if g == nil || other == nil {
+		return false
+	}
+	return g.RepoURL == other.RepoURL &&
+		g.ID == other.ID &&
+		g.Branch == other.Branch &&
+		g.Tag == other.Tag &&
+		g.HealthCheckCommit == other.HealthCheckCommit &&
+		g.Message == other.Message &&
+		g.Author == other.Author &&
+		g.Committer == other.Committer
+}
+
+// Equals returns a bool indicating whether two GitCommits are equivalent.
+func (g *GitCommit) Equals(rhs *GitCommit) bool {
+	if g == nil && rhs == nil {
+		return true
+	}
+	if (g == nil && rhs != nil) || (g != nil && rhs == nil) {
+		return false
+	}
+	// If we get to here, both operands are non-nil
+	return g.RepoURL == rhs.RepoURL && g.ID == rhs.ID
+}
+
 // FreightStatus describes a piece of Freight's most recently observed state.
 type FreightStatus struct {
 	// VerifiedIn describes the Stages in which this Freight has been verified

--- a/api/v1alpha1/freight_types.go
+++ b/api/v1alpha1/freight_types.go
@@ -120,7 +120,7 @@ type GitCommit struct {
 	// resolved to this commit.
 	Tag string `json:"tag,omitempty" protobuf:"bytes,4,opt,name=tag"`
 	// HealthCheckCommit is the ID of a specific commit. When specified,
-	// assessments of Stage health will used this value (instead of ID) when
+	// assessments of Stage health will use this value (instead of ID) when
 	// determining if applicable sources of Argo CD Application resources
 	// associated with the Stage are or are not synced to this commit. Note that
 	// there are cases (as in that of Kargo Render being utilized as a promotion

--- a/api/v1alpha1/freight_types_test.go
+++ b/api/v1alpha1/freight_types_test.go
@@ -6,6 +6,167 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGitCommitDeepEquals(t *testing.T) {
+	testCases := []struct {
+		name           string
+		a              *GitCommit
+		b              *GitCommit
+		expectedResult bool
+	}{
+		{
+			name:           "a and b both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "only a is nil",
+			b:              &GitCommit{},
+			expectedResult: false,
+		},
+		{
+			name:           "only b is nil",
+			a:              &GitCommit{},
+			expectedResult: false,
+		},
+		{
+			name: "repoURLs differ",
+			a: &GitCommit{
+				RepoURL: "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "commit IDs differ",
+			a: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "branch names differ",
+			a: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Branch:  "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Branch:  "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "tags differ",
+			a: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Tag:     "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Tag:     "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "health check commits differ",
+			a: &GitCommit{
+				RepoURL:           "fake-url",
+				ID:                "fake-commit-id",
+				HealthCheckCommit: "foo",
+			},
+			b: &GitCommit{
+				RepoURL:           "fake-url",
+				ID:                "fake-commit-id",
+				HealthCheckCommit: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "messages differ",
+			a: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Message: "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Message: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "authors differ",
+			a: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Author:  "foo",
+			},
+			b: &GitCommit{
+				RepoURL: "fake-url",
+				ID:      "fake-commit-id",
+				Author:  "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "committers differ",
+			a: &GitCommit{
+				RepoURL:   "fake-url",
+				ID:        "fake-commit-id",
+				Committer: "foo",
+			},
+			b: &GitCommit{
+				RepoURL:   "fake-url",
+				ID:        "fake-commit-id",
+				Committer: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "perfect match",
+			a: &GitCommit{
+				RepoURL:           "fake-url",
+				ID:                "fake-commit-id",
+				Branch:            "fake-branch",
+				Tag:               "fake-tag",
+				HealthCheckCommit: "fake-health-id",
+				Message:           "fake-message",
+				Author:            "fake-author",
+				Committer:         "fake-committer",
+			},
+			b: &GitCommit{
+				RepoURL:           "fake-url",
+				ID:                "fake-commit-id",
+				Branch:            "fake-branch",
+				Tag:               "fake-tag",
+				HealthCheckCommit: "fake-health-id",
+				Message:           "fake-message",
+				Author:            "fake-author",
+				Committer:         "fake-committer",
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expectedResult, testCase.a.DeepEquals(testCase.b))
+			require.Equal(t, testCase.expectedResult, testCase.b.DeepEquals(testCase.a))
+		})
+	}
+}
+
 func TestGitCommitEquals(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -485,7 +485,7 @@ message GitCommit {
   optional string tag = 4;
 
   // HealthCheckCommit is the ID of a specific commit. When specified,
-  // assessments of Stage health will used this value (instead of ID) when
+  // assessments of Stage health will use this value (instead of ID) when
   // determining if applicable sources of Argo CD Application resources
   // associated with the Stage are or are not synced to this commit. Note that
   // there are cases (as in that of Kargo Render being utilized as a promotion

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -613,6 +613,21 @@ type Image struct {
 	Digest string `json:"digest,omitempty" protobuf:"bytes,4,opt,name=digest"`
 }
 
+// DeepEquals returns a bool indicating whether the receiver deep-equals the
+// provided Image. I.e., all fields must be equal.
+func (i *Image) DeepEquals(other *Image) bool {
+	if i == nil && other == nil {
+		return true
+	}
+	if i == nil || other == nil {
+		return false
+	}
+	return i.RepoURL == other.RepoURL &&
+		i.GitRepoURL == other.GitRepoURL &&
+		i.Tag == other.Tag &&
+		i.Digest == other.Digest
+}
+
 // Chart describes a specific version of a Helm chart.
 type Chart struct {
 	// RepoURL specifies the URL of a Helm chart repository. Classic chart
@@ -628,16 +643,18 @@ type Chart struct {
 	Version string `json:"version,omitempty" protobuf:"bytes,3,opt,name=version"`
 }
 
-// Equals returns a bool indicating whether two GitCommits are equivalent.
-func (g *GitCommit) Equals(rhs *GitCommit) bool {
-	if g == nil && rhs == nil {
+// DeepEquals returns a bool indicating whether the receiver deep-equals the
+// provided Chart. I.e., all fields must be equal.
+func (c *Chart) DeepEquals(other *Chart) bool {
+	if c == nil && other == nil {
 		return true
 	}
-	if (g == nil && rhs != nil) || (g != nil && rhs == nil) {
+	if c == nil || other == nil {
 		return false
 	}
-	// If we get to here, both operands are non-nil
-	return g.RepoURL == rhs.RepoURL && g.ID == rhs.ID
+	return c.RepoURL == other.RepoURL &&
+		c.Name == other.Name &&
+		c.Version == other.Version
 }
 
 // Health describes the health of a Stage.

--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -224,3 +224,177 @@ func TestVerificationInfoStack_UpdateOrPush(t *testing.T) {
 		})
 	}
 }
+
+func TestImageDeepEquals(t *testing.T) {
+	testCases := []struct {
+		name           string
+		a              *Image
+		b              *Image
+		expectedResult bool
+	}{
+		{
+			name:           "a and b both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "only a is nil",
+			b:              &Image{},
+			expectedResult: false,
+		},
+		{
+			name:           "only b is nil",
+			a:              &Image{},
+			expectedResult: false,
+		},
+		{
+			name: "repo URLs differ",
+			a: &Image{
+				RepoURL: "foo",
+			},
+			b: &Image{
+				RepoURL: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "git repo URLs differ",
+			a: &Image{
+				RepoURL:    "fake-url",
+				GitRepoURL: "foo",
+			},
+			b: &Image{
+				RepoURL:    "fake-url",
+				GitRepoURL: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "image tags differ",
+			a: &Image{
+				RepoURL: "fake-url",
+				Tag:     "foo",
+			},
+			b: &Image{
+				RepoURL: "fake-url",
+				Tag:     "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "image digests differ",
+			a: &Image{
+				RepoURL: "fake-url",
+				Digest:  "foo",
+			},
+			b: &Image{
+				RepoURL: "fake-url",
+				Digest:  "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "perfect match",
+			a: &Image{
+				RepoURL:    "fake-url",
+				GitRepoURL: "fake-repo-url",
+				Tag:        "fake-tag",
+				Digest:     "fake-digest",
+			},
+			b: &Image{
+				RepoURL:    "fake-url",
+				GitRepoURL: "fake-repo-url",
+				Tag:        "fake-tag",
+				Digest:     "fake-digest",
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expectedResult, testCase.a.DeepEquals(testCase.b))
+			require.Equal(t, testCase.expectedResult, testCase.b.DeepEquals(testCase.a))
+		})
+	}
+}
+
+func TestChartDeepEquals(t *testing.T) {
+	testCases := []struct {
+		name           string
+		a              *Chart
+		b              *Chart
+		expectedResult bool
+	}{
+		{
+			name:           "a and b both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "only a is nil",
+			b:              &Chart{},
+			expectedResult: false,
+		},
+		{
+			name:           "only b is nil",
+			a:              &Chart{},
+			expectedResult: false,
+		},
+		{
+			name: "repo URLs differ",
+			a: &Chart{
+				RepoURL: "foo",
+			},
+			b: &Chart{
+				RepoURL: "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "chart names differ",
+			a: &Chart{
+				RepoURL: "fake-url",
+				Name:    "foo",
+			},
+			b: &Chart{
+				RepoURL: "fake-url",
+				Name:    "bar",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "chart versions differ",
+			a: &Chart{
+				RepoURL: "fake-url",
+				Name:    "fake-name",
+				Version: "v1.0.0",
+			},
+			b: &Chart{
+				RepoURL: "fake-url",
+				Name:    "fake-name",
+				Version: "v2.0.0",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "perfect match",
+			a: &Chart{
+				RepoURL: "fake-url",
+				Name:    "fake-name",
+				Version: "v1.0.0",
+			},
+			b: &Chart{
+				RepoURL: "fake-url",
+				Name:    "fake-name",
+				Version: "v1.0.0",
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expectedResult, testCase.a.DeepEquals(testCase.b))
+			require.Equal(t, testCase.expectedResult, testCase.b.DeepEquals(testCase.a))
+		})
+	}
+}

--- a/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
@@ -86,7 +86,7 @@ spec:
                 healthCheckCommit:
                   description: |-
                     HealthCheckCommit is the ID of a specific commit. When specified,
-                    assessments of Stage health will used this value (instead of ID) when
+                    assessments of Stage health will use this value (instead of ID) when
                     determining if applicable sources of Argo CD Application resources
                     associated with the Stage are or are not synced to this commit. Note that
                     there are cases (as in that of Kargo Render being utilized as a promotion

--- a/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
@@ -136,7 +136,7 @@ spec:
                         healthCheckCommit:
                           description: |-
                             HealthCheckCommit is the ID of a specific commit. When specified,
-                            assessments of Stage health will used this value (instead of ID) when
+                            assessments of Stage health will use this value (instead of ID) when
                             determining if applicable sources of Argo CD Application resources
                             associated with the Stage are or are not synced to this commit. Note that
                             there are cases (as in that of Kargo Render being utilized as a promotion

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -608,7 +608,7 @@ spec:
                         healthCheckCommit:
                           description: |-
                             HealthCheckCommit is the ID of a specific commit. When specified,
-                            assessments of Stage health will used this value (instead of ID) when
+                            assessments of Stage health will use this value (instead of ID) when
                             determining if applicable sources of Argo CD Application resources
                             associated with the Stage are or are not synced to this commit. Note that
                             there are cases (as in that of Kargo Render being utilized as a promotion
@@ -849,7 +849,7 @@ spec:
                             healthCheckCommit:
                               description: |-
                                 HealthCheckCommit is the ID of a specific commit. When specified,
-                                assessments of Stage health will used this value (instead of ID) when
+                                assessments of Stage health will use this value (instead of ID) when
                                 determining if applicable sources of Argo CD Application resources
                                 associated with the Stage are or are not synced to this commit. Note that
                                 there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1096,7 +1096,7 @@ spec:
                                 healthCheckCommit:
                                   description: |-
                                     HealthCheckCommit is the ID of a specific commit. When specified,
-                                    assessments of Stage health will used this value (instead of ID) when
+                                    assessments of Stage health will use this value (instead of ID) when
                                     determining if applicable sources of Argo CD Application resources
                                     associated with the Stage are or are not synced to this commit. Note that
                                     there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1424,7 +1424,7 @@ spec:
                           healthCheckCommit:
                             description: |-
                               HealthCheckCommit is the ID of a specific commit. When specified,
-                              assessments of Stage health will used this value (instead of ID) when
+                              assessments of Stage health will use this value (instead of ID) when
                               determining if applicable sources of Argo CD Application resources
                               associated with the Stage are or are not synced to this commit. Note that
                               there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1672,7 +1672,7 @@ spec:
                             healthCheckCommit:
                               description: |-
                                 HealthCheckCommit is the ID of a specific commit. When specified,
-                                assessments of Stage health will used this value (instead of ID) when
+                                assessments of Stage health will use this value (instead of ID) when
                                 determining if applicable sources of Argo CD Application resources
                                 associated with the Stage are or are not synced to this commit. Note that
                                 there are cases (as in that of Kargo Render being utilized as a promotion
@@ -1919,7 +1919,7 @@ spec:
                                 healthCheckCommit:
                                   description: |-
                                     HealthCheckCommit is the ID of a specific commit. When specified,
-                                    assessments of Stage health will used this value (instead of ID) when
+                                    assessments of Stage health will use this value (instead of ID) when
                                     determining if applicable sources of Argo CD Application resources
                                     associated with the Stage are or are not synced to this commit. Note that
                                     there are cases (as in that of Kargo Render being utilized as a promotion

--- a/internal/webhook/freight/webhook_test.go
+++ b/internal/webhook/freight/webhook_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -106,6 +107,18 @@ func TestDefault(t *testing.T) {
 			},
 		},
 		{
+			name:    "create with empty name",
+			op:      admissionv1.Create,
+			webhook: &webhook{},
+			freight: &kargoapi.Freight{
+				Alias: "fake-alias",
+			},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, freight.Name)
+			},
+		},
+		{
 			name:    "update with empty alias",
 			op:      admissionv1.Update,
 			webhook: &webhook{},
@@ -118,7 +131,6 @@ func TestDefault(t *testing.T) {
 			},
 			assertions: func(t *testing.T, freight *kargoapi.Freight, err error) {
 				require.NoError(t, err)
-				require.NotEmpty(t, freight.Name)
 				require.Empty(t, freight.Alias)
 				_, ok := freight.Labels[kargoapi.AliasLabelKey]
 				require.False(t, ok)
@@ -532,7 +544,7 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
 				require.ErrorContains(t, err, "is invalid")
-				require.ErrorContains(t, err, "freight is immutable")
+				require.ErrorContains(t, err, "Freight is immutable")
 			},
 		},
 
@@ -561,7 +573,7 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
 				require.ErrorContains(t, err, "is invalid")
-				require.ErrorContains(t, err, "freight is immutable")
+				require.ErrorContains(t, err, "Freight is immutable")
 			},
 		},
 		{
@@ -1031,6 +1043,111 @@ func TestValidateFreightArtifacts(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateFreightArtifacts(testCase.freight, testCase.warehouse)
 			testCase.assertions(t, err)
+		})
+	}
+}
+
+func TestCompareFreight(t *testing.T) {
+	tests := []struct {
+		name       string
+		old        *kargoapi.Freight
+		new        *kargoapi.Freight
+		assertions func(*testing.T, *kargoapi.Freight, *field.Path, any, bool)
+	}{
+		{
+			name: "Equal Freights",
+			old: &kargoapi.Freight{
+				Warehouse: "warehouse1",
+				Commits:   []kargoapi.GitCommit{{ID: "commit1"}}, Images: []kargoapi.Image{{RepoURL: "image1"}},
+				Charts: []kargoapi.Chart{{Name: "chart1"}},
+			},
+			new: &kargoapi.Freight{
+				Warehouse: "warehouse1",
+				Commits:   []kargoapi.GitCommit{{ID: "commit1"}},
+				Images:    []kargoapi.Image{{RepoURL: "image1"}}, Charts: []kargoapi.Chart{{Name: "chart1"}},
+			},
+			assertions: func(t *testing.T, _ *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Nil(t, path)
+				require.Nil(t, val)
+				require.True(t, eq)
+			},
+		},
+		{
+			name: "different Warehouse",
+			old:  &kargoapi.Freight{Warehouse: "warehouse1"},
+			new:  &kargoapi.Freight{Warehouse: "warehouse2"},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("warehouse"), path)
+				require.Equal(t, freight.Warehouse, val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different number of commits",
+			old:  &kargoapi.Freight{Commits: []kargoapi.GitCommit{{ID: "commit1"}}},
+			new:  &kargoapi.Freight{Commits: []kargoapi.GitCommit{{ID: "commit1"}, {ID: "commit2"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("commits"), path)
+				require.Equal(t, freight.Commits, val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different commit contents",
+			old:  &kargoapi.Freight{Commits: []kargoapi.GitCommit{{ID: "commit1"}, {ID: "commit2"}}},
+			new:  &kargoapi.Freight{Commits: []kargoapi.GitCommit{{ID: "commit1"}, {ID: "commit3"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("commits").Index(1), path)
+				require.Equal(t, freight.Commits[1], val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different number of images",
+			old:  &kargoapi.Freight{Images: []kargoapi.Image{{RepoURL: "image1"}}},
+			new:  &kargoapi.Freight{Images: []kargoapi.Image{{RepoURL: "image1"}, {RepoURL: "image2"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("images"), path)
+				require.Equal(t, freight.Images, val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different image contents",
+			old:  &kargoapi.Freight{Images: []kargoapi.Image{{RepoURL: "image1"}}},
+			new:  &kargoapi.Freight{Images: []kargoapi.Image{{RepoURL: "image2"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("images").Index(0), path)
+				require.Equal(t, freight.Images[0], val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different number of charts",
+			old:  &kargoapi.Freight{Charts: []kargoapi.Chart{{Name: "chart1"}}},
+			new:  &kargoapi.Freight{Charts: []kargoapi.Chart{{Name: "chart1"}, {Name: "chart2"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("charts"), path)
+				require.Equal(t, freight.Charts, val)
+				require.False(t, eq)
+			},
+		},
+		{
+			name: "different chart contents",
+			old:  &kargoapi.Freight{Charts: []kargoapi.Chart{{Name: "chart1"}, {Name: "chart2"}, {Name: "chart3"}}},
+			new:  &kargoapi.Freight{Charts: []kargoapi.Chart{{Name: "chart1"}, {Name: "chart2"}, {Name: "chart4"}}},
+			assertions: func(t *testing.T, freight *kargoapi.Freight, path *field.Path, val any, eq bool) {
+				require.Equal(t, field.NewPath("charts").Index(2), path)
+				require.Equal(t, freight.Charts[2], val)
+				require.False(t, eq)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, val, eq := compareFreight(tt.old, tt.new)
+			tt.assertions(t, tt.new, path, val, eq)
 		})
 	}
 }

--- a/ui/src/gen/schema/freights.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/freights.kargo.akuity.io_v1alpha1.json
@@ -50,7 +50,7 @@
             "type": "string"
           },
           "healthCheckCommit": {
-            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
             "type": "string"
           },
           "id": {

--- a/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
@@ -85,7 +85,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -495,7 +495,7 @@
                     "type": "string"
                   },
                   "healthCheckCommit": {
-                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                    "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                     "type": "string"
                   },
                   "id": {
@@ -721,7 +721,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -951,7 +951,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {
@@ -1275,7 +1275,7 @@
                       "type": "string"
                     },
                     "healthCheckCommit": {
-                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                      "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                       "type": "string"
                     },
                     "id": {
@@ -1507,7 +1507,7 @@
                         "type": "string"
                       },
                       "healthCheckCommit": {
-                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                        "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                         "type": "string"
                       },
                       "id": {
@@ -1737,7 +1737,7 @@
                             "type": "string"
                           },
                           "healthCheckCommit": {
-                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will used this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
+                            "description": "HealthCheckCommit is the ID of a specific commit. When specified,\nassessments of Stage health will use this value (instead of ID) when\ndetermining if applicable sources of Argo CD Application resources\nassociated with the Stage are or are not synced to this commit. Note that\nthere are cases (as in that of Kargo Render being utilized as a promotion\nmechanism) wherein the value of this field may differ from the commit ID\nfound in the ID field.",
                             "type": "string"
                           },
                           "id": {

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -1589,7 +1589,7 @@ export class GitCommit extends Message<GitCommit> {
 
   /**
    * HealthCheckCommit is the ID of a specific commit. When specified,
-   * assessments of Stage health will used this value (instead of ID) when
+   * assessments of Stage health will use this value (instead of ID) when
    * determining if applicable sources of Argo CD Application resources
    * associated with the Stage are or are not synced to this commit. Note that
    * there are cases (as in that of Kargo Render being utilized as a promotion


### PR DESCRIPTION
This ensures that from now on, the webhook mechanism is no longer affected by changes to the logic of Freight ID generation.

Which previously, could cause "Freight is immutable" errors when e.g. Freight from a (much) older version of Kargo would receive an update to its alias, or get verified for a Stage.