### PR TITLE
feat: add v0.7.x --> v0.8.x upgrade logic

### DIFF
--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -115,3 +115,20 @@ func patchAnnotations(
 	}
 	return nil
 }
+
+// AddV08CompatibilityLabel adds the v0.8 compatibility label to the given
+// object.
+func AddV08CompatibilityLabel(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+) error {
+	patchBytes := []byte(
+		fmt.Sprintf(
+			`{"metadata":{"labels":{"%s":"true"}}}`,
+			V08CompatibilityLabelKey,
+		),
+	)
+	patch := client.RawPatch(types.MergePatchType, patchBytes)
+	return c.Patch(ctx, obj, patch)
+}

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -19,4 +19,6 @@ const (
 	LabelTrueValue = "true"
 
 	FinalizerName = "kargo.akuity.io/finalizer"
+
+	V08CompatibilityLabelKey = "kargo.akuity.io/v0.8-compatible"
 )

--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -23,6 +23,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kargo.akuity.io
   resources:
   - projects
@@ -48,6 +56,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - promote
   - watch
 - apiGroups:

--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -32,6 +32,14 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kargo.akuity.io
   resources:
   - projects
@@ -39,6 +47,16 @@ rules:
   - delete
   - get
   - list
+  - watch
+- apiGroups:
+  - kargo.akuity.io
+  resources:
+  - freights
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - kargo.akuity.io

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -143,6 +144,12 @@ func (o *controllerOptions) setupKargoManager(
 	if err = corev1.AddToScheme(scheme); err != nil {
 		return nil, stagesReconcilerCfg, fmt.Errorf(
 			"error adding Kubernetes core API to Kargo controller manager scheme: %w",
+			err,
+		)
+	}
+	if err = extv1.AddToScheme(scheme); err != nil {
+		return nil, stagesReconcilerCfg, fmt.Errorf(
+			"error adding Kubernetes API extensions API to Kargo controller manager scheme: %w",
 			err,
 		)
 	}

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ require (
 	gopkg.in/evanphx/json-patch.v5 v5.6.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.30.1 // indirect
+	k8s.io/apiextensions-apiserver v0.30.1
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.16.0 // indirect

--- a/internal/controller/management/upgrade/freight.go
+++ b/internal/controller/management/upgrade/freight.go
@@ -116,7 +116,6 @@ func (f *freightReconciler) Reconcile(
 	// Migrate the Warehouse field to the Origin field.
 	freight.Origin.Kind = kargoapi.FreightOriginKindWarehouse
 	freight.Origin.Name = freight.Warehouse // nolint: staticcheck
-	freight.Warehouse = ""                  // nolint: staticcheck
 
 	if err = f.client.Update(ctx, freight); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/management/upgrade/freight.go
+++ b/internal/controller/management/upgrade/freight.go
@@ -1,0 +1,132 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/logging"
+)
+
+// freightReconciler reconciles Freight resources to upgrade them from
+// v0.7.x to v0.8.x.
+type freightReconciler struct {
+	client client.Client
+}
+
+// SetupFreightReconcilerWithManager initializes a freightReconciler and
+// registers it with the provided Manager.
+func SetupFreightReconcilerWithManager(mgr manager.Manager) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&kargoapi.Freight{}).
+		WithEventFilter(
+			predicate.Funcs{
+				DeleteFunc: func(event.DeleteEvent) bool {
+					return false
+				},
+			},
+		).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			freight, ok := object.(*kargoapi.Freight)
+			if !ok {
+				return false
+			}
+
+			// Ignore Freight that are already v0.8 compatible.
+			if _, ok = freight.Labels[kargoapi.V08CompatibilityLabelKey]; ok {
+				return false
+			}
+
+			// Ignore Freight that have an origin set.
+			if freight.Origin.Kind != "" && freight.Origin.Name != "" {
+				return false
+			}
+
+			// Ignore Freight that are missing the Warehouse field.
+			return freight.Warehouse != "" // nolint: staticcheck
+		})).
+		Build(&freightReconciler{
+			client: mgr.GetClient(),
+		})
+	return err
+}
+
+// Reconcile is part of the main Kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (f *freightReconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request,
+) (ctrl.Result, error) {
+	logger := logging.LoggerFromContext(ctx).WithValues(
+		"namespace", req.NamespacedName.Namespace,
+		"freight", req.NamespacedName.Name,
+	)
+	logger.Debug("reconciling Freight")
+
+	// Check if the freights.kargo.akuity.io CRD has the origin field.
+	// If it does not, we need to wait for the CRD to be updated.
+	var freightCRD extv1.CustomResourceDefinition
+	if err := f.client.Get(
+		ctx,
+		types.NamespacedName{
+			Name: "freights.kargo.akuity.io",
+		},
+		&freightCRD,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+	if _, hasOriginField := freightCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.
+		Properties["origin"]; !hasOriginField {
+		return ctrl.Result{}, errors.New(
+			"freights.kargo.akuity.io does not have an origin field: waiting for update",
+		)
+	}
+
+	// Find the Freight.
+	freight, err := kargoapi.GetFreight(ctx, f.client, req.NamespacedName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if freight == nil {
+		// Ignore if not found. This can happen if the Freight was deleted after the
+		// current reconciliation request was issued.
+		return ctrl.Result{}, nil // Do not requeue
+	}
+
+	// Check if the Freight is already v0.8.x compatible.
+	if freight.Origin.Kind != "" && freight.Origin.Name != "" {
+		logger.Debug("Freight is already v0.8 compatible")
+		return ctrl.Result{}, nil
+	}
+
+	// If the Warehouse field is not set, we can't migrate the Freight.
+	if freight.Warehouse == "" { // nolint: staticcheck
+		logger.Debug("Freight is missing Warehouse")
+		return ctrl.Result{}, nil
+	}
+
+	// Migrate the Warehouse field to the Origin field.
+	freight.Origin.Kind = kargoapi.FreightOriginKindWarehouse
+	freight.Origin.Name = freight.Warehouse // nolint: staticcheck
+	freight.Warehouse = ""                  // nolint: staticcheck
+
+	if err = f.client.Update(ctx, freight); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If the update was successful, add the v0.8 compatibility label.
+	if err = kargoapi.AddV08CompatibilityLabel(ctx, f.client, freight); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	logger.Debug("updated Freight for v0.8 compatibility")
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -256,6 +256,17 @@ func (r *reconciler) Reconcile(
 		)
 	}
 
+	if freight != nil && (freight.Origin.Kind == "" || freight.Origin.Name == "") {
+		// This Freight looks like it is old Freight that has not been updated.
+		// The management controller handles that. Wait and try again.
+		return ctrl.Result{}, fmt.Errorf(
+			"Freight %q in namespace %q has not been updated for v0.8 "+
+				"compatibility; waiting for update",
+			promo.Spec.Freight,
+			promo.Namespace,
+		)
+	}
+
 	logger = logger.WithValues(
 		"namespace", req.NamespacedName.Namespace,
 		"promotion", req.NamespacedName.Name,

--- a/internal/controller/stages/upgrade.go
+++ b/internal/controller/stages/upgrade.go
@@ -1,0 +1,203 @@
+package stages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/kubeclient"
+)
+
+// upgradeStage upgrades a Stage to be v0.8-compatible.
+func (r *reconciler) upgradeStage(ctx context.Context, stage *kargoapi.Stage) (ctrl.Result, error) {
+	// If we have already upgraded this Stage, requestedFreight will be set.
+	var patchedSpec bool
+	if len(stage.Spec.RequestedFreight) == 0 {
+		// Check if the stages.kargo.akuity.io CRD has the requestedFreight field.
+		// If it does not, we need to wait for the CRD to be updated.
+		var stageCRD extv1.CustomResourceDefinition
+		if err := r.kargoClient.Get(
+			ctx,
+			types.NamespacedName{
+				Name: "stages.kargo.akuity.io",
+			},
+			&stageCRD,
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if _, hasRequestedFreightField := stageCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.
+			Properties["spec"].
+			Properties["requestedFreight"]; !hasRequestedFreightField {
+			return ctrl.Result{},
+				errors.New("stages.kargo.akuity.io does not have a requestedFreight field: waiting for update")
+		}
+
+		// Start the migration process.
+		var requestedFreight kargoapi.FreightRequest
+		switch stage.Spec.Subscriptions.Warehouse { // nolint: staticcheck
+		case "":
+			warehouses, err := r.resolveUpstreamSubscriptionsToWarehouse(
+				ctx,
+				stage.Namespace,
+				stage.Spec.Subscriptions.UpstreamStages, // nolint: staticcheck
+				nil,
+			)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to migrate: %w", err)
+			}
+
+			if len(warehouses) > 1 {
+				return ctrl.Result{}, fmt.Errorf(
+					"unable to migrate: upstream Stages resolve to more than one Warehouse: %v", warehouses,
+				)
+			}
+			warehouse := warehouses[0]
+
+			requestedFreight = kargoapi.FreightRequest{
+				Origin: kargoapi.FreightOrigin{
+					Kind: kargoapi.FreightOriginKindWarehouse,
+					Name: warehouse,
+				},
+			}
+			for _, upstreamStage := range stage.Spec.Subscriptions.UpstreamStages { // nolint: staticcheck
+				requestedFreight.Sources.Stages = append(requestedFreight.Sources.Stages, upstreamStage.Name)
+			}
+		default:
+			requestedFreight = kargoapi.FreightRequest{
+				Origin: kargoapi.FreightOrigin{
+					Kind: kargoapi.FreightOriginKindWarehouse,
+					Name: stage.Spec.Subscriptions.Warehouse, // nolint: staticcheck
+				},
+				Sources: kargoapi.FreightSources{
+					Direct: true,
+				},
+			}
+		}
+
+		// Update the Stage with the newly created requestedFreight, and clear
+		// the deprecated subscriptions.
+		stage.Spec.RequestedFreight = []kargoapi.FreightRequest{requestedFreight}
+		stage.Spec.Subscriptions = kargoapi.Subscriptions{} // nolint: staticcheck
+
+		// Update the Stage.
+		if err := r.kargoClient.Update(ctx, stage); err != nil {
+			return ctrl.Result{}, err
+		}
+		patchedSpec = true
+	}
+
+	// If the Stage has a history, we need to migrate it to the new format.
+	var patchedStatus bool
+	if len(stage.Status.History) > 0 { // nolint: staticcheck
+		// Migrate the history to the new format.
+		freightHistory := make(kargoapi.FreightHistory, 0, len(stage.Status.History)) // nolint: staticcheck
+		for _, item := range stage.Status.History {                                   // nolint: staticcheck
+			freightCollection := kargoapi.FreightCollection{
+				VerificationHistory: item.VerificationHistory, // nolint: staticcheck
+			}
+			freightCollection.UpdateOrPush(item)
+			freightHistory = append(freightHistory, &freightCollection)
+		}
+
+		// Update the Stage status.
+		if err := kubeclient.PatchStatus(ctx, r.kargoClient, stage, func(status *kargoapi.StageStatus) {
+			status.FreightHistory = freightHistory
+			status.History = nil        // nolint: staticcheck
+			status.CurrentFreight = nil // nolint: staticcheck
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		patchedStatus = true
+	}
+
+	// If we have patched the spec or status, we need to requeue the Stage.
+	if patchedSpec || patchedStatus {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// No changes were made.
+	return ctrl.Result{}, nil
+}
+
+// resolveUpstreamSubscriptionsToWarehouse resolves the Warehouse of a Stage by
+// looking at its upstream Stages. This function will recursively resolve the
+// Warehouse of each upstream Stage until it finds a Warehouse or reaches the
+// end of the chain.
+func (r *reconciler) resolveUpstreamSubscriptionsToWarehouse(
+	ctx context.Context,
+	namespace string,
+	subscriptions []kargoapi.StageSubscription, // nolint: staticcheck
+	visited map[string]struct{},
+) ([]string, error) {
+	if visited == nil {
+		visited = make(map[string]struct{})
+	}
+
+	var warehouses []string
+	for _, subscription := range subscriptions {
+		// Prevent infinite loops by checking if we have already visited this
+		// subscription.
+		if _, found := visited[subscription.Name]; found {
+			continue
+		}
+		visited[subscription.Name] = struct{}{}
+
+		var upstreamStage kargoapi.Stage
+		if err := r.kargoClient.Get(
+			ctx,
+			types.NamespacedName{
+				Name:      subscription.Name,
+				Namespace: namespace,
+			},
+			&upstreamStage,
+		); err != nil {
+			return nil, err
+		}
+
+		// Take into account that this resource may have already been upgraded.
+		if freightReqNum := len(upstreamStage.Spec.RequestedFreight); freightReqNum > 0 {
+			if freightReqNum > 1 {
+				// If there is more than one requestedFreight, we cannot
+				// resolve the Warehouse because we don't know which one
+				// to choose.
+				return nil, fmt.Errorf("upstream Stage %s has more than one requestedFreight", upstreamStage.Name)
+			}
+
+			// If the upstream Stage has a requestedFreight, we can
+			// resolve the Warehouse by looking at the origin of the
+			// requestedFreight.
+			warehouses = append(warehouses, upstreamStage.Spec.RequestedFreight[0].Origin.Name)
+			continue
+		}
+
+		// We found a direct match!
+		if upstreamStage.Spec.Subscriptions.Warehouse != "" { // nolint: staticcheck
+			warehouses = append(warehouses, upstreamStage.Spec.Subscriptions.Warehouse) // nolint: staticcheck
+			continue
+		}
+
+		// This Stage by itself does not have a Warehouse, so we need to
+		// continue checking upstream Stages.
+		upstreamWarehouses, err := r.resolveUpstreamSubscriptionsToWarehouse(
+			ctx,
+			namespace,
+			upstreamStage.Spec.Subscriptions.UpstreamStages, // nolint: staticcheck
+			visited,
+		)
+		if err != nil {
+			return nil, err
+		}
+		warehouses = append(warehouses, upstreamWarehouses...)
+	}
+
+	// Sort and compact the list of Warehouses.
+	slices.Sort(warehouses)
+	return slices.Compact(warehouses), nil
+}

--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -293,6 +293,9 @@ func FreightByWarehouseIndexer(obj client.Object) []string {
 	if freight.Origin.Kind == kargoapi.FreightOriginKindWarehouse {
 		return []string{freight.Origin.Name}
 	}
+	if freight.Warehouse != "" { // nolint: staticcheck
+		return []string{freight.Warehouse} // nolint: staticcheck
+	}
 	return nil
 }
 

--- a/internal/webhook/freight/webhook.go
+++ b/internal/webhook/freight/webhook.go
@@ -150,6 +150,14 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 		delete(freight.Labels, kargoapi.AliasLabelKey)
 	}
 
+	// Sync new Origin field with deprecated Warehouse field. This ensures that
+	// newer Freight remain compatible with controllers running an older version
+	// of the Kargo -- which is possible because the upgrade of the control plane
+	// and the distributed controllers is not atomic.
+	if freight.Origin.Kind == kargoapi.FreightOriginKindWarehouse && freight.Origin.Name != "" {
+		freight.Warehouse = freight.Origin.Name // nolint: staticcheck
+	}
+
 	return nil
 }
 
@@ -549,12 +557,6 @@ func compareFreight(old, new *kargoapi.Freight) (*field.Path, any, bool) {
 func allowWarehouseToOriginMigration(old, new *kargoapi.Freight) bool {
 	// If the Origin field is already set, a migration is not allowed.
 	if old.Origin.Name != "" {
-		return false
-	}
-
-	// If the Warehouse field is still set on the new Freight, a migration is
-	// not allowed.
-	if new.Warehouse != "" { // nolint: staticcheck
 		return false
 	}
 


### PR DESCRIPTION
This PR provides a smooth upgrade path from Kargo v0.7.x to v0.8.x, focusing on migrating Stages and Freight resources to support the multi-pipeline functionality.

Key changes:

1. Stage migration:
   - Adds upgrade logic to the Stage reconciler to migrate Stages from <=0.7.x to 0.8.x compatibility
   - Converts old `Subscriptions` field to new `RequestedFreight` field
   - Migrates `History` to new `FreightHistory` format
   - Adds v0.8 compatibility label to track which resources have been migrated

2. Freight migration:
   - Introduces a new Freight reconciler in the management controller to handle upgrades
   - Migrates `Warehouse` field to new `Origin` field
   - Ensures backward compatibility by syncing `Origin` and `Warehouse` fields
   - Adds v0.8 compatibility label to prevent further migrations

3. Warehouse reconciliation:
   - Prevents duplication of Freight after an upgrade by comparing existing Freight with newly created ones, this is required due to a change in how the Freight name is generated

4. Promotion reconciliation:
   - Adds a check for upgraded Freight in the promotion reconciliation loop
   - Waits for Freight to be updated before proceeding with promotions

5. Webhook updates:
   - Modifies Freight webhook to allow migration from Warehouse to Origin
   - Ensures immutability of Freight while allowing necessary upgrades

6. Chart updates:
   - Adds required permissions for migration to the (management-)controller cluster roles