### PR TITLE
feat: make local server work finally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,19 @@ build-nightly-cli:
 		-ldflags "-w -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).buildDate=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT) -X $(VERSION_PACKAGE).gitTreeState=$(GIT_TREE_STATE)" \
 		-o bin/kargo-cli/${VERSION}/${GOOS}/${GOARCH}/kargo$(shell [ ${GOOS} = windows ] && echo .exe) ./cmd/cli
 
+
+################################################################################
+# Used to build the CLI with the UI embedded                                   #
+################################################################################
+
+.PHONY: build-ui
+build-ui:
+	cd ui && NODE_ENV=production BUILD_TARGET_PATH=../internal/api/ui pnpm run build --emptyOutDir
+	touch internal/api/ui/.keep
+
+.PHONY: build-cli-with-ui
+build-cli-with-ui: build-ui build-cli
+
 ################################################################################
 # Code generation: To be run after modifications to API types                  #
 ################################################################################

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -6,24 +6,12 @@ import (
 	"net"
 
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubescheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	"github.com/akuity/kargo/internal/api/rbac"
-	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
-	"github.com/akuity/kargo/internal/kubeclient"
-	libEvent "github.com/akuity/kargo/internal/kubernetes/event"
+	"github.com/akuity/kargo/internal/kubernetes/event"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/os"
 	versionpkg "github.com/akuity/kargo/internal/version"
@@ -75,48 +63,56 @@ func (o *apiOptions) run(ctx context.Context) error {
 		"commit", version.GitCommit,
 	)
 
-	cfg := config.ServerConfigFromEnv()
+	serverCfg := config.ServerConfigFromEnv()
 
-	clientCfg, internalClient, recorder, err := o.setupAPIClient(ctx)
+	restCfg, err := kubernetes.GetRestConfig(ctx, o.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error setting up internal Kubernetes API client: %w", err)
+		return fmt.Errorf("error getting Kubernetes client REST config: %w", err)
 	}
-
-	kubeClient, err := newWrappedKubernetesClient(ctx, clientCfg, internalClient, cfg)
+	kubeClientOptions := kubernetes.ClientOptions{}
+	if serverCfg.OIDCConfig != nil {
+		kubeClientOptions.GlobalServiceAccountNamespaces = serverCfg.OIDCConfig.GlobalServiceAccountNamespaces
+	}
+	kubeClient, err := kubernetes.NewClient(ctx, restCfg, kubeClientOptions)
 	if err != nil {
 		return fmt.Errorf("error creating Kubernetes client for Kargo API server: %w", err)
 	}
+
 	switch {
-	case !cfg.RolloutsIntegrationEnabled:
+	case !serverCfg.RolloutsIntegrationEnabled:
 		o.Logger.Info("Argo Rollouts integration is disabled")
-	case !argoRolloutsExists(ctx, clientCfg):
+	case !argoRolloutsExists(ctx, restCfg):
 		o.Logger.Info(
 			"Argo Rollouts integration was enabled, but no Argo Rollouts " +
 				"CRDs were found. Proceeding without Argo Rollouts integration.",
 		)
-		cfg.RolloutsIntegrationEnabled = false
+		serverCfg.RolloutsIntegrationEnabled = false
 	default:
 		o.Logger.Info("Argo Rollouts integration is enabled")
 	}
 
-	if cfg.AdminConfig != nil {
+	if serverCfg.AdminConfig != nil {
 		o.Logger.Info("admin account is enabled")
 	}
-	if cfg.OIDCConfig != nil {
+	if serverCfg.OIDCConfig != nil {
 		o.Logger.Info(
 			"SSO via OpenID Connect is enabled",
-			"issuerURL", cfg.OIDCConfig.IssuerURL,
-			"clientID", cfg.OIDCConfig.ClientID,
-			"cliClientID", cfg.OIDCConfig.CLIClientID,
+			"issuerURL", serverCfg.OIDCConfig.IssuerURL,
+			"clientID", serverCfg.OIDCConfig.ClientID,
+			"cliClientID", serverCfg.OIDCConfig.CLIClientID,
 		)
 	}
 
 	srv := api.NewServer(
-		cfg,
+		serverCfg,
 		kubeClient,
-		internalClient,
 		rbac.NewKubernetesRolesDatabase(kubeClient),
-		recorder,
+		event.NewRecorder(
+			ctx,
+			kubeClient.InternalClient().Scheme(),
+			kubeClient.InternalClient(),
+			"api",
+		),
 	)
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.Host, o.Port))
 	if err != nil {
@@ -128,121 +124,4 @@ func (o *apiOptions) run(ctx context.Context) error {
 		return fmt.Errorf("error serving API: %w", err)
 	}
 	return nil
-}
-
-func (o *apiOptions) setupAPIClient(ctx context.Context) (*rest.Config, client.Client, record.EventRecorder, error) {
-	restCfg, err := kubernetes.GetRestConfig(ctx, o.KubeConfig)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("get REST config: %w", err)
-	}
-
-	scheme := runtime.NewScheme()
-	if err = kubescheme.AddToScheme(scheme); err != nil {
-		return nil, nil, nil, fmt.Errorf("error adding Kubernetes API to Kargo API manager scheme: %w", err)
-	}
-
-	if err = rbacv1.AddToScheme(scheme); err != nil {
-		return nil, nil, nil, fmt.Errorf(
-			"error adding Kubernetes RBAC API to Kargo controller manager scheme: %w",
-			err,
-		)
-	}
-
-	if err = rollouts.AddToScheme(scheme); err != nil {
-		return nil, nil, nil, fmt.Errorf("error adding Argo Rollouts API to Kargo API manager scheme: %w", err)
-	}
-
-	if err = kargoapi.AddToScheme(scheme); err != nil {
-		return nil, nil, nil, fmt.Errorf("error adding Kargo API to Kargo API manager scheme: %w", err)
-	}
-
-	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
-		Scheme: scheme,
-		Metrics: server.Options{
-			BindAddress: "0",
-		},
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.Secret{},
-				},
-			},
-		},
-	})
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error initializing Kargo API manager: %w", err)
-	}
-
-	if err = registerKargoIndexers(ctx, mgr); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to register Kargo indexers: %w", err)
-	}
-
-	go func() {
-		if err := mgr.Start(ctx); err != nil {
-			panic(fmt.Errorf("error starting Kargo API manager: %w", err))
-		}
-	}()
-
-	return restCfg, mgr.GetClient(), libEvent.NewRecorder(ctx, scheme, mgr.GetClient(), "api"), nil
-}
-
-func registerKargoIndexers(ctx context.Context, mgr ctrl.Manager) error {
-	// Index Promotions by Stage
-	if err := kubeclient.IndexPromotionsByStage(ctx, mgr); err != nil {
-		return fmt.Errorf("index Promotions by Stage: %w", err)
-	}
-
-	// Index Freight by Warehouse
-	if err := kubeclient.IndexFreightByWarehouse(ctx, mgr); err != nil {
-		return fmt.Errorf("index Freight by Warehouse: %w", err)
-	}
-
-	// Index Freight by Stages in which it has been verified
-	if err := kubeclient.IndexFreightByVerifiedStages(ctx, mgr); err != nil {
-		return fmt.Errorf("index Freight by Stages in which it has been verified: %w", err)
-	}
-
-	// Index Freight by Stages for which it is approved
-	if err := kubeclient.IndexFreightByApprovedStages(ctx, mgr); err != nil {
-		return fmt.Errorf("index Freight by Stages for which it has been approved: %w", err)
-	}
-
-	// Index ServiceAccounts by OIDC email
-	if err := kubeclient.IndexServiceAccountsByOIDCEmail(ctx, mgr); err != nil {
-		return fmt.Errorf("index ServiceAccounts by OIDC email: %w", err)
-	}
-
-	// Index ServiceAccounts by OIDC groups
-	if err := kubeclient.IndexServiceAccountsByOIDCGroups(ctx, mgr); err != nil {
-		return fmt.Errorf("index ServiceAccounts by OIDC groups: %w", err)
-	}
-
-	// Index ServiceAccounts by OIDC subjects
-	if err := kubeclient.IndexServiceAccountsByOIDCSubjects(ctx, mgr); err != nil {
-		return fmt.Errorf("index ServiceAccounts by OIDC subjects: %w", err)
-	}
-
-	// Index Events by InvolvedObject's API Group
-	if err := kubeclient.IndexEventsByInvolvedObjectAPIGroup(ctx, mgr); err != nil {
-		return fmt.Errorf("index Events by InvolvedObject's API group: %w", err)
-	}
-
-	return nil
-}
-
-func newWrappedKubernetesClient(
-	ctx context.Context,
-	restCfg *rest.Config,
-	internalClient client.Client,
-	serverCfg config.ServerConfig,
-) (kubernetes.Client, error) {
-	kubeClientOptions := kubernetes.ClientOptions{
-		NewInternalClient: func(context.Context, *rest.Config, *runtime.Scheme) (client.Client, error) {
-			return internalClient, nil
-		},
-	}
-	if serverCfg.OIDCConfig != nil {
-		kubeClientOptions.GlobalServiceAccountNamespaces = serverCfg.OIDCConfig.GlobalServiceAccountNamespaces
-	}
-	return kubernetes.NewClient(ctx, restCfg, kubeClientOptions)
 }

