### PR TITLE
feat(controller): more git pkg enhancements

### DIFF
--- a/internal/controller/git/bare_repo.go
+++ b/internal/controller/git/bare_repo.go
@@ -81,11 +81,10 @@ func CloneBare(
 	}
 	b := &bareRepo{
 		baseRepo: &baseRepo{
-			creds:                 clientOpts.Credentials,
-			dir:                   filepath.Join(homeDir, "repo"),
-			homeDir:               homeDir,
-			insecureSkipTLSVerify: cloneOpts.InsecureSkipTLSVerify,
-			url:                   repoURL,
+			creds:   clientOpts.Credentials,
+			dir:     filepath.Join(homeDir, "repo"),
+			homeDir: homeDir,
+			url:     repoURL,
 		},
 	}
 	if err = b.setupClient(clientOpts); err != nil {
@@ -110,8 +109,7 @@ func (b *bareRepo) clone() error {
 }
 
 type LoadBareRepoOptions struct {
-	Credentials           *RepoCredentials
-	InsecureSkipTLSVerify bool
+	Credentials *RepoCredentials
 }
 
 func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
@@ -120,9 +118,8 @@ func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
 	}
 	b := &bareRepo{
 		baseRepo: &baseRepo{
-			creds:                 opts.Credentials,
-			dir:                   path,
-			insecureSkipTLSVerify: opts.InsecureSkipTLSVerify,
+			creds: opts.Credentials,
+			dir:   path,
 		},
 	}
 	if err := b.loadHomeDir(); err != nil {
@@ -160,11 +157,10 @@ func (b *bareRepo) AddWorkTree(path, ref string) (WorkTree, error) {
 	}
 	return &workTree{
 		baseRepo: &baseRepo{
-			creds:                 b.creds,
-			dir:                   path,
-			homeDir:               b.homeDir,
-			insecureSkipTLSVerify: b.insecureSkipTLSVerify,
-			url:                   b.url,
+			creds:   b.creds,
+			dir:     path,
+			homeDir: b.homeDir,
+			url:     b.url,
 		},
 		bareRepo: b,
 	}, nil
@@ -211,11 +207,10 @@ func (b *bareRepo) WorkTrees() ([]WorkTree, error) {
 	for i, workTreePath := range workTreePaths {
 		workTrees[i] = &workTree{
 			baseRepo: &baseRepo{
-				creds:                 b.creds,
-				dir:                   workTreePath,
-				homeDir:               b.homeDir,
-				insecureSkipTLSVerify: b.insecureSkipTLSVerify,
-				url:                   b.url,
+				creds:   b.creds,
+				dir:     workTreePath,
+				homeDir: b.homeDir,
+				url:     b.url,
 			},
 			bareRepo: b,
 		}

--- a/internal/controller/git/bare_repo_test.go
+++ b/internal/controller/git/bare_repo_test.go
@@ -59,7 +59,7 @@ func TestBareRepo(t *testing.T) {
 	require.NoError(t, err)
 	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()))
 	require.NoError(t, err)
-	err = setupRep.Push(false)
+	err = setupRep.Push(nil)
 	require.NoError(t, err)
 	err = setupRep.Close()
 	require.NoError(t, err)

--- a/internal/controller/git/repo.go
+++ b/internal/controller/git/repo.go
@@ -55,10 +55,6 @@ type CloneOptions struct {
 	// - https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
 	// - https://docs.gitlab.com/ee/topics/git/partial_clone.html
 	Filter string
-	// InsecureSkipTLSVerify specifies whether certificate verification errors
-	// should be ignored when cloning the repository. The setting will be
-	// remembered for subsequent interactions with the remote repository.
-	InsecureSkipTLSVerify bool
 	// SingleBranch indicates whether the clone should be a single-branch clone.
 	// This option is ignored if Bare is true.
 	SingleBranch bool
@@ -90,11 +86,10 @@ func Clone(
 			fmt.Errorf("error resolving symlinks in path %s: %w", homeDir, err)
 	}
 	baseRepo := &baseRepo{
-		creds:                 clientOpts.Credentials,
-		dir:                   filepath.Join(homeDir, "repo"),
-		homeDir:               homeDir,
-		insecureSkipTLSVerify: cloneOpts.InsecureSkipTLSVerify,
-		url:                   repoURL,
+		creds:   clientOpts.Credentials,
+		dir:     filepath.Join(homeDir, "repo"),
+		homeDir: homeDir,
+		url:     repoURL,
 	}
 	r := &repo{
 		baseRepo: baseRepo,
@@ -138,8 +133,7 @@ func (r *repo) clone(opts *CloneOptions) error {
 }
 
 type LoadRepoOptions struct {
-	Credentials           *RepoCredentials
-	InsecureSkipTLSVerify bool
+	Credentials *RepoCredentials
 }
 
 func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
@@ -147,9 +141,8 @@ func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
 		opts = &LoadRepoOptions{}
 	}
 	baseRepo := &baseRepo{
-		creds:                 opts.Credentials,
-		dir:                   path,
-		insecureSkipTLSVerify: opts.InsecureSkipTLSVerify,
+		creds: opts.Credentials,
+		dir:   path,
 	}
 	r := &repo{
 		baseRepo: baseRepo,

--- a/internal/controller/git/repo_test.go
+++ b/internal/controller/git/repo_test.go
@@ -140,7 +140,7 @@ func TestRepo(t *testing.T) {
 		require.False(t, exists)
 	})
 
-	err = rep.Push(false)
+	err = rep.Push(nil)
 	require.NoError(t, err)
 
 	t.Run("can push", func(t *testing.T) {

--- a/internal/controller/git/work_tree_test.go
+++ b/internal/controller/git/work_tree_test.go
@@ -58,7 +58,7 @@ func TestWorkTree(t *testing.T) {
 	require.NoError(t, err)
 	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()))
 	require.NoError(t, err)
-	err = setupRep.Push(false)
+	err = setupRep.Push(nil)
 	require.NoError(t, err)
 	err = setupRep.Close()
 	require.NoError(t, err)

--- a/internal/controller/promotion/git.go
+++ b/internal/controller/promotion/git.go
@@ -197,12 +197,11 @@ func (g *gitMechanism) doSingleUpdate(
 	repo, err := git.Clone(
 		update.RepoURL,
 		&git.ClientOptions{
-			User:        author,
-			Credentials: creds,
-		},
-		&git.CloneOptions{
+			User:                  author,
+			Credentials:           creds,
 			InsecureSkipTLSVerify: update.InsecureSkipTLSVerify,
 		},
+		nil,
 	)
 	if err != nil {
 		return fmt.Errorf("error cloning git repo %q: %w", update.RepoURL, err)
@@ -464,7 +463,7 @@ func (g *gitMechanism) gitCommit(
 		if err = repo.AddAllAndCommit(commitMsg); err != nil {
 			return "", fmt.Errorf("error committing updates to git repo %q: %w", update.RepoURL, err)
 		}
-		if err = repo.Push(false); err != nil {
+		if err = repo.Push(nil); err != nil {
 			return "", fmt.Errorf("error pushing updates to git repo %q: %w", update.RepoURL, err)
 		}
 	}

--- a/internal/controller/promotion/pullrequest.go
+++ b/internal/controller/promotion/pullrequest.go
@@ -41,7 +41,7 @@ func preparePullRequestBranch(repo git.Repo, prBranch string, base string) error
 		); err != nil {
 			return err
 		}
-		if err = repo.Push(false); err != nil {
+		if err = repo.Push(nil); err != nil {
 			return err
 		}
 	} else if err = repo.Checkout(base); err != nil {
@@ -56,7 +56,7 @@ func preparePullRequestBranch(repo git.Repo, prBranch string, base string) error
 		if err := repo.CreateChildBranch(prBranch); err != nil {
 			return err
 		}
-		if err := repo.Push(false); err != nil {
+		if err := repo.Push(nil); err != nil {
 			return err
 		}
 	} else {
@@ -80,7 +80,7 @@ func preparePullRequestBranch(repo git.Repo, prBranch string, base string) error
 			if err = repo.CreateChildBranch(prBranch); err != nil {
 				return err
 			}
-			if err = repo.Push(true); err != nil {
+			if err = repo.Push(&git.PushOptions{Force: true}); err != nil {
 				return err
 			}
 		}

--- a/internal/controller/warehouses/git.go
+++ b/internal/controller/warehouses/git.go
@@ -69,15 +69,15 @@ func (r *reconciler) discoverCommits(
 
 		// Clone the Git repository.
 		cloneOpts := &git.CloneOptions{
-			Branch:                sub.Branch,
-			SingleBranch:          true,
-			Filter:                git.FilterBlobless,
-			InsecureSkipTLSVerify: sub.InsecureSkipTLSVerify,
+			Branch:       sub.Branch,
+			SingleBranch: true,
+			Filter:       git.FilterBlobless,
 		}
 		repo, err := r.gitCloneFn(
 			sub.RepoURL,
 			&git.ClientOptions{
-				Credentials: repoCreds,
+				Credentials:           repoCreds,
+				InsecureSkipTLSVerify: sub.InsecureSkipTLSVerify,
 			},
 			cloneOpts,
 		)


### PR DESCRIPTION
This adds a couple more enhancements to our git package:

* On clone, persists preference for ignoring cert errors as config so that preference does not need to be re-specified when loading an existing repo from the FS.

* Add option when pushing to push to a remote branch with a different name than the current local branch.

There are more prerequisite capabilities for the git-based promotion directives.