### PR TITLE
feat(controller): add argocd-update directive

### DIFF
--- a/internal/directives/argocd_update_directive.go
+++ b/internal/directives/argocd_update_directive.go
@@ -1,0 +1,1104 @@
+package directives
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gobwas/glob"
+	"github.com/xeipuuv/gojsonschema"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libargocd "github.com/akuity/kargo/internal/argocd"
+	argocd "github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/freight"
+	"github.com/akuity/kargo/internal/git"
+	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/logging"
+)
+
+const (
+	authorizedStageAnnotationKey = "kargo.akuity.io/authorized-stage"
+
+	applicationOperationInitiator = "kargo-controller"
+	freightCollectionInfoKey      = "kargo.akuity.io/freight-collection"
+)
+
+func init() {
+	// Register the argocd-update directive with the builtins registry.
+	builtins.RegisterDirective(
+		newArgocdUpdateDirective(),
+		&DirectivePermissions{
+			AllowKargoClient:  true,
+			AllowArgoCDClient: true,
+		},
+	)
+}
+
+// argocdUpdateDirective is a directive that updates one or more Argo CD
+// Application resources.
+type argocdUpdateDirective struct {
+	schemaLoader gojsonschema.JSONLoader
+
+	// These behaviors are overridable for testing purposes:
+
+	getStageFn func(
+		context.Context,
+		client.Client,
+		client.ObjectKey,
+	) (*kargoapi.Stage, error)
+
+	getAuthorizedApplicationFn func(
+		context.Context,
+		*StepContext,
+		client.ObjectKey,
+	) (*argocd.Application, error)
+
+	buildDesiredSourcesFn func(
+		context.Context,
+		*StepContext,
+		*ArgoCDUpdateConfig,
+		*kargoapi.Stage,
+		*ArgoCDAppUpdate,
+		*argocd.Application,
+	) (*argocd.ApplicationSource, argocd.ApplicationSources, error)
+
+	mustPerformUpdateFn func(
+		context.Context,
+		*StepContext,
+		*ArgoCDUpdateConfig,
+		*kargoapi.Stage,
+		*ArgoCDAppUpdate,
+		*argocd.Application,
+		*argocd.ApplicationSource,
+		argocd.ApplicationSources,
+	) (argocd.OperationPhase, bool, error)
+
+	syncApplicationFn func(
+		ctx context.Context,
+		stepCtx *StepContext,
+		app *argocd.Application,
+		desiredSource *argocd.ApplicationSource,
+		desiredSources argocd.ApplicationSources,
+	) error
+
+	applyArgoCDSourceUpdateFn func(
+		context.Context,
+		*StepContext,
+		*ArgoCDUpdateConfig,
+		*kargoapi.Stage,
+		*ArgoCDAppSourceUpdate,
+		argocd.ApplicationSource,
+	) (argocd.ApplicationSource, error)
+
+	argoCDAppPatchFn func(
+		context.Context,
+		*StepContext,
+		kubeclient.ObjectWithKind,
+		kubeclient.UnstructuredPatchFn,
+	) error
+
+	logAppEventFn func(
+		ctx context.Context,
+		stepCtx *StepContext,
+		app *argocd.Application,
+		user string,
+		reason string,
+		message string,
+	)
+}
+
+// newArgocdUpdateDirective creates a new argocd-update directive.
+func newArgocdUpdateDirective() Directive {
+	d := &argocdUpdateDirective{}
+	d.getStageFn = kargoapi.GetStage
+	d.schemaLoader = getConfigSchemaLoader(d.Name())
+	d.getAuthorizedApplicationFn = d.getAuthorizedApplication
+	d.buildDesiredSourcesFn = d.buildDesiredSources
+	d.mustPerformUpdateFn = d.mustPerformUpdate
+	d.syncApplicationFn = d.syncApplication
+	d.applyArgoCDSourceUpdateFn = d.applyArgoCDSourceUpdate
+	d.argoCDAppPatchFn = d.argoCDAppPatch
+	d.logAppEventFn = d.logAppEvent
+	return d
+}
+
+// Name implements the Directive interface.
+func (a *argocdUpdateDirective) Name() string {
+	return "argocd-update"
+}
+
+// Run implements the Directive interface.
+func (a *argocdUpdateDirective) Run(
+	ctx context.Context,
+	stepCtx *StepContext,
+) (Result, error) {
+	if err := a.validate(stepCtx.Config); err != nil {
+		return Result{Status: StatusFailure}, err
+	}
+	cfg, err := configToStruct[ArgoCDUpdateConfig](stepCtx.Config)
+	if err != nil {
+		return Result{Status: StatusFailure},
+			fmt.Errorf("could not convert config into %s config: %w", a.Name(), err)
+	}
+	return a.run(ctx, stepCtx, cfg)
+}
+
+// validate validates the argocd-update directive configuration against the JSON
+// schema.
+func (a *argocdUpdateDirective) validate(cfg Config) error {
+	return validate(a.schemaLoader, gojsonschema.NewGoLoader(cfg), a.Name())
+}
+
+func (a *argocdUpdateDirective) run(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg ArgoCDUpdateConfig,
+) (Result, error) {
+	if stepCtx.ArgoCDClient == nil {
+		return Result{Status: StatusFailure}, errors.New(
+			"Argo CD integration is disabled on this controller; cannot update " +
+				"Argo CD Application resources",
+		)
+	}
+
+	logger := logging.LoggerFromContext(ctx)
+	logger.Debug("executing Argo CD-based promotion mechanisms")
+
+	stage, err := a.getStageFn(ctx, stepCtx.KargoClient, client.ObjectKey{
+		Namespace: stepCtx.Project,
+		Name:      stepCtx.Stage,
+	})
+	if err != nil {
+		return Result{Status: StatusFailure}, fmt.Errorf(
+			"error getting Stage %q in namespace %q: %w",
+			stepCtx.Stage, stepCtx.Project, err,
+		)
+	}
+	if stage == nil {
+		return Result{Status: StatusFailure}, fmt.Errorf(
+			"Stage %q not found in namespace %q",
+			stepCtx.Stage, stepCtx.Project,
+		)
+	}
+
+	var updateResults = make([]argocd.OperationPhase, 0, len(stepCfg.Apps))
+	for i := range stepCfg.Apps {
+		update := &stepCfg.Apps[i]
+		// Retrieve the Argo CD Application.
+		appKey := client.ObjectKey{
+			Namespace: update.Namespace,
+			Name:      update.Name,
+		}
+		if appKey.Namespace == "" {
+			appKey.Namespace = libargocd.Namespace()
+		}
+		app, err := a.getAuthorizedApplicationFn(ctx, stepCtx, appKey)
+		if err != nil {
+			return Result{Status: StatusFailure}, fmt.Errorf(
+				"error getting Argo CD Application %q in namespace %q: %w",
+				appKey.Name, appKey.Namespace, err,
+			)
+		}
+
+		// Build the desired source(s) for the Argo CD Application.
+		desiredSource, desiredSources, err := a.buildDesiredSourcesFn(
+			ctx,
+			stepCtx,
+			&stepCfg,
+			stage,
+			update,
+			app,
+		)
+		if err != nil {
+			return Result{Status: StatusFailure}, fmt.Errorf(
+				"error building desired sources for Argo CD Application %q in namespace %q: %w",
+				app.Name, app.Namespace, err,
+			)
+		}
+
+		// Check if the update needs to be performed and retrieve its phase.
+		phase, mustUpdate, err := a.mustPerformUpdateFn(
+			ctx,
+			stepCtx,
+			&stepCfg,
+			stage,
+			update,
+			app,
+			desiredSource,
+			desiredSources,
+		)
+
+		// If we have a phase, append it to the results.
+		if phase != "" {
+			updateResults = append(updateResults, phase)
+		}
+
+		// If we don't need to perform an update, further processing depends on
+		// the phase and whether an error occurred.
+		if !mustUpdate {
+			if err != nil {
+				if phase == "" {
+					// If we do not have a phase, we cannot continue processing
+					// this update by waiting.
+					return Result{Status: StatusFailure}, err
+				}
+				// Log the error as a warning, but continue to the next update.
+				logger.Info(err.Error())
+			}
+			if phase.Failed() {
+				// Record the reason for the failure if available.
+				if app.Status.OperationState != nil {
+					return Result{Status: StatusFailure}, fmt.Errorf(
+						"Argo CD Application %q in namespace %q failed with: %s",
+						app.Name,
+						app.Namespace,
+						app.Status.OperationState.Message,
+					)
+				}
+				// If the update failed, we can short-circuit. This is
+				// effectively "fail fast" behavior.
+				return Result{Status: StatusFailure}, nil
+			}
+			// If we get here, we can continue to the next update.
+			continue
+		}
+
+		// Perform the update.
+		if err = a.syncApplicationFn(
+			ctx,
+			stepCtx,
+			app,
+			desiredSource,
+			desiredSources,
+		); err != nil {
+			return Result{Status: StatusFailure}, fmt.Errorf(
+				"error syncing Argo CD Application %q in namespace %q: %w",
+				app.Name, app.Namespace, err,
+			)
+		}
+		// As we have initiated an update, we should wait for it to complete.
+		updateResults = append(updateResults, argocd.OperationRunning)
+	}
+
+	aggregatedStatus := operationPhaseToDirectiveStatus(updateResults...)
+	if aggregatedStatus == "" {
+		return Result{Status: StatusFailure}, fmt.Errorf(
+			"could not determine directive status from operation phases: %v",
+			updateResults,
+		)
+	}
+
+	logger.Debug("done executing Argo CD-based promotion mechanisms")
+	return Result{Status: aggregatedStatus}, nil
+}
+
+// buildDesiredSources returns the desired source(s) for an Argo CD Application,
+// by updating the current source(s) with the given source updates.
+func (a *argocdUpdateDirective) buildDesiredSources(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDAppUpdate,
+	app *argocd.Application,
+) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+	desiredSource, desiredSources := app.Spec.Source.DeepCopy(), app.Spec.Sources.DeepCopy()
+
+	for i := range update.Sources {
+		srcUpdate := &update.Sources[i]
+		if desiredSource != nil {
+			newSrc, err := a.applyArgoCDSourceUpdateFn(ctx, stepCtx, stepCfg, stage, srcUpdate, *desiredSource)
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"error applying source update to Argo CD Application %q in namespace %q: %w",
+					app.Name,
+					app.Namespace,
+					err,
+				)
+			}
+			desiredSource = &newSrc
+		}
+
+		for j, curSrc := range desiredSources {
+			newSrc, err := a.applyArgoCDSourceUpdateFn(ctx, stepCtx, stepCfg, stage, srcUpdate, curSrc)
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"error applying source update to Argo CD Application %q in namespace %q: %w",
+					app.Name,
+					app.Namespace,
+					err,
+				)
+			}
+			desiredSources[j] = newSrc
+		}
+	}
+
+	return desiredSource, desiredSources, nil
+}
+
+func (a *argocdUpdateDirective) mustPerformUpdate(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDAppUpdate,
+	app *argocd.Application,
+	desiredSource *argocd.ApplicationSource,
+	desiredSources argocd.ApplicationSources,
+) (phase argocd.OperationPhase, mustUpdate bool, err error) {
+	status := app.Status.OperationState
+	if status == nil {
+		// The application has no operation.
+		return "", true, nil
+	}
+
+	// Deal with the possibility that the operation was not initiated by the
+	// expected user.
+	if status.Operation.InitiatedBy.Username != applicationOperationInitiator {
+		// The operation was not initiated by the expected user.
+		if !status.Phase.Completed() {
+			// We should wait for the operation to complete before attempting to
+			// apply an update ourselves.
+			// NB: We return the current phase here because we want the caller
+			//     to know that an operation is still running.
+			return status.Phase, false, fmt.Errorf(
+				"current operation was not initiated by %q and not by %q: waiting for operation to complete",
+				applicationOperationInitiator, status.Operation.InitiatedBy.Username,
+			)
+		}
+		// Initiate our own operation.
+		return "", true, nil
+	}
+
+	// Deal with the possibility that the operation was not initiated for the
+	// current freight collection. i.e. Not related to the current promotion.
+	var correctFreightColIDFound bool
+	for _, info := range status.Operation.Info {
+		if info.Name == freightCollectionInfoKey {
+			correctFreightColIDFound = info.Value == stepCtx.Freight.ID
+			break
+		}
+	}
+	if !correctFreightColIDFound {
+		// The operation was not initiated for the current freight collection.
+		if !status.Phase.Completed() {
+			// We should wait for the operation to complete before attempting to
+			// apply an update ourselves.
+			// NB: We return the current phase here because we want the caller
+			//     to know that an operation is still running.
+			return status.Phase, false, fmt.Errorf(
+				"current operation was not initiated for freight collection %q: waiting for operation to complete",
+				stepCtx.Freight.ID,
+			)
+		}
+		// Initiate our own operation.
+		return "", true, nil
+	}
+
+	if !status.Phase.Completed() {
+		// The operation is still running.
+		return status.Phase, false, nil
+	}
+
+	if status.SyncResult == nil {
+		// We do not have a sync result, so we cannot determine if the operation
+		// was successful. The best recourse is to retry the operation.
+		return "", true, errors.New("operation completed without a sync result")
+	}
+
+	// Check if the desired revision was applied.
+	if desiredRevision, err := getDesiredRevision(
+		ctx,
+		stepCtx,
+		stepCfg,
+		stage,
+		update,
+		app,
+	); err != nil {
+		return "", true, fmt.Errorf("error determining desired revision: %w", err)
+	} else if desiredRevision != "" && status.SyncResult.Revision != desiredRevision {
+		// The operation did not result in the desired revision being applied.
+		// We should attempt to retry the operation.
+		return "", true, fmt.Errorf(
+			"operation result revision %q does not match desired revision %q",
+			status.SyncResult.Revision, desiredRevision,
+		)
+	}
+
+	// Check if the desired source(s) were applied.
+	if len(update.Sources) > 0 {
+		if (desiredSource != nil && !desiredSource.Equals(&status.SyncResult.Source)) ||
+			!desiredSources.Equals(status.SyncResult.Sources) {
+			// The operation did not result in the desired source(s) being applied.
+			// We should attempt to retry the operation.
+			return "", true, fmt.Errorf(
+				"operation result source does not match desired source",
+			)
+		}
+	}
+
+	// The operation has completed.
+	return status.Phase, false, nil
+}
+
+func (a *argocdUpdateDirective) syncApplication(
+	ctx context.Context,
+	stepCtx *StepContext,
+	app *argocd.Application,
+	desiredSource *argocd.ApplicationSource,
+	desiredSources argocd.ApplicationSources,
+) error {
+	// Initiate a "hard" refresh.
+	if app.ObjectMeta.Annotations == nil {
+		app.ObjectMeta.Annotations = make(map[string]string, 1)
+	}
+	app.ObjectMeta.Annotations[argocd.AnnotationKeyRefresh] = string(argocd.RefreshTypeHard)
+
+	// Update the desired source(s) in the Argo CD Application.
+	app.Spec.Source = desiredSource.DeepCopy()
+	app.Spec.Sources = desiredSources.DeepCopy()
+
+	// Initiate a new operation.
+	app.Operation = &argocd.Operation{
+		InitiatedBy: argocd.OperationInitiator{
+			Username:  applicationOperationInitiator,
+			Automated: true,
+		},
+		Info: []*argocd.Info{
+			{
+				Name:  "Reason",
+				Value: "Promotion triggered a sync of this Application resource.",
+			},
+			{
+				Name:  freightCollectionInfoKey,
+				Value: stepCtx.Freight.ID,
+			},
+		},
+		Sync: &argocd.SyncOperation{
+			Revisions: []string{},
+		},
+	}
+	if app.Spec.SyncPolicy != nil {
+		if app.Spec.SyncPolicy.Retry != nil {
+			app.Operation.Retry = *app.Spec.SyncPolicy.Retry
+		}
+		if app.Spec.SyncPolicy.SyncOptions != nil {
+			app.Operation.Sync.SyncOptions = app.Spec.SyncPolicy.SyncOptions
+		}
+	}
+	if app.Spec.Source != nil {
+		app.Operation.Sync.Revisions = []string{app.Spec.Source.TargetRevision}
+	}
+	for _, source := range app.Spec.Sources {
+		app.Operation.Sync.Revisions = append(app.Operation.Sync.Revisions, source.TargetRevision)
+	}
+
+	// Patch the Argo CD Application.
+	if err := a.argoCDAppPatchFn(ctx, stepCtx, app, func(src, dst unstructured.Unstructured) error {
+		// If the resource has been modified since we fetched it, an update
+		// can result in unexpected merge results. Detect this, and return an
+		// error if it occurs.
+		if src.GetGeneration() != dst.GetGeneration() {
+			return fmt.Errorf("unable to update sources to desired revisions: resource has been modified")
+		}
+
+		dst.SetAnnotations(src.GetAnnotations())
+		dst.Object["spec"] = recursiveMerge(src.Object["spec"], dst.Object["spec"])
+		dst.Object["operation"] = src.Object["operation"]
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error patching Argo CD Application %q: %w", app.Name, err)
+	}
+	logging.LoggerFromContext(ctx).Debug("patched Argo CD Application", "app", app.Name)
+
+	// NB: This attempts to mimic the behavior of the Argo CD API server,
+	// which logs an event when a sync is initiated. However, we do not
+	// have access to the same enriched event data the Argo CD API server
+	// has, so we are limited to logging an event with the best
+	// information we have at hand.
+	// xref: https://github.com/argoproj/argo-cd/blob/44894e9e438bca5adccf58d2f904adc63365805c/server/application/application.go#L1887-L1895
+	// nolint:lll
+	//
+	// TODO(hidde): It is not clear what we should do if we have a list of
+	// sources.
+	message := "initiated sync"
+	if app.Spec.Source != nil {
+		message += " to " + app.Spec.Source.TargetRevision
+	}
+	a.logAppEventFn(
+		ctx,
+		stepCtx,
+		app,
+		"kargo-controller",
+		argocd.EventReasonOperationStarted,
+		message,
+	)
+	return nil
+}
+
+func (a *argocdUpdateDirective) argoCDAppPatch(
+	ctx context.Context,
+	stepCtx *StepContext,
+	app kubeclient.ObjectWithKind,
+	modify kubeclient.UnstructuredPatchFn,
+) error {
+	return kubeclient.PatchUnstructured(ctx, stepCtx.ArgoCDClient, app, modify)
+}
+
+func (a *argocdUpdateDirective) logAppEvent(
+	ctx context.Context,
+	stepCtx *StepContext,
+	app *argocd.Application,
+	user string,
+	reason string,
+	message string,
+) {
+	logger := logging.LoggerFromContext(ctx).WithValues("app", app.Name)
+
+	// xref: https://github.com/argoproj/argo-cd/blob/44894e9e438bca5adccf58d2f904adc63365805c/server/application/application.go#L2145-L2147
+	// nolint:lll
+	if user == "" {
+		user = "Unknown user"
+	}
+
+	t := metav1.Time{Time: time.Now()}
+	event := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", app.Name, t.UnixNano()),
+			Namespace: app.Namespace,
+			// xref: https://github.com/argoproj/argo-cd/blob/44894e9e438bca5adccf58d2f904adc63365805c/util/argo/audit_logger.go#L118-L124
+			// nolint:lll
+			Annotations: map[string]string{
+				"user": user,
+			},
+		},
+		Source: corev1.EventSource{
+			Component: user,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion:      argocd.GroupVersion.String(),
+			Kind:            app.TypeMeta.Kind,
+			Namespace:       app.ObjectMeta.Namespace,
+			Name:            app.ObjectMeta.Name,
+			UID:             app.ObjectMeta.UID,
+			ResourceVersion: app.ObjectMeta.ResourceVersion,
+		},
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		// xref: https://github.com/argoproj/argo-cd/blob/44894e9e438bca5adccf58d2f904adc63365805c/server/application/application.go#L2148
+		// nolint:lll
+		Message: user + " " + message,
+		Type:    corev1.EventTypeNormal,
+		Reason:  reason,
+	}
+	if err := stepCtx.ArgoCDClient.Create(context.Background(), &event); err != nil {
+		logger.Error(
+			err, "unable to create event for Argo CD Application",
+			"reason", reason,
+		)
+	}
+}
+
+// getAuthorizedApplication returns an Argo CD Application in the given namespace
+// with the given name, if it is authorized for mutation by the Kargo Stage
+// represented by stageMeta.
+func (a *argocdUpdateDirective) getAuthorizedApplication(
+	ctx context.Context,
+	stepCtx *StepContext,
+	appKey client.ObjectKey,
+) (*argocd.Application, error) {
+	app, err := argocd.GetApplication(
+		ctx,
+		stepCtx.ArgoCDClient,
+		appKey.Namespace,
+		appKey.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error finding Argo CD Application %q in namespace %q: %w",
+			appKey.Name, appKey.Namespace, err,
+		)
+	}
+	if app == nil {
+		return nil, fmt.Errorf(
+			"unable to find Argo CD Application %q in namespace %q",
+			appKey.Name, appKey.Namespace,
+		)
+	}
+
+	if err = authorizeArgoCDAppUpdate(stepCtx, app.ObjectMeta); err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}
+
+// authorizeArgoCDAppUpdate returns an error if the Argo CD Application
+// represented by appMeta does not explicitly permit mutation by the Kargo Stage
+// represented by stageMeta.
+func authorizeArgoCDAppUpdate(
+	stepCtx *StepContext,
+	appMeta metav1.ObjectMeta,
+) error {
+	permErr := fmt.Errorf(
+		"Argo CD Application %q in namespace %q does not permit mutation by "+
+			"Kargo Stage %s in namespace %s",
+		appMeta.Name,
+		appMeta.Namespace,
+		stepCtx.Stage,
+		stepCtx.Project,
+	)
+	if appMeta.Annotations == nil {
+		return permErr
+	}
+	allowedStage, ok := appMeta.Annotations[authorizedStageAnnotationKey]
+	if !ok {
+		return permErr
+	}
+	tokens := strings.SplitN(allowedStage, ":", 2)
+	if len(tokens) != 2 {
+		return fmt.Errorf(
+			"unable to parse value of annotation %q (%q) on Argo CD Application "+
+				"%q in namespace %q",
+			authorizedStageAnnotationKey,
+			allowedStage,
+			appMeta.Name,
+			appMeta.Namespace,
+		)
+	}
+	allowedNamespaceGlob, err := glob.Compile(tokens[0])
+	if err != nil {
+		return fmt.Errorf(
+			"Argo CD Application %q in namespace %q has invalid glob expression: %q",
+			appMeta.Name,
+			appMeta.Namespace,
+			tokens[0],
+		)
+	}
+	allowedNameGlob, err := glob.Compile(tokens[1])
+	if err != nil {
+		return fmt.Errorf(
+			"Argo CD Application %q in namespace %q has invalid glob expression: %q",
+			appMeta.Name,
+			appMeta.Namespace,
+			tokens[1],
+		)
+	}
+	if !allowedNamespaceGlob.Match(stepCtx.Project) ||
+		!allowedNameGlob.Match(stepCtx.Stage) {
+		return permErr
+	}
+	return nil
+}
+
+// applyArgoCDSourceUpdate updates a single Argo CD ApplicationSource.
+func (a *argocdUpdateDirective) applyArgoCDSourceUpdate(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDAppSourceUpdate,
+	source argocd.ApplicationSource,
+) (argocd.ApplicationSource, error) {
+	if source.Chart != "" || update.Chart != "" {
+
+		if source.RepoURL != update.RepoURL || source.Chart != update.Chart {
+			// There's no change to make in this case.
+			return source, nil
+		}
+
+		// If we get to here, we have confirmed that this update is applicable to
+		// this source.
+
+		if update.UpdateTargetRevision {
+			desiredOrigin := getDesiredOrigin(stepCfg, update)
+			repoURL := update.RepoURL
+			chartName := update.Chart
+			if !strings.Contains(repoURL, "://") {
+				// Where OCI is concerned, ArgoCDSourceUpdates play by Argo CD rules. i.e.
+				// No leading oci://, and the repository URL is really a registry URL, and
+				// the chart name is a repository within that registry. Warehouses and
+				// Freight, however, do lead with oci:// and handle things more correctly
+				// where a repoURL points directly to a repository and chart name is
+				// irrelevant / blank. We need to account for this when we search our
+				// Freight for the chart.
+				repoURL = fmt.Sprintf(
+					"oci://%s/%s",
+					strings.TrimSuffix(repoURL, "/"),
+					chartName,
+				)
+				chartName = ""
+			}
+			chart, err := freight.FindChart(
+				ctx,
+				stepCtx.KargoClient,
+				stepCtx.Project,
+				stage.Spec.RequestedFreight,
+				desiredOrigin,
+				stepCtx.Freight.References(),
+				repoURL,
+				chartName,
+			)
+			if err != nil {
+				return source,
+					fmt.Errorf("error chart from repo %q: %w", update.RepoURL, err)
+			}
+			if chart != nil {
+				source.TargetRevision = chart.Version
+			}
+		}
+	} else {
+		// We're dealing with a git repo, so we should normalize the repo URLs
+		// before comparing them.
+		sourceRepoURL := git.NormalizeURL(source.RepoURL)
+		if sourceRepoURL != git.NormalizeURL(update.RepoURL) {
+			return source, nil
+		}
+
+		// If we get to here, we have confirmed that this update is applicable to
+		// this source.
+
+		if update.UpdateTargetRevision {
+			desiredOrigin := getDesiredOrigin(stepCfg, update)
+			commit, err := freight.FindCommit(
+				ctx,
+				stepCtx.KargoClient,
+				stepCtx.Project,
+				stage.Spec.RequestedFreight,
+				desiredOrigin,
+				stepCtx.Freight.References(),
+				update.RepoURL,
+			)
+			if err != nil {
+				return source,
+					fmt.Errorf("error finding commit from repo %q: %w", update.RepoURL, err)
+			}
+			if commit != nil {
+				if commit.Tag != "" {
+					source.TargetRevision = commit.Tag
+				} else {
+					source.TargetRevision = commit.ID
+				}
+			}
+		}
+	}
+
+	if update.Kustomize != nil && len(update.Kustomize.Images) > 0 {
+		if source.Kustomize == nil {
+			source.Kustomize = &argocd.ApplicationSourceKustomize{}
+		}
+		var err error
+		if source.Kustomize.Images, err = a.buildKustomizeImagesForArgoCDAppSource(
+			ctx,
+			stepCtx,
+			stepCfg,
+			stage,
+			update.Kustomize,
+		); err != nil {
+			return source, err
+		}
+	}
+
+	if update.Helm != nil && len(update.Helm.Images) > 0 {
+		if source.Helm == nil {
+			source.Helm = &argocd.ApplicationSourceHelm{}
+		}
+		if source.Helm.Parameters == nil {
+			source.Helm.Parameters = []argocd.HelmParameter{}
+		}
+		changes, err := a.buildHelmParamChangesForArgoCDAppSource(
+			ctx,
+			stepCtx,
+			stepCfg,
+			stage,
+			update.Helm,
+		)
+		if err != nil {
+			return source,
+				fmt.Errorf("error building Helm parameter changes: %w", err)
+		}
+	imageUpdateLoop:
+		for k, v := range changes {
+			newParam := argocd.HelmParameter{
+				Name:  k,
+				Value: v,
+			}
+			for i, param := range source.Helm.Parameters {
+				if param.Name == k {
+					source.Helm.Parameters[i] = newParam
+					continue imageUpdateLoop
+				}
+			}
+			source.Helm.Parameters = append(source.Helm.Parameters, newParam)
+		}
+	}
+
+	return source, nil
+}
+
+func (a *argocdUpdateDirective) buildKustomizeImagesForArgoCDAppSource(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDKustomizeImageUpdates,
+) (argocd.KustomizeImages, error) {
+	kustomizeImages := make(argocd.KustomizeImages, 0, len(update.Images))
+	for i := range update.Images {
+		imageUpdate := &update.Images[i]
+		desiredOrigin := getDesiredOrigin(stepCfg, imageUpdate)
+		image, err := freight.FindImage(
+			ctx,
+			stepCtx.KargoClient,
+			stepCtx.Project,
+			stage.Spec.RequestedFreight,
+			desiredOrigin,
+			stepCtx.Freight.References(),
+			imageUpdate.RepoURL,
+		)
+		if err != nil {
+			return nil,
+				fmt.Errorf("error finding image from repo %q: %w", imageUpdate.RepoURL, err)
+		}
+		if image == nil {
+			// There's no change to make in this case.
+			continue
+		}
+		kustomizeImageStr := imageUpdate.RepoURL
+		if imageUpdate.NewName != "" {
+			kustomizeImageStr = fmt.Sprintf("%s=%s", kustomizeImageStr, imageUpdate.NewName)
+		}
+		if imageUpdate.UseDigest {
+			kustomizeImageStr = fmt.Sprintf("%s@%s", kustomizeImageStr, image.Digest)
+		} else {
+			kustomizeImageStr = fmt.Sprintf("%s:%s", kustomizeImageStr, image.Tag)
+		}
+		kustomizeImages = append(
+			kustomizeImages,
+			argocd.KustomizeImage(kustomizeImageStr),
+		)
+	}
+	return kustomizeImages, nil
+}
+
+func (a *argocdUpdateDirective) buildHelmParamChangesForArgoCDAppSource(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDHelmParameterUpdates,
+) (map[string]string, error) {
+	changes := map[string]string{}
+	for i := range update.Images {
+		imageUpdate := &update.Images[i]
+		switch imageUpdate.Value {
+		case ImageAndTag, Tag, ImageAndDigest, Digest:
+		default:
+			// This really shouldn't happen, so we'll ignore it.
+			continue
+		}
+		desiredOrigin := getDesiredOrigin(stepCfg, imageUpdate)
+		image, err := freight.FindImage(
+			ctx,
+			stepCtx.KargoClient,
+			stepCtx.Project,
+			stage.Spec.RequestedFreight,
+			desiredOrigin,
+			stepCtx.Freight.References(),
+			imageUpdate.RepoURL,
+		)
+		if err != nil {
+			return nil,
+				fmt.Errorf("error finding image from repo %q: %w", imageUpdate.RepoURL, err)
+		}
+		if image == nil {
+			continue
+		}
+		switch imageUpdate.Value {
+		case ImageAndTag:
+			changes[imageUpdate.Key] = fmt.Sprintf("%s:%s", imageUpdate.RepoURL, image.Tag)
+		case Tag:
+			changes[imageUpdate.Key] = image.Tag
+		case ImageAndDigest:
+			changes[imageUpdate.Key] = fmt.Sprintf("%s@%s", imageUpdate.RepoURL, image.Digest)
+		case Digest:
+			changes[imageUpdate.Key] = image.Digest
+		}
+	}
+	return changes, nil
+}
+
+func operationPhaseToDirectiveStatus(phases ...argocd.OperationPhase) Status {
+	if len(phases) == 0 {
+		return ""
+	}
+
+	libargocd.ByOperationPhase(phases).Sort()
+
+	switch phases[0] {
+	case argocd.OperationRunning, argocd.OperationTerminating:
+		return StatusPending
+	case argocd.OperationFailed, argocd.OperationError:
+		return StatusFailure
+	case argocd.OperationSucceeded:
+		return StatusSuccess
+	default:
+		return ""
+	}
+}
+
+func recursiveMerge(src, dst any) any {
+	switch src := src.(type) {
+	case map[string]any:
+		dst, ok := dst.(map[string]any)
+		if !ok {
+			return src
+		}
+		for srcK, srcV := range src {
+			if dstV, ok := dst[srcK]; ok {
+				dst[srcK] = recursiveMerge(srcV, dstV)
+			} else {
+				dst[srcK] = srcV
+			}
+		}
+	case []any:
+		dst, ok := dst.([]any)
+		if !ok {
+			return src
+		}
+		result := make([]any, len(src))
+		for i, srcV := range src {
+			if i < len(dst) {
+				result[i] = recursiveMerge(srcV, dst[i])
+			} else {
+				result[i] = srcV
+			}
+		}
+		return result
+	default:
+		return src
+	}
+	return dst
+}
+
+// getDesiredRevision returns the desired revision for the given
+// v1alpha1.Application. If that cannot be determined, an empty string is
+// returned.
+func getDesiredRevision(
+	ctx context.Context,
+	stepCtx *StepContext,
+	stepCfg *ArgoCDUpdateConfig,
+	stage *kargoapi.Stage,
+	update *ArgoCDAppUpdate,
+	app *argocd.Application,
+) (string, error) {
+	switch {
+	case app == nil || app.Spec.Source == nil:
+		// Without an Application, we can't determine the desired revision.
+		return "", nil
+	case app.Spec.Source.Chart != "":
+		// This source points to a Helm chart.
+		// NB: This has to go first, as the repository URL can also point to
+		//     a Helm repository.
+
+		// If there is a source update that targets app.Spec.Source, it might
+		// have its own ideas about the desired revision.
+		var targetUpdate any
+		for i := range update.Sources {
+			sourceUpdate := &update.Sources[i]
+			if sourceUpdate.RepoURL == app.Spec.Source.RepoURL && sourceUpdate.Chart == app.Spec.Source.Chart {
+				targetUpdate = sourceUpdate
+				break
+			}
+		}
+		if targetUpdate == nil {
+			targetUpdate = &update
+		}
+		desiredOrigin := getDesiredOrigin(stepCfg, targetUpdate)
+		repoURL := app.Spec.Source.RepoURL
+		chartName := app.Spec.Source.Chart
+		if !strings.Contains(repoURL, "://") {
+			// In Argo CD ApplicationSource, if a repo URL specifies no protocol and a
+			// chart name is set (already confirmed at this point), we can assume that
+			// the repo URL is an OCI registry URL. Kargo Warehouses and Freight,
+			// however, do use oci:// at the beginning of such URLs.
+			//
+			// Additionally, where OCI is concerned, an ApplicationSource's repoURL is
+			// really a registry URL, and the chart name is a repository within that
+			// registry. Warehouses and Freight, however, handle things more correctly
+			// where a repoURL points directly to a repository and chart name is
+			// irrelevant / blank. We need to account for this when we search our
+			// Freight for the chart.
+			repoURL = fmt.Sprintf(
+				"oci://%s/%s",
+				strings.TrimSuffix(repoURL, "/"),
+				chartName,
+			)
+			chartName = ""
+		}
+		chart, err := freight.FindChart(
+			ctx,
+			stepCtx.KargoClient,
+			stepCtx.Project,
+			stage.Spec.RequestedFreight,
+			desiredOrigin,
+			stepCtx.Freight.References(),
+			repoURL,
+			chartName,
+		)
+		if err != nil {
+			return "", fmt.Errorf("error chart from repo %q: %w", app.Spec.Source.RepoURL, err)
+		}
+		if chart == nil {
+			return "", nil
+		}
+		return chart.Version, nil
+	case app.Spec.Source.RepoURL != "":
+		// This source points to a Git repository.
+
+		// If there is a source update that targets app.Spec.Source, it might
+		// have its own ideas about the desired revision.
+		var targetUpdate any
+		for i := range update.Sources {
+			sourceUpdate := &update.Sources[i]
+			if sourceUpdate.RepoURL == app.Spec.Source.RepoURL {
+				targetUpdate = sourceUpdate
+				break
+			}
+		}
+		if targetUpdate == nil {
+			targetUpdate = update
+		}
+		desiredOrigin := getDesiredOrigin(stepCfg, targetUpdate)
+		commit, err := freight.FindCommit(
+			ctx,
+			stepCtx.KargoClient,
+			stepCtx.Project,
+			stage.Spec.RequestedFreight,
+			desiredOrigin,
+			stepCtx.Freight.References(),
+			app.Spec.Source.RepoURL,
+		)
+		if err != nil {
+			return "",
+				fmt.Errorf("error finding commit from repo %q: %w", app.Spec.Source.RepoURL, err)
+		}
+		if commit == nil {
+			return "", nil
+		}
+		if commit.HealthCheckCommit != "" {
+			return commit.HealthCheckCommit, nil
+		}
+		return commit.ID, nil
+	}
+	// If we end up here, no desired revision was found.
+	return "", nil
+}

