### PR TITLE
fix: allow overwriter promotion step to handle individual files

### DIFF
--- a/internal/directives/git_tree_overwriter.go
+++ b/internal/directives/git_tree_overwriter.go
@@ -95,6 +95,14 @@ func (g *gitTreeOverwriter) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusFailure},
 			fmt.Errorf("error clearing working tree at %s: %w", cfg.OutPath, err)
 	}
+	inFI, err := os.Stat(inPath)
+	if err != nil {
+		return PromotionStepResult{Status: PromotionStatusFailure},
+			fmt.Errorf("error getting info for path %s: %w", inPath, err)
+	}
+	if !inFI.IsDir() {
+		outPath = filepath.Join(outPath, inFI.Name())
+	}
 	if err = copy.Copy(
 		inPath,
 		outPath,


### PR DESCRIPTION
It escaped my notice until now that `git-overwrite` promotion step couldn't handle a single file as a source.

This is essential because the `helm-template` and `kustomize-build` promotion steps both write their output to a single file. (Aside: I will open a separate issue for adding the option to split the output into individual files for every resource the way that Kargo Render could.)