### PR TITLE
feat(controller): complementary health checks for argocd-update promotion step

### DIFF
--- a/internal/controller/argocd/api/v1alpha1/application_types.go
+++ b/internal/controller/argocd/api/v1alpha1/application_types.go
@@ -140,7 +140,9 @@ type ApplicationList struct {
 type SyncStatusCode string
 
 const (
-	SyncStatusCodeSynced SyncStatusCode = "Synced"
+	SyncStatusCodeSynced    SyncStatusCode = "Synced"
+	SyncStatusCodeOutOfSync SyncStatusCode = "OutOfSync"
+	SyncStatusCodeUnknown   SyncStatusCode = "Unknown"
 )
 
 type SyncStatus struct {

--- a/internal/directives/argocd_health.go
+++ b/internal/directives/argocd_health.go
@@ -1,0 +1,361 @@
+package directives
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	kubeerr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libargocd "github.com/akuity/kargo/internal/argocd"
+	argocd "github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
+)
+
+const applicationStatusesKey = "applicationStatuses"
+
+// ArgoCDHealthConfig is the configuration for a health check to be executed by
+// the argocd-update directive.
+type ArgoCDHealthConfig struct {
+	// Apps is a list health checks to perform on specific Argo CD Applications.
+	Apps []ArgoCDAppHealthCheck `json:"apps"`
+}
+
+// ArgoCDAppHealthCheck is the configuration for a health check on a single Argo
+// CD Application.
+type ArgoCDAppHealthCheck struct {
+	// Name is the name of the Argo CD Application to check.
+	Name string `json:"name"`
+	// Namespace is the namespace of the Argo CD Application to check. If empty,
+	// the default Argo CD namespace is used.
+	Namespace string `json:"namespace,omitempty"`
+	// DesiredRevisions is a list of desired revisions for the Argo CD Application
+	// to be synced to.
+	DesiredRevisions []string `json:"desiredRevisions,omitempty"`
+}
+
+// ArgoCDAppStatus describes the current state of a single ArgoCD Application.
+type ArgoCDAppStatus struct {
+	// Namespace is the namespace of the ArgoCD Application.
+	Namespace string
+	// Name is the name of the ArgoCD Application.
+	Name                     string
+	argocd.ApplicationStatus `json:",inline"`
+}
+
+// compositeError is an interface for wrapped standard errors produced by
+// errors.Join.
+type compositeError interface {
+	// Unwrap returns the wrapped errors.
+	Unwrap() []error
+}
+
+// RunHealthCheckStep implements the Directive interface.
+func (a *argocdUpdater) RunHealthCheckStep(
+	ctx context.Context,
+	healthCtx *HealthCheckStepContext,
+) HealthCheckStepResult {
+	cfg, err := configToStruct[ArgoCDHealthConfig](healthCtx.Config)
+	if err != nil {
+		return HealthCheckStepResult{
+			Status: kargoapi.HealthStateUnknown,
+			Issues: []string{
+				fmt.Sprintf(
+					"could not convert config into %s health check config: %s",
+					a.Name(), err.Error(),
+				),
+			},
+		}
+	}
+	return a.runHealthCheckStep(ctx, healthCtx, cfg)
+}
+
+func (a *argocdUpdater) runHealthCheckStep(
+	ctx context.Context,
+	healthCtx *HealthCheckStepContext,
+	healthCfg ArgoCDHealthConfig,
+) HealthCheckStepResult {
+	if healthCtx.ArgoCDClient == nil {
+		return HealthCheckStepResult{
+			Status: kargoapi.HealthStateUnknown,
+			Issues: []string{
+				"Argo CD integration is disabled on this controller; cannot assess " +
+					"the health or sync status of Argo CD Applications",
+			},
+		}
+	}
+	health := HealthCheckStepResult{
+		Status: kargoapi.HealthStateHealthy,
+		Issues: make([]string, 0),
+	}
+	appStatuses := make([]ArgoCDAppStatus, len(healthCfg.Apps))
+	for i, appHealthCheck := range healthCfg.Apps {
+		namespace := appHealthCheck.Namespace
+		if namespace == "" {
+			namespace = libargocd.Namespace()
+		}
+		appStatuses[i] = ArgoCDAppStatus{
+			Namespace: namespace,
+			Name:      appHealthCheck.Name,
+		}
+		var state kargoapi.HealthState
+		var err error
+		state, appStatuses[i], err = a.getApplicationHealth(
+			ctx,
+			healthCtx,
+			client.ObjectKey{
+				Namespace: namespace,
+				Name:      appHealthCheck.Name,
+			},
+			appHealthCheck.DesiredRevisions,
+		)
+		health.Status = health.Status.Merge(state)
+		if err != nil {
+			if cErr, ok := err.(compositeError); ok {
+				for _, e := range cErr.Unwrap() {
+					health.Issues = append(health.Issues, e.Error())
+				}
+			} else {
+				health.Issues = append(health.Issues, err.Error())
+			}
+		}
+	}
+	health.Output = State{
+		applicationStatusesKey: appStatuses,
+	}
+	return health
+}
+
+// healthErrorConditions are the v1alpha1.ApplicationConditionType conditions
+// that indicate an Argo CD Application is unhealthy.
+var healthErrorConditions = []argocd.ApplicationConditionType{
+	argocd.ApplicationConditionComparisonError,
+	argocd.ApplicationConditionInvalidSpecError,
+}
+
+// getApplicationHealth assesses the health of an Argo CD Application by looking
+// at its conditions, health status, and sync status. Based on these, it returns
+// an overall health state, the Argo CD Application's health status, and its sync
+// status. If it can not (fully) assess the health of the Argo CD Application, it
+// returns an error with a message explaining why.
+func (a *argocdUpdater) getApplicationHealth(
+	ctx context.Context,
+	healthCtx *HealthCheckStepContext,
+	appKey client.ObjectKey,
+	desiredRevisions []string,
+) (kargoapi.HealthState, ArgoCDAppStatus, error) {
+	appStatus := ArgoCDAppStatus{
+		Namespace: appKey.Namespace,
+		Name:      appKey.Name,
+		ApplicationStatus: argocd.ApplicationStatus{
+			Health: argocd.HealthStatus{
+				Status: argocd.HealthStatusUnknown,
+			},
+			Sync: argocd.SyncStatus{
+				Status: argocd.SyncStatusCodeUnknown,
+			},
+		},
+	}
+	app := &argocd.Application{}
+	if err := healthCtx.ArgoCDClient.Get(ctx, appKey, app); err != nil {
+		if kubeerr.IsNotFound(err) {
+			err = fmt.Errorf(
+				"unable to find Argo CD Application %q in namespace %q",
+				appKey.Name, appKey.Namespace,
+			)
+		} else {
+			err = fmt.Errorf(
+				"error finding Argo CD Application %q in namespace %q: %w",
+				appKey.Name, appKey.Namespace, err,
+			)
+		}
+		return kargoapi.HealthStateUnknown, appStatus, err
+	}
+
+	// Reflect the health and sync status of the Argo CD Application.
+	appStatus.ApplicationStatus = app.Status
+
+	// Check for any error conditions. If these are found, the application is
+	// considered unhealthy as they may indicate a problem which can result in
+	// e.g. the health status result to become unreliable.
+	if errConditions := a.filterAppConditions(app, healthErrorConditions...); len(errConditions) > 0 {
+		issues := make([]error, len(errConditions))
+		for _, condition := range errConditions {
+			issues = append(issues, fmt.Errorf(
+				"Argo CD Application %q in namespace %q has %q condition: %s",
+				appKey.Name,
+				appKey.Namespace,
+				condition.Type,
+				condition.Message,
+			))
+		}
+		return kargoapi.HealthStateUnhealthy, appStatus, errors.Join(issues...)
+	}
+
+	if len(desiredRevisions) > 0 {
+		if stageHealth, err := a.stageHealthForAppSync(app, desiredRevisions); err != nil {
+			return stageHealth, appStatus, err
+		}
+		// If we care about revisions, and recently finished an operation, we
+		// should wait for a cooldown period before assessing the health of the
+		// application. This is to ensure the health check has a chance to run
+		// after the sync operation has finished.
+		//
+		// xref: https://github.com/akuity/kargo/issues/2196
+		//
+		// TODO: revisit this when https://github.com/argoproj/argo-cd/pull/18660
+		// 	 is merged and released.
+		if app.Status.OperationState != nil {
+			cooldown := app.Status.OperationState.FinishedAt.Time.Add(10 * time.Second)
+			if duration := time.Until(cooldown); duration > 0 {
+				time.Sleep(duration)
+				// Re-fetch the application to get the latest state.
+				if err := healthCtx.ArgoCDClient.Get(ctx, appKey, app); err != nil {
+					if kubeerr.IsNotFound(err) {
+						err = fmt.Errorf(
+							"unable to find Argo CD Application %q in namespace %q",
+							appKey.Name, appKey.Namespace,
+						)
+					} else {
+						err = fmt.Errorf(
+							"error finding Argo CD Application %q in namespace %q: %w",
+							appKey.Name, appKey.Namespace, err,
+						)
+					}
+					return kargoapi.HealthStateUnknown, appStatus, err
+				}
+			}
+		}
+	}
+
+	// With all the above checks passed, we can now assume the Argo CD
+	// Application's health state is reliable.
+	stageHealth, err := a.stageHealthForAppHealth(app)
+	return stageHealth, appStatus, err
+}
+
+// stageHealthForAppSync returns the v1alpha1.HealthState for an Argo CD
+// Application based on its sync status.
+func (a *argocdUpdater) stageHealthForAppSync(
+	app *argocd.Application,
+	desiredRevisions []string,
+) (kargoapi.HealthState, error) {
+	if !slices.ContainsFunc(desiredRevisions, func(rev string) bool { return rev != "" }) {
+		// We have no idea what this App should be synced to, so it does not
+		// negatively impact Stage health.
+		return kargoapi.HealthStateHealthy, nil
+	}
+	if (app.Operation != nil && app.Operation.Sync != nil) ||
+		app.Status.OperationState == nil || app.Status.OperationState.FinishedAt.IsZero() {
+		// A sync appears to be in progress
+		return kargoapi.HealthStateUnknown, fmt.Errorf(
+			"Argo CD Application %q in namespace %q is being synced",
+			app.Name, app.Namespace,
+		)
+	}
+	sources := app.Spec.Sources
+	if len(sources) == 0 && app.Spec.Source != nil {
+		sources = []argocd.ApplicationSource{*app.Spec.Source}
+	}
+	if len(sources) != len(desiredRevisions) {
+		// This really shouldn't happen because the sources would have been
+		// consulted when determining the desired revisions.
+		return kargoapi.HealthStateUnknown, fmt.Errorf(
+			"Argo CD Application %q in namespace %q has %d sources but %d desired revisions",
+			app.Name, app.Namespace, len(sources), len(desiredRevisions),
+		)
+	}
+	observedRevisions := app.Status.Sync.Revisions
+	if len(observedRevisions) == 0 {
+		observedRevisions = []string{app.Status.Sync.Revision}
+	}
+	if len(observedRevisions) != len(desiredRevisions) {
+		// This really shouldn't happen.
+		return kargoapi.HealthStateUnknown, fmt.Errorf(
+			"Argo CD Application %q in namespace %q has %d observed revisions but %d desired revisions",
+			app.Name, app.Namespace, len(observedRevisions), len(desiredRevisions),
+		)
+	}
+	// Aggregate issues for all sources
+	issues := make([]string, 0)
+	for i, observedRevision := range observedRevisions {
+		desiredRevision := desiredRevisions[i]
+		if desiredRevision == "" {
+			// We have no idea what this source should be synced to, so it does not
+			// negatively impact Stage health.
+			continue
+		}
+		if observedRevision != desiredRevision {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"Source %d with RepoURL %s of Application %q in namespace %q does not match the desired revision %q.",
+					i, sources[i].RepoURL, app.Name, app.Namespace, desiredRevision,
+				),
+			)
+		}
+	}
+	if len(issues) > 0 {
+		return kargoapi.HealthStateUnhealthy, fmt.Errorf(
+			"Not all sources of Application %q in namespace %q "+
+				"are synced to the desired revisions. Issues: %s",
+			app.Name, app.Namespace, strings.Join(issues, "; "),
+		)
+	}
+	return kargoapi.HealthStateHealthy, nil
+}
+
+// stageHealthForAppHealth returns the v1alpha1.HealthState for an Argo CD
+// Application based on its health status.
+func (a *argocdUpdater) stageHealthForAppHealth(
+	app *argocd.Application,
+) (kargoapi.HealthState, error) {
+	switch app.Status.Health.Status {
+	case argocd.HealthStatusProgressing, "":
+		err := fmt.Errorf(
+			"Argo CD Application %q in namespace %q is progressing",
+			app.GetName(),
+			app.GetNamespace(),
+		)
+		return kargoapi.HealthStateProgressing, err
+	case argocd.HealthStatusSuspended:
+		err := fmt.Errorf(
+			"Argo CD Application %q in namespace %q is suspended",
+			app.GetName(),
+			app.GetNamespace(),
+		)
+		// To Kargo, a suspended Application is considered progressing until
+		// the suspension is lifted.
+		// xref: https://github.com/akuity/kargo/issues/2216
+		return kargoapi.HealthStateProgressing, err
+	case argocd.HealthStatusHealthy:
+		return kargoapi.HealthStateHealthy, nil
+	default:
+		err := fmt.Errorf(
+			"Argo CD Application %q in namespace %q has health state %q",
+			app.GetName(),
+			app.GetNamespace(),
+			app.Status.Health.Status,
+		)
+		return kargoapi.HealthStateUnhealthy, err
+	}
+}
+
+// filterAppConditions returns a slice of v1alpha1.ApplicationCondition that
+// match the provided types.
+func (a *argocdUpdater) filterAppConditions(
+	app *argocd.Application,
+	t ...argocd.ApplicationConditionType,
+) []argocd.ApplicationCondition {
+	errs := make([]argocd.ApplicationCondition, 0, len(app.Status.Conditions))
+	for _, condition := range app.Status.Conditions {
+		if slices.Contains(t, condition.Type) {
+			errs = append(errs, condition)
+		}
+	}
+	return errs
+}

