### PR TITLE
feat(controller): more git pkg improvements

### DIFF
--- a/internal/controller/git/bare_repo_test.go
+++ b/internal/controller/git/bare_repo_test.go
@@ -107,9 +107,13 @@ func TestBareRepo(t *testing.T) {
 	})
 
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
-	// "master" is still the default branch name for a new repository unless
-	// you configure it otherwise.
-	workTree, err := rep.AddWorkTree(workingTreePath, "master")
+	workTree, err := rep.AddWorkTree(
+		workingTreePath,
+		// "master" is still the default branch name for a new repository unless
+		// you configure it otherwise.
+		&AddWorkTreeOptions{Ref: "master"},
+	)
+
 	require.NoError(t, err)
 	defer workTree.Close()
 

--- a/internal/controller/git/work_tree_test.go
+++ b/internal/controller/git/work_tree_test.go
@@ -75,9 +75,12 @@ func TestWorkTree(t *testing.T) {
 	defer rep.Close()
 
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
-	// "master" is still the default branch name for a new repository unless
-	// you configure it otherwise.
-	workTree, err := rep.AddWorkTree(workingTreePath, "master")
+	workTree, err := rep.AddWorkTree(
+		workingTreePath,
+		// "master" is still the default branch name for a new repository unless
+		// you configure it otherwise.
+		&AddWorkTreeOptions{Ref: "master"},
+	)
 	require.NoError(t, err)
 	defer workTree.Close()
 


### PR DESCRIPTION
These are more incremental improvements to the git package that will be important for git-based promotion directives:

* Add `Clear()` (`git rm -rf .`) to the WorkingTree interface.
* Add `RemoteBranchExists()` to the `BareRepo` interface and move the existing implementation of that from the `workTree` type to the `baseRepo` type.
* Add options to the `BareRepo.AddWorkTree()` func so that it is possible now possible to add a working tree for a brand new orphaned branch.

cc @hiddeco

These improvements felt small and non-controversial enough that I thought it best, as with other recent improvements to the git package, to directly PR these to `main` so that our feature branch you and I have been working on isn't bigger than it really needs to be.