### PR TITLE
fix(promotion): wait for open pull request

### DIFF
--- a/internal/controller/promotion/pullrequest.go
+++ b/internal/controller/promotion/pullrequest.go
@@ -163,7 +163,9 @@ func reconcilePullRequest(
 		if err != nil {
 			return "", err
 		}
-		if !pr.IsOpen() {
+		if pr.IsOpen() {
+			promo.Status.Phase = kargoapi.PromotionPhaseRunning
+		} else {
 			merged, err := gpClient.IsPullRequestMerged(ctx, prNumber)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
This addresses the immediate issue (from #2450), by ensuring the Phase of the Promotion is set to Running for as long as a pull request is open.

However, I do feel this is the result of us not taking a defensive approach when composing the Phase the Promotion is in, by assuming a Promotion to be Successful (in multiple places) until we are told it isn't.

The less error prone approach would be to assume the opposite, but this is arguably much more difficult to achieve.