### PR TITLE
fix: prefer map[string]any everywhere where we don't actually need to use DeepCopy

### DIFF
--- a/internal/directives/argocd_health.go
+++ b/internal/directives/argocd_health.go
@@ -124,7 +124,7 @@ func (a *argocdUpdater) runHealthCheckStep(
 			}
 		}
 	}
-	health.Output = State{
+	health.Output = map[string]any{
 		applicationStatusesKey: appStatuses,
 	}
 	return health

--- a/internal/directives/argocd_revisions.go
+++ b/internal/directives/argocd_revisions.go
@@ -171,12 +171,12 @@ func getCommitFromStep(sharedState State, stepAlias string) (string, error) {
 	if !exists {
 		return "", fmt.Errorf("no output found from step with alias %q", stepAlias)
 	}
-	stepOutputState, ok := stepOutput.(State)
+	stepOutputMap, ok := stepOutput.(map[string]any)
 	if !ok {
 		return "",
-			fmt.Errorf("output from step with alias %q is not a State", stepAlias)
+			fmt.Errorf("output from step with alias %q is not a map[string]any", stepAlias)
 	}
-	commitAny, exists := stepOutputState.Get(commitKey)
+	commitAny, exists := stepOutputMap[commitKey]
 	if !exists {
 		return "",
 			fmt.Errorf("no commit found in output from step with alias %q", stepAlias)

--- a/internal/directives/git_commiter.go
+++ b/internal/directives/git_commiter.go
@@ -103,7 +103,7 @@ func (g *gitCommitter) runPromotionStep(
 	}
 	return PromotionStepResult{
 		Status: PromotionStatusSuccess,
-		Output: State{commitKey: commitID},
+		Output: map[string]any{commitKey: commitID},
 	}, nil
 }
 
@@ -125,15 +125,15 @@ func (g *gitCommitter) buildCommitMessage(
 					alias,
 				)
 			}
-			stepOutputState, ok := stepOutput.(State)
+			stepOutputMap, ok := stepOutput.(map[string]any)
 			if !ok {
 				return "", fmt.Errorf(
-					"output from step with alias %q is not a State; cannot construct "+
+					"output from step with alias %q is not a map[string]any; cannot construct "+
 						"commit message",
 					alias,
 				)
 			}
-			commitMsgPart, exists := stepOutputState.Get("commitMessage")
+			commitMsgPart, exists := stepOutputMap["commitMessage"]
 			if !exists {
 				return "", fmt.Errorf(
 					"no commit message found in output from step with alias %q; cannot "+

--- a/internal/directives/git_commiter_test.go
+++ b/internal/directives/git_commiter_test.go
@@ -224,7 +224,7 @@ func Test_gitCommitter_runPromotionStep(t *testing.T) {
 	require.Equal(t, PromotionStatusSuccess, res.Status)
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
-	actualCommit, ok := res.Output.Get(commitKey)
+	actualCommit, ok := res.Output[commitKey]
 	require.True(t, ok)
 	require.Equal(t, expectedCommit, actualCommit)
 	lastCommitMsg, err := workTree.CommitMessage("HEAD")
@@ -263,13 +263,13 @@ func Test_gitCommitter_buildCommitMessage(t *testing.T) {
 			cfg: GitCommitConfig{MessageFromSteps: []string{"fake-step-alias"}},
 			assertions: func(t *testing.T, _ string, err error) {
 				require.ErrorContains(t, err, "output from step with alias")
-				require.ErrorContains(t, err, "is not a State")
+				require.ErrorContains(t, err, "is not a map[string]any")
 			},
 		},
 		{
 			name: "output from step with alias does not contain a commit message",
 			sharedState: State{
-				"fake-step-alias": State{},
+				"fake-step-alias": map[string]any{},
 			},
 			cfg: GitCommitConfig{MessageFromSteps: []string{"fake-step-alias"}},
 			assertions: func(t *testing.T, _ string, err error) {
@@ -281,7 +281,7 @@ func Test_gitCommitter_buildCommitMessage(t *testing.T) {
 		{
 			name: "output from step with alias contain a commit message that isn't a string",
 			sharedState: State{
-				"fake-step-alias": State{
+				"fake-step-alias": map[string]any{
 					"commitMessage": 42,
 				},
 			},
@@ -296,10 +296,10 @@ func Test_gitCommitter_buildCommitMessage(t *testing.T) {
 		{
 			name: "successful message construction",
 			sharedState: State{
-				"fake-step-alias": State{
+				"fake-step-alias": map[string]any{
 					"commitMessage": "part one",
 				},
-				"another-fake-step-alias": State{
+				"another-fake-step-alias": map[string]any{
 					"commitMessage": "part two",
 				},
 			},

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -174,7 +174,7 @@ func (g *gitPROpener) runPromotionStep(
 	}
 	return PromotionStepResult{
 		Status: PromotionStatusSuccess,
-		Output: State{
+		Output: map[string]any{
 			prNumberKey: pr.Number,
 		},
 	}, nil
@@ -190,14 +190,14 @@ func getSourceBranch(sharedState State, cfg GitOpenPRConfig) (string, error) {
 				cfg.SourceBranchFromStep,
 			)
 		}
-		stepOutputState, ok := stepOutput.(State)
+		stepOutputMap, ok := stepOutput.(map[string]any)
 		if !ok {
 			return "", fmt.Errorf(
-				"output from step with alias %q is not a State",
+				"output from step with alias %q is not a mao[string]any",
 				cfg.SourceBranchFromStep,
 			)
 		}
-		sourceBranchAny, exists := stepOutputState.Get(branchKey)
+		sourceBranchAny, exists := stepOutputMap[branchKey]
 		if !exists {
 			return "", fmt.Errorf(
 				"no branch found in output from step with alias %q",

--- a/internal/directives/git_pr_opener_test.go
+++ b/internal/directives/git_pr_opener_test.go
@@ -199,7 +199,7 @@ func Test_gitPROpener_runPromotionStep(t *testing.T) {
 			WorkDir:       workDir,
 			CredentialsDB: &credentials.FakeDB{},
 			SharedState: State{
-				"fake-step": State{
+				"fake-step": map[string]any{
 					branchKey: testSourceBranch,
 				},
 			},
@@ -214,7 +214,7 @@ func Test_gitPROpener_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	prNumber, ok := res.Output.Get(prNumberKey)
+	prNumber, ok := res.Output[prNumberKey]
 	require.True(t, ok)
 	require.Equal(t, testPRNumber, prNumber)
 

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -126,7 +126,7 @@ func (g *gitPRWaiter) runPromotionStep(
 
 	return PromotionStepResult{
 		Status: PromotionStatusSuccess,
-		Output: State{commitKey: pr.MergeCommitSHA},
+		Output: map[string]any{commitKey: pr.MergeCommitSHA},
 	}, nil
 }
 
@@ -140,14 +140,14 @@ func getPRNumber(sharedState State, cfg GitWaitForPRConfig) (int64, error) {
 				cfg.PRNumberFromOpen,
 			)
 		}
-		stepOutputState, ok := stepOutput.(State)
+		stepOutputMap, ok := stepOutput.(map[string]any)
 		if !ok {
 			return 0, fmt.Errorf(
-				"output from step with alias %q is not a State",
+				"output from step with alias %q is not a map[string]any",
 				cfg.PRNumberFromOpen,
 			)
 		}
-		prNumberAny, exists := stepOutputState.Get(branchKey)
+		prNumberAny, exists := stepOutputMap[branchKey]
 		if !exists {
 			return 0, fmt.Errorf(
 				"no PR number found in output from step with alias %q",

--- a/internal/directives/git_pusher.go
+++ b/internal/directives/git_pusher.go
@@ -132,7 +132,7 @@ func (g *gitPushPusher) runPromotionStep(
 	}
 	return PromotionStepResult{
 		Status: PromotionStatusSuccess,
-		Output: State{
+		Output: map[string]any{
 			branchKey: targetBranch,
 			commitKey: commitID,
 		},

--- a/internal/directives/git_pusher_test.go
+++ b/internal/directives/git_pusher_test.go
@@ -205,12 +205,12 @@ func Test_gitPusher_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	branchName, ok := res.Output.Get(branchKey)
+	branchName, ok := res.Output[branchKey]
 	require.True(t, ok)
 	require.Equal(t, "kargo/fake-project/fake-stage/promotion", branchName)
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
-	actualCommit, ok := res.Output.Get(commitKey)
+	actualCommit, ok := res.Output[commitKey]
 	require.True(t, ok)
 	require.Equal(t, expectedCommit, actualCommit)
 }

--- a/internal/directives/health_checks.go
+++ b/internal/directives/health_checks.go
@@ -86,7 +86,7 @@ type HealthCheckStepResult struct {
 	// HealthCheckStepRunner. The Engine will aggregate this output and include it
 	// in the final results of the health check, which will ultimately be included
 	// in StageStatus.
-	Output State
+	Output map[string]any
 	// Issues is a list of issues that were encountered during the execution of
 	// the HealthCheckStep by a HealthCheckStepRunner.
 	Issues []string

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -124,8 +124,9 @@ func (h *helmChartUpdater) runPromotionStep(
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}
 	if commitMsg := h.generateCommitMessage(cfg.Path, newVersions); commitMsg != "" {
-		result.Output = make(State, 1)
-		result.Output.Set("commitMessage", commitMsg)
+		result.Output = map[string]any{
+			"commitMessage": commitMsg,
+		}
 	}
 	return result, nil
 }

--- a/internal/directives/helm_chart_updater_test.go
+++ b/internal/directives/helm_chart_updater_test.go
@@ -100,7 +100,7 @@ func Test_helmChartUpdater_runPromotionStep(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
 					Status: PromotionStatusSuccess,
-					Output: State{
+					Output: map[string]any{
 						"commitMessage": `Updated chart dependencies for testchart
 
 - examplechart: 0.1.0`,

--- a/internal/directives/helm_image_updater.go
+++ b/internal/directives/helm_image_updater.go
@@ -85,8 +85,9 @@ func (h *helmImageUpdater) runPromotionStep(
 		}
 
 		if commitMsg := h.generateCommitMessage(cfg.Path, fullImageRefs); commitMsg != "" {
-			result.Output = make(State, 1)
-			result.Output.Set("commitMessage", commitMsg)
+			result.Output = map[string]any{
+				"commitMessage": commitMsg,
+			}
 		}
 	}
 	return result, nil

--- a/internal/directives/helm_image_updater_test.go
+++ b/internal/directives/helm_image_updater_test.go
@@ -77,7 +77,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
 					Status: PromotionStatusSuccess,
-					Output: State{
+					Output: map[string]any{
 						"commitMessage": "Updated values.yaml to use new image\n\n- docker.io/library/nginx:1.19.0",
 					},
 				}, result)

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -99,8 +99,9 @@ func (k *kustomizeImageSetter) runPromotionStep(
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}
 	if commitMsg := k.generateCommitMessage(cfg.Path, targetImages); commitMsg != "" {
-		result.Output = make(State, 1)
-		result.Output.Set("commitMessage", commitMsg)
+		result.Output = map[string]any{
+			"commitMessage": commitMsg,
+		}
 	}
 	return result, nil
 }

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -77,7 +77,7 @@ kind: Kustomization
 				require.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
 					Status: PromotionStatusSuccess,
-					Output: State{
+					Output: map[string]any{
 						"commitMessage": "Updated . to use new image\n\n- nginx:1.21.0",
 					},
 				}, result)

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -177,7 +177,7 @@ type PromotionStepResult struct {
 	// Output is the opaque output of a PromotionStep executed by a
 	// PromotionStepRunner. The Engine will update shared state with this output,
 	// making it available to subsequent steps.
-	Output State
+	Output map[string]any
 	// HealthCheckStep is health check opaque configuration optionally returned by
 	// a PromotionStepRunner's successful execution of a PromotionStep. This
 	// configuration can later be used as input to health check processes.

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -99,7 +99,7 @@ func (e *SimpleEngine) Promote(
 		}
 
 		if step.Alias != "" {
-			state[step.Alias] = map[string]any(result.Output)
+			state[step.Alias] = result.Output
 		}
 
 		if result.HealthCheckStep != nil {

--- a/internal/directives/simple_engine_test.go
+++ b/internal/directives/simple_engine_test.go
@@ -145,7 +145,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 }
 
 func TestSimpleEngine_CheckHealth(t *testing.T) {
-	testOutput := State{
+	testOutput := map[string]any{
 		"fake-key": "fake-value",
 	}
 	testOutputBytes, err := json.Marshal(testOutput)


### PR DESCRIPTION
Follow-up on #2589

The change wasn't as safe as I thought.

This is a more holistic fix that switches the output from promotion steps from a `State` to a regular `map[string]any`.

The only benefit a `State` has over a normal `map[string]any` is a few convenience methods, including `DeepCopy()`. We only need that at the _top_ of the state map. i.e. There's no reason that output from individual steps can't be a normal map.

I can vouch for this fix better than I could for #2589 because when this is combined with #2590, I can now observe most of the Git-based promotion steps working together correctly from end-to-end.