### PR TITLE
feat(directives): support multi file write for `helm-template`

### DIFF
--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -1,11 +1,14 @@
 package directives
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/xeipuuv/gojsonschema"
@@ -14,6 +17,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/release"
 )
 
 func init() {
@@ -24,6 +28,14 @@ func init() {
 			AllowCredentialsDB: true,
 		},
 	)
+}
+
+// OutPathIsFile returns true if the output path contains a YAML extension.
+// Otherwise, the output path is considered to target a directory where the
+// rendered manifest will be written to.
+func (c HelmTemplateConfig) OutPathIsFile() bool {
+	ext := filepath.Ext(c.OutPath)
+	return ext == ".yaml" || ext == ".yml"
 }
 
 // helmTemplateRunner is an implementation of the PromotionStepRunner interface
@@ -92,7 +104,13 @@ func (h *helmTemplateRunner) runPromotionStep(
 			fmt.Errorf("missing chart dependencies: %w", err)
 	}
 
-	install, err := h.newInstallAction(cfg, stepCtx.Project)
+	absOutPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
+	if err != nil {
+		return PromotionStepResult{Status: PromotionStatusFailure},
+			fmt.Errorf("failed to join path %q: %w", cfg.OutPath, err)
+	}
+
+	install, err := h.newInstallAction(cfg, stepCtx.Project, absOutPath)
 	if err != nil {
 		return PromotionStepResult{Status: PromotionStatusFailure},
 			fmt.Errorf("failed to initialize Helm action config: %w", err)
@@ -104,7 +122,7 @@ func (h *helmTemplateRunner) runPromotionStep(
 			fmt.Errorf("failed to render chart: %w", err)
 	}
 
-	if err = h.writeOutput(stepCtx.WorkDir, cfg.OutPath, rls.Manifest); err != nil {
+	if err = h.writeOutput(cfg, rls, absOutPath); err != nil {
 		return PromotionStepResult{Status: PromotionStatusFailure},
 			fmt.Errorf("failed to write rendered chart: %w", err)
 	}
@@ -128,7 +146,10 @@ func (h *helmTemplateRunner) composeValues(workDir string, valuesFiles []string)
 // newInstallAction creates a new Helm install action with the given
 // configuration. It sets the action to dry-run mode and client-only mode,
 // meaning that it will not install the chart, but only render the manifest.
-func (h *helmTemplateRunner) newInstallAction(cfg HelmTemplateConfig, project string) (*action.Install, error) {
+func (h *helmTemplateRunner) newInstallAction(
+	cfg HelmTemplateConfig,
+	project, absOutPath string,
+) (*action.Install, error) {
 	client := action.NewInstall(&action.Configuration{})
 
 	client.DryRun = true
@@ -139,6 +160,13 @@ func (h *helmTemplateRunner) newInstallAction(cfg HelmTemplateConfig, project st
 	client.Namespace = defaultValue(cfg.Namespace, project)
 	client.IncludeCRDs = cfg.IncludeCRDs
 	client.APIVersions = cfg.APIVersions
+	client.DisableHooks = cfg.DisableHooks
+
+	// If the output path does not have a YAML extension, it is considered a
+	// directory where the manifest will be written to.
+	if !cfg.OutPathIsFile() {
+		client.OutputDir = absOutPath
+	}
 
 	if cfg.KubeVersion != "" {
 		kubeVersion, err := chartutil.ParseKubeVersion(cfg.KubeVersion)
@@ -152,10 +180,10 @@ func (h *helmTemplateRunner) newInstallAction(cfg HelmTemplateConfig, project st
 }
 
 // loadChart loads the chart from the given path.
-func (h *helmTemplateRunner) loadChart(workDir, path string) (*chart.Chart, error) {
-	absChartPath, err := securejoin.SecureJoin(workDir, path)
+func (h *helmTemplateRunner) loadChart(workDir, relPath string) (*chart.Chart, error) {
+	absChartPath, err := securejoin.SecureJoin(workDir, relPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to join path %q: %w", path, err)
+		return nil, fmt.Errorf("failed to join relPath %q: %w", relPath, err)
 	}
 	return loader.Load(absChartPath)
 }
@@ -170,17 +198,50 @@ func (h *helmTemplateRunner) checkDependencies(chartRequested *chart.Chart) erro
 	return nil
 }
 
-// writeOutput writes the rendered manifest to the output path. It creates the
-// directory if it does not exist.
-func (h *helmTemplateRunner) writeOutput(workDir, outPath, manifest string) error {
-	absOutPath, err := securejoin.SecureJoin(workDir, outPath)
-	if err != nil {
-		return fmt.Errorf("failed to join path %q: %w", outPath, err)
+// writeOutput writes the rendered manifest to the output path.
+func (h *helmTemplateRunner) writeOutput(cfg HelmTemplateConfig, rls *release.Release, outPath string) error {
+	var (
+		manifests     bytes.Buffer
+		outPathIsFile = cfg.OutPathIsFile()
+	)
+
+	if outPathIsFile {
+		_, _ = fmt.Fprintln(&manifests, strings.TrimSpace(rls.Manifest))
 	}
-	if err = os.MkdirAll(filepath.Dir(absOutPath), 0o700); err != nil {
-		return fmt.Errorf("failed to create directory %q: %w", outPath, err)
+
+	if !cfg.DisableHooks {
+		for _, h := range rls.Hooks {
+			if cfg.SkipTests && isTestHook(h) {
+				continue
+			}
+
+			if outPathIsFile {
+				_, _ = fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
+				continue
+			}
+
+			exists := true
+			if _, err := os.Stat(filepath.Join(outPath, h.Path)); err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("failed to check if file %q exists: %w", h.Path, err)
+				}
+				exists = false
+			}
+
+			if err := writeToHelmFile(outPath, h.Path, h.Manifest, exists); err != nil {
+				return fmt.Errorf("failed to write hook %q: %w", h.Path, err)
+			}
+		}
 	}
-	return os.WriteFile(absOutPath, []byte(manifest), 0o600)
+
+	if !outPathIsFile {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o700); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", cfg.OutPath, err)
+	}
+	return os.WriteFile(outPath, manifests.Bytes(), 0o600)
 }
 
 // defaultValue returns the value if it is not zero or empty, otherwise it
@@ -190,4 +251,64 @@ func defaultValue[T any](value, defaultValue T) T {
 		return defaultValue
 	}
 	return value
+}
+
+// isTestHook returns true if the hook is a test hook.
+func isTestHook(h *release.Hook) bool {
+	for _, e := range h.Events {
+		if e == release.HookTest {
+			return true
+		}
+	}
+	return false
+}
+
+// The logic below is directly derived from the Helm source code:
+// https://github.com/helm/helm/blob/b2286c4caabdfdcf2baaecb42819db9d38c04597/cmd/helm/template.go#L222
+// Licensed under the Apache License 2.0.
+
+// writeToHelmFile writes the given data to the output directory with the given
+// name. If the append flag is set to true, the data is appended to the file.
+func writeToHelmFile(outputDir string, name string, data string, append bool) (err error) {
+	outfileName := strings.Join([]string{outputDir, name}, string(filepath.Separator))
+
+	if err = ensureDirectoryForHelmFile(outfileName); err != nil {
+		return err
+	}
+
+	f, err := createOrOpenHelmFile(outfileName, append)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	if _, err = f.WriteString(fmt.Sprintf("---\n# Source: %s\n%s\n", name, data)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createOrOpenHelmFile creates or opens the file with the given name. If the
+// append flag is set to true, the file is opened in append mode.
+func createOrOpenHelmFile(filename string, append bool) (*os.File, error) {
+	if append {
+		return os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0o600)
+	}
+	return os.Create(filename)
+}
+
+// ensureDirectoryForHelmFile ensures that the directory for the given file
+// exists. If the directory does not exist, it is created with the default
+// permissions.
+func ensureDirectoryForHelmFile(file string) error {
+	baseDir := path.Dir(file)
+	if _, err := os.Stat(baseDir); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.MkdirAll(baseDir, 0o755)
 }

--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -157,6 +157,7 @@ func (h *helmTemplateRunner) newInstallAction(
 	client.Replace = true
 	client.ClientOnly = true
 	client.ReleaseName = defaultValue(cfg.ReleaseName, "release-name")
+	client.UseReleaseName = cfg.UseReleaseName
 	client.Namespace = defaultValue(cfg.Namespace, project)
 	client.IncludeCRDs = cfg.IncludeCRDs
 	client.APIVersions = cfg.APIVersions
@@ -221,7 +222,11 @@ func (h *helmTemplateRunner) writeOutput(cfg HelmTemplateConfig, rls *release.Re
 			}
 
 			exists := true
-			if _, err := os.Stat(filepath.Join(outPath, h.Path)); err != nil {
+			outDir := outPath
+			if cfg.UseReleaseName {
+				outDir = filepath.Join(outDir, cfg.ReleaseName)
+			}
+			if _, err := os.Stat(filepath.Join(outDir, h.Path)); err != nil {
 				if !os.IsNotExist(err) {
 					return fmt.Errorf("failed to check if file %q exists: %w", h.Path, err)
 				}

--- a/internal/directives/helm_template_runner_test.go
+++ b/internal/directives/helm_template_runner_test.go
@@ -11,6 +11,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/release"
 )
 
 func Test_helmTemplateRunner_runPromotionStep(t *testing.T) {
@@ -108,6 +109,51 @@ metadata:
 data:
   value1: value1
   value2: value2
+`, string(content))
+			},
+		},
+		{
+			name: "successful run with output directory",
+			files: map[string]string{
+				"values.yaml": "key: value",
+				"charts/test-chart/Chart.yaml": `apiVersion: v1
+name: test-chart
+version: 0.1.0`,
+				"charts/test-chart/templates/test.yaml": `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  value: {{ .Values.key }}
+`,
+			},
+			cfg: HelmTemplateConfig{
+				Path:        "charts/test-chart",
+				ValuesFiles: []string{"values.yaml"},
+				OutPath:     "output/",
+				ReleaseName: "test-release",
+				Namespace:   "test-namespace",
+			},
+			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+
+				outPath := filepath.Join(workDir, "output", "test-chart")
+				require.DirExists(t, outPath)
+
+				content, err := os.ReadFile(filepath.Join(outPath, "templates/test.yaml"))
+				require.NoError(t, err)
+				assert.Equal(t, `---
+# Source: test-chart/templates/test.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-release-configmap
+  namespace: test-namespace
+data:
+  value: value
 `, string(content))
 			},
 		},
@@ -283,7 +329,7 @@ func Test_helmTemplateRunner_composeValues(t *testing.T) {
 		},
 	}
 
-	runner := (&helmTemplateRunner{})
+	runner := &helmTemplateRunner{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -301,6 +347,7 @@ func Test_helmTemplateRunner_newInstallAction(t *testing.T) {
 		name       string
 		cfg        HelmTemplateConfig
 		project    string
+		absOutPath string
 		assertions func(*testing.T, *action.Install, error)
 	}{
 		{
@@ -339,6 +386,39 @@ func Test_helmTemplateRunner_newInstallAction(t *testing.T) {
 			},
 		},
 		{
+			name: "output directory",
+			cfg: HelmTemplateConfig{
+				OutPath: "output/",
+			},
+			absOutPath: "/tmp/output",
+			assertions: func(t *testing.T, client *action.Install, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, "/tmp/output", client.OutputDir)
+			},
+		},
+		{
+			name: "output file (YAML)",
+			cfg: HelmTemplateConfig{
+				OutPath: "output.yaml",
+			},
+			absOutPath: "/tmp/output.yaml",
+			assertions: func(t *testing.T, client *action.Install, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, client.OutputDir)
+			},
+		},
+		{
+			name: "output file (YML)",
+			cfg: HelmTemplateConfig{
+				OutPath: "output.yml",
+			},
+			absOutPath: "/tmp/output.yml",
+			assertions: func(t *testing.T, client *action.Install, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, client.OutputDir)
+			},
+		},
+		{
 			name: "KubeVersion parsing error",
 			cfg: HelmTemplateConfig{
 				KubeVersion: "invalid",
@@ -350,11 +430,11 @@ func Test_helmTemplateRunner_newInstallAction(t *testing.T) {
 		},
 	}
 
-	runner := (&helmTemplateRunner{})
+	runner := &helmTemplateRunner{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := runner.newInstallAction(tt.cfg, tt.project)
+			client, err := runner.newInstallAction(tt.cfg, tt.project, tt.absOutPath)
 			tt.assertions(t, client, err)
 		})
 	}
@@ -443,46 +523,181 @@ func Test_helmTemplateRunner_checkDependencies(t *testing.T) {
 func Test_helmTemplateRunner_writeOutput(t *testing.T) {
 	tests := []struct {
 		name       string
-		workDir    string
-		outPath    string
-		manifest   string
-		setup      func(string)
+		cfg        HelmTemplateConfig
+		rls        *release.Release
+		setup      func(*testing.T) (outPath string)
 		assertions func(*testing.T, string, error)
 	}{
 		{
-			name:     "successful write",
-			workDir:  t.TempDir(),
-			outPath:  "output.yaml",
-			manifest: "key: value",
+			name: "successful write to file",
+			cfg: HelmTemplateConfig{
+				OutPath: "output.yaml",
+			},
+			rls: &release.Release{
+				Manifest: "key: value",
+			},
+			setup: func(t *testing.T) (workDir string) {
+				return t.TempDir()
+			},
 			assertions: func(t *testing.T, workDir string, err error) {
 				require.NoError(t, err)
+
 				content, err := os.ReadFile(filepath.Join(workDir, "output.yaml"))
 				require.NoError(t, err)
-				assert.Equal(t, "key: value", string(content))
+				assert.Equal(t, "key: value\n", string(content))
 			},
 		},
 		{
-			name:     "write to non-existent directory",
-			workDir:  t.TempDir(),
-			outPath:  "subdir/output.yaml",
-			manifest: "key: value",
+			name: "write to non-existent directory",
+			cfg: HelmTemplateConfig{
+				OutPath: "subdir/output.yaml",
+			},
+			rls: &release.Release{
+				Manifest: "key: value",
+			},
+			setup: func(t *testing.T) (workDir string) {
+				return t.TempDir()
+			},
 			assertions: func(t *testing.T, workDir string, err error) {
 				require.NoError(t, err)
+
 				content, err := os.ReadFile(filepath.Join(workDir, "subdir", "output.yaml"))
 				require.NoError(t, err)
-				assert.Equal(t, "key: value", string(content))
+				assert.Equal(t, "key: value\n", string(content))
 			},
 		},
 		{
-			name:     "path traversal outside work directory",
-			workDir:  t.TempDir(),
-			outPath:  "../../output.yaml",
-			manifest: "key: value",
+			name: "write hooks to separate files",
+			cfg: HelmTemplateConfig{
+				OutPath: "output",
+			},
+			rls: &release.Release{
+				Manifest: "main: manifest",
+				Hooks: []*release.Hook{
+					{Path: "hook1.yaml", Manifest: "hook1: content"},
+					{Path: "hook2.yaml", Manifest: "hook2: content"},
+				},
+			},
+			setup: func(t *testing.T) (outPath string) {
+				return t.TempDir()
+			},
+			assertions: func(t *testing.T, workDir string, err error) {
+				require.NoError(t, err)
+
+				hook1Content, err := os.ReadFile(filepath.Join(workDir, "output", "hook1.yaml"))
+				require.NoError(t, err)
+				assert.Equal(t, "---\n# Source: hook1.yaml\nhook1: content\n", string(hook1Content))
+
+				hook2Content, err := os.ReadFile(filepath.Join(workDir, "output", "hook2.yaml"))
+				require.NoError(t, err)
+				assert.Equal(t, "---\n# Source: hook2.yaml\nhook2: content\n", string(hook2Content))
+			},
+		},
+		{
+			name: "skip test hooks",
+			cfg: HelmTemplateConfig{
+				OutPath:   "output",
+				SkipTests: true,
+			},
+			rls: &release.Release{
+				Manifest: "main: manifest",
+				Hooks: []*release.Hook{
+					{Path: "hook1.yaml", Manifest: "hook1: content"},
+					{Path: "test.yaml", Manifest: "test: content", Events: []release.HookEvent{release.HookTest}},
+				},
+			},
+			setup: func(t *testing.T) (outPath string) {
+				return t.TempDir()
+			},
+			assertions: func(t *testing.T, workDir string, err error) {
+				require.NoError(t, err)
+
+				hook1Content, err := os.ReadFile(filepath.Join(workDir, "output", "hook1.yaml"))
+				require.NoError(t, err)
+				assert.Equal(t, "---\n# Source: hook1.yaml\nhook1: content\n", string(hook1Content))
+
+				assert.NoFileExists(t, filepath.Join(workDir, "output", "test.yaml"))
+			},
+		},
+		{
+			name: "write hooks to single file",
+			cfg: HelmTemplateConfig{
+				OutPath: "output.yaml",
+			},
+			rls: &release.Release{
+				Manifest: "main: manifest",
+				Hooks: []*release.Hook{
+					{Path: "hook1.yaml", Manifest: "hook1: content"},
+					{Path: "hook2.yaml", Manifest: "hook2: content"},
+				},
+			},
+			setup: func(t *testing.T) (outPath string) {
+				return t.TempDir()
+			},
 			assertions: func(t *testing.T, workDir string, err error) {
 				require.NoError(t, err)
 				content, err := os.ReadFile(filepath.Join(workDir, "output.yaml"))
 				require.NoError(t, err)
-				assert.Equal(t, "key: value", string(content))
+				assert.Equal(t, `main: manifest
+---
+# Source: hook1.yaml
+hook1: content
+---
+# Source: hook2.yaml
+hook2: content
+`, string(content))
+			},
+		},
+		{
+			name: "disable hooks",
+			cfg: HelmTemplateConfig{
+				OutPath:      "output",
+				DisableHooks: true,
+			},
+			rls: &release.Release{
+				Manifest: "main: manifest",
+				Hooks: []*release.Hook{
+					{Path: "hook1.yaml", Manifest: "hook1: content"},
+				},
+			},
+			setup: func(t *testing.T) (outPath string) {
+				return t.TempDir()
+			},
+			assertions: func(t *testing.T, workDir string, err error) {
+				require.NoError(t, err)
+				_, err = os.Stat(filepath.Join(workDir, "output", "hook1.yaml"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "append to existing hook file",
+			cfg: HelmTemplateConfig{
+				OutPath: "output",
+			},
+			rls: &release.Release{
+				Manifest: "main: manifest",
+				Hooks: []*release.Hook{
+					{Path: "hook1.yaml", Manifest: "new content"},
+				},
+			},
+			setup: func(t *testing.T) (workDir string) {
+				workDir = t.TempDir()
+
+				require.NoError(t, os.MkdirAll(filepath.Join(workDir, "output"), 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(workDir, "output", "hook1.yaml"),
+					[]byte("existing content\n"),
+					0o600,
+				))
+
+				return workDir
+			},
+			assertions: func(t *testing.T, workDir string, err error) {
+				require.NoError(t, err)
+
+				content, err := os.ReadFile(filepath.Join(workDir, "output", "hook1.yaml"))
+				require.NoError(t, err)
+				assert.Equal(t, "existing content\n---\n# Source: hook1.yaml\nnew content\n", string(content))
 			},
 		},
 	}
@@ -491,11 +706,9 @@ func Test_helmTemplateRunner_writeOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.setup != nil {
-				tt.setup(tt.workDir)
-			}
-			err := runner.writeOutput(tt.workDir, tt.outPath, tt.manifest)
-			tt.assertions(t, tt.workDir, err)
+			workDir := tt.setup(t)
+			err := runner.writeOutput(tt.cfg, tt.rls, filepath.Join(workDir, tt.cfg.OutPath))
+			tt.assertions(t, workDir, err)
 		})
 	}
 }

--- a/internal/directives/schemas/helm-template-config.json
+++ b/internal/directives/schemas/helm-template-config.json
@@ -36,6 +36,16 @@
       "description": "Whether to include CRDs in the rendered manifests.",
       "default": false
     },
+    "disableHooks": {
+      "type": "boolean",
+      "description": "Whether to disable hooks in the rendered manifests.",
+      "default": false
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "Whether to skip tests when rendering the manifests.",
+      "default": false
+    },
     "kubeVersion": {
       "type": "string",
       "description": "KubeVersion allows for passing a specific Kubernetes version to use when rendering the manifests."

--- a/internal/directives/schemas/helm-template-config.json
+++ b/internal/directives/schemas/helm-template-config.json
@@ -12,12 +12,17 @@
     },
     "outPath": {
       "type": "string",
-      "description": "OutPath to write the rendered manifests to.",
+      "description": "OutPath to write the rendered manifests to. If it points to a .yaml or .yml file, the rendered manifests will be written to that file. If it points to a directory, the rendered manifests will be written to this directory joined with the chart name.",
       "minLength": 1
     },
     "releaseName": {
       "type": "string",
       "description": "ReleaseName to use for the rendered manifests."
+    },
+    "useReleaseName": {
+      "type": "boolean",
+      "description": "Whether to use the release name in the output path (instead of the chart name). This only has an effect if outPath is set to a directory.",
+      "default": false
     },
     "namespace": {
       "type": "string",

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -229,7 +229,9 @@ type HelmTemplateConfig struct {
 	KubeVersion string `json:"kubeVersion,omitempty"`
 	// Namespace to use for the rendered manifests.
 	Namespace string `json:"namespace,omitempty"`
-	// OutPath to write the rendered manifests to.
+	// OutPath to write the rendered manifests to. If it points to a .yaml or .yml file, the
+	// rendered manifests will be written to that file. If it points to a directory, the
+	// rendered manifests will be written to this directory joined with the chart name.
 	OutPath string `json:"outPath"`
 	// Path at which the Helm chart can be found.
 	Path string `json:"path"`
@@ -237,6 +239,9 @@ type HelmTemplateConfig struct {
 	ReleaseName string `json:"releaseName,omitempty"`
 	// Whether to skip tests when rendering the manifests.
 	SkipTests bool `json:"skipTests,omitempty"`
+	// Whether to use the release name in the output path (instead of the chart name). This only
+	// has an effect if outPath is set to a directory.
+	UseReleaseName bool `json:"useReleaseName,omitempty"`
 	// ValuesFiles to use for rendering the Helm chart.
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 }

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -220,6 +220,8 @@ type HelmTemplateConfig struct {
 	// APIVersions allows a manual set of supported API Versions to be passed when rendering the
 	// manifests.
 	APIVersions []string `json:"apiVersions,omitempty"`
+	// Whether to disable hooks in the rendered manifests.
+	DisableHooks bool `json:"disableHooks,omitempty"`
 	// Whether to include CRDs in the rendered manifests.
 	IncludeCRDs bool `json:"includeCRDs,omitempty"`
 	// KubeVersion allows for passing a specific Kubernetes version to use when rendering the
@@ -233,6 +235,8 @@ type HelmTemplateConfig struct {
 	Path string `json:"path"`
 	// ReleaseName to use for the rendered manifests.
 	ReleaseName string `json:"releaseName,omitempty"`
+	// Whether to skip tests when rendering the manifests.
+	SkipTests bool `json:"skipTests,omitempty"`
 	// ValuesFiles to use for rendering the Helm chart.
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 }


### PR DESCRIPTION
Helm-related part for #2596.

This makes the directive behave the same as `helm template` when passing a directory (non `.yaml` or `.yml`) as output path. Writing each manifests to `<outPath>/<chartName>/<pathInChart>`, or `<outPath>/<releaseName>/<pathInChart>` when `useReleaseName` is configured.