### PR TITLE
fix(controller): improve logic to determine when syncing an argo cd app is required

### DIFF
--- a/internal/controller/promotion/argocd_test.go
+++ b/internal/controller/promotion/argocd_test.go
@@ -50,9 +50,8 @@ func TestArgoCDPromote(t *testing.T) {
 		newFreight []kargoapi.FreightReference
 		assertions func(
 			t *testing.T,
-			newStatus *kargoapi.PromotionStatus,
-			newFreightIn []kargoapi.FreightReference,
-			newFreightOut []kargoapi.FreightReference,
+			origFreight *kargoapi.FreightCollection,
+			promo *kargoapi.Promotion,
 			err error,
 		)
 	}{
@@ -66,13 +65,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -89,9 +88,8 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				_ []kargoapi.FreightReference,
-				_ []kargoapi.FreightReference,
+				_ *kargoapi.FreightCollection,
+				_ *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(
@@ -123,13 +121,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -164,14 +162,14 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseSucceeded, status.Phase)
-				require.Equal(t, newFreightIn, newFreightOut)
+				require.Equal(t, kargoapi.PromotionPhaseSucceeded, promo.Status.Phase)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -206,13 +204,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -252,13 +250,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -287,7 +285,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -309,13 +307,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -344,7 +342,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -374,13 +372,12 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				_ []kargoapi.FreightReference,
-				_ []kargoapi.FreightReference,
+				_ *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseRunning, status.Phase)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, promo.Status.Phase)
 			},
 		},
 		{
@@ -409,7 +406,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -431,14 +428,14 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseRunning, status.Phase)
-				require.Equal(t, newFreightIn, newFreightOut)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, promo.Status.Phase)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -467,7 +464,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -489,14 +486,14 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseRunning, status.Phase)
-				require.Equal(t, newFreightIn, newFreightOut)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, promo.Status.Phase)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -525,7 +522,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -555,9 +552,8 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.Error(t, err)
@@ -566,7 +562,8 @@ func TestArgoCDPromote(t *testing.T) {
 					"something went wrong",
 					err.Error(),
 				)
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -595,7 +592,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -605,7 +602,7 @@ func TestArgoCDPromote(t *testing.T) {
 						*kargoapi.Stage,
 						*kargoapi.ArgoCDAppUpdate,
 						*argocd.Application,
-						[]kargoapi.FreightReference,
+						*kargoapi.FreightCollection,
 						*argocd.ApplicationSource,
 						argocd.ApplicationSources,
 					) (argocd.OperationPhase, bool, error) {
@@ -645,14 +642,14 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseFailed, status.Phase)
-				require.Equal(t, newFreightIn, newFreightOut)
+				require.Equal(t, kargoapi.PromotionPhaseFailed, promo.Status.Phase)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -681,7 +678,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -703,13 +700,13 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "could not determine promotion phase from operation phases")
-				require.Equal(t, newFreightIn, newFreightOut)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 		{
@@ -738,7 +735,7 @@ func TestArgoCDPromote(t *testing.T) {
 					*kargoapi.Stage,
 					*kargoapi.ArgoCDAppUpdate,
 					*argocd.Application,
-					[]kargoapi.FreightReference,
+					*kargoapi.FreightCollection,
 					*argocd.ApplicationSource,
 					argocd.ApplicationSources,
 				) (argocd.OperationPhase, bool, error) {
@@ -760,29 +757,37 @@ func TestArgoCDPromote(t *testing.T) {
 			},
 			assertions: func(
 				t *testing.T,
-				status *kargoapi.PromotionStatus,
-				newFreightIn []kargoapi.FreightReference,
-				newFreightOut []kargoapi.FreightReference,
+				origFreight *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
-				require.Equal(t, kargoapi.PromotionPhaseSucceeded, status.Phase)
-				require.Equal(t, newFreightIn, newFreightOut)
+				require.Equal(t, kargoapi.PromotionPhaseSucceeded, promo.Status.Phase)
+				// The freight collection should be unaltered
+				require.Equal(t, origFreight, promo.Status.FreightCollection)
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			newStatus, newFreightOut, err := testCase.promoMech.Promote(
+			promo := &kargoapi.Promotion{
+				Status: kargoapi.PromotionStatus{
+					FreightCollection: &kargoapi.FreightCollection{},
+				},
+			}
+			for _, freight := range testCase.newFreight {
+				promo.Status.FreightCollection.UpdateOrPush(freight)
+			}
+			origFreight := promo.Status.FreightCollection.DeepCopy()
+			err := testCase.promoMech.Promote(
 				logging.ContextWithLogger(
 					context.Background(),
 					logging.Wrap(logr.Discard()),
 				),
 				testCase.stage,
-				&kargoapi.Promotion{},
-				testCase.newFreight,
+				promo,
 			)
-			testCase.assertions(t, newStatus, testCase.newFreight, newFreightOut, err)
+			testCase.assertions(t, origFreight, promo, err)
 		})
 	}
 }