--- a/internal/directives/argocd_update_directive.go
+++ b/internal/directives/argocd_update_directive.go
@@ -536,7 +536,7 @@ func (a *argocdUpdateDirective) syncApplication(
 		ctx,
 		stepCtx,
 		app,
-		"kargo-controller",
+		applicationOperationInitiator,
 		argocd.EventReasonOperationStarted,
 		message,
 	)

--- a/internal/directives/argocd_update_directive.go
+++ b/internal/directives/argocd_update_directive.go
@@ -169,7 +169,7 @@ func (a *argocdUpdateDirective) run(
 	}
 
 	logger := logging.LoggerFromContext(ctx)
-	logger.Debug("executing Argo CD-based promotion mechanisms")
+	logger.Debug("executing argocd-update directive")
 
 	stage, err := a.getStageFn(ctx, stepCtx.KargoClient, client.ObjectKey{
 		Namespace: stepCtx.Project,
@@ -295,7 +295,7 @@ func (a *argocdUpdateDirective) run(
 		)
 	}
 
-	logger.Debug("done executing Argo CD-based promotion mechanisms")
+	logger.Debug("done executing argocd-update directive")
 	return Result{Status: aggregatedStatus}, nil
 }
 

--- a/internal/directives/argocd_update_directive_test.go
+++ b/internal/directives/argocd_update_directive_test.go
@@ -1,0 +1,2464 @@
+package directives
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
+	argocd "github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
+	"github.com/akuity/kargo/internal/kubeclient"
+)
+
+func TestNewArgocdUpdateDirective(t *testing.T) {
+	d := newArgocdUpdateDirective()
+	dir, ok := d.(*argocdUpdateDirective)
+	require.True(t, ok)
+	require.Equal(t, "argocd-update", d.Name())
+	require.NotNil(t, dir.getStageFn)
+	require.NotNil(t, dir.schemaLoader)
+	require.NotNil(t, dir.getAuthorizedApplicationFn)
+	require.NotNil(t, dir.buildDesiredSourcesFn)
+	require.NotNil(t, dir.mustPerformUpdateFn)
+	require.NotNil(t, dir.syncApplicationFn)
+	require.NotNil(t, dir.applyArgoCDSourceUpdateFn)
+	require.NotNil(t, dir.argoCDAppPatchFn)
+	require.NotNil(t, dir.logAppEventFn)
+}
+
+func TestArgoCDUpdateDirective_validate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		config           Config
+		expectedProblems []string
+	}{
+		{
+			name:   "apps not specified",
+			config: Config{},
+			expectedProblems: []string{
+				"(root): apps is required",
+			},
+		},
+		{
+			name: "apps is empty array",
+			config: Config{
+				"apps": []Config{},
+			},
+			expectedProblems: []string{
+				"apps: Array must have at least 1 items",
+			},
+		},
+		{
+			name: "app name not specified",
+			config: Config{
+				"apps": []Config{{}},
+			},
+			expectedProblems: []string{
+				"apps.0: name is required",
+			},
+		},
+		{
+			name: "app name is empty string",
+			config: Config{
+				"apps": []Config{{
+					"name": "",
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.name: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "app namespace is empty string",
+			config: Config{
+				"apps": []Config{{
+					"namespace": "",
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.namespace: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "app sources is empty array",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources: Array must have at least 1 items",
+			},
+		},
+		{
+			name: "source repoURL not specified",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0: repoURL is required",
+			},
+		},
+		{
+			name: "source repoURL is empty string",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"repoURL": "",
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.repoURL: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "helm images is empty array",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images: Array must have at least 1 items",
+			},
+		},
+		{
+			name: "helm images update key is not specified",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0: key is required",
+			},
+		},
+		{
+			name: "helm images update key is empty string",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{
+								"key": "",
+							}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0.key: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "helm images update repoURL is not specified",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0: repoURL is required",
+			},
+		},
+		{
+			name: "helm images update repoURL is empty string",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{
+								"repoURL": "",
+							}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0.repoURL: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "helm images update value is not specified",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0: value is required",
+			},
+		},
+		{
+			name: "helm images update value is invalid",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"helm": Config{
+							"images": []Config{{
+								"value": "bogus",
+							}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.helm.images.0.value must be one of the following",
+			},
+		},
+		{
+			name: "kustomize images is empty array",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"kustomize": Config{
+							"images": []Config{},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.kustomize.images: Array must have at least 1 items",
+			},
+		},
+		{
+			name: "kustomize images update newName is empty string",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"kustomize": Config{
+							"images": []Config{{
+								"newName": "",
+							}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.kustomize.images.0.newName: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "kustomize images update repoURL is not specified",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"kustomize": Config{
+							"images": []Config{{}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.kustomize.images.0: repoURL is required",
+			},
+		},
+		{
+			name: "kustomize images update repoURL is empty string",
+			config: Config{
+				"apps": []Config{{
+					"sources": []Config{{
+						"kustomize": Config{
+							"images": []Config{{
+								"repoURL": "",
+							}},
+						},
+					}},
+				}},
+			},
+			expectedProblems: []string{
+				"apps.0.sources.0.kustomize.images.0.repoURL: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "valid kitchen sink",
+			config: Config{
+				"apps": []Config{{
+					"name":      "app",
+					"namespace": "argocd",
+					"sources": []Config{{
+						"repoURL":              "fake-git-url",
+						"updateTargetRevision": true,
+						"helm": Config{
+							"images": []Config{{
+								"repoURL": "fake-image-url",
+								"key":     "fake-key",
+								"value":   Tag,
+							}},
+						},
+						"kustomize": Config{
+							"images": []Config{{
+								"repoURL":   "fake-image-url",
+								"newName":   "fake-new-name",
+								"useDigest": true,
+							}},
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	d := newArgocdUpdateDirective()
+	dir, ok := d.(*argocdUpdateDirective)
+	require.True(t, ok)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := dir.validate(testCase.config)
+			if len(testCase.expectedProblems) == 0 {
+				require.NoError(t, err)
+			} else {
+				for _, problem := range testCase.expectedProblems {
+					require.ErrorContains(t, err, problem)
+				}
+			}
+		})
+	}
+}
+
+func TestArgoCDUpdateDirective_run(t *testing.T) {
+	testCases := []struct {
+		name       string
+		dir        *argocdUpdateDirective
+		stepCtx    *StepContext
+		stepCfg    ArgoCDUpdateConfig
+		assertions func(*testing.T, Result, error)
+	}{
+		{
+			name:    "argo cd integration disabled",
+			dir:     &argocdUpdateDirective{},
+			stepCtx: &StepContext{},
+			stepCfg: ArgoCDUpdateConfig{},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(
+					t, err, "Argo CD integration is disabled on this controller",
+				)
+			},
+		},
+		{
+			name: "error getting Stage",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "error getting Stage")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "Stage not found",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return nil, nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "Stage")
+				require.ErrorContains(t, err, "not found in namespace")
+			},
+		},
+		{
+			name: "error retrieving authorized application",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "error getting Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "error building desired sources",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return nil, nil, errors.New("something went wrong")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "error building desired sources for Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "error determining if update is necessary",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return "", false, errors.New("something went wrong")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "determination error can be solved by applying update",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return "", true, errors.New("something went wrong")
+				},
+				syncApplicationFn: func(
+					context.Context,
+					*StepContext,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) error {
+					return nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusPending, res.Status)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "must wait for update to complete",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return argocd.OperationRunning, false, nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusPending, res.Status)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "must wait for operation from different user to complete",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return argocd.OperationRunning, false, fmt.Errorf("waiting for operation to complete")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusPending, res.Status)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "error applying update",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return "", true, nil
+				},
+				syncApplicationFn: func(
+					context.Context,
+					*StepContext,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "error syncing Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "failed and pending update",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func() func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					var count uint
+					return func(
+						context.Context,
+						*StepContext,
+						*ArgoCDUpdateConfig,
+						*kargoapi.Stage,
+						*ArgoCDAppUpdate,
+						*argocd.Application,
+						*argocd.ApplicationSource,
+						argocd.ApplicationSources,
+					) (argocd.OperationPhase, bool, error) {
+						count++
+						if count > 1 {
+							return argocd.OperationFailed, false, nil
+						}
+						return "", true, nil
+					}
+				}(),
+				syncApplicationFn: func(
+					context.Context,
+					*StepContext,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) error {
+					return nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{
+					{},
+					{},
+				},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "operation phase aggregation error",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return "Unknown", false, nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusFailure, res.Status)
+				require.ErrorContains(t, err, "could not determine directive status")
+			},
+		},
+		{
+			name: "completed",
+			dir: &argocdUpdateDirective{
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					client.ObjectKey,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getAuthorizedApplicationFn: func(
+					context.Context,
+					*StepContext,
+					client.ObjectKey,
+				) (*v1alpha1.Application, error) {
+					return &argocd.Application{}, nil
+				},
+				buildDesiredSourcesFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+				) (*argocd.ApplicationSource, argocd.ApplicationSources, error) {
+					return &argocd.ApplicationSource{}, nil, nil
+				},
+				mustPerformUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppUpdate,
+					*argocd.Application,
+					*argocd.ApplicationSource,
+					argocd.ApplicationSources,
+				) (argocd.OperationPhase, bool, error) {
+					return argocd.OperationSucceeded, false, nil
+				},
+			},
+			stepCtx: &StepContext{
+				ArgoCDClient: fake.NewFakeClient(),
+			},
+			stepCfg: ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{}},
+			},
+			assertions: func(t *testing.T, res Result, err error) {
+				require.Equal(t, StatusSuccess, res.Status)
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			res, err := testCase.dir.run(
+				context.Background(),
+				testCase.stepCtx,
+				testCase.stepCfg,
+			)
+			testCase.assertions(t, res, err)
+		})
+	}
+}
+
+func TestArgoCDUpdateDirective_buildDesiredSources(t *testing.T) {
+	testCases := []struct {
+		name              string
+		dir               *argocdUpdateDirective
+		modifyApplication func(*argocd.Application)
+		update            *ArgoCDAppUpdate
+		assertions        func(
+			t *testing.T,
+			oldSource, newSource *argocd.ApplicationSource,
+			oldSources, newSources argocd.ApplicationSources,
+			err error,
+		)
+	}{
+		{
+			name: "applies updates to source",
+			dir: &argocdUpdateDirective{
+				applyArgoCDSourceUpdateFn: func(
+					_ context.Context,
+					_ *StepContext,
+					_ *ArgoCDUpdateConfig,
+					_ *kargoapi.Stage,
+					_ *ArgoCDAppSourceUpdate,
+					src argocd.ApplicationSource,
+				) (argocd.ApplicationSource, error) {
+					if src.RepoURL == "updated-url" {
+						src.TargetRevision = "updated-revision"
+						return src, nil
+					}
+					if src.RepoURL == "" {
+						src.RepoURL = "updated-url"
+					}
+					return src, nil
+				},
+			},
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{}
+			},
+			update: &ArgoCDAppUpdate{
+				Sources: []ArgoCDAppSourceUpdate{{}, {}},
+			},
+			assertions: func(
+				t *testing.T,
+				oldSource, newSource *argocd.ApplicationSource,
+				oldSources, newSources argocd.ApplicationSources,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.True(t, oldSources.Equals(newSources))
+
+				require.False(t, oldSource.Equals(newSource))
+				require.Equal(t, "updated-url", newSource.RepoURL)
+				require.Equal(t, "updated-revision", newSource.TargetRevision)
+			},
+		},
+		{
+			name: "error applying update to source",
+			dir: &argocdUpdateDirective{
+				applyArgoCDSourceUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppSourceUpdate,
+					argocd.ApplicationSource,
+				) (argocd.ApplicationSource, error) {
+					return argocd.ApplicationSource{}, errors.New("something went wrong")
+				},
+			},
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{}
+			},
+			update: &ArgoCDAppUpdate{
+				Sources: []ArgoCDAppSourceUpdate{{}},
+			},
+			assertions: func(
+				t *testing.T,
+				_, newSource *argocd.ApplicationSource,
+				_, newSources argocd.ApplicationSources,
+				err error,
+			) {
+				require.ErrorContains(t, err, "something went wrong")
+				require.Nil(t, newSource)
+				require.Nil(t, newSources)
+			},
+		},
+		{
+			name: "applies updates to sources",
+			dir: &argocdUpdateDirective{
+				applyArgoCDSourceUpdateFn: func(
+					_ context.Context,
+					_ *StepContext,
+					_ *ArgoCDUpdateConfig,
+					_ *kargoapi.Stage,
+					_ *ArgoCDAppSourceUpdate,
+					src argocd.ApplicationSource,
+				) (argocd.ApplicationSource, error) {
+					if src.RepoURL == "url-1" {
+						src.TargetRevision = "updated-revision-1"
+						return src, nil
+					}
+					if src.RepoURL == "url-2" {
+						src.TargetRevision = "updated-revision-2"
+						return src, nil
+					}
+					return src, nil
+				},
+			},
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Sources = argocd.ApplicationSources{
+					{
+						RepoURL: "url-1",
+					},
+					{
+						RepoURL: "url-2",
+					},
+				}
+			},
+			update: &ArgoCDAppUpdate{
+				Sources: []ArgoCDAppSourceUpdate{{}},
+			},
+			assertions: func(
+				t *testing.T,
+				oldSource, newSource *argocd.ApplicationSource,
+				oldSources, newSources argocd.ApplicationSources,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.True(t, oldSource.Equals(newSource))
+				require.False(t, oldSources.Equals(newSources))
+
+				require.Equal(t, 2, len(newSources))
+				require.Equal(t, "updated-revision-1", newSources[0].TargetRevision)
+				require.Equal(t, "updated-revision-2", newSources[1].TargetRevision)
+			},
+		},
+		{
+			name: "error applying update to sources",
+			dir: &argocdUpdateDirective{
+				applyArgoCDSourceUpdateFn: func(
+					context.Context,
+					*StepContext,
+					*ArgoCDUpdateConfig,
+					*kargoapi.Stage,
+					*ArgoCDAppSourceUpdate,
+					argocd.ApplicationSource,
+				) (argocd.ApplicationSource, error) {
+					return argocd.ApplicationSource{}, errors.New("something went wrong")
+				},
+			},
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Sources = argocd.ApplicationSources{
+					{},
+				}
+			},
+			update: &ArgoCDAppUpdate{
+				Sources: []ArgoCDAppSourceUpdate{{}},
+			},
+			assertions: func(
+				t *testing.T,
+				_, newSource *argocd.ApplicationSource,
+				_, newSources argocd.ApplicationSources,
+				err error,
+			) {
+				require.ErrorContains(t, err, "something went wrong")
+				require.Nil(t, newSource)
+				require.Nil(t, newSources)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			app := &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-app",
+					Namespace: "fake-namespace",
+				},
+			}
+			if testCase.modifyApplication != nil {
+				testCase.modifyApplication(app)
+			}
+			oldSource, oldSources := app.Spec.Source.DeepCopy(), app.Spec.Sources.DeepCopy()
+			newSource, newSources, err := testCase.dir.buildDesiredSources(
+				context.Background(),
+				&StepContext{},
+				&ArgoCDUpdateConfig{},
+				&kargoapi.Stage{},
+				testCase.update,
+				app,
+			)
+			testCase.assertions(t, oldSource, newSource, oldSources, newSources, err)
+		})
+	}
+}
+
+func TestArgoCDUpdateDirective_mustPerformUpdate(t *testing.T) {
+	testFreightCollectionID := "fake-freight-collection"
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+	testCases := []struct {
+		name              string
+		modifyApplication func(*argocd.Application)
+		newFreight        []kargoapi.FreightReference
+		desiredSource     *argocd.ApplicationSource
+		desiredSources    argocd.ApplicationSources
+		assertions        func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error)
+	}{
+		{
+			name: "no operation state",
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.Empty(t, phase)
+				require.True(t, mustUpdate)
+			},
+		},
+		{
+			name: "running operation initiated by different user",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationRunning,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: "someone-else",
+						},
+					},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "current operation was not initiated by")
+				require.ErrorContains(t, err, "waiting for operation to complete")
+				require.Equal(t, argocd.OperationRunning, phase)
+				require.False(t, mustUpdate)
+			},
+		},
+		{
+			name: "completed operation initiated by different user",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: "someone-else",
+						},
+					},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.True(t, mustUpdate)
+				require.Empty(t, phase)
+			},
+		},
+		{
+			name: "running operation initiated for incorrect freight collection",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationRunning,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: "wrong-freight-collection",
+						}},
+					},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "current operation was not initiated for")
+				require.ErrorContains(t, err, "waiting for operation to complete")
+				require.Equal(t, argocd.OperationRunning, phase)
+				require.False(t, mustUpdate)
+			},
+		},
+		{
+			name: "completed operation initiated for incorrect freight collection",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: "wrong-freight-collection",
+						}},
+					},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.True(t, mustUpdate)
+				require.Empty(t, phase)
+			},
+		},
+		{
+			name: "running operation",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationRunning,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.False(t, mustUpdate)
+				require.Equal(t, argocd.OperationRunning, phase)
+			},
+		},
+		{
+			name: "unable to determine desired revision",
+			modifyApplication: func(app *argocd.Application) {
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+					SyncResult: &argocd.SyncOperationResult{},
+				}
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.Equal(t, argocd.OperationSucceeded, phase)
+				require.False(t, mustUpdate)
+			},
+		},
+		{
+			name: "no sync result",
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{
+					RepoURL: "https://github.com/universe/42",
+				}
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+				}
+			},
+			newFreight: []kargoapi.FreightReference{{
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL:           "https://github.com/universe/42",
+						HealthCheckCommit: "fake-revision",
+					},
+				},
+			}},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "operation completed without a sync result")
+				require.Empty(t, phase)
+				require.True(t, mustUpdate)
+			},
+		},
+		{
+			name: "desired revision does not match operation state",
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{
+					RepoURL: "https://github.com/universe/42",
+				}
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+					SyncResult: &argocd.SyncOperationResult{
+						Revision: "other-fake-revision",
+					},
+				}
+			},
+			newFreight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL: "https://github.com/universe/42",
+						ID:      "fake-revision",
+					},
+				},
+			}},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "does not match desired revision")
+				require.Empty(t, phase)
+				require.True(t, mustUpdate)
+			},
+		},
+		{
+			name: "desired source does not match operation state",
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{
+					RepoURL: "https://github.com/universe/42",
+				}
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+					SyncResult: &argocd.SyncOperationResult{
+						Revision: "fake-revision",
+						Source: argocd.ApplicationSource{
+							RepoURL: "https://github.com/different/universe",
+						},
+					},
+				}
+			},
+			desiredSource: &argocd.ApplicationSource{
+				RepoURL: "http://github.com/universe/42",
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "does not match desired source")
+				require.Empty(t, phase)
+				require.True(t, mustUpdate)
+			},
+		},
+		{
+			name: "desired sources do not match operation state",
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Sources = argocd.ApplicationSources{
+					{
+						RepoURL: "https://github.com/universe/42",
+					},
+				}
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+					SyncResult: &argocd.SyncOperationResult{
+						Revision: "fake-revision",
+						Sources: argocd.ApplicationSources{
+							{
+								RepoURL: "https://github.com/different/universe",
+							},
+						},
+					},
+				}
+			},
+			desiredSource: &argocd.ApplicationSource{},
+			desiredSources: argocd.ApplicationSources{
+				{
+					RepoURL: "https://github.com/universe/42",
+				},
+			},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.ErrorContains(t, err, "does not match desired source")
+				require.Empty(t, phase)
+				require.True(t, mustUpdate)
+			},
+		},
+		{
+			name: "operation completed",
+			modifyApplication: func(app *argocd.Application) {
+				app.Spec.Source = &argocd.ApplicationSource{
+					RepoURL: "https://github.com/universe/42",
+				}
+				app.Status.OperationState = &argocd.OperationState{
+					Phase: argocd.OperationSucceeded,
+					Operation: argocd.Operation{
+						InitiatedBy: argocd.OperationInitiator{
+							Username: applicationOperationInitiator,
+						},
+						Info: []*argocd.Info{{
+							Name:  freightCollectionInfoKey,
+							Value: testFreightCollectionID,
+						}},
+					},
+					SyncResult: &argocd.SyncOperationResult{
+						Revision: "fake-revision",
+					},
+				}
+			},
+			newFreight: []kargoapi.FreightReference{{
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL: "https://github.com/universe/42",
+						ID:      "fake-revision",
+					},
+				},
+			}},
+			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
+				require.NoError(t, err)
+				require.Equal(t, argocd.OperationSucceeded, phase)
+				require.False(t, mustUpdate)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			app := &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-name",
+					Namespace: "fake-namespace",
+				},
+			}
+			if testCase.modifyApplication != nil {
+				testCase.modifyApplication(app)
+			}
+
+			dir := &argocdUpdateDirective{}
+
+			freight := kargoapi.FreightCollection{}
+			for _, ref := range testCase.newFreight {
+				freight.UpdateOrPush(ref)
+			}
+			// Tamper with the freight collection ID for testing purposes
+			freight.ID = testFreightCollectionID
+
+			stepCfg := &ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{
+					Sources: []ArgoCDAppSourceUpdate{{
+						FromOrigin: &AppFromOrigin{
+							Kind: Kind(testOrigin.Kind),
+							Name: testOrigin.Name,
+						},
+						RepoURL: "https://github.com/universe/42",
+					}},
+				}},
+			}
+
+			phase, mustUpdate, err := dir.mustPerformUpdate(
+				context.Background(),
+				&StepContext{
+					Freight: freight,
+				},
+				stepCfg,
+				&kargoapi.Stage{},
+				&stepCfg.Apps[0],
+				app,
+				testCase.desiredSource,
+				testCase.desiredSources,
+			)
+			testCase.assertions(t, phase, mustUpdate, err)
+		})
+	}
+}
+
+func TestArgoCDSyncApplication(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dir            *argocdUpdateDirective
+		app            *argocd.Application
+		desiredSource  *argocd.ApplicationSource
+		desiredSources argocd.ApplicationSources
+		assertions     func(*testing.T, error)
+	}{
+		{
+			name: "error patching Application",
+			dir: &argocdUpdateDirective{
+				argoCDAppPatchFn: func(
+					context.Context,
+					*StepContext,
+					kubeclient.ObjectWithKind,
+					kubeclient.UnstructuredPatchFn,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			app: &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-name",
+					Namespace: "fake-namespace",
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "fake-namespace:fake-name",
+					},
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "error patching Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "success",
+			dir: &argocdUpdateDirective{
+				argoCDAppPatchFn: func(
+					context.Context,
+					*StepContext,
+					kubeclient.ObjectWithKind,
+					kubeclient.UnstructuredPatchFn,
+				) error {
+					return nil
+				},
+				logAppEventFn: func(
+					context.Context,
+					*StepContext,
+					*argocd.Application,
+					string,
+					string,
+					string,
+				) {
+				},
+			},
+			app: &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-name",
+					Namespace: "fake-namespace",
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "fake-namespace:fake-name",
+					},
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	stepCtx := &StepContext{
+		Freight: kargoapi.FreightCollection{},
+	}
+	// Tamper with the freight collection ID for testing purposes
+	stepCtx.Freight.ID = "fake-freight-collection-id"
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.assertions(
+				t,
+				testCase.dir.syncApplication(
+					context.Background(),
+					stepCtx,
+					testCase.app,
+					testCase.desiredSource,
+					testCase.desiredSources,
+				),
+			)
+		})
+	}
+}
+
+func TestLogAppEvent(t *testing.T) {
+	testCases := []struct {
+		name         string
+		app          *argocd.Application
+		user         string
+		eventReason  string
+		eventMessage string
+		assertions   func(*testing.T, client.Client, *argocd.Application)
+	}{
+		{
+			name: "success",
+			app: &argocd.Application{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Application",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "fake-name",
+					Namespace:       "fake-namespace",
+					UID:             "fake-uid",
+					ResourceVersion: "fake-resource-version",
+				},
+			},
+			user:         "fake-user",
+			eventReason:  "fake-reason",
+			eventMessage: "fake-message",
+			assertions: func(t *testing.T, c client.Client, app *argocd.Application) {
+				events := &corev1.EventList{}
+				require.NoError(t, c.List(context.Background(), events))
+				require.Len(t, events.Items, 1)
+
+				event := events.Items[0]
+				require.Equal(t, corev1.ObjectReference{
+					APIVersion:      argocd.GroupVersion.String(),
+					Kind:            app.TypeMeta.Kind,
+					Name:            app.ObjectMeta.Name,
+					Namespace:       app.ObjectMeta.Namespace,
+					UID:             app.ObjectMeta.UID,
+					ResourceVersion: app.ObjectMeta.ResourceVersion,
+				}, event.InvolvedObject)
+				require.NotNil(t, event.FirstTimestamp)
+				require.NotNil(t, event.LastTimestamp)
+				require.Equal(t, 1, int(event.Count))
+				require.Equal(t, corev1.EventTypeNormal, event.Type)
+				require.Equal(t, "fake-reason", event.Reason)
+				require.Equal(t, "fake-user fake-message", event.Message)
+			},
+		},
+		{
+			name: "unknown user",
+			app: &argocd.Application{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Application",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "fake-name",
+					Namespace:       "fake-namespace",
+					UID:             "fake-uid",
+					ResourceVersion: "fake-resource-version",
+				},
+			},
+			eventReason:  "fake-reason",
+			eventMessage: "fake-message",
+			assertions: func(t *testing.T, c client.Client, _ *argocd.Application) {
+				events := &corev1.EventList{}
+				require.NoError(t, c.List(context.Background(), events))
+				require.Len(t, events.Items, 1)
+
+				event := events.Items[0]
+				require.Equal(t, "Unknown user fake-message", event.Message)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			c := fake.NewFakeClient()
+			(&argocdUpdateDirective{}).logAppEvent(
+				context.Background(),
+				&StepContext{
+					ArgoCDClient: c,
+				},
+				testCase.app,
+				testCase.user,
+				testCase.eventReason,
+				testCase.eventMessage,
+			)
+			testCase.assertions(t, c, testCase.app)
+		})
+	}
+}
+
+func TestArgoCDGetAuthorizedApplication(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, argocd.AddToScheme(scheme))
+
+	testCases := []struct {
+		name        string
+		app         *argocd.Application
+		interceptor interceptor.Funcs
+		assertions  func(*testing.T, *argocd.Application, error)
+	}{
+		{
+			name: "error getting Application",
+			interceptor: interceptor.Funcs{
+				Get: func(
+					context.Context,
+					client.WithWatch,
+					client.ObjectKey,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(t *testing.T, app *argocd.Application, err error) {
+				require.ErrorContains(t, err, "error finding Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+				require.Nil(t, app)
+			},
+		},
+		{
+			name: "Application not found",
+			assertions: func(t *testing.T, app *argocd.Application, err error) {
+				require.ErrorContains(t, err, "unable to find Argo CD Application")
+				require.Nil(t, app)
+			},
+		},
+		{
+			name: "Application not authorized for Stage",
+			app: &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-app",
+					Namespace: "fake-namespace",
+				},
+			},
+			assertions: func(t *testing.T, app *argocd.Application, err error) {
+				require.ErrorContains(t, err, "does not permit mutation by Kargo Stage")
+				require.Nil(t, app)
+			},
+		},
+		{
+			name: "success",
+			app: &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-app",
+					Namespace: "fake-namespace",
+					Annotations: map[string]string{
+						authorizedStageAnnotationKey: "fake-namespace:fake-stage",
+					},
+				},
+			},
+			assertions: func(t *testing.T, app *argocd.Application, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, app)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(testCase.interceptor)
+
+			if testCase.app != nil {
+				c.WithObjects(testCase.app)
+			}
+
+			app, err := (&argocdUpdateDirective{}).getAuthorizedApplication(
+				context.Background(),
+				&StepContext{
+					Project:      "fake-namespace",
+					Stage:        "fake-stage",
+					ArgoCDClient: c.Build(),
+				},
+				client.ObjectKey{
+					Namespace: "fake-namespace",
+					Name:      "fake-app",
+				},
+			)
+			testCase.assertions(t, app, err)
+		})
+	}
+}
+
+func TestAuthorizeArgoCDAppUpdate(t *testing.T) {
+	permErr := "does not permit mutation"
+	parseErr := "unable to parse"
+	invalidGlobErr := "invalid glob expression"
+	testCases := []struct {
+		name    string
+		appMeta metav1.ObjectMeta
+		errMsg  string
+	}{
+		{
+			name:    "annotations are nil",
+			appMeta: metav1.ObjectMeta{},
+			errMsg:  permErr,
+		},
+		{
+			name: "annotation is missing",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			errMsg: permErr,
+		},
+		{
+			name: "annotation cannot be parsed",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "bogus",
+				},
+			},
+			errMsg: parseErr,
+		},
+		{
+			name: "mutation is not allowed",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "ns-nope:name-nope",
+				},
+			},
+			errMsg: permErr,
+		},
+		{
+			name: "mutation is allowed",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "ns-yep:name-yep",
+				},
+			},
+		},
+		{
+			name: "wildcard namespace with full name",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "*:name-yep",
+				},
+			},
+		},
+		{
+			name: "full namespace with wildcard name",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "ns-yep:*",
+				},
+			},
+		},
+		{
+			name: "partial wildcards in namespace and name",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "*-ye*:*-y*",
+				},
+			},
+		},
+		{
+			name: "wildcards do not match",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "*-nope:*-nope",
+				},
+			},
+			errMsg: permErr,
+		},
+		{
+			name: "invalid namespace glob",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "*[:*",
+				},
+			},
+			errMsg: invalidGlobErr,
+		},
+		{
+			name: "invalid name glob",
+			appMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					authorizedStageAnnotationKey: "*:*[",
+				},
+			},
+			errMsg: invalidGlobErr,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := authorizeArgoCDAppUpdate(
+				&StepContext{
+					Project: "ns-yep",
+					Stage:   "name-yep",
+				},
+				testCase.appMeta,
+			)
+			if testCase.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, testCase.errMsg)
+			}
+		})
+	}
+}
+
+func TestApplyArgoCDSourceUpdate(t *testing.T) {
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+	testCases := []struct {
+		name       string
+		source     argocd.ApplicationSource
+		freight    []kargoapi.FreightReference
+		update     ArgoCDAppSourceUpdate
+		assertions func(
+			t *testing.T,
+			originalSource argocd.ApplicationSource,
+			updatedSource argocd.ApplicationSource,
+			err error,
+		)
+	}{
+		{
+			name: "update doesn't apply to this source",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+			},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL: "different-fake-url",
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// Source should be entirely unchanged
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+
+		{
+			name: "update target revision (git)",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+			},
+			freight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL: "fake-url",
+						ID:      "fake-commit",
+					},
+				},
+			}},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL:              "fake-url",
+				UpdateTargetRevision: true,
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// TargetRevision should be updated
+				require.Equal(t, "fake-commit", updatedSource.TargetRevision)
+				// Everything else should be unchanged
+				updatedSource.TargetRevision = originalSource.TargetRevision
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+
+		{
+			name: "update target revision (git with tag)",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+			},
+			freight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Commits: []kargoapi.GitCommit{
+					{
+						RepoURL: "fake-url",
+						ID:      "fake-commit",
+						Tag:     "fake-tag",
+					},
+				},
+			}},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL:              "fake-url",
+				UpdateTargetRevision: true,
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// TargetRevision should be updated
+				require.Equal(t, "fake-tag", updatedSource.TargetRevision)
+				// Everything else should be unchanged
+				updatedSource.TargetRevision = originalSource.TargetRevision
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+
+		{
+			name: "update target revision (helm chart)",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+				Chart:   "fake-chart",
+			},
+			freight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Charts: []kargoapi.Chart{
+					{
+						RepoURL: "oci://fake-url/fake-chart",
+						Version: "fake-version",
+					},
+				},
+			}},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL:              "fake-url",
+				Chart:                "fake-chart",
+				UpdateTargetRevision: true,
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// TargetRevision should be updated
+				require.Equal(t, "fake-version", updatedSource.TargetRevision)
+				// Everything else should be unchanged
+				updatedSource.TargetRevision = originalSource.TargetRevision
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+
+		{
+			name: "update images with kustomize",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+			},
+			freight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Images: []kargoapi.Image{
+					{
+						RepoURL: "fake-image-url",
+						Tag:     "fake-tag",
+					},
+					{
+						// This one should not be updated because it's not a match for
+						// anything in the update instructions
+						RepoURL: "another-fake-image-url",
+						Tag:     "another-fake-tag",
+					},
+				},
+			}},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL: "fake-url",
+				Kustomize: &ArgoCDKustomizeImageUpdates{
+					Images: []ArgoCDKustomizeImageUpdate{{
+						RepoURL: "fake-image-url",
+					}},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// Kustomize attributes should be updated
+				require.NotNil(t, updatedSource.Kustomize)
+				require.Equal(
+					t,
+					argocd.KustomizeImages{
+						argocd.KustomizeImage("fake-image-url:fake-tag"),
+					},
+					updatedSource.Kustomize.Images,
+				)
+				// Everything else should be unchanged
+				updatedSource.Kustomize = originalSource.Kustomize
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+
+		{
+			name: "update images with helm",
+			source: argocd.ApplicationSource{
+				RepoURL: "fake-url",
+			},
+			freight: []kargoapi.FreightReference{{
+				Origin: testOrigin,
+				Images: []kargoapi.Image{
+					{
+						RepoURL: "fake-image-url",
+						Tag:     "fake-tag",
+					},
+					{
+						// This one should not be updated because it's not a match for
+						// anything in the update instructions
+						RepoURL: "another-fake-image-url",
+						Tag:     "another-fake-tag",
+					},
+				},
+			}},
+			update: ArgoCDAppSourceUpdate{
+				RepoURL: "fake-url",
+				Helm: &ArgoCDHelmParameterUpdates{
+					Images: []ArgoCDHelmImageUpdate{
+						{
+							RepoURL: "fake-image-url",
+							Key:     "image",
+							Value:   ImageAndTag,
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				originalSource argocd.ApplicationSource,
+				updatedSource argocd.ApplicationSource,
+				err error,
+			) {
+				require.NoError(t, err)
+				// Helm attributes should be updated
+				require.NotNil(t, updatedSource.Helm)
+				require.NotNil(t, updatedSource.Helm.Parameters)
+				require.Equal(
+					t,
+					[]argocd.HelmParameter{
+						{
+							Name:  "image",
+							Value: "fake-image-url:fake-tag",
+						},
+					},
+					updatedSource.Helm.Parameters,
+				)
+				// Everything else should be unchanged
+				updatedSource.Helm = originalSource.Helm
+				require.Equal(t, originalSource, updatedSource)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		dir := &argocdUpdateDirective{}
+		t.Run(testCase.name, func(t *testing.T) {
+			freight := kargoapi.FreightCollection{}
+			for _, ref := range testCase.freight {
+				freight.UpdateOrPush(ref)
+			}
+			stepCfg := &ArgoCDUpdateConfig{
+				Apps: []ArgoCDAppUpdate{{
+					FromOrigin: &AppFromOrigin{
+						Kind: Kind(testOrigin.Kind),
+						Name: testOrigin.Name,
+					},
+					Sources: []ArgoCDAppSourceUpdate{testCase.update},
+				}},
+			}
+			updatedSource, err := dir.applyArgoCDSourceUpdate(
+				context.Background(),
+				&StepContext{
+					Freight: freight,
+				},
+				stepCfg,
+				&kargoapi.Stage{},
+				&stepCfg.Apps[0].Sources[0],
+				testCase.source,
+			)
+			testCase.assertions(t, testCase.source, updatedSource, err)
+		})
+	}
+}
+
+func TestBuildKustomizeImagesForArgoCDAppSource(t *testing.T) {
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+
+	freight := kargoapi.FreightCollection{}
+	freight.UpdateOrPush(kargoapi.FreightReference{
+		Origin: testOrigin,
+		Images: []kargoapi.Image{
+			{
+				RepoURL: "fake-url",
+				Tag:     "fake-tag",
+				Digest:  "fake-digest",
+			},
+			{
+				RepoURL: "another-fake-url",
+				Tag:     "another-fake-tag",
+				Digest:  "another-fake-digest",
+			},
+		},
+	})
+
+	stepCfg := &ArgoCDUpdateConfig{
+		Apps: []ArgoCDAppUpdate{{
+			Sources: []ArgoCDAppSourceUpdate{{
+				Kustomize: &ArgoCDKustomizeImageUpdates{
+					FromOrigin: &AppFromOrigin{
+						Kind: Kind(testOrigin.Kind),
+						Name: testOrigin.Name,
+					},
+					Images: []ArgoCDKustomizeImageUpdate{
+						{RepoURL: "fake-url"},
+						{
+							RepoURL:   "another-fake-url",
+							UseDigest: true,
+						},
+						{RepoURL: "image-that-is-not-in-list"},
+					},
+				},
+				RepoURL: "https://github.com/universe/42",
+			}},
+		}},
+	}
+
+	dir := &argocdUpdateDirective{}
+	result, err := dir.buildKustomizeImagesForArgoCDAppSource(
+		context.Background(),
+		&StepContext{
+			Freight: freight,
+		},
+		stepCfg,
+		&kargoapi.Stage{},
+		stepCfg.Apps[0].Sources[0].Kustomize,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		argocd.KustomizeImages{
+			"fake-url:fake-tag",
+			"another-fake-url@another-fake-digest",
+		},
+		result,
+	)
+}
+
+func TestBuildHelmParamChangesForArgoCDAppSource(t *testing.T) {
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+
+	freight := kargoapi.FreightCollection{}
+	freight.UpdateOrPush(kargoapi.FreightReference{
+		Origin: testOrigin,
+		Images: []kargoapi.Image{
+			{
+				RepoURL: "fake-url",
+				Tag:     "fake-tag",
+				Digest:  "fake-digest",
+			},
+			{
+				RepoURL: "second-fake-url",
+				Tag:     "second-fake-tag",
+				Digest:  "second-fake-digest",
+			},
+			{
+				RepoURL: "third-fake-url",
+				Tag:     "third-fake-tag",
+				Digest:  "third-fake-digest",
+			},
+			{
+				RepoURL: "fourth-fake-url",
+				Tag:     "fourth-fake-tag",
+				Digest:  "fourth-fake-digest",
+			},
+		},
+	})
+
+	stepCfg := &ArgoCDUpdateConfig{
+		Apps: []ArgoCDAppUpdate{{
+			Sources: []ArgoCDAppSourceUpdate{{
+				Helm: &ArgoCDHelmParameterUpdates{
+					FromOrigin: &AppFromOrigin{
+						Kind: Kind(testOrigin.Kind),
+						Name: testOrigin.Name,
+					},
+					Images: []ArgoCDHelmImageUpdate{
+						{
+							RepoURL: "fake-url",
+							Key:     "fake-key",
+							Value:   ImageAndTag,
+						},
+						{
+							RepoURL: "second-fake-url",
+							Key:     "second-fake-key",
+							Value:   Tag,
+						},
+						{
+							RepoURL: "third-fake-url",
+							Key:     "third-fake-key",
+							Value:   ImageAndDigest,
+						},
+						{
+							RepoURL: "fourth-fake-url",
+							Key:     "fourth-fake-key",
+							Value:   Digest,
+						},
+						{
+							RepoURL: "image-that-is-not-in-list",
+							Key:     "fake-key",
+							Value:   Tag,
+						},
+					},
+				},
+			}},
+		}},
+	}
+
+	dir := &argocdUpdateDirective{}
+	result, err := dir.buildHelmParamChangesForArgoCDAppSource(
+		context.Background(),
+		&StepContext{
+			Freight: freight,
+		},
+		stepCfg,
+		&kargoapi.Stage{},
+		stepCfg.Apps[0].Sources[0].Helm,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		map[string]string{
+			"fake-key":        "fake-url:fake-tag",
+			"second-fake-key": "second-fake-tag",
+			"third-fake-key":  "third-fake-url@third-fake-digest",
+			"fourth-fake-key": "fourth-fake-digest",
+		},
+		result,
+	)
+}
+
+func TestRecursiveMerge(t *testing.T) {
+	testCases := []struct {
+		name     string
+		src      any
+		dst      any
+		expected any
+	}{
+		{
+			name: "merge maps",
+			src: map[string]any{
+				"key1": "value1",
+				"key2": map[string]any{
+					"subkey1": "subvalue1",
+					"subkey2": true,
+				},
+			},
+			dst: map[string]any{
+				"key1": "old_value1",
+				"key2": map[string]any{
+					"subkey2": false,
+					"subkey3": "subvalue3",
+				},
+			},
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": map[string]any{
+					"subkey1": "subvalue1",
+					"subkey2": true,
+					"subkey3": "subvalue3",
+				},
+			},
+		},
+		{
+			name: "merge arrays",
+			src: []any{
+				"value1",
+				map[string]any{
+					"key1": "subvalue1",
+				},
+				true,
+			},
+			dst: []any{
+				"old_value1",
+				map[string]any{
+					"key1": "old_subvalue1",
+					"key2": "subvalue2",
+				},
+				false,
+			},
+			expected: []any{
+				"value1",
+				map[string]any{
+					"key1": "subvalue1",
+					"key2": "subvalue2",
+				},
+				true,
+			},
+		},
+		{
+			name:     "merge incompatible types (map to array)",
+			src:      map[string]any{"key1": "value1"},
+			dst:      []any{"old_value1"},
+			expected: map[string]any{"key1": "value1"},
+		},
+		{
+			name:     "merge incompatible types (array to map)",
+			src:      []any{"value1"},
+			dst:      map[string]any{"key1": "old_value1"},
+			expected: []any{"value1"},
+		},
+		{
+			name:     "overwrite types (string to int)",
+			src:      "value1",
+			dst:      42,
+			expected: "value1",
+		},
+		{
+			name:     "overwrite types (int to string)",
+			src:      true,
+			dst:      "old_value1",
+			expected: true,
+		},
+		{
+			name:     "overwrite value with nil",
+			src:      nil,
+			dst:      map[string]any{"key1": "old_value1"},
+			expected: nil,
+		},
+		{
+			name:     "overwrite nil with value",
+			src:      map[string]any{"key1": "value1"},
+			dst:      nil,
+			expected: map[string]any{"key1": "value1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := recursiveMerge(tc.src, tc.dst)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/directives/origins.go
+++ b/internal/directives/origins.go
@@ -1,0 +1,93 @@
+package directives
+
+import (
+	"reflect"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// getDesiredOrigin recursively walks a the object graph of an
+// ArgoCDUpdateConfig, taking note of the origin of node (if specified) until it
+// finds the "target" node. At each step, if no origin is found, the parent's
+// origin is inherited. This function essentially permits children to inherit or
+// override origins specified by their ancestors despite the fact that they
+// never have any back-reference to their parent.
+func getDesiredOrigin(mechanism any, targetMechanism any) *kargoapi.FreightOrigin {
+	origin := getDesiredOriginInternal(mechanism, targetMechanism, nil)
+	if origin == nil {
+		return nil
+	}
+	return &kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKind(origin.Kind),
+		Name: origin.Name,
+	}
+}
+
+func getDesiredOriginInternal(
+	mechanism any,
+	targetMechanism any,
+	defaultOrigin *AppFromOrigin,
+) *AppFromOrigin {
+	// As a small sanity check, verify that mechanism and targetMechanism are both
+	// pointers.
+	if reflect.ValueOf(mechanism).Kind() != reflect.Ptr {
+		panic("mechanism must be a pointer")
+	}
+	if reflect.ValueOf(targetMechanism).Kind() != reflect.Ptr {
+		panic("targetMechanism must be a pointer")
+	}
+
+	var origin *AppFromOrigin
+	var subMechs []any
+	switch m := mechanism.(type) {
+	// Begin root
+	case *ArgoCDUpdateConfig:
+		origin = m.FromOrigin
+		subMechs = make([]any, len(m.Apps))
+		for i := range m.Apps {
+			subMechs[i] = &m.Apps[i]
+		}
+	case *ArgoCDAppUpdate:
+		origin = m.FromOrigin
+		subMechs = make([]any, len(m.Sources))
+		for i := range m.Sources {
+			subMechs[i] = &m.Sources[i]
+		}
+	case *ArgoCDAppSourceUpdate:
+		origin = m.FromOrigin
+		subMechs = []any{m.Kustomize, m.Helm}
+	// Begin Kustomize-based
+	case *ArgoCDKustomizeImageUpdates:
+		origin = m.FromOrigin
+		subMechs = make([]any, len(m.Images))
+		for i := range m.Images {
+			subMechs[i] = &m.Images[i]
+		}
+	case *ArgoCDKustomizeImageUpdate:
+		origin = m.FromOrigin
+	case *ArgoCDHelmParameterUpdates:
+		origin = m.FromOrigin
+		subMechs = make([]any, len(m.Images))
+		for i := range m.Images {
+			subMechs[i] = &m.Images[i]
+		}
+	case *ArgoCDHelmImageUpdate:
+		origin = m.FromOrigin
+	}
+	if origin == nil {
+		origin = defaultOrigin
+	}
+	if mechanism == targetMechanism {
+		return origin
+	}
+	for _, ts := range subMechs {
+		if reflect.ValueOf(ts).IsNil() {
+			continue
+		}
+		result := getDesiredOriginInternal(ts, targetMechanism, origin)
+		if result != nil {
+			return result
+		}
+	}
+	return nil
+}

--- a/internal/directives/origins_test.go
+++ b/internal/directives/origins_test.go
@@ -192,8 +192,8 @@ func TestGetDesiredOrigin(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mechanism, targetMechanism := tc.setup()
-			actual := getDesiredOrigin(mechanism, targetMechanism)
+			update, targetUpdate := tc.setup()
+			actual := getDesiredOrigin(update, targetUpdate)
 			require.Equal(t, expectedOrigin, actual)
 		})
 	}

--- a/internal/directives/origins_test.go
+++ b/internal/directives/origins_test.go
@@ -1,0 +1,200 @@
+package directives
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestGetDesiredOrigin(t *testing.T) {
+	testOrigin := &AppFromOrigin{
+		Kind: "Foo",
+		Name: "bar",
+	}
+	expectedOrigin := &kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKind(testOrigin.Kind),
+		Name: testOrigin.Name,
+	}
+	testCases := []struct {
+		name  string
+		setup func() (any, any)
+	}{
+		{
+			name: "ArgoCDUpdateConfig",
+			setup: func() (any, any) {
+				m := &ArgoCDUpdateConfig{
+					FromOrigin: testOrigin,
+				}
+				return m, m
+			},
+		},
+		{
+			name: "ArgoCDAppUpdate can inherit from ArgoCDUpdateConfig",
+			setup: func() (any, any) {
+				m := &ArgoCDUpdateConfig{
+					FromOrigin: testOrigin,
+					Apps:       []ArgoCDAppUpdate{{}},
+				}
+				return m, &m.Apps[0]
+			},
+		},
+		{
+			name: "ArgoCDAppUpdate can override ArgoCDUpdateConfig",
+			setup: func() (any, any) {
+				m := &ArgoCDUpdateConfig{
+					Apps: []ArgoCDAppUpdate{{
+						FromOrigin: testOrigin,
+					}},
+				}
+				return m, &m.Apps[0]
+			},
+		},
+		{
+			name: "ArgoCDAppSourceUpdate can inherit from ArgoCDAppUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppUpdate{
+					FromOrigin: testOrigin,
+					Sources:    []ArgoCDAppSourceUpdate{{}},
+				}
+				return m, &m.Sources[0]
+			},
+		},
+		{
+			name: "ArgoCDAppSourceUpdate can override ArgoCDAppUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppUpdate{
+					Sources: []ArgoCDAppSourceUpdate{{
+						FromOrigin: testOrigin,
+					}},
+				}
+				return m, &m.Sources[0]
+			},
+		},
+		{
+			name: "ArgoCDKustomizeImageUpdates can inherit from ArgoCDAppSourceUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppSourceUpdate{
+					FromOrigin: testOrigin,
+					Kustomize:  &ArgoCDKustomizeImageUpdates{},
+				}
+				return m, m.Kustomize
+			},
+		},
+		{
+			name: "ArgoCDKustomizeImageUpdates can override ArgoCDAppSourceUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppSourceUpdate{
+					Kustomize: &ArgoCDKustomizeImageUpdates{
+						FromOrigin: testOrigin,
+					},
+				}
+				return m, m.Kustomize
+			},
+		},
+		{
+			name: "ArgoCDKustomizeImageUpdate can inherit from ArgoCDKustomizeImageUpdates",
+			setup: func() (any, any) {
+				m := &ArgoCDKustomizeImageUpdates{
+					FromOrigin: testOrigin,
+					Images:     []ArgoCDKustomizeImageUpdate{{}},
+				}
+				return m, &m.Images[0]
+			},
+		},
+		{
+			name: "ArgoCDKustomizeImageUpdate can override ArgoCDKustomizeImageUpdates",
+			setup: func() (any, any) {
+				m := &ArgoCDKustomizeImageUpdates{
+					Images: []ArgoCDKustomizeImageUpdate{{
+						FromOrigin: testOrigin,
+					}},
+				}
+				return m, &m.Images[0]
+			},
+		},
+		{
+			name: "ArgoCDHelmParameterUpdates can inherit from ArgoCDAppSourceUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppSourceUpdate{
+					FromOrigin: testOrigin,
+					Helm:       &ArgoCDHelmParameterUpdates{},
+				}
+				return m, m.Helm
+			},
+		},
+		{
+			name: "ArgoCDHelmParameterUpdates can override ArgoCDAppSourceUpdate",
+			setup: func() (any, any) {
+				m := &ArgoCDAppSourceUpdate{
+					Helm: &ArgoCDHelmParameterUpdates{
+						FromOrigin: testOrigin,
+					},
+				}
+				return m, m.Helm
+			},
+		},
+		{
+			name: "ArgoCDHelmImageUpdate can inherit from ArgoCDHelmParameterUpdates",
+			setup: func() (any, any) {
+				m := &ArgoCDHelmParameterUpdates{
+					FromOrigin: testOrigin,
+					Images:     []ArgoCDHelmImageUpdate{{}},
+				}
+				return m, &m.Images[0]
+			},
+		},
+		{
+			name: "ArgoCDHelmImageUpdate can override ArgoCDHelmParameterUpdates",
+			setup: func() (any, any) {
+				m := &ArgoCDHelmParameterUpdates{
+					Images: []ArgoCDHelmImageUpdate{{
+						FromOrigin: testOrigin,
+					}},
+				}
+				return m, &m.Images[0]
+			},
+		},
+		{
+			name: "transitive inheritance",
+			setup: func() (any, any) {
+				m := &ArgoCDUpdateConfig{
+					FromOrigin: testOrigin,
+					Apps: []ArgoCDAppUpdate{{
+						Sources: []ArgoCDAppSourceUpdate{{
+							Kustomize: &ArgoCDKustomizeImageUpdates{
+								Images: []ArgoCDKustomizeImageUpdate{{}},
+							},
+						}},
+					}},
+				}
+				return m, &m.Apps[0].Sources[0].Kustomize.Images[0]
+			},
+		},
+		{
+			name: "override transitive inheritance",
+			setup: func() (any, any) {
+				m := &ArgoCDUpdateConfig{
+					Apps: []ArgoCDAppUpdate{{
+						Sources: []ArgoCDAppSourceUpdate{{
+							Kustomize: &ArgoCDKustomizeImageUpdates{
+								Images: []ArgoCDKustomizeImageUpdate{{
+									FromOrigin: testOrigin,
+								}},
+							},
+						}},
+					}},
+				}
+				return m, &m.Apps[0].Sources[0].Kustomize.Images[0]
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mechanism, targetMechanism := tc.setup()
+			actual := getDesiredOrigin(mechanism, targetMechanism)
+			require.Equal(t, expectedOrigin, actual)
+		})
+	}
+}

