### PR TITLE
fix(controller): fix source branch used by pr-opener

### DIFF
--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -127,7 +127,7 @@ func (g *gitPROpener) runPromotionStep(
 		ctx,
 		repo,
 		gitProviderSvc,
-		cfg.SourceBranch,
+		sourceBranch,
 		cfg.TargetBranch,
 	)
 	if err != nil {
@@ -163,7 +163,7 @@ func (g *gitPROpener) runPromotionStep(
 	pr, err := gitProviderSvc.CreatePullRequest(
 		ctx,
 		gitprovider.CreatePullRequestOpts{
-			Head:  cfg.SourceBranch,
+			Head:  sourceBranch,
 			Base:  cfg.TargetBranch,
 			Title: title,
 		},


### PR DESCRIPTION
There was some logic that ran prior to this that might have found a branch to use other than `cfg.SourceBranch`, but incorrectly using `cfg.SourceBranch` instead of `sourceBranch` means that logic was not being taken into account.