--- a/internal/api/delete_analysistemplate_v1alpha1_test.go
+++ b/internal/api/delete_analysistemplate_v1alpha1_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -81,14 +80,7 @@ func TestDeleteAnalysisTemplate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			cfg := config.ServerConfigFromEnv()
 			if testCase.rolloutsDisabled {
@@ -99,15 +91,12 @@ func TestDeleteAnalysisTemplate(t *testing.T) {
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,
 						scheme *runtime.Scheme,
 					) (client.Client, error) {
-						if err := rollouts.AddToScheme(scheme); err != nil {
-							return nil, err
-						}
-
 						return fake.NewClientBuilder().
 							WithScheme(scheme).
 							WithObjects(

--- a/internal/api/get_analysisrun_v1alpha1_test.go
+++ b/internal/api/get_analysisrun_v1alpha1_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -187,14 +186,7 @@ func TestGetAnalysisRun(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			cfg := config.ServerConfigFromEnv()
 			if testCase.rolloutsDisabled {
@@ -205,15 +197,12 @@ func TestGetAnalysisRun(t *testing.T) {
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,
 						scheme *runtime.Scheme,
 					) (client.Client, error) {
-						if err := rollouts.AddToScheme(scheme); err != nil {
-							return nil, err
-						}
-
 						return fake.NewClientBuilder().
 							WithScheme(scheme).
 							WithObjects(

--- a/internal/api/get_analysistemplate_v1alpha1_test.go
+++ b/internal/api/get_analysistemplate_v1alpha1_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -188,14 +187,7 @@ func TestGetAnalysisTemplate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			cfg := config.ServerConfigFromEnv()
 			if testCase.rolloutsDisabled {
@@ -206,15 +198,12 @@ func TestGetAnalysisTemplate(t *testing.T) {
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,
 						scheme *runtime.Scheme,
 					) (client.Client, error) {
-						if err := rollouts.AddToScheme(scheme); err != nil {
-							return nil, err
-						}
-
 						return fake.NewClientBuilder().
 							WithScheme(scheme).
 							WithObjects(

--- a/internal/api/get_config_v1alpha1_test.go
+++ b/internal/api/get_config_v1alpha1_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/internal/api/config"
-	"github.com/akuity/kargo/internal/api/user"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -37,20 +36,10 @@ func TestGetConfig(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
-
 			svr := &server{
 				cfg: tc.cfg,
 			}
-			res, err := svr.GetConfig(ctx, connect.NewRequest(tc.req))
+			res, err := svr.GetConfig(context.Background(), connect.NewRequest(tc.req))
 			require.NoError(t, err)
 			if tc.assertions != nil {
 				tc.assertions(res.Msg)

--- a/internal/api/get_credentials_v1alpha1_test.go
+++ b/internal/api/get_credentials_v1alpha1_test.go
@@ -16,7 +16,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	libCreds "github.com/akuity/kargo/internal/credentials"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -251,19 +250,13 @@ func TestGetCredentials(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/get_freight_v1alpha1_test.go
+++ b/internal/api/get_freight_v1alpha1_test.go
@@ -18,7 +18,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -301,19 +300,13 @@ func TestGetFreight(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/get_project_v1alpha1_test.go
+++ b/internal/api/get_project_v1alpha1_test.go
@@ -17,7 +17,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -181,19 +180,13 @@ func TestGetProject(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/get_promotion_v1alpha1_test.go
+++ b/internal/api/get_promotion_v1alpha1_test.go
@@ -18,7 +18,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -226,19 +225,13 @@ func TestGetPromotion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/get_stage_v1alpha1_test.go
+++ b/internal/api/get_stage_v1alpha1_test.go
@@ -17,7 +17,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -172,19 +171,13 @@ func TestGetStage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/get_warehouse_v1alpha1_test.go
+++ b/internal/api/get_warehouse_v1alpha1_test.go
@@ -18,7 +18,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -227,19 +226,13 @@ func TestGetWarehouse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/list_analysistemplates_v1alpha1_test.go
+++ b/internal/api/list_analysistemplates_v1alpha1_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
@@ -117,14 +116,7 @@ func TestListAnalysisTemplates(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			cfg := config.ServerConfigFromEnv()
 			if testCase.rolloutsDisabled {
@@ -135,15 +127,12 @@ func TestListAnalysisTemplates(t *testing.T) {
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,
 						scheme *runtime.Scheme,
 					) (client.Client, error) {
-						if err := rollouts.AddToScheme(scheme); err != nil {
-							return nil, err
-						}
-
 						c := fake.NewClientBuilder().WithScheme(scheme)
 						if len(testCase.objects) > 0 {
 							c.WithObjects(testCase.objects...)

--- a/internal/api/list_projects_v1alpha1_test.go
+++ b/internal/api/list_projects_v1alpha1_test.go
@@ -14,7 +14,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -71,19 +70,13 @@ func TestListProjects(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/list_promotions_v1alpha1_test.go
+++ b/internal/api/list_promotions_v1alpha1_test.go
@@ -17,9 +17,7 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
-	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
 
@@ -135,28 +133,18 @@ func TestListPromotions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,
 						scheme *runtime.Scheme,
 					) (client.Client, error) {
-						if err := rollouts.AddToScheme(scheme); err != nil {
-							return nil, err
-						}
-
 						c := fake.NewClientBuilder().WithScheme(scheme)
 						if len(testCase.objects) > 0 {
 							c.WithObjects(testCase.objects...)

--- a/internal/api/list_stages_v1alpha1_test.go
+++ b/internal/api/list_stages_v1alpha1_test.go
@@ -14,7 +14,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -50,19 +49,13 @@ func TestListStages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
 
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						context.Context,
 						*rest.Config,

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	libClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/internal/api/config"
 	"github.com/akuity/kargo/internal/logging"
@@ -15,14 +15,14 @@ import (
 func NewHandlerOption(
 	ctx context.Context,
 	cfg config.ServerConfig,
-	internalClient libClient.Client,
+	kubeclient client.Client,
 ) (connect.HandlerOption, error) {
 	interceptors := []connect.Interceptor{
 		newLogInterceptor(logging.LoggerFromContext(ctx), loggingIgnorableMethods),
 		newErrorInterceptor(),
 	}
 	if !cfg.LocalMode {
-		authInterceptor, err := newAuthInterceptor(ctx, cfg, internalClient)
+		authInterceptor, err := newAuthInterceptor(ctx, cfg, kubeclient)
 		if err != nil {
 			return nil, fmt.Errorf("initialize authentication interceptor: %w", err)
 		}

--- a/internal/api/refresh_stage_v1alpha1.go
+++ b/internal/api/refresh_stage_v1alpha1.go
@@ -39,7 +39,7 @@ func (s *server) RefreshStage(
 	// server's own internal client so that individual users are not required to
 	// have this permission, which they really do not otherwise need.
 	if stage.Status.CurrentPromotion != nil {
-		if _, err := kargoapi.RefreshPromotion(ctx, s.internalClient, client.ObjectKey{
+		if _, err := kargoapi.RefreshPromotion(ctx, s.client.InternalClient(), client.ObjectKey{
 			Namespace: project,
 			Name:      stage.Status.CurrentPromotion.Name,
 		}); err != nil {

--- a/internal/api/refresh_stage_v1alpha1_test.go
+++ b/internal/api/refresh_stage_v1alpha1_test.go
@@ -15,7 +15,6 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
-	"github.com/akuity/kargo/internal/api/user"
 	"github.com/akuity/kargo/internal/api/validation"
 	svcv1alpha1 "github.com/akuity/kargo/pkg/api/service/v1alpha1"
 )
@@ -70,18 +69,13 @@ func TestRefreshStage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate an admin user to prevent any authz issues with the authorizing
-			// client.
-			ctx := user.ContextWithInfo(
-				context.Background(),
-				user.Info{
-					IsAdmin: true,
-				},
-			)
+			ctx := context.Background()
+
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},
 				kubernetes.ClientOptions{
+					SkipAuthorization: true,
 					NewInternalClient: func(
 						_ context.Context,
 						_ *rest.Config,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -44,11 +44,10 @@ var (
 )
 
 type server struct {
-	cfg            config.ServerConfig
-	client         kubernetes.Client
-	internalClient client.Client
-	rolesDB        rbac.RolesDatabase
-	recorder       record.EventRecorder
+	cfg      config.ServerConfig
+	client   kubernetes.Client
+	rolesDB  rbac.RolesDatabase
+	recorder record.EventRecorder
 
 	// The following behaviors are overridable for testing purposes:
 
@@ -160,16 +159,14 @@ type Server interface {
 func NewServer(
 	cfg config.ServerConfig,
 	kubeClient kubernetes.Client,
-	internalClient client.Client,
 	rolesDB rbac.RolesDatabase,
 	recorder record.EventRecorder,
 ) Server {
 	s := &server{
-		cfg:            cfg,
-		client:         kubeClient,
-		internalClient: internalClient,
-		rolesDB:        rolesDB,
-		recorder:       recorder,
+		cfg:      cfg,
+		client:   kubeClient,
+		rolesDB:  rolesDB,
+		recorder: recorder,
 	}
 
 	s.validateProjectExistsFn = s.validateProjectExists
@@ -196,7 +193,7 @@ func (s *server) Serve(ctx context.Context, l net.Listener) error {
 	logger := logging.LoggerFromContext(ctx)
 	mux := http.NewServeMux()
 
-	opts, err := option.NewHandlerOption(ctx, s.cfg, s.internalClient)
+	opts, err := option.NewHandlerOption(ctx, s.cfg, s.client.InternalClient())
 	if err != nil {
 		return fmt.Errorf("error initializing handler options: %w", err)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -37,7 +37,6 @@ func TestNewServer(t *testing.T) {
 	s, ok := NewServer(
 		testServerConfig,
 		testClient,
-		testClient,
 		rbac.NewKubernetesRolesDatabase(testClient),
 		testRecorder,
 	).(*server)
@@ -45,7 +44,6 @@ func TestNewServer(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, s)
 	require.Same(t, testClient, s.client)
-	require.Same(t, testClient, s.internalClient)
 	require.NotNil(t, testClient, s.rolesDB)
 	require.Same(t, testRecorder, s.recorder)
 	require.Equal(t, testServerConfig, s.cfg)

--- a/internal/cli/cmd/server/server.go
+++ b/internal/cli/cmd/server/server.go
@@ -67,24 +67,18 @@ func (o *serverOptions) validate() error {
 
 // run starts a local server on the provided address.
 func (o *serverOptions) run(ctx context.Context) error {
-	// TODO: This is at present incomplete, and is a placeholder for future work.
-	//
-	// - The server should be started with a Kubernetes client which does NOT
-	//   make use of an authorization wrapper.
-	// - It should allow the user to visit the UI in their browser.
-	// - It should allow the user to interact with the API through `kargo`
-	//   commands, but _without_ needing to authenticate, as the server is
-	//   running locally using the user's kubeconfig.
-	// - It should properly handle signals and clean up after itself.
-	//
-	// xref: https://github.com/akuity/kargo/issues/1569
-
 	restCfg, err := config.GetConfig()
 	if err != nil {
 		return fmt.Errorf("get REST config: %w", err)
 	}
 
-	client, err := kubernetes.NewClient(ctx, restCfg, kubernetes.ClientOptions{})
+	client, err := kubernetes.NewClient(
+		ctx,
+		restCfg,
+		kubernetes.ClientOptions{
+			SkipAuthorization: true,
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
@@ -99,7 +93,6 @@ func (o *serverOptions) run(ctx context.Context) error {
 		apiconfig.ServerConfig{
 			LocalMode: true,
 		},
-		client,
 		client,
 		rbac.NewKubernetesRolesDatabase(client),
 		&fakeevent.EventRecorder{},

--- a/internal/kubeclient/indexer.go
+++ b/internal/kubeclient/indexer.go
@@ -8,8 +8,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	rbacapi "github.com/akuity/kargo/api/rbac/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -43,11 +43,11 @@ const (
 // IndexEventsByInvolvedObjectAPIGroup sets up the indexing of Events by the
 // API group of the involved object.
 //
-// It configures the field indexer of the provided manager to allow querying
+// It configures the field indexer of the provided cluster to allow querying
 // Events by the API group of the involved object using the
 // EventsByInvolvedObjectAPIGroupIndexField selector.
-func IndexEventsByInvolvedObjectAPIGroup(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexEventsByInvolvedObjectAPIGroup(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.Event{},
 		EventsByInvolvedObjectAPIGroupIndexField,
@@ -70,11 +70,11 @@ func indexEventsByInvolvedObjectAPIGroup(obj client.Object) []string {
 // IndexStagesByAnalysisRun sets up the indexing of Stages by the AnalysisRun
 // they are associated with.
 //
-// It configures the field indexer of the provided manager to allow querying
+// It configures the field indexer of the provided cluster to allow querying
 // Stages by the AnalysisRun they are associated with using the
 // StagesByAnalysisRunIndexField selector.
-func IndexStagesByAnalysisRun(ctx context.Context, mgr ctrl.Manager, shardName string) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexStagesByAnalysisRun(ctx context.Context, clstr cluster.Cluster, shardName string) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Stage{},
 		StagesByAnalysisRunIndexField,
@@ -120,15 +120,15 @@ func indexStagesByAnalysisRun(shardName string) client.IndexerFunc {
 // IndexStagesByArgoCDApplications sets up the indexing of Stages by the Argo CD
 // Applications they are associated with.
 //
-// It configures the field indexer of the provided manager to allow querying
+// It configures the field indexer of the provided cluster to allow querying
 // Stages by the Argo CD Applications they are associated with using the
 // StagesByArgoCDApplicationsIndexField selector.
 //
 // When the provided shardName is non-empty, only Stages labeled with the
 // provided shardName are indexed. When the provided shardName is empty, only
 // Stages not labeled with a shardName are indexed.
-func IndexStagesByArgoCDApplications(ctx context.Context, mgr ctrl.Manager, shardName string) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexStagesByArgoCDApplications(ctx context.Context, clstr cluster.Cluster, shardName string) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Stage{},
 		StagesByArgoCDApplicationsIndexField,
@@ -175,10 +175,10 @@ func indexStagesByArgoCDApplications(shardName string) client.IndexerFunc {
 // IndexPromotionsByStage sets up the indexing of Promotions by the Stage they
 // reference.
 //
-// It configures the field indexer of the provided manager to allow querying
+// It configures the field indexer of the provided cluster to allow querying
 // Promotions by the Stage they reference using the PromotionsByStageIndexField.
-func IndexPromotionsByStage(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexPromotionsByStage(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Promotion{},
 		PromotionsByStageIndexField,
@@ -207,7 +207,7 @@ func indexPromotionsByStage(predicates ...func(*kargoapi.Promotion) bool) client
 // IndexRunningPromotionsByArgoCDApplications sets up the indexing of running
 // Promotions by the Argo CD Applications they are associated with.
 //
-// It configures the field indexer of the provided manager to allow querying
+// It configures the field indexer of the provided cluster to allow querying
 // running Promotions by the Argo CD Applications they are associated with using
 // the RunningPromotionsByArgoCDApplicationsIndexField selector.
 //
@@ -216,14 +216,14 @@ func indexPromotionsByStage(predicates ...func(*kargoapi.Promotion) bool) client
 // Promotions not labeled with a shardName are indexed.
 func IndexRunningPromotionsByArgoCDApplications(
 	ctx context.Context,
-	mgr ctrl.Manager,
+	clstr cluster.Cluster,
 	shardName string,
 ) error {
-	return mgr.GetFieldIndexer().IndexField(
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Promotion{},
 		RunningPromotionsByArgoCDApplicationsIndexField,
-		indexRunningPromotionsByArgoCDApplications(ctx, mgr.GetClient(), shardName),
+		indexRunningPromotionsByArgoCDApplications(ctx, clstr.GetClient(), shardName),
 	)
 }
 
@@ -303,15 +303,15 @@ func indexRunningPromotionsByArgoCDApplications(
 // IndexPromotionsByStageAndFreight sets up indexing of Promotions by the Stage
 // and Freight they reference.
 //
-// It configures the manager's field indexer to allow querying Promotions using
+// It configures the cluster's field indexer to allow querying Promotions using
 // the PromotionsByStageAndFreightIndexField selector. The value of the index is
 // the concatenation of the Stage and Freight keys, as returned by the
 // StageAndFreightKey function.
 func IndexPromotionsByStageAndFreight(
 	ctx context.Context,
-	mgr ctrl.Manager,
+	clstr cluster.Cluster,
 ) error {
-	return mgr.GetFieldIndexer().IndexField(
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Promotion{},
 		PromotionsByStageAndFreightIndexField,
@@ -337,10 +337,10 @@ func StageAndFreightKey(stage, freight string) string {
 // IndexFreightByWarehouse sets up indexing of Freight by the Warehouse they are
 // associated with.
 //
-// It configures the manager's field indexer to allow querying Freight using the
+// It configures the cluster's field indexer to allow querying Freight using the
 // FreightByWarehouseIndexField selector.
-func IndexFreightByWarehouse(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexFreightByWarehouse(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Freight{},
 		FreightByWarehouseIndexField,
@@ -361,10 +361,10 @@ func FreightByWarehouseIndexer(obj client.Object) []string {
 // IndexFreightByVerifiedStages sets up indexing of Freight by the Stages that
 // have verified it.
 //
-// It configures the manager's field indexer to allow querying Freight using
+// It configures the cluster's field indexer to allow querying Freight using
 // the FreightByVerifiedStagesIndexField selector.
-func IndexFreightByVerifiedStages(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexFreightByVerifiedStages(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Freight{},
 		FreightByVerifiedStagesIndexField,
@@ -388,10 +388,10 @@ func FreightByVerifiedStagesIndexer(obj client.Object) []string {
 // IndexFreightByApprovedStages sets up indexing of Freight by the Stages for
 // which it has been (manually) approved.
 //
-// It configures the manager's field indexer to allow querying Freight using
+// It configures the cluster's field indexer to allow querying Freight using
 // the FreightApprovedForStagesIndexField selector.
-func IndexFreightByApprovedStages(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexFreightByApprovedStages(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Freight{},
 		FreightApprovedForStagesIndexField,
@@ -415,10 +415,10 @@ func FreightApprovedForStagesIndexer(obj client.Object) []string {
 // IndexStagesByFreight sets up indexing of Stages by the Freight they
 // reference.
 //
-// It configures the manager's field indexer to allow querying Stages using the
+// It configures the cluster's field indexer to allow querying Stages using the
 // StagesByFreightIndexField selector.
-func IndexStagesByFreight(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexStagesByFreight(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Stage{},
 		StagesByFreightIndexField,
@@ -447,10 +447,10 @@ func indexStagesByFreight(obj client.Object) []string {
 // IndexStagesByUpstreamStages sets up indexing of Stages by the upstream Stages
 // they reference.
 //
-// It configures the manager's field indexer to allow querying Stages using the
+// It configures the cluster's field indexer to allow querying Stages using the
 // StagesByUpstreamStagesIndexField selector.
-func IndexStagesByUpstreamStages(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexStagesByUpstreamStages(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Stage{},
 		StagesByUpstreamStagesIndexField,
@@ -473,10 +473,10 @@ func indexStagesByUpstreamStages(obj client.Object) []string {
 // IndexStagesByWarehouse sets up indexing of Stages by the Warehouse they are
 // associated with.
 //
-// It configures the manager's field indexer to allow querying Stages using the
+// It configures the cluster's field indexer to allow querying Stages using the
 // StagesByWarehouseIndexField selector.
-func IndexStagesByWarehouse(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexStagesByWarehouse(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Stage{},
 		StagesByWarehouseIndexField,
@@ -501,10 +501,10 @@ func indexStagesByWarehouse(obj client.Object) []string {
 // IndexServiceAccountsByOIDCEmail sets up indexing of ServiceAccounts by their
 // OIDC email annotations.
 //
-// It configures the manager's field indexer to allow querying ServiceAccounts
+// It configures the cluster's field indexer to allow querying ServiceAccounts
 // using the ServiceAccountsByOIDCEmailIndexField selector.
-func IndexServiceAccountsByOIDCEmail(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexServiceAccountsByOIDCEmail(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.ServiceAccount{},
 		ServiceAccountsByOIDCEmailIndexField,
@@ -533,10 +533,10 @@ func indexServiceAccountsOIDCEmail(obj client.Object) []string {
 // IndexServiceAccountsByOIDCGroups sets up indexing of ServiceAccounts by
 // their OIDC group annotations.
 //
-// It configures the manager's field indexer to allow querying ServiceAccounts
+// It configures the cluster's field indexer to allow querying ServiceAccounts
 // using the ServiceAccountsByOIDCGroupIndexField selector.
-func IndexServiceAccountsByOIDCGroups(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexServiceAccountsByOIDCGroups(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.ServiceAccount{},
 		ServiceAccountsByOIDCGroupIndexField,
@@ -565,10 +565,10 @@ func indexServiceAccountsByOIDCGroups(obj client.Object) []string {
 // IndexServiceAccountsByOIDCSubjects sets up indexing of ServiceAccounts by
 // their OIDC subject annotations.
 //
-// It configures the manager's field indexer to allow querying ServiceAccounts
+// It configures the cluster's field indexer to allow querying ServiceAccounts
 // using the ServiceAccountsByOIDCSubjectIndexField selector.
-func IndexServiceAccountsByOIDCSubjects(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(
+func IndexServiceAccountsByOIDCSubjects(ctx context.Context, clstr cluster.Cluster) error {
+	return clstr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.ServiceAccount{},
 		ServiceAccountsByOIDCSubjectIndexField,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -13,6 +13,7 @@ const mapToken = defaultAlgorithm(defaultSeed);
 
 export const UI_VERSION = process.env.VERSION || 'development';
 export const API_URL = process.env.API_URL || 'http://localhost:30081';
+export const BUILD_TARGET_PATH = process.env.BUILD_TARGET_PATH || 'build';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -20,7 +21,7 @@ export default defineConfig({
     __UI_VERSION__: JSON.stringify(UI_VERSION)
   },
   build: {
-    outDir: 'build',
+    outDir: BUILD_TARGET_PATH,
     sourcemap: false
   },
   css: {


### PR DESCRIPTION
Fixes #1728

Follows up on #2395 cc @rbreeze 

This makes some modifications to how we construct the custom k8s client used by the API server only. This makes a lot of the boilerplate configuration of that client a bit DRYer so that we can more easily use it in multiple places -- with one of those places being the `kargo server` command.

`kargo server` fully works after this.

Note that to try this, you need to make sure the UI is baked into the CLI, which it typically isn't except by our actual release process.

I did something like this to ensure that:

```console
# Build UI to be embedded into CLI binary             
cd ui
pnpm install
NODE_ENV=production pnpm run build
cd ..
rm -rf internal/api/ui
mv ui/build internal/api/ui

# Start server
go run cmd/cli/*.go server
```