### PR TITLE
fix(controller): make simple engine short-circuit step execution on non-success

### DIFF
--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -98,6 +98,10 @@ func (e *SimpleEngine) Promote(
 				fmt.Errorf("failed to run step %q: %w", step.Kind, err)
 		}
 
+		if result.Status != PromotionStatusSuccess {
+			return PromotionResult{Status: result.Status}, nil
+		}
+
 		if step.Alias != "" {
 			state[step.Alias] = result.Output
 		}


### PR DESCRIPTION
The simple engine was allowing for success or failure only and wasn't accounting for the possibility of a step that is pending a change in external state, such as waiting for a PR to be merged.