### PR TITLE
fix: cast output from promotion steps as map[string]any

### DIFF
--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -99,7 +99,7 @@ func (e *SimpleEngine) Promote(
 		}
 
 		if step.Alias != "" {
-			state[step.Alias] = result.Output
+			state[step.Alias] = map[string]any(result.Output)
 		}
 
 		if result.HealthCheckStep != nil {


### PR DESCRIPTION
The `DeepCopyJSON()` logic borrowed from apimachinery doesn't seem to like our `State` type. But our `State` type is just a `map[string]any` with some additional methods added to it. If we cast the output from our promotion steps as `map[string]any`, the deep copy succeeds and we're no worse off.