### PR TITLE
fix(directives): require release name for `helm-template`

### DIFF
--- a/internal/directives/schemas/helm-template-config.json
+++ b/internal/directives/schemas/helm-template-config.json
@@ -17,7 +17,8 @@
     },
     "releaseName": {
       "type": "string",
-      "description": "ReleaseName to use for the rendered manifests."
+      "description": "ReleaseName to use for the rendered manifests.",
+      "minLength": 1
     },
     "useReleaseName": {
       "type": "boolean",

--- a/internal/directives/schemas/helm-template-config.json
+++ b/internal/directives/schemas/helm-template-config.json
@@ -3,7 +3,7 @@
   "title": "HelmTemplateConfig",
   "type": "object",
   "additionalProperties": false,
-  "required": ["path", "outPath"],
+  "required": ["outPath", "path", "releaseName"],
   "properties": {
     "path": {
       "type": "string",

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -236,7 +236,7 @@ type HelmTemplateConfig struct {
 	// Path at which the Helm chart can be found.
 	Path string `json:"path"`
 	// ReleaseName to use for the rendered manifests.
-	ReleaseName string `json:"releaseName,omitempty"`
+	ReleaseName string `json:"releaseName"`
 	// Whether to skip tests when rendering the manifests.
 	SkipTests bool `json:"skipTests,omitempty"`
 	// Whether to use the release name in the output path (instead of the chart name). This only


### PR DESCRIPTION
This solves a potential annoyance people could run into as without a release name specified, Helm defaults it to `release-name`. Which causes something like you see in the screenshot below:

![image](https://github.com/user-attachments/assets/ca8283de-4848-4f70-96aa-6a8652004e20)
