### PR TITLE
fix(directives): return `kustomize-set-image` result

### DIFF
--- a/internal/directives/kustomize_set_image_directive.go
+++ b/internal/directives/kustomize_set_image_directive.go
@@ -96,7 +96,7 @@ func (d *kustomizeSetImageDirective) run(
 		result.Output = make(State, 1)
 		result.Output.Set("commitMessage", commitMsg)
 	}
-	return Result{Status: StatusSuccess}, nil
+	return result, nil
 }
 
 func (d *kustomizeSetImageDirective) buildTargetImages(


### PR DESCRIPTION
Plus some minor changes to the tests to properly reference images (without a tag).