--- a/internal/directives/argocd_health_test.go
+++ b/internal/directives/argocd_health_test.go
@@ -1,0 +1,780 @@
+package directives
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	kubeerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	argocd "github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
+)
+
+func Test_argocdUpdater_runHealthCheckStep(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, argocd.AddToScheme(scheme))
+
+	const testAppNamespace = "fake-namespace"
+	const testAppName1 = "fake-app"
+	const testAppName2 = "another-fake-app"
+
+	testCases := []struct {
+		name       string
+		healthCtx  *HealthCheckStepContext
+		assertions func(*testing.T, HealthCheckStepResult)
+	}{
+		{
+			name:      "Argo CD integration disabled",
+			healthCtx: &HealthCheckStepContext{},
+			assertions: func(t *testing.T, res HealthCheckStepResult) {
+				require.Equal(t, kargoapi.HealthStateUnknown, res.Status)
+				require.Len(t, res.Issues, 1)
+				require.Contains(t, res.Issues[0], "Argo CD integration is disabled")
+			},
+		},
+		{
+			name: "composite error checking Application health",
+			healthCtx: &HealthCheckStepContext{
+				ArgoCDClient: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&argocd.Application{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: testAppNamespace,
+								Name:      testAppName1,
+							},
+							Spec: argocd.ApplicationSpec{
+								Sources: []argocd.ApplicationSource{{}},
+							},
+							Status: argocd.ApplicationStatus{
+								Health: argocd.HealthStatus{
+									Status: argocd.HealthStatusHealthy,
+								},
+								Sync: argocd.SyncStatus{
+									Status:    argocd.SyncStatusCodeSynced,
+									Revisions: []string{"fake-version"},
+								},
+								OperationState: &argocd.OperationState{
+									FinishedAt: ptr.To(metav1.Now()),
+								},
+							},
+						},
+						&argocd.Application{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: testAppNamespace,
+								Name:      testAppName2,
+							},
+							Status: argocd.ApplicationStatus{
+								Conditions: []argocd.ApplicationCondition{
+									{
+										Type: argocd.ApplicationConditionComparisonError,
+									},
+									{
+										Type: argocd.ApplicationConditionInvalidSpecError,
+									},
+								},
+							},
+						},
+					).
+					Build(),
+			},
+			assertions: func(t *testing.T, res HealthCheckStepResult) {
+				require.Equal(t, kargoapi.HealthStateUnhealthy, res.Status)
+				require.Contains(t, res.Output, applicationStatusesKey)
+				require.Len(t, res.Issues, 2)
+				require.Contains(t, res.Issues[0], testAppName1)
+				require.Contains(t, res.Issues[0], "ComparisonError")
+				require.Contains(t, res.Issues[1], testAppName1)
+				require.Contains(t, res.Issues[1], "InvalidSpecError")
+			},
+		},
+		{
+			name: "all apps healthy and synced",
+			healthCtx: &HealthCheckStepContext{
+				ArgoCDClient: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&argocd.Application{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: testAppNamespace,
+								Name:      testAppName1,
+							},
+							Spec: argocd.ApplicationSpec{
+								Sources: []argocd.ApplicationSource{{}},
+							},
+							Status: argocd.ApplicationStatus{
+								Health: argocd.HealthStatus{
+									Status: argocd.HealthStatusHealthy,
+								},
+								Sync: argocd.SyncStatus{
+									Status:    argocd.SyncStatusCodeSynced,
+									Revisions: []string{"fake-version"},
+								},
+								OperationState: &argocd.OperationState{
+									FinishedAt: ptr.To(metav1.Now()),
+								},
+							},
+						},
+						&argocd.Application{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: testAppNamespace,
+								Name:      testAppName2,
+							},
+							Spec: argocd.ApplicationSpec{
+								Sources: []argocd.ApplicationSource{{}},
+							},
+							Status: argocd.ApplicationStatus{
+								Health: argocd.HealthStatus{
+									Status: argocd.HealthStatusHealthy,
+								},
+								Sync: argocd.SyncStatus{
+									Status:    argocd.SyncStatusCodeSynced,
+									Revisions: []string{"fake-commit"},
+								},
+								OperationState: &argocd.OperationState{
+									FinishedAt: ptr.To(metav1.Now()),
+								},
+							},
+						},
+					).
+					Build(),
+			},
+			assertions: func(t *testing.T, res HealthCheckStepResult) {
+				require.Equal(t, kargoapi.HealthStateHealthy, res.Status)
+				require.Contains(t, res.Output, applicationStatusesKey)
+				require.Empty(t, res.Issues)
+			},
+		},
+	}
+
+	runner := &argocdUpdater{}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.assertions(
+				t,
+				runner.runHealthCheckStep(
+					context.Background(),
+					testCase.healthCtx,
+					ArgoCDHealthConfig{
+						Apps: []ArgoCDAppHealthCheck{
+							{
+								Namespace:        testAppNamespace,
+								Name:             testAppName1,
+								DesiredRevisions: []string{"fake-version"},
+							},
+							{
+								Namespace:        testAppNamespace,
+								Name:             testAppName2,
+								DesiredRevisions: []string{"fake-commit"},
+							},
+						},
+					},
+				),
+			)
+		})
+	}
+}
+
+func Test_argocdUpdater_getApplicationHealth(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, argocd.AddToScheme(scheme))
+
+	testApp := &argocd.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fake-namespace",
+			Name:      "fake-name",
+		},
+		Spec: argocd.ApplicationSpec{
+			Sources: []argocd.ApplicationSource{
+				{
+					RepoURL: "https://example.com",
+					Chart:   "fake-chart",
+				},
+				{
+					RepoURL: "https://example.com/universe/42",
+				},
+				{
+					RepoURL: "https://example.com/another-universe/42",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		appStatus        argocd.ApplicationStatus
+		interceptor      interceptor.Funcs
+		desiredRevisions []string
+		assertions       func(*testing.T, kargoapi.HealthState, ArgoCDAppStatus, error)
+	}{
+		{
+			name: "Application not found",
+			interceptor: interceptor.Funcs{
+				Get: func(
+					context.Context,
+					client.WithWatch,
+					client.ObjectKey,
+					client.Object,
+					...client.GetOption,
+				) error {
+					// return not found error
+					return kubeerr.NewNotFound(schema.GroupResource{}, "")
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.ErrorContains(t, err, "unable to find Argo CD Application")
+				require.Equal(t, kargoapi.HealthStateUnknown, stageHealth)
+				require.Equal(t, argocd.HealthStatusUnknown, appStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeUnknown, appStatus.Sync.Status)
+			},
+		},
+		{
+			name: "error getting Application",
+			interceptor: interceptor.Funcs{
+				Get: func(
+					context.Context,
+					client.WithWatch,
+					client.ObjectKey,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.ErrorContains(t, err, "error finding Argo CD Application")
+				require.ErrorContains(t, err, "something went wrong")
+				require.Equal(t, kargoapi.HealthStateUnknown, stageHealth)
+				require.Equal(t, argocd.HealthStatusUnknown, appStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeUnknown, appStatus.Sync.Status)
+			},
+		},
+		{
+			name: "Application has error conditions",
+			appStatus: argocd.ApplicationStatus{
+				Conditions: []argocd.ApplicationCondition{
+					{
+						Type:    argocd.ApplicationConditionComparisonError,
+						Message: "fake-error",
+					},
+					{
+						Type:    argocd.ApplicationConditionInvalidSpecError,
+						Message: "fake-error",
+					},
+				},
+				Health: argocd.HealthStatus{
+					Status:  argocd.HealthStatusHealthy,
+					Message: "fake-message",
+				},
+				Sync: argocd.SyncStatus{
+					Status: argocd.SyncStatusCodeSynced,
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.Error(t, err)
+				require.ErrorContains(t, err, `has "ComparisonError" condition`)
+				require.ErrorContains(t, err, `has "InvalidSpecError" condition`)
+				unwrappedErr, ok := err.(compositeError)
+				require.True(t, ok)
+				require.Len(t, unwrappedErr.Unwrap(), 2)
+				require.Equal(t, kargoapi.HealthStateUnhealthy, stageHealth)
+				require.Equal(t, testApp.Namespace, appStatus.Namespace)
+				require.Equal(t, testApp.Name, appStatus.Name)
+				require.Equal(t, argocd.HealthStatusHealthy, appStatus.ApplicationStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeSynced, appStatus.ApplicationStatus.Sync.Status)
+			},
+		},
+		{
+			name: "no error conditions and no desired revisions",
+			appStatus: argocd.ApplicationStatus{
+				Health: argocd.HealthStatus{
+					Status:  argocd.HealthStatusHealthy,
+					Message: "fake-message",
+				},
+				Sync: argocd.SyncStatus{
+					Status: argocd.SyncStatusCodeSynced,
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, stageHealth)
+				require.Equal(t, testApp.Namespace, appStatus.Namespace)
+				require.Equal(t, testApp.Name, appStatus.Name)
+				require.Equal(t, argocd.HealthStatusHealthy, appStatus.ApplicationStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeSynced, appStatus.ApplicationStatus.Sync.Status)
+			},
+		},
+		{
+			name: "no error conditions, but revisions out of sync",
+			appStatus: argocd.ApplicationStatus{
+				Health: argocd.HealthStatus{
+					Status: argocd.HealthStatusHealthy,
+				},
+				Sync: argocd.SyncStatus{
+					Status:    argocd.SyncStatusCodeSynced,
+					Revisions: []string{"fake-version", "wrong-fake-commit", "another-fake-commit"},
+				},
+				OperationState: &argocd.OperationState{
+					FinishedAt: ptr.To(metav1.Now()),
+				},
+			},
+			desiredRevisions: []string{"fake-version", "fake-commit", "another-fake-commit"},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.ErrorContains(t, err, "Not all sources of Application")
+				require.ErrorContains(t, err, "are synced to the desired revisions")
+				require.ErrorContains(t, err, "Source 1 with RepoURL https://example.com/universe/42")
+				require.Equal(t, kargoapi.HealthStateUnhealthy, stageHealth)
+				require.Equal(t, testApp.Namespace, appStatus.Namespace)
+				require.Equal(t, testApp.Name, appStatus.Name)
+				require.Equal(t, argocd.HealthStatusHealthy, appStatus.ApplicationStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeSynced, appStatus.ApplicationStatus.Sync.Status)
+			},
+		},
+		{
+			name: "no error conditions and revisions in sync",
+			appStatus: argocd.ApplicationStatus{
+				Health: argocd.HealthStatus{
+					Status: argocd.HealthStatusHealthy,
+				},
+				Sync: argocd.SyncStatus{
+					Status:    argocd.SyncStatusCodeSynced,
+					Revisions: []string{"fake-version", "fake-commit", "another-fake-commit"},
+				},
+				OperationState: &argocd.OperationState{
+					FinishedAt: &metav1.Time{Time: metav1.Now().Add(-10 * time.Second)},
+				},
+			},
+			desiredRevisions: []string{"fake-version", "fake-commit", "another-fake-commit"},
+			assertions: func(
+				t *testing.T,
+				stageHealth kargoapi.HealthState,
+				appStatus ArgoCDAppStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, stageHealth)
+				require.Equal(t, testApp.Namespace, appStatus.Namespace)
+				require.Equal(t, testApp.Name, appStatus.Name)
+				require.Equal(t, argocd.HealthStatusHealthy, appStatus.ApplicationStatus.Health.Status)
+				require.Equal(t, argocd.SyncStatusCodeSynced, appStatus.ApplicationStatus.Sync.Status)
+			},
+		},
+	}
+
+	runner := &argocdUpdater{}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			app := testApp.DeepCopy()
+			app.Status = testCase.appStatus
+			stageHealth, appStatus, err := runner.getApplicationHealth(
+				context.Background(),
+				&HealthCheckStepContext{
+					ArgoCDClient: fake.NewClientBuilder().
+						WithScheme(scheme).
+						WithObjects(app).
+						WithInterceptorFuncs(testCase.interceptor).
+						Build(),
+				},
+				client.ObjectKey{
+					Namespace: app.Namespace,
+					Name:      app.Name,
+				},
+				testCase.desiredRevisions,
+			)
+			testCase.assertions(t, stageHealth, appStatus, err)
+		})
+	}
+
+	t.Run("waits for operation cooldown", func(t *testing.T) {
+		app := testApp.DeepCopy()
+		app.Status = argocd.ApplicationStatus{
+			Health: argocd.HealthStatus{
+				Status: argocd.HealthStatusProgressing,
+			},
+			Sync: argocd.SyncStatus{
+				Status:    argocd.SyncStatusCodeSynced,
+				Revisions: []string{"fake-version", "fake-commit", "another-fake-commit"},
+			},
+			OperationState: &argocd.OperationState{
+				FinishedAt: ptr.To(metav1.Now()),
+			},
+		}
+		var count int
+		_, _, err := runner.getApplicationHealth(
+			context.Background(),
+			&HealthCheckStepContext{
+				ArgoCDClient: fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(
+						_ context.Context,
+						_ client.WithWatch,
+						_ client.ObjectKey,
+						obj client.Object,
+						_ ...client.GetOption,
+					) error {
+						count++
+
+						appCopy := app.DeepCopy()
+						if count > 1 {
+							appCopy.Status.Health.Status = argocd.HealthStatusHealthy
+						}
+
+						*obj.(*argocd.Application) = *appCopy // nolint: forcetypeassert
+						return nil
+					},
+				}).Build(),
+			},
+			client.ObjectKey{
+				Namespace: testApp.Namespace,
+				Name:      testApp.Name,
+			},
+			[]string{"fake-version", "fake-commit", "another-fake-commit"},
+		)
+		elapsed := time.Since(app.Status.OperationState.FinishedAt.Time)
+		require.NoError(t, err)
+		// We wait for 10 seconds after the sync operation has finished. As such,
+		// the elapsed time should be greater than 8 seconds, but less than 12
+		// seconds. To ensure we do not introduce flakes in the tests.
+		require.Greater(t, elapsed, 8*time.Second)
+		require.Less(t, elapsed, 12*time.Second)
+		require.Equal(t, 2, count)
+	})
+}
+
+func Test_argocdUpdater_stageHealthForAppSync(t *testing.T) {
+	testCases := []struct {
+		name       string
+		app        *argocd.Application
+		revisions  []string
+		assertions func(*testing.T, kargoapi.HealthState, error)
+	}{
+		{
+			name: "empty revisions list",
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, health)
+			},
+		},
+		{
+			name:      "all revisions are empty string",
+			revisions: []string{"", ""},
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, health)
+			},
+		},
+		{
+			name:      "ongoing sync operation",
+			revisions: []string{"fake-revision"},
+			app: &argocd.Application{
+				Operation: &argocd.Operation{
+					Sync: &argocd.SyncOperation{},
+				},
+			},
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is being synced")
+				require.Equal(t, kargoapi.HealthStateUnknown, health)
+			},
+		},
+		{
+			name:      "no operation state",
+			revisions: []string{"fake-revision"},
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Sync: argocd.SyncStatus{
+						Revision: "fake-revision",
+					},
+				},
+			},
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is being synced")
+				require.Equal(t, kargoapi.HealthStateUnknown, health)
+			},
+		},
+		{
+			name:      "operation state without finished time",
+			revisions: []string{"fake-revision"},
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Sync: argocd.SyncStatus{
+						Revision: "fake-revision",
+					},
+					OperationState: &argocd.OperationState{},
+				},
+			},
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is being synced")
+				require.Equal(t, kargoapi.HealthStateUnknown, health)
+			},
+		},
+		{
+			name:      "sync revision mismatch",
+			revisions: []string{"fake-revision", "another-fake-revision"},
+			app: &argocd.Application{
+				Spec: argocd.ApplicationSpec{
+					Sources: []argocd.ApplicationSource{{}, {}},
+				},
+				Status: argocd.ApplicationStatus{
+					Sync: argocd.SyncStatus{
+						Revisions: []string{"fake-revision", "wrong-fake-revision"},
+					},
+					OperationState: &argocd.OperationState{
+						FinishedAt: ptr.To(metav1.Now()),
+					},
+				},
+			},
+			assertions: func(t *testing.T, health kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "Not all sources of Application")
+				require.ErrorContains(t, err, "are synced to the desired revisions")
+				require.Equal(t, kargoapi.HealthStateUnhealthy, health)
+			},
+		},
+		{
+			name:      "synced",
+			revisions: []string{"fake-revision", "another-fake-revision"},
+			app: &argocd.Application{
+				Spec: argocd.ApplicationSpec{
+					Sources: []argocd.ApplicationSource{{}, {}},
+				},
+				Status: argocd.ApplicationStatus{
+					Sync: argocd.SyncStatus{
+						Revisions: []string{"fake-revision", "another-fake-revision"},
+					},
+					OperationState: &argocd.OperationState{
+						FinishedAt: ptr.To(metav1.Now()),
+					},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, state)
+			},
+		},
+	}
+
+	runner := &argocdUpdater{}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			health, err := runner.stageHealthForAppSync(
+				testCase.app,
+				testCase.revisions,
+			)
+			testCase.assertions(t, health, err)
+		})
+	}
+}
+
+func Test_argocdUpdater_stageHealthForAppHealth(t *testing.T) {
+	testCases := []struct {
+		name       string
+		app        *argocd.Application
+		assertions func(*testing.T, kargoapi.HealthState, error)
+	}{
+		{
+			name: "progressing",
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{
+						Status: argocd.HealthStatusProgressing,
+					},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is progressing")
+				require.Equal(t, kargoapi.HealthStateProgressing, state)
+			},
+		},
+		{
+			name: "progressing (due to suspension)",
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{
+						Status: argocd.HealthStatusSuspended,
+					},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is suspended")
+				require.Equal(t, kargoapi.HealthStateProgressing, state)
+			},
+		},
+		{
+			name: "empty health status",
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "is progressing")
+				require.Equal(t, kargoapi.HealthStateProgressing, state)
+			},
+		},
+		{
+			name: "healthy",
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{
+						Status: argocd.HealthStatusHealthy,
+					},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.HealthStateHealthy, state)
+			},
+		},
+		{
+			name: "degraded",
+			app: &argocd.Application{
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{
+						Status: argocd.HealthStatusDegraded,
+					},
+				},
+			},
+			assertions: func(t *testing.T, state kargoapi.HealthState, err error) {
+				require.ErrorContains(t, err, "has health state")
+				require.Equal(t, kargoapi.HealthStateUnhealthy, state)
+			},
+		},
+	}
+
+	runner := &argocdUpdater{}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := runner.stageHealthForAppHealth(testCase.app)
+			testCase.assertions(t, got, err)
+		})
+	}
+}
+
+func Test_argocdUpdater_filterAppConditions(t *testing.T) {
+	testCases := []struct {
+		name       string
+		conditions []argocd.ApplicationCondition
+		types      []argocd.ApplicationConditionType
+		assertions func(*testing.T, []argocd.ApplicationCondition)
+	}{
+		{
+			name: "no conditions",
+			assertions: func(t *testing.T, conditions []argocd.ApplicationCondition) {
+				require.Len(t, conditions, 0)
+			},
+		},
+		{
+			name: "single matching condition",
+			conditions: []argocd.ApplicationCondition{
+				{
+					Type: argocd.ApplicationConditionComparisonError,
+				},
+			},
+			types: []argocd.ApplicationConditionType{
+				argocd.ApplicationConditionComparisonError,
+			},
+			assertions: func(t *testing.T, conditions []argocd.ApplicationCondition) {
+				require.Len(t, conditions, 1)
+				require.Equal(t, argocd.ApplicationConditionComparisonError, conditions[0].Type)
+			},
+		},
+		{
+			name: "multiple matching conditions",
+			conditions: []argocd.ApplicationCondition{
+				{
+					Type: argocd.ApplicationConditionComparisonError,
+				},
+				{
+					Type: argocd.ApplicationConditionInvalidSpecError,
+				},
+				{
+					Type: argocd.ApplicationConditionComparisonError,
+				},
+				{
+					Type: "SomeOtherType",
+				},
+			},
+			types: []argocd.ApplicationConditionType{
+				argocd.ApplicationConditionComparisonError,
+				"SomeOtherType",
+			},
+			assertions: func(t *testing.T, conditions []argocd.ApplicationCondition) {
+				require.Len(t, conditions, 3)
+				require.Equal(t, argocd.ApplicationConditionComparisonError, conditions[0].Type)
+				require.Equal(t, argocd.ApplicationConditionComparisonError, conditions[1].Type)
+				require.Equal(t, argocd.ApplicationConditionType("SomeOtherType"), conditions[2].Type)
+			},
+		}, {
+			name: "no matching conditions",
+			conditions: []argocd.ApplicationCondition{
+				{
+					Type: argocd.ApplicationConditionComparisonError,
+				},
+				{
+					Type: argocd.ApplicationConditionInvalidSpecError,
+				},
+			},
+			types: []argocd.ApplicationConditionType{
+				"NonMatchingType",
+			},
+			assertions: func(t *testing.T, conditions []argocd.ApplicationCondition) {
+				require.Len(t, conditions, 0)
+			},
+		},
+	}
+
+	runner := (&argocdUpdater{})
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.assertions(
+				t,
+				runner.filterAppConditions(
+					&argocd.Application{
+						Status: argocd.ApplicationStatus{
+							Conditions: testCase.conditions,
+						},
+					},
+					testCase.types...,
+				),
+			)
+		})
+	}
+}

