### PR TITLE
docs: update docs and scripts to work with v0.9.0-rc.1

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -163,7 +163,7 @@ To download the Kargo CLI:
 ```shell
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch=amd64
-curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
+curl -L -o kargo https://github.com/akuity/kargo/releases/download/v0.9.0-rc.1/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
 chmod +x kargo
 ```
 
@@ -176,7 +176,7 @@ value of your `PATH` environment variable.
 To download the Kargo CLI:
 
 ```shell
-Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/download/v0.9.0-rc.1/kargo-windows-amd64.exe -OutFile kargo.exe
 ```
 
 Then move `kargo.exe` to a location in your file system that is included in the value

--- a/docs/docs/30-how-to-guides/10-installing-kargo.md
+++ b/docs/docs/30-how-to-guides/10-installing-kargo.md
@@ -45,6 +45,7 @@ user-specified admin password:
 ```shell
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.9.0-rc.1 \
   --namespace kargo \
   --create-namespace \
   --set api.adminAccount.passwordHash='$2a$10$Zrhhie4vLz5ygtVSaif6o.qN36jgs6vjtMBdM6yrU1FOeiAAMMxOm' \
@@ -83,6 +84,7 @@ following:
    ```shell
    helm install kargo \
      oci://ghcr.io/akuity/kargo-charts/kargo \
+     --version 0.9.0-rc.1 \
      --namespace kargo \
      --create-namespace \
      --values ~/kargo-values.yaml \

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -39,6 +39,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.9.0-rc.1 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -46,6 +46,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.9.0-rc.1 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -60,6 +60,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 0.9.0-rc.1 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \


### PR DESCRIPTION
This PR updates `main` and the edge docs at https://main.kargo.akuity.io/ in a way that facilitates non-engineers being able to easily test-drive the `v0.9.0-rc.1` release candidate just by following the quickstart exactly as it is written.

These changes will outlive their usefulness and should be reverted after we cut the official `v0.9.0` release.