### PR TITLE
fix(controller): account for differences in kargo, argo cd, and helm before searching for oci helm charts

### DIFF
--- a/internal/controller/promotion/argocd_test.go
+++ b/internal/controller/promotion/argocd_test.go
@@ -1820,8 +1820,7 @@ func TestApplyArgoCDSourceUpdate(t *testing.T) {
 				Origin: testOrigin,
 				Charts: []kargoapi.Chart{
 					{
-						RepoURL: "fake-url",
-						Name:    "fake-chart",
+						RepoURL: "oci://fake-url/fake-chart",
 						Version: "fake-version",
 					},
 				},


### PR DESCRIPTION
Fixes #2407

If I am not mistaken, these differences were more thoroughly accounted for prior to the large bit of refactoring in v0.8.0, where they were overlooked.