### PR TITLE
fix(ui): promoting freight cutoff + health status icon fixes

### DIFF
--- a/ui/src/features/common/health-status/health-status-icon.tsx
+++ b/ui/src/features/common/health-status/health-status-icon.tsx
@@ -3,6 +3,7 @@ import {
   faCircleNotch,
   faHeart,
   faHeartBroken,
+  faInfoCircle,
   faQuestionCircle,
   IconDefinition
 } from '@fortawesome/free-solid-svg-icons';
@@ -23,13 +24,29 @@ export const HealthStatusIcon = (props: {
   const reason = health?.issues?.join('; ') ?? '';
 
   return (
-    <Tooltip title={health?.status ?? '' + (reason !== '' ? `: ${reason}` : '')}>
+    <Tooltip
+      title={
+        <>
+          <div className='mb-2'>
+            {health?.status && (
+              <>
+                <b>Health Status:</b> {health.status}
+              </>
+            )}
+          </div>
+          {reason !== '' && (
+            <>
+              <FontAwesomeIcon icon={faInfoCircle} className='mr-2' /> {reason}
+            </>
+          )}
+        </>
+      }
+    >
       <FontAwesomeIcon
         icon={iconForHealthStatus(health)}
         spin={healthStatusToEnum(health?.status) === HealthStatus.PROGRESSING}
         style={{
           color: !hideColor ? colorForHealthStatus(health) : undefined,
-          fontSize: '18px',
           ...props.style
         }}
       />

--- a/ui/src/features/freight-timeline/freight-item.tsx
+++ b/ui/src/features/freight-timeline/freight-item.tsx
@@ -26,6 +26,14 @@ export const FreightItem = ({
   onHover: (hovering: boolean) => void;
   hideLabel?: boolean;
 }) => {
+  let width = '';
+  if (mode !== FreightMode.Confirming) {
+    if (empty) {
+      width = '96px';
+    } else {
+      width = '135px';
+    }
+  }
   return (
     <div
       className={classNames('relative h-full cursor-pointer', styles.freightItem, {
@@ -40,7 +48,7 @@ export const FreightItem = ({
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
       style={{
-        width: empty ? '96px' : mode === FreightMode.Confirming ? '' : '135px'
+        width
       }}
     >
       <div className='flex w-full h-full mb-1 items-center justify-center max-w-full text-ellipsis overflow-hidden'>

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -104,14 +104,11 @@ export const StageNode = ({
               </Tooltip>
             )}
             {!stage?.status?.currentPromotion && stage.status?.lastPromotion && (
-              <div className='pb-1'>
-                <PromotionStatusIcon
-                  placement='top'
-                  status={stage.status?.lastPromotion.status}
-                  color='white'
-                  size='1x'
-                />
-              </div>
+              <PromotionStatusIcon
+                placement='top'
+                status={stage.status?.lastPromotion.status}
+                color='white'
+              />
             )}
             {stage.status?.currentPromotion ? (
               <Tooltip
@@ -125,11 +122,7 @@ export const StageNode = ({
               </Tooltip>
             ) : (
               stage.status?.health && (
-                <HealthStatusIcon
-                  health={stage.status?.health}
-                  style={{ fontSize: '14px' }}
-                  hideColor={true}
-                />
+                <HealthStatusIcon health={stage.status?.health} hideColor={true} />
               )
             )}
           </div>


### PR DESCRIPTION
Two small fixes.

Before:
<img width="363" alt="Screenshot 2024-08-05 at 10 40 55" src="https://github.com/user-attachments/assets/c8260bb2-1511-4f17-bff1-d5f4776486e4">

After:
<img width="495" alt="Screenshot 2024-08-05 at 10 40 16" src="https://github.com/user-attachments/assets/11ae1cf9-8a59-4164-a4f4-5a568687c2e1">

Before:
<img width="311" alt="Screenshot 2024-08-05 at 10 40 48" src="https://github.com/user-attachments/assets/a540c504-2aa4-43d0-a79e-2c8044cd5d4e">

After:
<img width="443" alt="Screenshot 2024-08-05 at 10 39 54" src="https://github.com/user-attachments/assets/4342cca8-f9d7-40a0-8b5b-9930638f2715">
