### PR TITLE
fix: make git-commit promotion step check for diffs before committing

### DIFF
--- a/internal/directives/git_commiter.go
+++ b/internal/directives/git_commiter.go
@@ -92,9 +92,16 @@ func (g *gitCommitter) runPromotionStep(
 			commitOpts.Author.Email = cfg.Author.Email
 		}
 	}
-	if err = workTree.Commit(commitMsg, commitOpts); err != nil {
+	hasDiffs, err := workTree.HasDiffs()
+	if err != nil {
 		return PromotionStepResult{Status: PromotionStatusFailure},
-			fmt.Errorf("error committing to working tree: %w", err)
+			fmt.Errorf("error checking for diffs in working tree: %w", err)
+	}
+	if hasDiffs {
+		if err = workTree.Commit(commitMsg, commitOpts); err != nil {
+			return PromotionStepResult{Status: PromotionStatusFailure},
+				fmt.Errorf("error committing to working tree: %w", err)
+		}
 	}
 	commitID, err := workTree.LastCommitID()
 	if err != nil {


### PR DESCRIPTION
This logic was present in the legacy promotion mechanisms and was overlooked in the git-commit directive.