@@ -1289,12 +1294,17 @@ func TestArgoCDMustPerformUpdate(t *testing.T) {
 				},
 			}
 
+			freight := &kargoapi.FreightCollection{}
+			for _, ref := range testCase.newFreight {
+				freight.UpdateOrPush(ref)
+			}
+
 			phase, mustUpdate, err := argocdMech.mustPerformUpdate(
 				context.Background(),
 				stage,
 				&stage.Spec.PromotionMechanisms.ArgoCDAppUpdates[0],
 				app,
-				testCase.newFreight,
+				freight,
 				testCase.desiredSource,
 				testCase.desiredSources,
 			)

--- a/internal/controller/promotion/composite.go
+++ b/internal/controller/promotion/composite.go
@@ -43,31 +43,25 @@ func (c *compositeMechanism) Promote(
 	ctx context.Context,
 	stage *kargoapi.Stage,
 	promo *kargoapi.Promotion,
-	newFreight []kargoapi.FreightReference,
-) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error) {
+) error {
 	if stage.Spec.PromotionMechanisms == nil {
-		return &kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseSucceeded},
-			newFreight, nil
+		promo.Status.Phase = kargoapi.PromotionPhaseSucceeded
+		return nil
 	}
-
-	var newStatus *kargoapi.PromotionStatus
 
 	logger := logging.LoggerFromContext(ctx).WithValues("name", c.name)
 	logger.Debug("executing composite promotion mechanism")
 