--- a/internal/directives/schemas/argocd-update-config.json
+++ b/internal/directives/schemas/argocd-update-config.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ArgoCDUpdateConfig",
+  
+  "definitions": {
+
+    "argoCDAppUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "name": {
+          "type": "string",
+          "description": "Specifies the name of an Argo CD Application resource to be updated.",
+          "minLength": 1
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Specifies the namespace of an Argo CD Application resource to be updated. If left unspecified, the namespace will be the controller's configured default.",
+          "minLength": 1
+        },
+        "sources": {
+          "type": "array",
+          "description": "Describes updates to be applied to various sources of an Argo CD Application resource.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/argoCDAppSourceUpdate"
+          }
+        }
+      }
+    },
+
+    "argoCDAppSourceUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repoURL"],
+      "properties": {
+        "chart": {
+          "type": "string",
+          "description": "If applicable, identifies a specific chart within the Helm chart repository specified by the 'repoURL' field. When the source to be updated references a Helm chart repository, the values of the 'repoURL' and 'chart' fields should exactly match the values of the same fields in the source. i.e. Do not match the values of these two fields to your Warehouse; match them to the Application source you wish to update.",
+          "minLength": 1
+        },
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "helm": {
+          "$ref": "#/definitions/argoCDHelmParameterUpdates"
+        },
+        "kustomize": {
+          "$ref": "#/definitions/argoCDKustomizeImageUpdates"
+        },
+        "repoURL": {
+          "type": "string",
+          "description": "With possible help from the 'chart' field, identifies which of an Argo CD Application's sources is to be updated. When the source to be updated references a Helm chart repository, the values of the 'repoURL' and 'chart' fields should exactly match the values of the same fields in the source. i.e. Do not match the values of these two fields to your Warehouse; match them to the Application source you wish to update.",
+          "minLength": 1
+        },
+        "updateTargetRevision": {
+          "type": "boolean",
+          "description": "Indicates whether the source should be updated such that its TargetRevision field points at the most recently git commit (if 'repoURL' references a Git repository) or chart version (if 'repoURL' references a chart repository)."
+        }
+      }
+    },
+
+    "argoCDHelmParameterUpdates": {
+      "type": "object",
+      "description": "Describes updates to an Argo CD Application source's Helm parameters.",
+      "additionalProperties": false,
+      "required": ["images"],
+      "properties": {
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "images": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/argoCDHelmImageUpdate"
+          }
+        }
+      }
+    },
+
+    "argoCDHelmImageUpdate": {
+      "type": "object",
+      "description": "Describes how to update a Helm parameter to reference a specific version of a container image.",
+      "additionalProperties": false,
+      "required": ["key", "repoURL", "value"],
+      "properties": {
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "key": {
+          "type": "string",
+          "description": "Specifies a key within an Argo CD Application source's Helm parameters that is to be updated.",
+          "minLength": 1
+        },
+        "repoURL": {
+          "type": "string",
+          "description": "The URL of a container image repository.",
+          "minLength": 1
+        },
+        "value": {
+          "type": "string",
+          "description": "Specifies a new value for the setting within an Argo CD Application source's Helm parameters identified by the 'key' field.",
+          "enum": ["Digest", "ImageAndDigest", "ImageAndTag", "Tag"]
+        }
+      }
+    },
+
+    "argoCDKustomizeImageUpdates": {
+      "type": "object",
+      "description": "Describes updates to an Argo CD Application source's Kustomize images.",
+      "additionalProperties": false,
+      "properties": {
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "images": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/argoCDKustomizeImageUpdate"
+          }
+        }
+      }
+    },    
+
+    "argoCDKustomizeImageUpdate": {
+      "type": "object",
+      "description": "Describes how to update a Kustomize image to reference a specific version of a container image.",
+      "additionalProperties": false,
+      "required": ["repoURL"],
+      "properties": {
+        "fromOrigin": {
+          "$ref": "#definitions/origin"
+        },
+        "newName": {
+          "type": "string",
+          "description": "Specifies a container image name override.",
+          "minLength": 1
+        },
+        "repoURL": {
+          "type": "string",
+          "description": "The URL of a container image repository.",
+          "minLength": 1
+        },
+        "useDigest": {
+          "type": "boolean",
+          "description": "Specifies whether the image's digest should be used instead of its tag."
+        }
+      }
+    },
+
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind of origin. Currently only 'Warehouse' is supported. Required.",
+          "enum": ["Warehouse"]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the origin. Required.",
+          "minLength": 1
+        }
+      }
+    }
+
+  },
+  
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apps"],
+  "properties": {
+    "apps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/argoCDAppUpdate"
+      }
+    },
+    "fromOrigin": {
+      "$ref": "#definitions/origin"
+    }
+  }
+}

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -4,6 +4,89 @@ package directives
 
 type CommonDefs interface{}
 
