### PR TITLE
fix: webhook server and controller permissions

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -20,6 +20,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - secrets
   - serviceaccounts
   verbs:

--- a/charts/kargo/templates/webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/webhooks-server/cluster-role.yaml
@@ -27,6 +27,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - secrets
   - serviceaccounts
   verbs:


### PR DESCRIPTION
#2430 gave new permissions to the ClusterRole that is dynamically bound (with a RoleBinding) to the API server's and Project admin's ServicesAccounts at Project creation time, however, the webhook server and management controller, both of which play a role in creating those bindings, were not updated with the same permissions. This makes these two components incapable of delegating this permission they lack.

This PR fixes it.