### PR TITLE
refactor: update wait-for-pr step for improved consistency with other built-ins

### DIFF
--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -131,28 +131,28 @@ func (g *gitPRWaiter) runPromotionStep(
 }
 
 func getPRNumber(sharedState State, cfg GitWaitForPRConfig) (int64, error) {
-	if cfg.PRNumberFromOpen == "" {
+	if cfg.PRNumberFromStep == "" {
 		return cfg.PRNumber, nil
 	}
-	stepOutput, exists := sharedState.Get(cfg.PRNumberFromOpen)
+	stepOutput, exists := sharedState.Get(cfg.PRNumberFromStep)
 	if !exists {
 		return 0, fmt.Errorf(
 			"no output found from step with alias %q",
-			cfg.PRNumberFromOpen,
+			cfg.PRNumberFromStep,
 		)
 	}
 	stepOutputMap, ok := stepOutput.(map[string]any)
 	if !ok {
 		return 0, fmt.Errorf(
 			"output from step with alias %q is not a map[string]any",
-			cfg.PRNumberFromOpen,
+			cfg.PRNumberFromStep,
 		)
 	}
 	prNumberAny, exists := stepOutputMap[prNumberKey]
 	if !exists {
 		return 0, fmt.Errorf(
 			"no PR number found in output from step with alias %q",
-			cfg.PRNumberFromOpen,
+			cfg.PRNumberFromStep,
 		)
 	}
 	// If the state was rehydrated from PromotionStatus, which makes use of
@@ -166,7 +166,7 @@ func getPRNumber(sharedState State, cfg GitWaitForPRConfig) (int64, error) {
 	default:
 		return 0, fmt.Errorf(
 			"PR number in output from step with alias %q is not an int64",
-			cfg.PRNumberFromOpen,
+			cfg.PRNumberFromStep,
 		)
 	}
 }

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -36,17 +36,17 @@ func Test_gitPRWaiter_validate(t *testing.T) {
 			},
 		},
 		{
-			name:   "neither prNumber nor prNumberFromOpen specified",
+			name:   "neither prNumber nor PRNumberFromStep specified",
 			config: Config{},
 			expectedProblems: []string{
 				"(root): Must validate one and only one schema",
 			},
 		},
 		{
-			name: "both prNumber and prNumberFromOpen specified",
+			name: "both prNumber and PRNumberFromStep specified",
 			config: Config{
 				"prNumber":         42,
-				"prNumberFromOpen": "fake-step",
+				"PRNumberFromStep": "fake-step",
 			},
 			expectedProblems: []string{
 				"(root): Must validate one and only one schema",

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -36,17 +36,17 @@ func Test_gitPRWaiter_validate(t *testing.T) {
 			},
 		},
 		{
-			name:   "neither prNumber nor PRNumberFromStep specified",
+			name:   "neither prNumber nor prNumberFromStep specified",
 			config: Config{},
 			expectedProblems: []string{
 				"(root): Must validate one and only one schema",
 			},
 		},
 		{
-			name: "both prNumber and PRNumberFromStep specified",
+			name: "both prNumber and prNumberFromStep specified",
 			config: Config{
 				"prNumber":         42,
-				"PRNumberFromStep": "fake-step",
+				"prNumberFromStep": "fake-step",
 			},
 			expectedProblems: []string{
 				"(root): Must validate one and only one schema",

--- a/internal/directives/schemas/git-wait-for-pr-config.json
+++ b/internal/directives/schemas/git-wait-for-pr-config.json
@@ -34,11 +34,11 @@
     {
       "required": ["prNumber"],
       "properties": {
-        "prNumberFromOpen": {  "enum": ["", null] }
+        "prNumberFromStep": {  "enum": ["", null] }
       }
     },
     {
-      "required": ["prNumberFromOpen"],
+      "required": ["prNumberFromStep"],
       "properties": {
         "prNumber": {  "enum": [0, null] }
       }

--- a/internal/directives/schemas/git-wait-for-pr-config.json
+++ b/internal/directives/schemas/git-wait-for-pr-config.json
@@ -18,9 +18,9 @@
       "type": "number",
       "description": "The number of the pull request to wait for."
     },
-    "prNumberFromOpen": {
+    "prNumberFromStep": {
       "type": "string",
-      "description": "References a previous open step by alias and will use the PR number opened by that step.",
+      "description": "This field references the 'prNumber' output from a previous step and uses it as the number of the pull request to wait for.",
       "minLength": 1
     },
     "repoURL": {

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -206,8 +206,9 @@ type GitWaitForPRConfig struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// The number of the pull request to wait for.
 	PRNumber int64 `json:"prNumber,omitempty"`
-	// References a previous open step by alias and will use the PR number opened by that step.
-	PRNumberFromOpen string `json:"prNumberFromOpen,omitempty"`
+	// This field references the 'prNumber' output from a previous step and uses it as the
+	// number of the pull request to wait for.
+	PRNumberFromStep string `json:"prNumberFromStep,omitempty"`
 	// The name of the Git provider to use. Currently only 'github' and 'gitlab' are supported.
 	// Kargo will try to infer the provider if it is not explicitly specified.
 	Provider *Provider `json:"provider,omitempty"`


### PR DESCRIPTION
This swaps the `prNumberFromOpen` field for `prNumberFromStep`, thereby not implying that the `prNumber` output this step consumes _needs_ to have come from an `git-open-pr` step.

This improves consistency with the other built-in promotion steps, which use the same syntax to avoid implying that input _needs_ to have come from a particular kind of step.

All this will be moot once we have some kind of EL built, but for now, this matters.