### PR TITLE
feat(api): grant API to manage ConfigMap

### DIFF
--- a/charts/kargo/templates/api/cluster-role.yaml
+++ b/charts/kargo/templates/api/cluster-role.yaml
@@ -116,6 +116,7 @@ rules:
 - apiGroups:
     - ""
   resources:
+    - configmaps
     - secrets
     - serviceaccounts
   verbs:


### PR DESCRIPTION
This commit grants API to manage ConfigMap, which allows users to manage ConfigMaps that used in `AnalysisTemplate` through Kargo API.