### PR TITLE
docs: updating freight aliases

### DIFF
--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -46,7 +46,7 @@ include one or more:
 Freight can therefore be thought of as a sort of meta-artifact. Freight is what
 Kargo seeks to progress from one stage to another.
 For detailed guidance on working with Freight, refer to
-[this guide](https://kargo.akuity.io/how-to-guides/working-with-freight).
+[this guide](./30-how-to-guides/15-working-with-freight.md).
 
 ### What is a Warehouse?
 

--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -119,6 +119,7 @@ kargo update freight \
   --new-alias=frozen-tauntaun
 ```
 Alternatively, you can reference the `Freight` to which you want to assign a new alias using its existing alias:
+
 ```shell
 kargo update freight \
   --project=kargo-demo \


### PR DESCRIPTION
Addressed an inconsistency in the [Kargo documentation related to updating aliases for Freight resources.](https://kargo.akuity.io/how-to-guides/working-with-freight#updating-aliases)

# Before
![image](https://github.com/user-attachments/assets/683a28dd-6c99-4d5b-9169-51577d4367bf)

# After
![image](https://github.com/user-attachments/assets/99f2ead5-8394-4099-919c-dd3de2790488)
