### PR TITLE
chore(ui): indicate resource type in Warehouse Details view

### DIFF
--- a/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
+++ b/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
@@ -1,4 +1,9 @@
-import { faArrowDownShortWide, faFileLines, faTools } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowDownShortWide,
+  faBuilding,
+  faFileLines,
+  faTools
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Drawer, Tabs, Typography } from 'antd';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
@@ -30,7 +35,13 @@ export const WarehouseDetails = ({
           <div className='flex items-center justify-between mb-2'>
             <div className='flex gap-1 items-start'>
               <div>
-                <Typography.Title level={1} style={{ margin: 0 }}>
+                <div className='font-medium text-xs text-gray-500'>WAREHOUSE</div>
+                <Typography.Title
+                  level={1}
+                  style={{ margin: 0 }}
+                  className='flex items-center mb-2'
+                >
+                  <FontAwesomeIcon icon={faBuilding} className='mr-2 text-base text-gray-400' />
                   {warehouse.metadata?.name}
                 </Typography.Title>
                 <Typography.Text type='secondary'>{projectName}</Typography.Text>

--- a/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
+++ b/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
@@ -32,19 +32,18 @@ export const WarehouseDetails = ({
     <Drawer open={!!warehouse} onClose={onClose} width={'80%'} closable={false}>
       {warehouse && (
         <div className='flex flex-col h-full'>
-          <div className='flex items-center justify-between mb-2'>
+          <div className='flex items-center justify-between mb-4'>
             <div className='flex gap-1 items-start'>
               <div>
                 <div className='font-medium text-xs text-gray-500'>WAREHOUSE</div>
-                <Typography.Title
-                  level={1}
-                  style={{ margin: 0 }}
-                  className='flex items-center mb-2'
-                >
+                <Typography.Title level={1} className='flex items-center m-0 !mb-2'>
                   <FontAwesomeIcon icon={faBuilding} className='mr-2 text-base text-gray-400' />
                   {warehouse.metadata?.name}
                 </Typography.Title>
-                <Typography.Text type='secondary'>{projectName}</Typography.Text>
+                <Typography.Text type='secondary'>
+                  <span className='uppercase text-xs'>Project: </span>
+                  <span className='font-semibold'>{projectName}</span>
+                </Typography.Text>
               </div>
             </div>
             <WarehouseActions warehouse={warehouse} />


### PR DESCRIPTION
Before, if a warehouse had the same name as its project (common in demos), the Warehouse Details view could be confusing:

![CleanShot 2024-07-25 at 14 30 59@2x](https://github.com/user-attachments/assets/a240c2a3-b54e-40c2-8f9e-c0ebb2755bd8)

This PR adds a label and icon to make it clear that this is the Warehouse Details view:

![CleanShot 2024-07-25 at 14 34 35@2x](https://github.com/user-attachments/assets/ed1586cc-9aa5-41ef-a43c-cf7331f4a2cb)

