### PR TITLE
fix(docs): specify pnpm version for building docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"
   },
+  "packageManager": "pnpm@9.0.3",
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.11.0",
     "@docusaurus/core": "^3.0.0",

--- a/docs/plugins/gtag/package.json
+++ b/docs/plugins/gtag/package.json
@@ -7,6 +7,7 @@
     "build": "tsc --build",
     "watch": "tsc --build --watch"
   },
+  "packageManager": "pnpm@9.0.3",
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/types": "^3.0.0",


### PR DESCRIPTION
Unlike the UI's `package.json`, the `package.json` for the docs site and for the custom plugin it uses were not specifying what version of pnpm to use. As a result, build/deploy of the docs site on Netlify was using their default pnpm version, which was older. Thanks to [a recent PR from Dependapot](https://github.com/akuity/kargo/pull/2469) the plugin's `pnpm-lock.yaml` is no longer compatible with that older pnpm...

This made pnpm _ignore_ the lock file and resolve _different_ versions of some dependencies, which, in turn, was responsible for the recent failed doc site builds on Netlify.

This PR should set things straight again and because the current production docs are built and deployed from the `release-0.8` branch, I am going to also backport this.

cc @fykaa this may solve some recent troubles you've had.

cc @rbreeze for node ecosystem sanity check.