### PR TITLE
fix(ui): empty freights in some cases

### DIFF
--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -237,6 +237,21 @@ export const Pipelines = ({
     return freightMap;
   }, [freightData]);
 
+  // if we find any stage with freight and UI don't have details, refresh freights
+  useEffect(() => {
+    if (fullFreightById && stagesPerFreight) {
+      const freights = Object.keys(fullFreightById || {});
+      const freightsInStages = Object.keys(stagesPerFreight);
+
+      for (const freightInStage of freightsInStages) {
+        if (!freights?.find((freight) => freight === freightInStage)) {
+          refetchFreightData();
+          return;
+        }
+      }
+    }
+  }, [stagesPerFreight, fullFreightById]);
+
   if (isLoading || isLoadingFreight || isLoadingImages) return <LoadingState />;
 
   const stage = stageName && (data?.stages || []).find((item) => item.metadata?.name === stageName);


### PR DESCRIPTION
fixes https://github.com/akuity/kargo/issues/2384

I was able to [reproduce](https://github.com/akuity/kargo/issues/2384#issuecomment-2361824549). I have tested and now UI won't show stages with empty freight if they have freight. 