+type ArgoCDUpdateConfig struct {
+	Apps       []ArgoCDAppUpdate `json:"apps"`
+	FromOrigin *AppFromOrigin    `json:"fromOrigin,omitempty"`
+}
+
+type ArgoCDAppUpdate struct {
+	FromOrigin *AppFromOrigin `json:"fromOrigin,omitempty"`
+	// Specifies the name of an Argo CD Application resource to be updated.
+	Name string `json:"name"`
+	// Specifies the namespace of an Argo CD Application resource to be updated. If left
+	// unspecified, the namespace will be the controller's configured default.
+	Namespace string `json:"namespace,omitempty"`
+	// Describes updates to be applied to various sources of an Argo CD Application resource.
+	Sources []ArgoCDAppSourceUpdate `json:"sources,omitempty"`
+}
+
+type AppFromOrigin struct {
+	// The kind of origin. Currently only 'Warehouse' is supported. Required.
+	Kind Kind `json:"kind"`
+	// The name of the origin. Required.
+	Name string `json:"name"`
+}
+
+type ArgoCDAppSourceUpdate struct {
+	// If applicable, identifies a specific chart within the Helm chart repository specified by
+	// the 'repoURL' field. When the source to be updated references a Helm chart repository,
+	// the values of the 'repoURL' and 'chart' fields should exactly match the values of the
+	// same fields in the source. i.e. Do not match the values of these two fields to your
+	// Warehouse; match them to the Application source you wish to update.
+	Chart      string                       `json:"chart,omitempty"`
+	FromOrigin *AppFromOrigin               `json:"fromOrigin,omitempty"`
+	Helm       *ArgoCDHelmParameterUpdates  `json:"helm,omitempty"`
+	Kustomize  *ArgoCDKustomizeImageUpdates `json:"kustomize,omitempty"`
+	// With possible help from the 'chart' field, identifies which of an Argo CD Application's
+	// sources is to be updated. When the source to be updated references a Helm chart
+	// repository, the values of the 'repoURL' and 'chart' fields should exactly match the
+	// values of the same fields in the source. i.e. Do not match the values of these two fields
+	// to your Warehouse; match them to the Application source you wish to update.
+	RepoURL string `json:"repoURL"`
+	// Indicates whether the source should be updated such that its TargetRevision field points
+	// at the most recently git commit (if 'repoURL' references a Git repository) or chart
+	// version (if 'repoURL' references a chart repository).
+	UpdateTargetRevision bool `json:"updateTargetRevision,omitempty"`
+}
+
+// Describes updates to an Argo CD Application source's Helm parameters.
+type ArgoCDHelmParameterUpdates struct {
+	FromOrigin *AppFromOrigin          `json:"fromOrigin,omitempty"`
+	Images     []ArgoCDHelmImageUpdate `json:"images"`
+}
+
+// Describes how to update a Helm parameter to reference a specific version of a container
+// image.
+type ArgoCDHelmImageUpdate struct {
+	FromOrigin *AppFromOrigin `json:"fromOrigin,omitempty"`
+	// Specifies a key within an Argo CD Application source's Helm parameters that is to be
+	// updated.
+	Key string `json:"key"`
+	// The URL of a container image repository.
+	RepoURL string `json:"repoURL"`
+	// Specifies a new value for the setting within an Argo CD Application source's Helm
+	// parameters identified by the 'key' field.
+	Value Value `json:"value"`
+}
+
+// Describes updates to an Argo CD Application source's Kustomize images.
+type ArgoCDKustomizeImageUpdates struct {
+	FromOrigin *AppFromOrigin               `json:"fromOrigin,omitempty"`
+	Images     []ArgoCDKustomizeImageUpdate `json:"images,omitempty"`
+}
+
+// Describes how to update a Kustomize image to reference a specific version of a container
+// image.
+type ArgoCDKustomizeImageUpdate struct {
+	FromOrigin *AppFromOrigin `json:"fromOrigin,omitempty"`
+	// Specifies a container image name override.
+	NewName string `json:"newName,omitempty"`
+	// The URL of a container image repository.
+	RepoURL string `json:"repoURL"`
+	// Specifies whether the image's digest should be used instead of its tag.
+	UseDigest bool `json:"useDigest,omitempty"`
+}
+
 type CopyConfig struct {
 	// InPath is the path to the file or directory to copy.
 	InPath string `json:"inPath"`
@@ -220,15 +303,9 @@ const (
 	Warehouse Kind = "Warehouse"
 )
 
-// The name of the Git provider to use. Currently only 'github' and 'gitlab' are supported.
-// Kargo will try to infer the provider if it is not explicitly specified.
-type Provider string
-
-const (
-	Github Provider = "github"
-	Gitlab Provider = "gitlab"
-)
-
+// Specifies a new value for the setting within an Argo CD Application source's Helm
+// parameters identified by the 'key' field.
+//
 // Specifies the new value for the specified key in the Helm values file.
 type Value string
 
@@ -237,4 +314,13 @@ const (
 	ImageAndDigest Value = "ImageAndDigest"
 	ImageAndTag    Value = "ImageAndTag"
 	Tag            Value = "Tag"
+)
+
+// The name of the Git provider to use. Currently only 'github' and 'gitlab' are supported.
+// Kargo will try to infer the provider if it is not explicitly specified.
+type Provider string
+
+const (
+	Github Provider = "github"
+	Gitlab Provider = "gitlab"
 )


### PR DESCRIPTION
This adds the `argocd-update` directive.

It's a lot of code, _but_ a vast majority of it is copied from the existing `internal/controller/promotion` package and then _minimally_ adapted to work with the configs for directive, which have been generated from JSON schema.

This means this logic is mostly tried and true and also means we have pretty decent test coverage.

Note there was no attempt to make this code common and shared between the older promotion mechanisms and this directive since it is anticipated that the older promotion mechanisms will be removed within a couple releases anyway.

Unsurprisingly, configuration should look remarkably similar to the existing Argo CD promotion mechanism:

```yaml
steps:
- step: argocd-update
  config:
    apps:
    - name: my-app
      namespace: my-namespace (optional; defaults to controller's configured default -- usually argocd)
      sources:
      - repoURL: https://github.com/example/repo.git
        updateTargetRevision: true
        helm:
          images:
          - repoURL: nginx
            key: image.tag
            value: Tag
        kustomize:
          images:
          - repoURL: nginx
            newName: foo
            useDigest: true
```