--- a/internal/directives/argocd_revisions.go
+++ b/internal/directives/argocd_revisions.go
@@ -20,7 +20,6 @@ func (a *argocdUpdater) getDesiredRevisions(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 	stepCfg *ArgoCDUpdateConfig,
-	stage *kargoapi.Stage,
 	update *ArgoCDAppUpdate,
 	app *argocd.Application,
 ) ([]string, error) {
@@ -48,7 +47,6 @@ func (a *argocdUpdater) getDesiredRevisions(
 		desiredRevision, err := a.getDesiredRevisionForSource(
 			ctx,
 			stepCtx,
-			stage,
 			&src,
 			desiredOrigin,
 		)
@@ -63,7 +61,6 @@ func (a *argocdUpdater) getDesiredRevisions(
 func (a *argocdUpdater) getDesiredRevisionForSource(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
-	stage *kargoapi.Stage,
 	src *argocd.ApplicationSource,
 	desiredOrigin *kargoapi.FreightOrigin,
 ) (string, error) {
@@ -95,7 +92,7 @@ func (a *argocdUpdater) getDesiredRevisionForSource(
 			ctx,
 			stepCtx.KargoClient,
 			stepCtx.Project,
-			stage.Spec.RequestedFreight,
+			stepCtx.FreightRequests,
 			desiredOrigin,
 			stepCtx.Freight.References(),
 			repoURL,
@@ -115,7 +112,7 @@ func (a *argocdUpdater) getDesiredRevisionForSource(
 			ctx,
 			stepCtx.KargoClient,
 			stepCtx.Project,
-			stage.Spec.RequestedFreight,
+			stepCtx.FreightRequests,
 			desiredOrigin,
 			stepCtx.Freight.References(),
 			src.RepoURL,

--- a/internal/directives/argocd_revisions_test.go
+++ b/internal/directives/argocd_revisions_test.go
@@ -150,7 +150,6 @@ func Test_argoCDUpdater_getDesiredRevisions(t *testing.T) {
 				context.Background(),
 				stepCtx,
 				stepCfg,
-				&kargoapi.Stage{},
 				&stepCfg.Apps[0],
 				testCase.app,
 			)

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -25,7 +25,6 @@ func Test_newArgocdUpdater(t *testing.T) {
 	runner, ok := r.(*argocdUpdater)
 	require.True(t, ok)
 	require.Equal(t, "argocd-update", r.Name())
-	require.NotNil(t, runner.getStageFn)
 	require.NotNil(t, runner.schemaLoader)
 	require.NotNil(t, runner.getAuthorizedApplicationFn)
 	require.NotNil(t, runner.buildDesiredSourcesFn)
@@ -367,57 +366,8 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 			},
 		},
 		{
-			name: "error getting Stage",
-			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return nil, errors.New("something went wrong")
-				},
-			},
-			stepCtx: &PromotionStepContext{
-				ArgoCDClient: fake.NewFakeClient(),
-			},
-			stepCfg: ArgoCDUpdateConfig{},
-			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
-				require.ErrorContains(t, err, "error getting Stage")
-				require.ErrorContains(t, err, "something went wrong")
-			},
-		},
-		{
-			name: "Stage not found",
-			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return nil, nil
-				},
-			},
-			stepCtx: &PromotionStepContext{
-				ArgoCDClient: fake.NewFakeClient(),
-			},
-			stepCfg: ArgoCDUpdateConfig{},
-			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
-				require.ErrorContains(t, err, "Stage")
-				require.ErrorContains(t, err, "not found in namespace")
-			},
-		},
-		{
 			name: "error retrieving authorized application",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -441,13 +391,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "error building desired sources",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -459,7 +402,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -481,13 +423,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "error determining if update is necessary",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -499,7 +434,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -509,7 +443,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -531,13 +464,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "determination error can be solved by applying update",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -549,7 +475,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -559,7 +484,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -589,13 +513,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "must wait for update to complete",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -607,7 +524,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -617,7 +533,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -639,13 +554,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "must wait for operation from different user to complete",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -657,7 +565,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -667,7 +574,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -689,13 +595,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "error applying update",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -707,7 +606,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -717,7 +615,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -748,13 +645,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "failed and pending update",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -766,7 +656,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -776,7 +665,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -786,7 +674,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 						context.Context,
 						*PromotionStepContext,
 						*ArgoCDUpdateConfig,
-						*kargoapi.Stage,
 						*ArgoCDAppUpdate,
 						*argocd.Application,
 						argocd.ApplicationSources,
@@ -824,13 +711,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "operation phase aggregation error",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -842,7 +722,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -852,7 +731,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -874,13 +752,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 		{
 			name: "completed",
 			runner: &argocdUpdater{
-				getStageFn: func(
-					context.Context,
-					client.Client,
-					client.ObjectKey,
-				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
-				},
 				getAuthorizedApplicationFn: func(
 					context.Context,
 					*PromotionStepContext,
@@ -892,7 +763,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 				) (argocd.ApplicationSources, error) {
@@ -902,7 +772,6 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppUpdate,
 					*argocd.Application,
 					argocd.ApplicationSources,
@@ -953,7 +822,6 @@ func Test_argoCDUpdater_buildDesiredSources(t *testing.T) {
 					context.Context,
 					*PromotionStepContext,
 					*ArgoCDUpdateConfig,
-					*kargoapi.Stage,
 					*ArgoCDAppSourceUpdate,
 					argocd.ApplicationSource,
 				) (argocd.ApplicationSource, error) {
@@ -982,7 +850,6 @@ func Test_argoCDUpdater_buildDesiredSources(t *testing.T) {
 					_ context.Context,
 					_ *PromotionStepContext,
 					_ *ArgoCDUpdateConfig,
-					_ *kargoapi.Stage,
 					_ *ArgoCDAppSourceUpdate,
 					src argocd.ApplicationSource,
 				) (argocd.ApplicationSource, error) {
@@ -1037,7 +904,6 @@ func Test_argoCDUpdater_buildDesiredSources(t *testing.T) {
 				context.Background(),
 				&PromotionStepContext{},
 				&ArgoCDUpdateConfig{},
-				nil,
 				testCase.update,
 				app,
 			)
@@ -1382,7 +1248,6 @@ func Test_argoCDUpdater_mustPerformUpdate(t *testing.T) {
 					Freight: freight,
 				},
 				stepCfg,
-				&kargoapi.Stage{},
 				&stepCfg.Apps[0],
 				app,
 				testCase.desiredSources,
@@ -2063,7 +1928,6 @@ func Test_argoCDUpdater_applyArgoCDSourceUpdate(t *testing.T) {
 					Freight: freight,
 				},
 				stepCfg,
-				&kargoapi.Stage{},
 				&stepCfg.Apps[0].Sources[0],
 				testCase.source,
 			)
@@ -2124,7 +1988,6 @@ func Test_argoCDUpdater_buildKustomizeImagesForAppSource(t *testing.T) {
 				Freight: freight,
 			},
 			stepCfg,
-			&kargoapi.Stage{},
 			stepCfg.Apps[0].Sources[0].Kustomize,
 		)
 	require.NoError(t, err)
@@ -2218,7 +2081,6 @@ func Test_argoCDUpdater_buildHelmParamChangesForAppSource(t *testing.T) {
 				Freight: freight,
 			},
 			stepCfg,
-			&kargoapi.Stage{},
 			stepCfg.Apps[0].Sources[0].Helm,
 		)
 	require.NoError(t, err)


### PR DESCRIPTION
* Ports legacy Argo CD App health check code to the `argocdUpdater` that was introduced by #2545. Includes recent health check improvements from #2552 (multi-source health checks).

* Further simplifies the above. `Stage` was passed around to a lot of places that didn't need it.

* Implements the new `HealthCheckStepRunner` introduced in #2554.