+	// Start with success and degrade as child mechanisms report more severe
+	// phases.
+	promo.Status.Phase = kargoapi.PromotionPhaseSucceeded
 	for _, childMechanism := range c.childMechanisms {
-		var err error
-		var otherStatus *kargoapi.PromotionStatus
-		otherStatus, newFreight, err = childMechanism.Promote(ctx, stage, promo, newFreight)
-		if err != nil {
-			return nil, newFreight, fmt.Errorf(
-				"error executing %s: %w",
-				childMechanism.GetName(),
-				err,
-			)
+		origStatus := promo.Status.DeepCopy()
+		if err := childMechanism.Promote(ctx, stage, promo); err != nil {
+			return fmt.Errorf("error executing %s: %w", childMechanism.GetName(), err)
 		}
-		newStatus = aggregateGitPromoStatus(newStatus, *otherStatus)
-		if newStatus.Phase != kargoapi.PromotionPhaseSucceeded {
+		promo.Status = *mergePromoStatus(&promo.Status, origStatus)
+		if promo.Status.Phase != kargoapi.PromotionPhaseSucceeded {
 			// We only continue to the next promotion mechanism if the current
 			// mechanism succeeded. This is because a PR must be merged before
 			// performing the ArgoCD sync.
@@ -77,46 +71,56 @@ func (c *compositeMechanism) Promote(
 
 	logger.Debug(
 		"done executing composite promotion mechanism",
-		"aggregatedStatus", newStatus.Phase,
+		"aggregatedStatus", promo.Status.Phase,
 	)
 
-	return newStatus, newFreight, nil
+	return nil
 }
 
-// aggregateGitPromoStatus returns the aggregated status of two promotion statuses when
-// multiple promote mechanisms are used. Returns the most severe phase. In order of precedence:
+// mergePromoStatus merges the PromotionStatus represented by newerStatus into a
+// deep copy of the PromotionStatus represented by olderStatus and returns the
+// result. The returned status will differ from the olderStatus in the following
+// ways:
 //
-//	Error, Failed, Running, Succeeded
-func aggregateGitPromoStatus(curr *kargoapi.PromotionStatus, other kargoapi.PromotionStatus) *kargoapi.PromotionStatus {
-	if curr == nil {
-		return other.DeepCopy()
+//  1. The Phase and corresponding Message are updated to reflect the more
+//     severe of the two. The order of severity is:
+//     Errored > Failed > Running > Succeeded.
+//  2. The FreightCollection is unconditionally updated to that of src.
+//  3. Metadata from src is merged into Metadata from olderStatus, with Metadata
+//     from src taking precedence in case of key conflicts.
+//
+// Both arguments must be non-nil.
+func mergePromoStatus(
+	newerStatus *kargoapi.PromotionStatus,
+	olderStatus *kargoapi.PromotionStatus,
+) *kargoapi.PromotionStatus {
+	mergedStatus := olderStatus.DeepCopy()
+	switch {
+	case mergedStatus.Phase == kargoapi.PromotionPhaseErrored:
+		// Do nothing. We are already at most severe phase.
+	case newerStatus.Phase == kargoapi.PromotionPhaseErrored:
+		mergedStatus.Phase = kargoapi.PromotionPhaseErrored
+		mergedStatus.Message = newerStatus.Message
+	case mergedStatus.Phase == kargoapi.PromotionPhaseFailed || newerStatus.Phase == kargoapi.PromotionPhaseFailed:
+		mergedStatus.Phase = kargoapi.PromotionPhaseFailed
+		mergedStatus.Message = firstNonEmpty(mergedStatus.Message, newerStatus.Message)
+	case mergedStatus.Phase == kargoapi.PromotionPhaseRunning || newerStatus.Phase == kargoapi.PromotionPhaseRunning:
+		mergedStatus.Phase = kargoapi.PromotionPhaseRunning
+		mergedStatus.Message = firstNonEmpty(mergedStatus.Message, newerStatus.Message)
+	case mergedStatus.Phase == kargoapi.PromotionPhaseSucceeded && newerStatus.Phase == kargoapi.PromotionPhaseSucceeded:
+		mergedStatus.Message = firstNonEmpty(mergedStatus.Message, newerStatus.Message)
 	}
-	newStatus := curr.DeepCopy()
-	if curr.Phase == kargoapi.PromotionPhaseErrored {
-		// do nothing. we are already at most severe phase
-	} else if other.Phase == kargoapi.PromotionPhaseErrored {
-		newStatus.Phase = kargoapi.PromotionPhaseErrored
-		newStatus.Message = other.Message
-	} else if curr.Phase == kargoapi.PromotionPhaseFailed || other.Phase == kargoapi.PromotionPhaseFailed {
-		newStatus.Phase = kargoapi.PromotionPhaseFailed
-		newStatus.Message = firstNonEmpty(curr.Message, other.Message)
-	} else if curr.Phase == kargoapi.PromotionPhaseRunning || other.Phase == kargoapi.PromotionPhaseRunning {
-		newStatus.Phase = kargoapi.PromotionPhaseRunning
-		newStatus.Message = firstNonEmpty(curr.Message, other.Message)
-	} else {
-		newStatus.Phase = kargoapi.PromotionPhaseSucceeded
-		newStatus.Message = firstNonEmpty(curr.Message, other.Message)
-	}
+	mergedStatus.FreightCollection = newerStatus.FreightCollection
 	// Merge the two metadata maps
-	if len(other.Metadata) > 0 {
-		if newStatus.Metadata == nil {
-			newStatus.Metadata = make(map[string]string)
+	if len(newerStatus.Metadata) > 0 {
+		if mergedStatus.Metadata == nil {
+			mergedStatus.Metadata = make(map[string]string, len(newerStatus.Metadata))
 		}
-		for k, v := range other.Metadata {
-			newStatus.Metadata[k] = v
+		for k, v := range newerStatus.Metadata {
+			mergedStatus.Metadata[k] = v
 		}
 	}
-	return newStatus
+	return mergedStatus
 }
 
 func firstNonEmpty(a, b string) string {

--- a/internal/controller/promotion/composite_test.go
+++ b/internal/controller/promotion/composite_test.go
@@ -3,6 +3,7 @@ package promotion
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,8 +45,8 @@ func TestCompositePromote(t *testing.T) {
 		freight    []kargoapi.FreightReference
 		assertions func(
 			t *testing.T,
-			promoStatus *kargoapi.PromotionStatus,
-			updatedFreight []kargoapi.FreightReference,
+			origFreight *kargoapi.FreightCollection,
+			promo *kargoapi.Promotion,
 			err error,
 		)
 	}{
@@ -55,22 +56,16 @@ func TestCompositePromote(t *testing.T) {
 				childMechanisms: []Mechanism{
 					&FakeMechanism{
 						Name: "fake promotion mechanism",
-						PromoteFn: func(
-							context.Context,
-							*kargoapi.Stage,
-							[]kargoapi.FreightReference,
-						) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error) {
-							return &kargoapi.PromotionStatus{},
-								[]kargoapi.FreightReference{},
-								errors.New("something went wrong")
+						PromoteFn: func(context.Context, *kargoapi.Stage, *kargoapi.Promotion) error {
+							return errors.New("something went wrong")
 						},
 					},
 				},
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				_ []kargoapi.FreightReference,
+				_ *kargoapi.FreightCollection,
+				_ *kargoapi.Promotion,
 				err error,
 			) {
 				require.ErrorContains(t, err, "error executing fake promotion mechanism")
@@ -80,7 +75,8 @@ func TestCompositePromote(t *testing.T) {
 		{
 			name: "success",
 			freight: []kargoapi.FreightReference{{
-				Name: "fake-id",
+				Name:    "fake-id",
+				Commits: []kargoapi.GitCommit{{}},
 			}},
 			promoMech: &compositeMechanism{
 				childMechanisms: []Mechanism{
@@ -89,50 +85,151 @@ func TestCompositePromote(t *testing.T) {
 						PromoteFn: func(
 							_ context.Context,
 							_ *kargoapi.Stage,
-							newFreight []kargoapi.FreightReference,
-						) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error) {
-							require.True(t, len(newFreight) > 0)
-							// This is not a realistic change that a child promotion mechanism
-							// would make, but for testing purposes, this is good enough to
-							// help us assert that the function under test does return all
-							// modifications made by its child promotion mechanisms.
-							newFreight[0].Name = "fake-mutated-id"
-							return &kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseSucceeded}, newFreight, nil
+							promo *kargoapi.Promotion,
+						) error {
+							refs := promo.Status.FreightCollection.References()
+							require.NotEmpty(t, refs)
+							require.NotEmpty(t, refs[0].Commits)
+							refs[0].Commits[0].HealthCheckCommit = "fake-commit-id"
+							promo.Status.FreightCollection.UpdateOrPush(refs[0])
+							promo.Status.Phase = kargoapi.PromotionPhaseSucceeded
+							return nil
 						},
 					},
 				},
 			},
 			assertions: func(
 				t *testing.T,
-				_ *kargoapi.PromotionStatus,
-				updatedFreight []kargoapi.FreightReference,
+				_ *kargoapi.FreightCollection,
+				promo *kargoapi.Promotion,
 				err error,
 			) {
 				require.NoError(t, err)
 				// Verify that changes made by child promotion mechanism are returned
-				require.Equal(
-					t,
-					[]kargoapi.FreightReference{{
-						Name: "fake-mutated-id",
-					}},
-					updatedFreight,
-				)
+				refs := promo.Status.FreightCollection.References()
+				require.NotEmpty(t, refs)
+				require.NotEmpty(t, refs[0].Commits)
+				require.Equal(t, "fake-commit-id", refs[0].Commits[0].HealthCheckCommit)
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			promoStatus, updatedFreight, err := testCase.promoMech.Promote(
+			promo := &kargoapi.Promotion{
+				Status: kargoapi.PromotionStatus{
+					FreightCollection: &kargoapi.FreightCollection{},
+				},
+			}
+			for _, freight := range testCase.freight {
+				promo.Status.FreightCollection.UpdateOrPush(freight)
+			}
+			origFreight := promo.Status.FreightCollection.DeepCopy()
+			err := testCase.promoMech.Promote(
 				context.Background(),
 				&kargoapi.Stage{
 					Spec: kargoapi.StageSpec{
 						PromotionMechanisms: &kargoapi.PromotionMechanisms{},
 					},
 				},
-				&kargoapi.Promotion{},
-				testCase.freight,
+				promo,
 			)
-			testCase.assertions(t, promoStatus, updatedFreight, err)
+			testCase.assertions(t, origFreight, promo, err)
 		})
 	}
+}
+
+func TestMergePromoStatus(t *testing.T) {
+	t.Run("phase merging", func(t *testing.T) {
+		testCases := []struct {
+			olderPhase    kargoapi.PromotionPhase
+			newerPhase    kargoapi.PromotionPhase
+			expectedPhase kargoapi.PromotionPhase
+		}{
+			{
+				olderPhase:    kargoapi.PromotionPhaseErrored,
+				newerPhase:    kargoapi.PromotionPhaseFailed,
+				expectedPhase: kargoapi.PromotionPhaseErrored,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseFailed,
+				newerPhase:    kargoapi.PromotionPhaseErrored,
+				expectedPhase: kargoapi.PromotionPhaseErrored,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseFailed,
+				newerPhase:    kargoapi.PromotionPhaseRunning,
+				expectedPhase: kargoapi.PromotionPhaseFailed,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseRunning,
+				newerPhase:    kargoapi.PromotionPhaseFailed,
+				expectedPhase: kargoapi.PromotionPhaseFailed,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseRunning,
+				newerPhase:    kargoapi.PromotionPhaseSucceeded,
+				expectedPhase: kargoapi.PromotionPhaseRunning,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseSucceeded,
+				newerPhase:    kargoapi.PromotionPhaseRunning,
+				expectedPhase: kargoapi.PromotionPhaseRunning,
+			},
+			{
+				olderPhase:    kargoapi.PromotionPhaseSucceeded,
+				newerPhase:    kargoapi.PromotionPhaseSucceeded,
+				expectedPhase: kargoapi.PromotionPhaseSucceeded,
+			},
+		}
+		for _, testCase := range testCases {
+			t.Run(
+				fmt.Sprintf("old is %s, new is %s", testCase.olderPhase, testCase.newerPhase),
+				func(t *testing.T) {
+					mergedStatus := mergePromoStatus(
+						&kargoapi.PromotionStatus{Phase: testCase.newerPhase},
+						&kargoapi.PromotionStatus{Phase: testCase.olderPhase},
+					)
+					require.Equal(t, testCase.expectedPhase, mergedStatus.Phase)
+				},
+			)
+		}
+	})
+
+	t.Run("freight collection replacement", func(t *testing.T) {
+		olderStatus := &kargoapi.PromotionStatus{
+			FreightCollection: &kargoapi.FreightCollection{},
+		}
+		olderStatus.FreightCollection.UpdateOrPush(kargoapi.FreightReference{
+			Commits: []kargoapi.GitCommit{{}},
+		})
+		newerStatus := &kargoapi.PromotionStatus{
+			FreightCollection: olderStatus.FreightCollection.DeepCopy(),
+		}
+		newerStatus.FreightCollection.UpdateOrPush(kargoapi.FreightReference{
+			Commits: []kargoapi.GitCommit{{
+				HealthCheckCommit: "fake-commit",
+			}},
+		})
+		mergedStatus := mergePromoStatus(newerStatus, olderStatus)
+		require.Same(t, newerStatus.FreightCollection, mergedStatus.FreightCollection)
+	})
+
+	t.Run("metadata merging", func(t *testing.T) {
+		olderStatus := &kargoapi.PromotionStatus{
+			Metadata: map[string]string{
+				"a": "b",
+				"c": "d", // Should be overwritten
+			},
+		}
+		newerStatus := &kargoapi.PromotionStatus{
+			Metadata: map[string]string{
+				"c": "D", // Should overwrite
+				"e": "f",
+			},
+		}
+		mergedStatus := mergePromoStatus(newerStatus, olderStatus)
+		require.Equal(t, "b", mergedStatus.Metadata["a"])
+		require.Equal(t, "D", mergedStatus.Metadata["c"])
+		require.Equal(t, "f", mergedStatus.Metadata["e"])
+	})
 }

--- a/internal/controller/promotion/pullrequest.go
+++ b/internal/controller/promotion/pullrequest.go
@@ -112,25 +112,24 @@ func newGitProvider(
 // it tracks (i.e. PR url).
 func reconcilePullRequest(
 	ctx context.Context,
-	status kargoapi.PromotionStatus,
+	promo *kargoapi.Promotion,
 	repo git.Repo,
 	gpClient gitprovider.GitProviderService,
 	prBranch string,
 	writeBranch string,
-) (string, *kargoapi.PromotionStatus, error) {
-	newStatus := status.DeepCopy()
+) (string, error) {
 	var mergeCommitSHA string
 
-	prNumber := getPullRequestNumberFromMetadata(status.Metadata, repo.URL())
+	prNumber := getPullRequestNumberFromMetadata(promo.Status.Metadata, repo.URL())
 	if prNumber == -1 {
 		needsPR, err := repo.RefsHaveDiffs(prBranch, writeBranch)
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 		if needsPR {
 			title, err := repo.CommitMessage(prBranch)
 			if err != nil {
-				return "", nil, err
+				return "", err
 			}
 			createOpts := gitprovider.CreatePullRequestOpts{
 				Head:  prBranch,
@@ -146,44 +145,44 @@ func reconcilePullRequest(
 					Base: writeBranch,
 				})
 				if listErr != nil || len(prs) != 1 {
-					return "", nil, err
+					return "", err
 				}
 				// If we get here, we found an existing open PR for the same branches
 				pr = prs[0]
 			}
-			newStatus.Phase = kargoapi.PromotionPhaseRunning
-			newStatus.Metadata = setPullRequestMetadata(newStatus.Metadata, repo.URL(), pr.Number, pr.URL)
+			promo.Status.Phase = kargoapi.PromotionPhaseRunning
+			promo.Status.Metadata = setPullRequestMetadata(promo.Status.Metadata, repo.URL(), pr.Number, pr.URL)
 		} else {
-			newStatus.Phase = kargoapi.PromotionPhaseSucceeded
-			newStatus.Message = "No changes to promote"
+			promo.Status.Phase = kargoapi.PromotionPhaseSucceeded
+			promo.Status.Message = "No changes to promote"
 		}
 	} else {
 		// check if existing PR is closed/merged and update promo status to either
 		// Succeeded or Failed depending if PR was merged
 		pr, err := gpClient.GetPullRequest(ctx, prNumber)
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 		if !pr.IsOpen() {
 			merged, err := gpClient.IsPullRequestMerged(ctx, prNumber)
 			if err != nil {
-				return "", nil, err
+				return "", err
 			}
 			if merged {
-				newStatus.Phase = kargoapi.PromotionPhaseSucceeded
-				newStatus.Message = "Pull request was merged"
+				promo.Status.Phase = kargoapi.PromotionPhaseSucceeded
+				promo.Status.Message = "Pull request was merged"
 				if pr.MergeCommitSHA == "" {
-					return "", nil, fmt.Errorf("merge commit SHA is empty")
+					return "", fmt.Errorf("merge commit SHA is empty")
 				}
 				mergeCommitSHA = pr.MergeCommitSHA
 			} else {
-				newStatus.Phase = kargoapi.PromotionPhaseFailed
-				newStatus.Message = "Pull request was closed without being merged"
+				promo.Status.Phase = kargoapi.PromotionPhaseFailed
+				promo.Status.Message = "Pull request was closed without being merged"
 			}
 		}
 	}
 
-	return mergeCommitSHA, newStatus, nil
+	return mergeCommitSHA, nil
 }
 
 // pullRequestMetadataKey returns the key used to store the pull request number in the metadata map.

--- a/internal/controller/promotion/root.go
+++ b/internal/controller/promotion/root.go
@@ -15,14 +15,8 @@ type Mechanism interface {
 	GetName() string
 	// Promote consults rules in the provided Stage to perform some portion of the
 	// transition to using artifacts from the provided FreightReferences. It
-	// returns updated PromotionStatus and FreightReferences, both of which may
-	// have been updated by the process.
-	Promote(
-		context.Context,
-		*kargoapi.Stage,
-		*kargoapi.Promotion,
-		[]kargoapi.FreightReference,
-	) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error)
+	// may modify the provided Promotion's status.
+	Promote(context.Context, *kargoapi.Stage, *kargoapi.Promotion) error
 }
 
 // NewMechanisms returns the entrypoint to a hierarchical tree of promotion

--- a/internal/controller/promotion/root_test.go
+++ b/internal/controller/promotion/root_test.go
@@ -27,8 +27,8 @@ type FakeMechanism struct {
 	PromoteFn func(
 		context.Context,
 		*kargoapi.Stage,
-		[]kargoapi.FreightReference,
-	) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error)
+		*kargoapi.Promotion,
+	) error
 }
 
 // GetName implements the Mechanism interface.
@@ -40,8 +40,7 @@ func (f *FakeMechanism) GetName() string {
 func (f *FakeMechanism) Promote(
 	ctx context.Context,
 	stage *kargoapi.Stage,
-	_ *kargoapi.Promotion,
-	freight []kargoapi.FreightReference,
-) (*kargoapi.PromotionStatus, []kargoapi.FreightReference, error) {
-	return f.PromoteFn(ctx, stage, freight)
+	promo *kargoapi.Promotion,
+) error {
+	return f.PromoteFn(ctx, stage, promo)
 }


### PR DESCRIPTION
Fixes #2427 

925b765b461bd3fc19fd7e9055698140bd76e5a3 (the second commit) is the actual bug fix and is pretty straightforward. It modifies the sync operations we initiate to include the id of the Freight collection that is being promoted. We check for this information when determining if we need to initiate a sync operation. This allows a promotion to wait for a sync operation to complete in cases where we previously would not have simply for lack of any means to determine whether the completed sync operation was indeed the one we'd been waiting for.

fe15116e9e8447a2f12b9f6da5a392216606b61c (the first commit) changes the interface of promotion mechanisms to be quite a bit cleaner. The bug fix described above required the Argo CD app update promotion mechanism to have access to the Freight collection ID. It could obtain it from `promo.Status.FreightCollection.ID`. Doing this made me realize how _seemingly_ redundant it was that promotion mechanisms were also receiving and returning `[]kargoapi.FreightReference`, since there is already access to the Freight collection. In fact, it was not entirely redundant because promotion mechanisms can make certain modifications to those Freight references (like set health check commit IDs) and return them, and then those modified references become the input to the next promotion mechanism. The situation was quite similar for Promotion status, which could be modified by each mechanism and returned. The more I looked at this, the more confusing it started to look and feel, and I felt it was leaving too much potential for future mistakes. So, while I don't usually love when functions modify an argument in place (Promotion, in this case), updating the promotion mechanisms to get all details from the Promotion argument and modify its status (including Freight collection) in place made everything feel much more straightforward.