### PR TITLE
refactor: promo step errors

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -554,7 +554,7 @@ func (r *reconciler) promote(
 			}
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseSucceeded
 			workingPromo.Status.HealthChecks = healthChecks
-		case directives.PromotionStatusFailure:
+		case directives.PromotionStatusFailed:
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseFailed
 		}
 		if err != nil {

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -540,6 +540,7 @@ func (r *reconciler) promote(
 
 		res, err := r.directivesEngine.Promote(ctx, promoCtx, steps)
 		workingPromo.Status.Phase = res.Status
+		workingPromo.Status.Message = res.Message
 		workingPromo.Status.CurrentStep = res.CurrentStep
 		workingPromo.Status.State = &apiextensionsv1.JSON{Raw: res.State.ToJSON()}
 		if res.Status == kargoapi.PromotionPhaseSucceeded {

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -542,7 +542,7 @@ func (r *reconciler) promote(
 		workingPromo.Status.CurrentStep = res.CurrentStep
 		workingPromo.Status.State = &apiextensionsv1.JSON{Raw: res.State.ToJSON()}
 		switch res.Status {
-		case directives.PromotionStatusPending:
+		case directives.PromotionStatusRunning:
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseRunning
 		case directives.PromotionStatusSuccess:
 			var healthChecks []kargoapi.HealthCheckStep

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -544,7 +544,7 @@ func (r *reconciler) promote(
 		switch res.Status {
 		case directives.PromotionStatusRunning:
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseRunning
-		case directives.PromotionStatusSuccess:
+		case directives.PromotionStatusSucceeded:
 			var healthChecks []kargoapi.HealthCheckStep
 			for _, step := range res.HealthCheckSteps {
 				healthChecks = append(healthChecks, kargoapi.HealthCheckStep{

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -554,7 +554,7 @@ func (r *reconciler) promote(
 			}
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseSucceeded
 			workingPromo.Status.HealthChecks = healthChecks
-		case directives.PromotionStatusFailed:
+		case directives.PromotionStatusErrored:
 			workingPromo.Status.Phase = kargoapi.PromotionPhaseFailed
 		}
 		if err != nil {

--- a/internal/directives/argocd_updater.go
+++ b/internal/directives/argocd_updater.go
@@ -133,11 +133,11 @@ func (a *argocdUpdater) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := a.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[ArgoCDUpdateConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into %s config: %w", a.Name(), err)
 	}
 	return a.runPromotionStep(ctx, stepCtx, cfg)
@@ -155,7 +155,7 @@ func (a *argocdUpdater) runPromotionStep(
 	stepCfg ArgoCDUpdateConfig,
 ) (PromotionStepResult, error) {
 	if stepCtx.ArgoCDClient == nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, errors.New(
+		return PromotionStepResult{Status: PromotionStatusFailed}, errors.New(
 			"Argo CD integration is disabled on this controller; cannot update " +
 				"Argo CD Application resources",
 		)
@@ -178,7 +178,7 @@ func (a *argocdUpdater) runPromotionStep(
 		}
 		app, err := a.getAuthorizedApplicationFn(ctx, stepCtx, appKey)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error getting Argo CD Application %q in namespace %q: %w",
 				appKey.Name, appKey.Namespace, err,
 			)
@@ -192,7 +192,7 @@ func (a *argocdUpdater) runPromotionStep(
 			app,
 		)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error determining desired revisions for Argo CD Application %q in "+
 					"namespace %q: %w",
 				app.Name, app.Namespace, err,
@@ -214,7 +214,7 @@ func (a *argocdUpdater) runPromotionStep(
 			app,
 		)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error building desired sources for Argo CD Application %q in namespace %q: %w",
 				app.Name, app.Namespace, err,
 			)
@@ -242,7 +242,7 @@ func (a *argocdUpdater) runPromotionStep(
 				if phase == "" {
 					// If we do not have a phase, we cannot continue processing
 					// this update by waiting.
-					return PromotionStepResult{Status: PromotionStatusFailure}, err
+					return PromotionStepResult{Status: PromotionStatusFailed}, err
 				}
 				// Log the error as a warning, but continue to the next update.
 				logger.Info(err.Error())
@@ -250,7 +250,7 @@ func (a *argocdUpdater) runPromotionStep(
 			if phase.Failed() {
 				// Record the reason for the failure if available.
 				if app.Status.OperationState != nil {
-					return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+					return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 						"Argo CD Application %q in namespace %q failed with: %s",
 						app.Name,
 						app.Namespace,
@@ -259,7 +259,7 @@ func (a *argocdUpdater) runPromotionStep(
 				}
 				// If the update failed, we can short-circuit. This is
 				// effectively "fail fast" behavior.
-				return PromotionStepResult{Status: PromotionStatusFailure}, nil
+				return PromotionStepResult{Status: PromotionStatusFailed}, nil
 			}
 			// If we get here, we can continue to the next update.
 			continue
@@ -272,7 +272,7 @@ func (a *argocdUpdater) runPromotionStep(
 			app,
 			desiredSources,
 		); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error syncing Argo CD Application %q in namespace %q: %w",
 				app.Name, app.Namespace, err,
 			)
@@ -283,7 +283,7 @@ func (a *argocdUpdater) runPromotionStep(
 
 	aggregatedStatus := a.operationPhaseToPromotionStatus(updateResults...)
 	if aggregatedStatus == "" {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"could not determine promotion step status from operation phases: %v",
 			updateResults,
 		)
@@ -894,7 +894,7 @@ func (a *argocdUpdater) operationPhaseToPromotionStatus(
 	case argocd.OperationRunning, argocd.OperationTerminating:
 		return PromotionStatusPending
 	case argocd.OperationFailed, argocd.OperationError:
-		return PromotionStatusFailure
+		return PromotionStatusFailed
 	case argocd.OperationSucceeded:
 		return PromotionStatusSuccess
 	default:

--- a/internal/directives/argocd_updater.go
+++ b/internal/directives/argocd_updater.go
@@ -892,7 +892,7 @@ func (a *argocdUpdater) operationPhaseToPromotionStatus(
 
 	switch phases[0] {
 	case argocd.OperationRunning, argocd.OperationTerminating:
-		return PromotionStatusPending
+		return PromotionStatusRunning
 	case argocd.OperationFailed, argocd.OperationError:
 		return PromotionStatusErrored
 	case argocd.OperationSucceeded:

--- a/internal/directives/argocd_updater.go
+++ b/internal/directives/argocd_updater.go
@@ -896,7 +896,7 @@ func (a *argocdUpdater) operationPhaseToPromotionStatus(
 	case argocd.OperationFailed, argocd.OperationError:
 		return PromotionStatusErrored
 	case argocd.OperationSucceeded:
-		return PromotionStatusSuccess
+		return PromotionStatusSucceeded
 	default:
 		return ""
 	}

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -355,7 +355,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 			stepCtx: &PromotionStepContext{},
 			stepCfg: ArgoCDUpdateConfig{},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(
 					t, err, "Argo CD integration is disabled on this controller",
 				)
@@ -379,7 +379,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(t, err, "error getting Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -412,7 +412,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(t, err, "error building desired sources for Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -455,7 +455,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -639,7 +639,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(t, err, "error syncing Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -707,7 +707,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -749,7 +749,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 				require.ErrorContains(t, err, "could not determine promotion step status")
 			},
 		},

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -355,7 +355,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 			stepCtx: &PromotionStepContext{},
 			stepCfg: ArgoCDUpdateConfig{},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(
 					t, err, "Argo CD integration is disabled on this controller",
 				)
@@ -379,7 +379,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(t, err, "error getting Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -412,7 +412,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(t, err, "error building desired sources for Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -455,7 +455,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -505,7 +505,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusRunning, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -547,7 +547,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusRunning, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -589,7 +589,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusRunning, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -639,7 +639,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(t, err, "error syncing Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -707,7 +707,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -749,7 +749,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				require.ErrorContains(t, err, "could not determine promotion step status")
 			},
 		},
@@ -791,7 +791,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusSucceeded, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 				require.NoError(t, err)
 			},
 		},

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -355,7 +355,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 			stepCtx: &PromotionStepContext{},
 			stepCfg: ArgoCDUpdateConfig{},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(
 					t, err, "Argo CD integration is disabled on this controller",
 				)
@@ -379,7 +379,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(t, err, "error getting Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -412,7 +412,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(t, err, "error building desired sources for Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -455,7 +455,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -639,7 +639,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(t, err, "error syncing Argo CD Application")
 				require.ErrorContains(t, err, "something went wrong")
 			},
@@ -707,7 +707,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -749,7 +749,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 				require.ErrorContains(t, err, "could not determine promotion step status")
 			},
 		},

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -505,7 +505,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusPending, res.Status)
+				require.Equal(t, PromotionStatusRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -547,7 +547,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusPending, res.Status)
+				require.Equal(t, PromotionStatusRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},
@@ -589,7 +589,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusPending, res.Status)
+				require.Equal(t, PromotionStatusRunning, res.Status)
 				require.NoError(t, err)
 			},
 		},

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -791,7 +791,7 @@ func Test_argoCDUpdater_runPromotionStep(t *testing.T) {
 				Apps: []ArgoCDAppUpdate{{}},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.Equal(t, PromotionStatusSuccess, res.Status)
+				require.Equal(t, PromotionStatusSucceeded, res.Status)
 				require.NoError(t, err)
 			},
 		},

--- a/internal/directives/fake_engine.go
+++ b/internal/directives/fake_engine.go
@@ -20,7 +20,7 @@ func (e *FakeEngine) Promote(
 	steps []PromotionStep,
 ) (PromotionResult, error) {
 	if e.ExecuteFn == nil {
-		return PromotionResult{Status: PromotionStatusSuccess}, nil
+		return PromotionResult{Status: PromotionStatusSucceeded}, nil
 	}
 	return e.ExecuteFn(ctx, promoCtx, steps)
 }

--- a/internal/directives/fake_engine.go
+++ b/internal/directives/fake_engine.go
@@ -20,7 +20,7 @@ func (e *FakeEngine) Promote(
 	steps []PromotionStep,
 ) (PromotionResult, error) {
 	if e.ExecuteFn == nil {
-		return PromotionResult{Status: PromotionStatusSucceeded}, nil
+		return PromotionResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 	}
 	return e.ExecuteFn(ctx, promoCtx, steps)
 }

--- a/internal/directives/fake_engine_test.go
+++ b/internal/directives/fake_engine_test.go
@@ -34,13 +34,13 @@ func TestFakeEngine_Promote(t *testing.T) {
 				assert.Equal(t, ctx, givenCtx)
 				assert.Equal(t, promoCtx, givenPromoCtx)
 				assert.Equal(t, steps, givenSteps)
-				return PromotionResult{Status: PromotionStatusFailed},
+				return PromotionResult{Status: PromotionStatusErrored},
 					errors.New("something went wrong")
 			},
 		}
 		res, err := engine.Promote(ctx, promoCtx, steps)
 		assert.ErrorContains(t, err, "something went wrong")
-		assert.Equal(t, PromotionStatusFailed, res.Status)
+		assert.Equal(t, PromotionStatusErrored, res.Status)
 	})
 }
 

--- a/internal/directives/fake_engine_test.go
+++ b/internal/directives/fake_engine_test.go
@@ -15,7 +15,7 @@ func TestFakeEngine_Promote(t *testing.T) {
 		engine := &FakeEngine{}
 		res, err := engine.Promote(context.Background(), PromotionContext{}, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, PromotionStatusSucceeded, res.Status)
+		assert.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 	})
 
 	t.Run("with function injection", func(t *testing.T) {
@@ -34,13 +34,13 @@ func TestFakeEngine_Promote(t *testing.T) {
 				assert.Equal(t, ctx, givenCtx)
 				assert.Equal(t, promoCtx, givenPromoCtx)
 				assert.Equal(t, steps, givenSteps)
-				return PromotionResult{Status: PromotionStatusErrored},
+				return PromotionResult{Status: kargoapi.PromotionPhaseErrored},
 					errors.New("something went wrong")
 			},
 		}
 		res, err := engine.Promote(ctx, promoCtx, steps)
 		assert.ErrorContains(t, err, "something went wrong")
-		assert.Equal(t, PromotionStatusErrored, res.Status)
+		assert.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 	})
 }
 

--- a/internal/directives/fake_engine_test.go
+++ b/internal/directives/fake_engine_test.go
@@ -15,7 +15,7 @@ func TestFakeEngine_Promote(t *testing.T) {
 		engine := &FakeEngine{}
 		res, err := engine.Promote(context.Background(), PromotionContext{}, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, PromotionStatusSuccess, res.Status)
+		assert.Equal(t, PromotionStatusSucceeded, res.Status)
 	})
 
 	t.Run("with function injection", func(t *testing.T) {

--- a/internal/directives/fake_engine_test.go
+++ b/internal/directives/fake_engine_test.go
@@ -34,13 +34,13 @@ func TestFakeEngine_Promote(t *testing.T) {
 				assert.Equal(t, ctx, givenCtx)
 				assert.Equal(t, promoCtx, givenPromoCtx)
 				assert.Equal(t, steps, givenSteps)
-				return PromotionResult{Status: PromotionStatusFailure},
+				return PromotionResult{Status: PromotionStatusFailed},
 					errors.New("something went wrong")
 			},
 		}
 		res, err := engine.Promote(ctx, promoCtx, steps)
 		assert.ErrorContains(t, err, "something went wrong")
-		assert.Equal(t, PromotionStatusFailure, res.Status)
+		assert.Equal(t, PromotionStatusFailed, res.Status)
 	})
 }
 

--- a/internal/directives/file_copier.go
+++ b/internal/directives/file_copier.go
@@ -93,7 +93,7 @@ func (f *fileCopier) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
-	return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 }
 
 // sanitizePathError sanitizes the path in a path error to be relative to the

--- a/internal/directives/file_copier.go
+++ b/internal/directives/file_copier.go
@@ -49,13 +49,13 @@ func (f *fileCopier) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(f.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), f.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[CopyConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into %s config: %w", f.Name(), err)
 	}
 
@@ -70,12 +70,12 @@ func (f *fileCopier) runPromotionStep(
 	// Secure join the paths to prevent path traversal attacks.
 	inPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.InPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not secure join inPath %q: %w", cfg.InPath, err)
 	}
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not secure join outPath %q: %w", cfg.OutPath, err)
 	}
 
@@ -90,7 +90,7 @@ func (f *fileCopier) runPromotionStep(
 		},
 	}
 	if err = copy.Copy(inPath, outPath, opts); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/file_copier.go
+++ b/internal/directives/file_copier.go
@@ -12,6 +12,7 @@ import (
 	"github.com/otiai10/copy"
 	"github.com/xeipuuv/gojsonschema"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/logging"
 )
 
@@ -49,13 +50,13 @@ func (f *fileCopier) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(f.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), f.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[CopyConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into %s config: %w", f.Name(), err)
 	}
 
@@ -70,12 +71,12 @@ func (f *fileCopier) runPromotionStep(
 	// Secure join the paths to prevent path traversal attacks.
 	inPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.InPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not secure join inPath %q: %w", cfg.InPath, err)
 	}
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not secure join outPath %q: %w", cfg.OutPath, err)
 	}
 
@@ -90,10 +91,10 @@ func (f *fileCopier) runPromotionStep(
 		},
 	}
 	if err = copy.Copy(inPath, outPath, opts); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
-	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+	return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 }
 
 // sanitizePathError sanitizes the path in a path error to be relative to the

--- a/internal/directives/file_copier.go
+++ b/internal/directives/file_copier.go
@@ -49,13 +49,13 @@ func (f *fileCopier) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(f.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), f.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[CopyConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into %s config: %w", f.Name(), err)
 	}
 
@@ -70,12 +70,12 @@ func (f *fileCopier) runPromotionStep(
 	// Secure join the paths to prevent path traversal attacks.
 	inPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.InPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not secure join inPath %q: %w", cfg.InPath, err)
 	}
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not secure join outPath %q: %w", cfg.OutPath, err)
 	}
 
@@ -90,7 +90,7 @@ func (f *fileCopier) runPromotionStep(
 		},
 	}
 	if err = copy.Copy(inPath, outPath, opts); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/file_copier_test.go
+++ b/internal/directives/file_copier_test.go
@@ -128,7 +128,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 				InPath: "input.txt",
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
-				require.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				require.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 				require.ErrorContains(t, err, "failed to copy")
 			},
 		},

--- a/internal/directives/file_copier_test.go
+++ b/internal/directives/file_copier_test.go
@@ -34,7 +34,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.txt")
 				b, err := os.ReadFile(outPath)
@@ -66,7 +66,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outDir := filepath.Join(workDir, "output")
 
@@ -104,7 +104,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				require.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				require.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outDir := filepath.Join(workDir, "output")
 

--- a/internal/directives/file_copier_test.go
+++ b/internal/directives/file_copier_test.go
@@ -128,7 +128,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 				InPath: "input.txt",
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
-				require.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				require.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 				require.ErrorContains(t, err, "failed to copy")
 			},
 		},

--- a/internal/directives/file_copier_test.go
+++ b/internal/directives/file_copier_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 func Test_fileCopier_runPromotionStep(t *testing.T) {
@@ -34,7 +36,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.txt")
 				b, err := os.ReadFile(outPath)
@@ -66,7 +68,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outDir := filepath.Join(workDir, "output")
 
@@ -104,7 +106,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				require.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				require.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outDir := filepath.Join(workDir, "output")
 
@@ -128,7 +130,7 @@ func Test_fileCopier_runPromotionStep(t *testing.T) {
 				InPath: "input.txt",
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
-				require.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				require.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 				require.ErrorContains(t, err, "failed to copy")
 			},
 		},

--- a/internal/directives/git_cloner.go
+++ b/internal/directives/git_cloner.go
@@ -78,7 +78,7 @@ func (g *gitCloner) runPromotionStep(
 		)
 	}
 	if !mustClone {
-		return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+		return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 	}
 
 	var repoCreds *git.RepoCredentials
@@ -171,7 +171,7 @@ func (g *gitCloner) runPromotionStep(
 	// Note: We do NOT defer repo.Close() because we want to keep the repository
 	// around on the FS for subsequent promotion steps to use. The Engine will
 	// handle all work dir cleanup.
-	return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 }
 
 // mustCloneRepo determines if the repository must be cloned. At present, there

--- a/internal/directives/git_cloner.go
+++ b/internal/directives/git_cloner.go
@@ -51,11 +51,11 @@ func (g *gitCloner) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[GitCloneConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -73,7 +73,7 @@ func (g *gitCloner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	mustClone, err := mustCloneRepo(stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error determining if repo %s must be cloned: %w", cfg.RepoURL, err,
 		)
 	}
@@ -89,7 +89,7 @@ func (g *gitCloner) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -110,7 +110,7 @@ func (g *gitCloner) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	for _, checkout := range cfg.Checkout {
@@ -119,7 +119,7 @@ func (g *gitCloner) runPromotionStep(
 		case checkout.Branch != "":
 			ref = checkout.Branch
 			if err = ensureRemoteBranch(repo, ref); err != nil {
-				return PromotionStepResult{Status: PromotionStatusFailure},
+				return PromotionStepResult{Status: PromotionStatusFailed},
 					fmt.Errorf("error ensuring existence of remote branch %s: %w", ref, err)
 			}
 		case checkout.FromFreight:
@@ -140,11 +140,11 @@ func (g *gitCloner) runPromotionStep(
 				stepCtx.Freight.References(),
 				cfg.RepoURL,
 			); err != nil {
-				return PromotionStepResult{Status: PromotionStatusFailure},
+				return PromotionStepResult{Status: PromotionStatusFailed},
 					fmt.Errorf("error finding commit from repo %s: %w", cfg.RepoURL, err)
 			}
 			if commit == nil {
-				return PromotionStepResult{Status: PromotionStatusFailure},
+				return PromotionStepResult{Status: PromotionStatusFailed},
 					fmt.Errorf("could not find any commit from repo %s", cfg.RepoURL)
 			}
 			ref = commit.ID
@@ -153,7 +153,7 @@ func (g *gitCloner) runPromotionStep(
 		}
 		path, err := securejoin.SecureJoin(stepCtx.WorkDir, checkout.Path)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error joining path %s with work dir %s: %w",
 				checkout.Path, stepCtx.WorkDir, err,
 			)
@@ -162,7 +162,7 @@ func (g *gitCloner) runPromotionStep(
 			path,
 			&git.AddWorkTreeOptions{Ref: ref},
 		); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 				"error adding work tree %s to repo %s: %w",
 				checkout.Path, cfg.RepoURL, err,
 			)

--- a/internal/directives/git_cloner.go
+++ b/internal/directives/git_cloner.go
@@ -51,11 +51,11 @@ func (g *gitCloner) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 	cfg, err := configToStruct[GitCloneConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -73,12 +73,12 @@ func (g *gitCloner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	mustClone, err := mustCloneRepo(stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"error determining if repo %s must be cloned: %w", cfg.RepoURL, err,
 		)
 	}
 	if !mustClone {
-		return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 	}
 
 	var repoCreds *git.RepoCredentials
@@ -89,7 +89,7 @@ func (g *gitCloner) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -110,7 +110,7 @@ func (g *gitCloner) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	for _, checkout := range cfg.Checkout {
@@ -119,7 +119,7 @@ func (g *gitCloner) runPromotionStep(
 		case checkout.Branch != "":
 			ref = checkout.Branch
 			if err = ensureRemoteBranch(repo, ref); err != nil {
-				return PromotionStepResult{Status: PromotionStatusErrored},
+				return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 					fmt.Errorf("error ensuring existence of remote branch %s: %w", ref, err)
 			}
 		case checkout.FromFreight:
@@ -140,11 +140,11 @@ func (g *gitCloner) runPromotionStep(
 				stepCtx.Freight.References(),
 				cfg.RepoURL,
 			); err != nil {
-				return PromotionStepResult{Status: PromotionStatusErrored},
+				return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 					fmt.Errorf("error finding commit from repo %s: %w", cfg.RepoURL, err)
 			}
 			if commit == nil {
-				return PromotionStepResult{Status: PromotionStatusErrored},
+				return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 					fmt.Errorf("could not find any commit from repo %s", cfg.RepoURL)
 			}
 			ref = commit.ID
@@ -153,7 +153,7 @@ func (g *gitCloner) runPromotionStep(
 		}
 		path, err := securejoin.SecureJoin(stepCtx.WorkDir, checkout.Path)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+			return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 				"error joining path %s with work dir %s: %w",
 				checkout.Path, stepCtx.WorkDir, err,
 			)
@@ -162,7 +162,7 @@ func (g *gitCloner) runPromotionStep(
 			path,
 			&git.AddWorkTreeOptions{Ref: ref},
 		); err != nil {
-			return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+			return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 				"error adding work tree %s to repo %s: %w",
 				checkout.Path, cfg.RepoURL, err,
 			)
@@ -171,7 +171,7 @@ func (g *gitCloner) runPromotionStep(
 	// Note: We do NOT defer repo.Close() because we want to keep the repository
 	// around on the FS for subsequent promotion steps to use. The Engine will
 	// handle all work dir cleanup.
-	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+	return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 }
 
 // mustCloneRepo determines if the repository must be cloned. At present, there

--- a/internal/directives/git_cloner.go
+++ b/internal/directives/git_cloner.go
@@ -51,11 +51,11 @@ func (g *gitCloner) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 	cfg, err := configToStruct[GitCloneConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -73,7 +73,7 @@ func (g *gitCloner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	mustClone, err := mustCloneRepo(stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error determining if repo %s must be cloned: %w", cfg.RepoURL, err,
 		)
 	}
@@ -89,7 +89,7 @@ func (g *gitCloner) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -110,7 +110,7 @@ func (g *gitCloner) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	for _, checkout := range cfg.Checkout {
@@ -119,7 +119,7 @@ func (g *gitCloner) runPromotionStep(
 		case checkout.Branch != "":
 			ref = checkout.Branch
 			if err = ensureRemoteBranch(repo, ref); err != nil {
-				return PromotionStepResult{Status: PromotionStatusFailed},
+				return PromotionStepResult{Status: PromotionStatusErrored},
 					fmt.Errorf("error ensuring existence of remote branch %s: %w", ref, err)
 			}
 		case checkout.FromFreight:
@@ -140,11 +140,11 @@ func (g *gitCloner) runPromotionStep(
 				stepCtx.Freight.References(),
 				cfg.RepoURL,
 			); err != nil {
-				return PromotionStepResult{Status: PromotionStatusFailed},
+				return PromotionStepResult{Status: PromotionStatusErrored},
 					fmt.Errorf("error finding commit from repo %s: %w", cfg.RepoURL, err)
 			}
 			if commit == nil {
-				return PromotionStepResult{Status: PromotionStatusFailed},
+				return PromotionStepResult{Status: PromotionStatusErrored},
 					fmt.Errorf("could not find any commit from repo %s", cfg.RepoURL)
 			}
 			ref = commit.ID
@@ -153,7 +153,7 @@ func (g *gitCloner) runPromotionStep(
 		}
 		path, err := securejoin.SecureJoin(stepCtx.WorkDir, checkout.Path)
 		if err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 				"error joining path %s with work dir %s: %w",
 				checkout.Path, stepCtx.WorkDir, err,
 			)
@@ -162,7 +162,7 @@ func (g *gitCloner) runPromotionStep(
 			path,
 			&git.AddWorkTreeOptions{Ref: ref},
 		); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+			return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 				"error adding work tree %s to repo %s: %w",
 				checkout.Path, cfg.RepoURL, err,
 			)

--- a/internal/directives/git_cloner_test.go
+++ b/internal/directives/git_cloner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sosedoff/gitkit"
 	"github.com/stretchr/testify/require"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 )
@@ -326,7 +327,7 @@ func Test_gitCloner_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSucceeded, res.Status)
+	require.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 	require.DirExists(t, filepath.Join(stepCtx.WorkDir, "master"))
 	// The checked out master branch should have the content we know is in the
 	// test remote's master branch.

--- a/internal/directives/git_cloner_test.go
+++ b/internal/directives/git_cloner_test.go
@@ -326,7 +326,7 @@ func Test_gitCloner_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSuccess, res.Status)
+	require.Equal(t, PromotionStatusSucceeded, res.Status)
 	require.DirExists(t, filepath.Join(stepCtx.WorkDir, "master"))
 	// The checked out master branch should have the content we know is in the
 	// test remote's master branch.

--- a/internal/directives/git_commiter.go
+++ b/internal/directives/git_commiter.go
@@ -109,7 +109,7 @@ func (g *gitCommitter) runPromotionStep(
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
 	return PromotionStepResult{
-		Status: PromotionStatusSuccess,
+		Status: PromotionStatusSucceeded,
 		Output: map[string]any{commitKey: commitID},
 	}, nil
 }

--- a/internal/directives/git_commiter.go
+++ b/internal/directives/git_commiter.go
@@ -7,6 +7,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/xeipuuv/gojsonschema"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 )
 
@@ -41,11 +42,11 @@ func (g *gitCommitter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 	cfg, err := configToStruct[GitCommitConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -63,23 +64,23 @@ func (g *gitCommitter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	path, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.Path, stepCtx.WorkDir, err,
 		)
 	}
 	workTree, err := git.LoadWorkTree(path, nil)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
 	if err = workTree.AddAll(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error adding all changes to working tree: %w", err)
 	}
 	commitMsg, err := g.buildCommitMessage(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error building commit message: %w", err)
 	}
 	commitOpts := &git.CommitOptions{}
@@ -94,22 +95,22 @@ func (g *gitCommitter) runPromotionStep(
 	}
 	hasDiffs, err := workTree.HasDiffs()
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error checking for diffs in working tree: %w", err)
 	}
 	if hasDiffs {
 		if err = workTree.Commit(commitMsg, commitOpts); err != nil {
-			return PromotionStepResult{Status: PromotionStatusErrored},
+			return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 				fmt.Errorf("error committing to working tree: %w", err)
 		}
 	}
 	commitID, err := workTree.LastCommitID()
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
 	return PromotionStepResult{
-		Status: PromotionStatusSucceeded,
+		Status: kargoapi.PromotionPhaseSucceeded,
 		Output: map[string]any{commitKey: commitID},
 	}, nil
 }

--- a/internal/directives/git_commiter.go
+++ b/internal/directives/git_commiter.go
@@ -41,11 +41,11 @@ func (g *gitCommitter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[GitCommitConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -63,23 +63,23 @@ func (g *gitCommitter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	path, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.Path, stepCtx.WorkDir, err,
 		)
 	}
 	workTree, err := git.LoadWorkTree(path, nil)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
 	if err = workTree.AddAll(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error adding all changes to working tree: %w", err)
 	}
 	commitMsg, err := g.buildCommitMessage(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error building commit message: %w", err)
 	}
 	commitOpts := &git.CommitOptions{}
@@ -94,18 +94,18 @@ func (g *gitCommitter) runPromotionStep(
 	}
 	hasDiffs, err := workTree.HasDiffs()
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error checking for diffs in working tree: %w", err)
 	}
 	if hasDiffs {
 		if err = workTree.Commit(commitMsg, commitOpts); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure},
+			return PromotionStepResult{Status: PromotionStatusFailed},
 				fmt.Errorf("error committing to working tree: %w", err)
 		}
 	}
 	commitID, err := workTree.LastCommitID()
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
 	return PromotionStepResult{

--- a/internal/directives/git_commiter_test.go
+++ b/internal/directives/git_commiter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sosedoff/gitkit"
 	"github.com/stretchr/testify/require"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 )
 
@@ -221,7 +222,7 @@ func Test_gitCommitter_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSucceeded, res.Status)
+	require.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[commitKey]

--- a/internal/directives/git_commiter_test.go
+++ b/internal/directives/git_commiter_test.go
@@ -221,7 +221,7 @@ func Test_gitCommitter_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSuccess, res.Status)
+	require.Equal(t, PromotionStatusSucceeded, res.Status)
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[commitKey]

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -45,11 +45,11 @@ func (g *gitPROpener) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 	cfg, err := configToStruct[GitOpenPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into git-open-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -67,7 +67,7 @@ func (g *gitPROpener) runPromotionStep(
 ) (PromotionStepResult, error) {
 	sourceBranch, err := getSourceBranch(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error determining source branch: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -102,7 +102,7 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	defer repo.Close()
@@ -118,7 +118,7 @@ func (g *gitPROpener) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error determining if pull request must be opened: %w", err)
 	}
 	if !mustOpen {
@@ -143,7 +143,7 @@ func (g *gitPROpener) runPromotionStep(
 	// that may involve creating a new branch and committing to it.
 	title, err := repo.CommitMessage(sourceBranch)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error getting commit message from head of branch %s: %w",
 			sourceBranch, err,
 		)
@@ -154,7 +154,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 		cfg.CreateTargetBranch,
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error ensuring existence of remote branch %s: %w",
 			cfg.TargetBranch, err,
 		)
@@ -169,7 +169,7 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error creating pull request: %w", err)
 	}
 	return PromotionStepResult{

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -135,7 +135,7 @@ func (g *gitPROpener) runPromotionStep(
 			fmt.Errorf("error determining if pull request must be opened: %w", err)
 	}
 	if !mustOpen {
-		return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+		return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 	}
 
 	// Get the title from the commit message of the head of the source branch
@@ -173,7 +173,7 @@ func (g *gitPROpener) runPromotionStep(
 			fmt.Errorf("error creating pull request: %w", err)
 	}
 	return PromotionStepResult{
-		Status: PromotionStatusSuccess,
+		Status: PromotionStatusSucceeded,
 		Output: map[string]any{
 			prNumberKey: pr.Number,
 		},

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/xeipuuv/gojsonschema"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/gitprovider"
@@ -45,11 +46,11 @@ func (g *gitPROpener) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 	cfg, err := configToStruct[GitOpenPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into git-open-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -67,7 +68,7 @@ func (g *gitPROpener) runPromotionStep(
 ) (PromotionStepResult, error) {
 	sourceBranch, err := getSourceBranch(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error determining source branch: %w", err)
 	}
 
@@ -79,7 +80,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -102,7 +103,7 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	defer repo.Close()
@@ -118,7 +119,7 @@ func (g *gitPROpener) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
@@ -131,11 +132,11 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error determining if pull request must be opened: %w", err)
 	}
 	if !mustOpen {
-		return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 	}
 
 	// Get the title from the commit message of the head of the source branch
@@ -143,7 +144,7 @@ func (g *gitPROpener) runPromotionStep(
 	// that may involve creating a new branch and committing to it.
 	title, err := repo.CommitMessage(sourceBranch)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"error getting commit message from head of branch %s: %w",
 			sourceBranch, err,
 		)
@@ -154,7 +155,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 		cfg.CreateTargetBranch,
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"error ensuring existence of remote branch %s: %w",
 			cfg.TargetBranch, err,
 		)
@@ -169,11 +170,11 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error creating pull request: %w", err)
 	}
 	return PromotionStepResult{
-		Status: PromotionStatusSucceeded,
+		Status: kargoapi.PromotionPhaseSucceeded,
 		Output: map[string]any{
 			prNumberKey: pr.Number,
 		},

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -45,11 +45,11 @@ func (g *gitPROpener) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[GitOpenPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into git-open-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -67,7 +67,7 @@ func (g *gitPROpener) runPromotionStep(
 ) (PromotionStepResult, error) {
 	sourceBranch, err := getSourceBranch(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error determining source branch: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -102,7 +102,7 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
 	defer repo.Close()
@@ -118,7 +118,7 @@ func (g *gitPROpener) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error determining if pull request must be opened: %w", err)
 	}
 	if !mustOpen {
@@ -143,7 +143,7 @@ func (g *gitPROpener) runPromotionStep(
 	// that may involve creating a new branch and committing to it.
 	title, err := repo.CommitMessage(sourceBranch)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error getting commit message from head of branch %s: %w",
 			sourceBranch, err,
 		)
@@ -154,7 +154,7 @@ func (g *gitPROpener) runPromotionStep(
 		cfg.TargetBranch,
 		cfg.CreateTargetBranch,
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error ensuring existence of remote branch %s: %w",
 			cfg.TargetBranch, err,
 		)
@@ -169,7 +169,7 @@ func (g *gitPROpener) runPromotionStep(
 		},
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error creating pull request: %w", err)
 	}
 	return PromotionStepResult{

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -43,11 +43,11 @@ func (g *gitPRWaiter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[GitWaitForPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into git-wait-for-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -65,7 +65,7 @@ func (g *gitPRWaiter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	prNumber, err := getPRNumber(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting PR number: %w", err)
 	}
 
@@ -77,7 +77,7 @@ func (g *gitPRWaiter) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -99,13 +99,13 @@ func (g *gitPRWaiter) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
 	pr, err := gitProviderSvc.GetPullRequest(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting pull request %d: %w", prNumber, err)
 	}
 	if pr.IsOpen() {
@@ -114,13 +114,13 @@ func (g *gitPRWaiter) runPromotionStep(
 
 	merged, err := gitProviderSvc.IsPullRequestMerged(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error checking if pull request %d was merged: %w",
 			prNumber, err,
 		)
 	}
 	if !merged {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("pull request %d was closed without being merged", prNumber)
 	}
 

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -109,7 +109,7 @@ func (g *gitPRWaiter) runPromotionStep(
 			fmt.Errorf("error getting pull request %d: %w", prNumber, err)
 	}
 	if pr.IsOpen() {
-		return PromotionStepResult{Status: PromotionStatusPending}, nil
+		return PromotionStepResult{Status: PromotionStatusRunning}, nil
 	}
 
 	merged, err := gitProviderSvc.IsPullRequestMerged(ctx, prNumber)

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -125,7 +125,7 @@ func (g *gitPRWaiter) runPromotionStep(
 	}
 
 	return PromotionStepResult{
-		Status: PromotionStatusSuccess,
+		Status: PromotionStatusSucceeded,
 		Output: map[string]any{commitKey: pr.MergeCommitSHA},
 	}, nil
 }

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -43,11 +43,11 @@ func (g *gitPRWaiter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 	cfg, err := configToStruct[GitWaitForPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into git-wait-for-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -65,7 +65,7 @@ func (g *gitPRWaiter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	prNumber, err := getPRNumber(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting PR number: %w", err)
 	}
 
@@ -77,7 +77,7 @@ func (g *gitPRWaiter) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -99,13 +99,13 @@ func (g *gitPRWaiter) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
 	pr, err := gitProviderSvc.GetPullRequest(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting pull request %d: %w", prNumber, err)
 	}
 	if pr.IsOpen() {
@@ -114,7 +114,7 @@ func (g *gitPRWaiter) runPromotionStep(
 
 	merged, err := gitProviderSvc.IsPullRequestMerged(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error checking if pull request %d was merged: %w",
 			prNumber, err,
 		)

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/xeipuuv/gojsonschema"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/gitprovider"
@@ -43,11 +44,11 @@ func (g *gitPRWaiter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 	cfg, err := configToStruct[GitWaitForPRConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into git-wait-for-pr config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -65,7 +66,7 @@ func (g *gitPRWaiter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	prNumber, err := getPRNumber(stepCtx.SharedState, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting PR number: %w", err)
 	}
 
@@ -77,7 +78,7 @@ func (g *gitPRWaiter) runPromotionStep(
 		cfg.RepoURL,
 	)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting credentials for %s: %w", cfg.RepoURL, err)
 	}
 	if found {
@@ -99,33 +100,33 @@ func (g *gitPRWaiter) runPromotionStep(
 	}
 	gitProviderSvc, err := gitprovider.NewGitProviderService(cfg.RepoURL, gpOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
 	pr, err := gitProviderSvc.GetPullRequest(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting pull request %d: %w", prNumber, err)
 	}
 	if pr.IsOpen() {
-		return PromotionStepResult{Status: PromotionStatusRunning}, nil
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseRunning}, nil
 	}
 
 	merged, err := gitProviderSvc.IsPullRequestMerged(ctx, prNumber)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"error checking if pull request %d was merged: %w",
 			prNumber, err,
 		)
 	}
 	if !merged {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseFailed},
 			fmt.Errorf("pull request %d was closed without being merged", prNumber)
 	}
 
 	return PromotionStepResult{
-		Status: PromotionStatusSucceeded,
+		Status: kargoapi.PromotionPhaseSucceeded,
 		Output: map[string]any{commitKey: pr.MergeCommitSHA},
 	}, nil
 }

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -121,8 +121,10 @@ func (g *gitPRWaiter) runPromotionStep(
 		)
 	}
 	if !merged {
-		return PromotionStepResult{Status: kargoapi.PromotionPhaseFailed},
-			fmt.Errorf("pull request %d was closed without being merged", prNumber)
+		return PromotionStepResult{
+			Status:  kargoapi.PromotionPhaseFailed,
+			Message: fmt.Sprintf("pull request %d was closed without being merged", prNumber),
+		}, err
 	}
 
 	return PromotionStepResult{

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -174,7 +174,8 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.ErrorContains(t, err, "was closed without being merged")
+				require.NoError(t, err)
+				require.Contains(t, res.Message, "closed without being merged")
 				require.Equal(t, kargoapi.PromotionPhaseFailed, res.Status)
 			},
 		},

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -115,7 +115,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "error getting pull request")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 				require.ErrorContains(t, err, "error checking if pull request")
 				require.ErrorContains(t, err, "was merged")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, PromotionStatusErrored, res.Status)
 			},
 		},
 		{

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -194,7 +194,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.NoError(t, err)
-				require.Equal(t, PromotionStatusSuccess, res.Status)
+				require.Equal(t, PromotionStatusSucceeded, res.Status)
 			},
 		},
 	}

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/gitprovider"
 )
@@ -115,7 +116,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "error getting pull request")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 			},
 		},
 		{
@@ -132,7 +133,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.NoError(t, err)
-				require.Equal(t, PromotionStatusRunning, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseRunning, res.Status)
 			},
 		},
 		{
@@ -154,7 +155,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 				require.ErrorContains(t, err, "error checking if pull request")
 				require.ErrorContains(t, err, "was merged")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusErrored, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 			},
 		},
 		{
@@ -174,7 +175,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "was closed without being merged")
-				require.Equal(t, PromotionStatusFailed, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseFailed, res.Status)
 			},
 		},
 		{
@@ -194,7 +195,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.NoError(t, err)
-				require.Equal(t, PromotionStatusSucceeded, res.Status)
+				require.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 			},
 		},
 	}

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -132,7 +132,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.NoError(t, err)
-				require.Equal(t, PromotionStatusPending, res.Status)
+				require.Equal(t, PromotionStatusRunning, res.Status)
 			},
 		},
 		{

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -115,7 +115,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "error getting pull request")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 				require.ErrorContains(t, err, "error checking if pull request")
 				require.ErrorContains(t, err, "was merged")
 				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 			},
 		},
 		{
@@ -174,7 +174,7 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "was closed without being merged")
-				require.Equal(t, PromotionStatusFailure, res.Status)
+				require.Equal(t, PromotionStatusFailed, res.Status)
 			},
 		},
 		{

--- a/internal/directives/git_pusher.go
+++ b/internal/directives/git_pusher.go
@@ -131,7 +131,7 @@ func (g *gitPushPusher) runPromotionStep(
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
 	return PromotionStepResult{
-		Status: PromotionStatusSuccess,
+		Status: PromotionStatusSucceeded,
 		Output: map[string]any{
 			branchKey: targetBranch,
 			commitKey: commitID,

--- a/internal/directives/git_pusher.go
+++ b/internal/directives/git_pusher.go
@@ -45,11 +45,11 @@ func (g *gitPushPusher) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 	cfg, err := configToStruct[GitPushConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into git-push config: %w", err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -70,7 +70,7 @@ func (g *gitPushPusher) runPromotionStep(
 	// credentials and, if found, reload the work tree with the credentials.
 	path, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.Path, stepCtx.WorkDir, err,
 		)
@@ -78,7 +78,7 @@ func (g *gitPushPusher) runPromotionStep(
 	loadOpts := &git.LoadWorkTreeOptions{}
 	workTree, err := git.LoadWorkTree(path, loadOpts)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
 	var creds credentials.Credentials
@@ -89,7 +89,7 @@ func (g *gitPushPusher) runPromotionStep(
 		credentials.TypeGit,
 		workTree.URL(),
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting credentials for %s: %w", workTree.URL(), err)
 	} else if found {
 		loadOpts.Credentials = &git.RepoCredentials{
@@ -99,7 +99,7 @@ func (g *gitPushPusher) runPromotionStep(
 		}
 	}
 	if workTree, err = git.LoadWorkTree(path, loadOpts); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
 	pushOpts := &git.PushOptions{
@@ -117,17 +117,17 @@ func (g *gitPushPusher) runPromotionStep(
 		// because we will want to return the branch that was pushed to, but we
 		// don't want to mess with the options any further.
 		if targetBranch, err = workTree.CurrentBranch(); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailed},
+			return PromotionStepResult{Status: PromotionStatusErrored},
 				fmt.Errorf("error getting current branch: %w", err)
 		}
 	}
 	if err = workTree.Push(pushOpts); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error pushing commits to remote: %w", err)
 	}
 	commitID, err := workTree.LastCommitID()
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
 	return PromotionStepResult{

--- a/internal/directives/git_tree_overwriter.go
+++ b/internal/directives/git_tree_overwriter.go
@@ -45,11 +45,11 @@ func (g *gitTreeOverwriter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 	cfg, err := configToStruct[GitOverwriteConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -67,37 +67,37 @@ func (g *gitTreeOverwriter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	inPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.InPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.InPath, stepCtx.WorkDir, err,
 		)
 	}
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.OutPath, stepCtx.WorkDir, err,
 		)
 	}
 	workTree, err := git.LoadWorkTree(outPath, nil)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.OutPath, err)
 	}
 	// workTree.Clear() won't remove any files that aren't indexed. This is a bit
 	// of a hack to ensure that we don't have any untracked files in the working
 	// tree so that workTree.Clear() will remove everything.
 	if err = workTree.AddAll(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error adding all files to working tree at %s: %w", cfg.OutPath, err)
 	}
 	if err = workTree.Clear(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error clearing working tree at %s: %w", cfg.OutPath, err)
 	}
 	inFI, err := os.Stat(inPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("error getting info for path %s: %w", inPath, err)
 	}
 	if !inFI.IsDir() {
@@ -119,7 +119,7 @@ func (g *gitTreeOverwriter) runPromotionStep(
 			},
 		},
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/git_tree_overwriter.go
+++ b/internal/directives/git_tree_overwriter.go
@@ -45,11 +45,11 @@ func (g *gitTreeOverwriter) RunPromotionStep(
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
 	if err := g.validate(stepCtx.Config); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 	cfg, err := configToStruct[GitOverwriteConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
 	}
 	return g.runPromotionStep(ctx, stepCtx, cfg)
@@ -67,37 +67,37 @@ func (g *gitTreeOverwriter) runPromotionStep(
 ) (PromotionStepResult, error) {
 	inPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.InPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.InPath, stepCtx.WorkDir, err,
 		)
 	}
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"error joining path %s with work dir %s: %w",
 			cfg.OutPath, stepCtx.WorkDir, err,
 		)
 	}
 	workTree, err := git.LoadWorkTree(outPath, nil)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.OutPath, err)
 	}
 	// workTree.Clear() won't remove any files that aren't indexed. This is a bit
 	// of a hack to ensure that we don't have any untracked files in the working
 	// tree so that workTree.Clear() will remove everything.
 	if err = workTree.AddAll(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error adding all files to working tree at %s: %w", cfg.OutPath, err)
 	}
 	if err = workTree.Clear(); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error clearing working tree at %s: %w", cfg.OutPath, err)
 	}
 	inFI, err := os.Stat(inPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("error getting info for path %s: %w", inPath, err)
 	}
 	if !inFI.IsDir() {
@@ -119,7 +119,7 @@ func (g *gitTreeOverwriter) runPromotionStep(
 			},
 		},
 	); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/git_tree_overwriter.go
+++ b/internal/directives/git_tree_overwriter.go
@@ -122,5 +122,5 @@ func (g *gitTreeOverwriter) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to copy %q to %q: %w", cfg.InPath, cfg.OutPath, err)
 	}
-	return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 }

--- a/internal/directives/git_tree_overwriter_test.go
+++ b/internal/directives/git_tree_overwriter_test.go
@@ -139,7 +139,7 @@ func Test_gitTreeOverwriter_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSuccess, res.Status)
+	require.Equal(t, PromotionStatusSucceeded, res.Status)
 
 	// Make sure old files are gone
 	_, err = os.Stat(filepath.Join(workTree.Dir(), "original.txt"))

--- a/internal/directives/git_tree_overwriter_test.go
+++ b/internal/directives/git_tree_overwriter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sosedoff/gitkit"
 	"github.com/stretchr/testify/require"
 
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/git"
 )
 
@@ -139,7 +140,7 @@ func Test_gitTreeOverwriter_runPromotionStep(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, PromotionStatusSucceeded, res.Status)
+	require.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 
 	// Make sure old files are gone
 	_, err = os.Stat(filepath.Join(workTree.Dir(), "original.txt"))

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -62,7 +62,7 @@ func (h *helmChartUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailure}
+	failure := PromotionStepResult{Status: PromotionStatusFailed}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,7 +89,7 @@ func (h *helmChartUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	absChartPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to join path %q: %w", cfg.Path, err)
 	}
 
@@ -97,31 +97,31 @@ func (h *helmChartUpdater) runPromotionStep(
 	chartDependencies, err := readChartDependencies(chartFilePath)
 	if err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusFailure,
+			Status: PromotionStatusFailed,
 		}, fmt.Errorf("failed to load chart dependencies from %q: %w", chartFilePath, err)
 	}
 
 	changes, err := h.processChartUpdates(ctx, stepCtx, cfg, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	if err = intyaml.SetStringsInFile(chartFilePath, changes); err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusFailure,
+			Status: PromotionStatusFailed,
 		}, fmt.Errorf("failed to update chart dependencies in %q: %w", chartFilePath, err)
 	}
 
 	helmHome, err := os.MkdirTemp("", "helm-chart-update-")
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to create temporary Helm home directory: %w", err)
 	}
 	defer os.RemoveAll(helmHome)
 
 	newVersions, err := h.updateDependencies(ctx, stepCtx, helmHome, absChartPath, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -62,7 +62,7 @@ func (h *helmChartUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailed}
+	failure := PromotionStepResult{Status: PromotionStatusErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,7 +89,7 @@ func (h *helmChartUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	absChartPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to join path %q: %w", cfg.Path, err)
 	}
 
@@ -97,31 +97,31 @@ func (h *helmChartUpdater) runPromotionStep(
 	chartDependencies, err := readChartDependencies(chartFilePath)
 	if err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusFailed,
+			Status: PromotionStatusErrored,
 		}, fmt.Errorf("failed to load chart dependencies from %q: %w", chartFilePath, err)
 	}
 
 	changes, err := h.processChartUpdates(ctx, stepCtx, cfg, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	if err = intyaml.SetStringsInFile(chartFilePath, changes); err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusFailed,
+			Status: PromotionStatusErrored,
 		}, fmt.Errorf("failed to update chart dependencies in %q: %w", chartFilePath, err)
 	}
 
 	helmHome, err := os.MkdirTemp("", "helm-chart-update-")
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to create temporary Helm home directory: %w", err)
 	}
 	defer os.RemoveAll(helmHome)
 
 	newVersions, err := h.updateDependencies(ctx, stepCtx, helmHome, absChartPath, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -124,7 +124,7 @@ func (h *helmChartUpdater) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSuccess}
+	result := PromotionStepResult{Status: PromotionStatusSucceeded}
 	if commitMsg := h.generateCommitMessage(cfg.Path, newVersions); commitMsg != "" {
 		result.Output = map[string]any{
 			"commitMessage": commitMsg,

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -62,7 +62,7 @@ func (h *helmChartUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusErrored}
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,7 +89,7 @@ func (h *helmChartUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	absChartPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to join path %q: %w", cfg.Path, err)
 	}
 
@@ -97,34 +97,34 @@ func (h *helmChartUpdater) runPromotionStep(
 	chartDependencies, err := readChartDependencies(chartFilePath)
 	if err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusErrored,
+			Status: kargoapi.PromotionPhaseErrored,
 		}, fmt.Errorf("failed to load chart dependencies from %q: %w", chartFilePath, err)
 	}
 
 	changes, err := h.processChartUpdates(ctx, stepCtx, cfg, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	if err = intyaml.SetStringsInFile(chartFilePath, changes); err != nil {
 		return PromotionStepResult{
-			Status: PromotionStatusErrored,
+			Status: kargoapi.PromotionPhaseErrored,
 		}, fmt.Errorf("failed to update chart dependencies in %q: %w", chartFilePath, err)
 	}
 
 	helmHome, err := os.MkdirTemp("", "helm-chart-update-")
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to create temporary Helm home directory: %w", err)
 	}
 	defer os.RemoveAll(helmHome)
 
 	newVersions, err := h.updateDependencies(ctx, stepCtx, helmHome, absChartPath, chartDependencies)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSucceeded}
+	result := PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}
 	if commitMsg := h.generateCommitMessage(cfg.Path, newVersions); commitMsg != "" {
 		result.Output = map[string]any{
 			"commitMessage": commitMsg,

--- a/internal/directives/helm_chart_updater_test.go
+++ b/internal/directives/helm_chart_updater_test.go
@@ -99,7 +99,7 @@ func Test_helmChartUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, tempDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSuccess,
+					Status: PromotionStatusSucceeded,
 					Output: map[string]any{
 						"commitMessage": `Updated chart dependencies for testchart
 

--- a/internal/directives/helm_chart_updater_test.go
+++ b/internal/directives/helm_chart_updater_test.go
@@ -99,7 +99,7 @@ func Test_helmChartUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, tempDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSucceeded,
+					Status: kargoapi.PromotionPhaseSucceeded,
 					Output: map[string]any{
 						"commitMessage": `Updated chart dependencies for testchart
 

--- a/internal/directives/helm_image_updater.go
+++ b/internal/directives/helm_image_updater.go
@@ -46,7 +46,7 @@ func (h *helmImageUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailure}
+	failure := PromotionStepResult{Status: PromotionStatusFailed}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -73,14 +73,14 @@ func (h *helmImageUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	updates, fullImageRefs, err := h.generateImageUpdates(ctx, stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to generate image updates: %w", err)
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}
 	if len(updates) > 0 {
 		if err = h.updateValuesFile(stepCtx.WorkDir, cfg.Path, updates); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailure},
+			return PromotionStepResult{Status: PromotionStatusFailed},
 				fmt.Errorf("values file update failed: %w", err)
 		}
 

--- a/internal/directives/helm_image_updater.go
+++ b/internal/directives/helm_image_updater.go
@@ -77,7 +77,7 @@ func (h *helmImageUpdater) runPromotionStep(
 			fmt.Errorf("failed to generate image updates: %w", err)
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSuccess}
+	result := PromotionStepResult{Status: PromotionStatusSucceeded}
 	if len(updates) > 0 {
 		if err = h.updateValuesFile(stepCtx.WorkDir, cfg.Path, updates); err != nil {
 			return PromotionStepResult{Status: PromotionStatusErrored},

--- a/internal/directives/helm_image_updater.go
+++ b/internal/directives/helm_image_updater.go
@@ -46,7 +46,7 @@ func (h *helmImageUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusErrored}
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -73,14 +73,14 @@ func (h *helmImageUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	updates, fullImageRefs, err := h.generateImageUpdates(ctx, stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to generate image updates: %w", err)
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSucceeded}
+	result := PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}
 	if len(updates) > 0 {
 		if err = h.updateValuesFile(stepCtx.WorkDir, cfg.Path, updates); err != nil {
-			return PromotionStepResult{Status: PromotionStatusErrored},
+			return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 				fmt.Errorf("values file update failed: %w", err)
 		}
 

--- a/internal/directives/helm_image_updater.go
+++ b/internal/directives/helm_image_updater.go
@@ -46,7 +46,7 @@ func (h *helmImageUpdater) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailed}
+	failure := PromotionStepResult{Status: PromotionStatusErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -73,14 +73,14 @@ func (h *helmImageUpdater) runPromotionStep(
 ) (PromotionStepResult, error) {
 	updates, fullImageRefs, err := h.generateImageUpdates(ctx, stepCtx, cfg)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to generate image updates: %w", err)
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}
 	if len(updates) > 0 {
 		if err = h.updateValuesFile(stepCtx.WorkDir, cfg.Path, updates); err != nil {
-			return PromotionStepResult{Status: PromotionStatusFailed},
+			return PromotionStepResult{Status: PromotionStatusErrored},
 				fmt.Errorf("values file update failed: %w", err)
 		}
 

--- a/internal/directives/helm_image_updater_test.go
+++ b/internal/directives/helm_image_updater_test.go
@@ -76,7 +76,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSucceeded,
+					Status: kargoapi.PromotionPhaseSucceeded,
 					Output: map[string]any{
 						"commitMessage": "Updated values.yaml to use new image\n\n- docker.io/library/nginx:1.19.0",
 					},
@@ -104,7 +104,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 				content, err := os.ReadFile(path.Join(workDir, "values.yaml"))
 				require.NoError(t, err)
 				assert.Contains(t, string(content), "tag: oldtag")
@@ -145,7 +145,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to generate image updates")
 				require.Errorf(t, err, "something went wrong")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				assert.Error(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 				assert.Contains(t, err.Error(), "values file update failed")
 			},
 		},

--- a/internal/directives/helm_image_updater_test.go
+++ b/internal/directives/helm_image_updater_test.go
@@ -145,7 +145,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to generate image updates")
 				require.Errorf(t, err, "something went wrong")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				assert.Error(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 				assert.Contains(t, err.Error(), "values file update failed")
 			},
 		},

--- a/internal/directives/helm_image_updater_test.go
+++ b/internal/directives/helm_image_updater_test.go
@@ -76,7 +76,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSuccess,
+					Status: PromotionStatusSucceeded,
 					Output: map[string]any{
 						"commitMessage": "Updated values.yaml to use new image\n\n- docker.io/library/nginx:1.19.0",
 					},
@@ -104,7 +104,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 				content, err := os.ReadFile(path.Join(workDir, "values.yaml"))
 				require.NoError(t, err)
 				assert.Contains(t, string(content), "tag: oldtag")

--- a/internal/directives/helm_image_updater_test.go
+++ b/internal/directives/helm_image_updater_test.go
@@ -145,7 +145,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to generate image updates")
 				require.Errorf(t, err, "something went wrong")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func Test_helmImageUpdater_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				assert.Error(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 				assert.Contains(t, err.Error(), "values file update failed")
 			},
 		},

--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -62,7 +62,7 @@ func (h *helmTemplateRunner) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailure}
+	failure := PromotionStepResult{Status: PromotionStatusFailed}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,41 +89,41 @@ func (h *helmTemplateRunner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	composedValues, err := h.composeValues(stepCtx.WorkDir, cfg.ValuesFiles)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to compose values: %w", err)
 	}
 
 	chartRequested, err := h.loadChart(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to load chart from %q: %w", cfg.Path, err)
 	}
 
 	if err = h.checkDependencies(chartRequested); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("missing chart dependencies: %w", err)
 	}
 
 	absOutPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to join path %q: %w", cfg.OutPath, err)
 	}
 
 	install, err := h.newInstallAction(cfg, stepCtx.Project, absOutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to initialize Helm action config: %w", err)
 	}
 
 	rls, err := install.RunWithContext(ctx, chartRequested, composedValues)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to render chart: %w", err)
 	}
 
 	if err = h.writeOutput(cfg, rls, absOutPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("failed to write rendered chart: %w", err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -18,6 +18,8 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/release"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 func init() {
@@ -62,7 +64,7 @@ func (h *helmTemplateRunner) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusErrored}
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,44 +91,44 @@ func (h *helmTemplateRunner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	composedValues, err := h.composeValues(stepCtx.WorkDir, cfg.ValuesFiles)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to compose values: %w", err)
 	}
 
 	chartRequested, err := h.loadChart(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to load chart from %q: %w", cfg.Path, err)
 	}
 
 	if err = h.checkDependencies(chartRequested); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("missing chart dependencies: %w", err)
 	}
 
 	absOutPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to join path %q: %w", cfg.OutPath, err)
 	}
 
 	install, err := h.newInstallAction(cfg, stepCtx.Project, absOutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to initialize Helm action config: %w", err)
 	}
 
 	rls, err := install.RunWithContext(ctx, chartRequested, composedValues)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to render chart: %w", err)
 	}
 
 	if err = h.writeOutput(cfg, rls, absOutPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("failed to write rendered chart: %w", err)
 	}
-	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+	return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 }
 
 // composeValues composes the values from the given values files. It merges the

--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -126,7 +126,7 @@ func (h *helmTemplateRunner) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to write rendered chart: %w", err)
 	}
-	return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 }
 
 // composeValues composes the values from the given values files. It merges the

--- a/internal/directives/helm_template_runner.go
+++ b/internal/directives/helm_template_runner.go
@@ -62,7 +62,7 @@ func (h *helmTemplateRunner) RunPromotionStep(
 	ctx context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailed}
+	failure := PromotionStepResult{Status: PromotionStatusErrored}
 
 	// Validate the configuration against the JSON Schema
 	if err := validate(
@@ -89,41 +89,41 @@ func (h *helmTemplateRunner) runPromotionStep(
 ) (PromotionStepResult, error) {
 	composedValues, err := h.composeValues(stepCtx.WorkDir, cfg.ValuesFiles)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to compose values: %w", err)
 	}
 
 	chartRequested, err := h.loadChart(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to load chart from %q: %w", cfg.Path, err)
 	}
 
 	if err = h.checkDependencies(chartRequested); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("missing chart dependencies: %w", err)
 	}
 
 	absOutPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to join path %q: %w", cfg.OutPath, err)
 	}
 
 	install, err := h.newInstallAction(cfg, stepCtx.Project, absOutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to initialize Helm action config: %w", err)
 	}
 
 	rls, err := install.RunWithContext(ctx, chartRequested, composedValues)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to render chart: %w", err)
 	}
 
 	if err = h.writeOutput(cfg, rls, absOutPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("failed to write rendered chart: %w", err)
 	}
 	return PromotionStepResult{Status: PromotionStatusSuccess}, nil

--- a/internal/directives/helm_template_runner_test.go
+++ b/internal/directives/helm_template_runner_test.go
@@ -47,7 +47,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.yaml")
 				require.FileExists(t, outPath)
@@ -93,7 +93,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.yaml")
 				require.FileExists(t, outPath)
@@ -138,7 +138,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output", "test-chart")
 				require.DirExists(t, outPath)

--- a/internal/directives/helm_template_runner_test.go
+++ b/internal/directives/helm_template_runner_test.go
@@ -164,7 +164,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to compose values")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -176,7 +176,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to load chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -199,7 +199,7 @@ dependencies:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "missing chart dependencies")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -217,7 +217,7 @@ version: 0.1.0`,
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to initialize Helm action config")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -243,7 +243,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to render chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -268,7 +268,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to write rendered chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},

--- a/internal/directives/helm_template_runner_test.go
+++ b/internal/directives/helm_template_runner_test.go
@@ -12,6 +12,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 func Test_helmTemplateRunner_runPromotionStep(t *testing.T) {
@@ -47,7 +49,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.yaml")
 				require.FileExists(t, outPath)
@@ -93,7 +95,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output.yaml")
 				require.FileExists(t, outPath)
@@ -138,7 +140,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				outPath := filepath.Join(workDir, "output", "test-chart")
 				require.DirExists(t, outPath)
@@ -164,7 +166,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to compose values")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -176,7 +178,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to load chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -199,7 +201,7 @@ dependencies:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "missing chart dependencies")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -217,7 +219,7 @@ version: 0.1.0`,
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to initialize Helm action config")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -243,7 +245,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to render chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -268,7 +270,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to write rendered chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},

--- a/internal/directives/helm_template_runner_test.go
+++ b/internal/directives/helm_template_runner_test.go
@@ -164,7 +164,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to compose values")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -176,7 +176,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to load chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -199,7 +199,7 @@ dependencies:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "missing chart dependencies")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -217,7 +217,7 @@ version: 0.1.0`,
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to initialize Helm action config")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -243,7 +243,7 @@ data:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to render chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},
@@ -268,7 +268,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "failed to write rendered chart")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				require.NoFileExists(t, filepath.Join(workDir, "output.yaml"))
 			},

--- a/internal/directives/kustomize_builder.go
+++ b/internal/directives/kustomize_builder.go
@@ -52,7 +52,7 @@ func (k *kustomizeBuilder) RunPromotionStep(
 	_ context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailed}
+	failure := PromotionStepResult{Status: PromotionStatusErrored}
 
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
@@ -75,24 +75,24 @@ func (k *kustomizeBuilder) runPromotionStep(
 	// Create a "chrooted" filesystem for the kustomize build.
 	fs, err := securefs.MakeFsOnDiskSecureBuild(stepCtx.WorkDir)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Build the manifests.
 	rm, err := kustomizeBuild(fs, filepath.Join(stepCtx.WorkDir, cfg.Path))
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Prepare the output path.
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Write the built manifests to the output path.
 	if err := k.writeResult(rm, outPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
 			"failed to write built manifests to %q: %w", cfg.OutPath,
 			sanitizePathError(err, stepCtx.WorkDir),
 		)

--- a/internal/directives/kustomize_builder.go
+++ b/internal/directives/kustomize_builder.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/kustomize/api/resmap"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 // kustomizeRenderMutex is a mutex that ensures only one kustomize build is
@@ -52,7 +54,7 @@ func (k *kustomizeBuilder) RunPromotionStep(
 	_ context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusErrored}
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
 
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
@@ -75,29 +77,29 @@ func (k *kustomizeBuilder) runPromotionStep(
 	// Create a "chrooted" filesystem for the kustomize build.
 	fs, err := securefs.MakeFsOnDiskSecureBuild(stepCtx.WorkDir)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Build the manifests.
 	rm, err := kustomizeBuild(fs, filepath.Join(stepCtx.WorkDir, cfg.Path))
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Prepare the output path.
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Write the built manifests to the output path.
 	if err := k.writeResult(rm, outPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, fmt.Errorf(
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, fmt.Errorf(
 			"failed to write built manifests to %q: %w", cfg.OutPath,
 			sanitizePathError(err, stepCtx.WorkDir),
 		)
 	}
-	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
+	return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
 }
 
 func (k *kustomizeBuilder) writeResult(rm resmap.ResMap, outPath string) error {

--- a/internal/directives/kustomize_builder.go
+++ b/internal/directives/kustomize_builder.go
@@ -97,7 +97,7 @@ func (k *kustomizeBuilder) runPromotionStep(
 			sanitizePathError(err, stepCtx.WorkDir),
 		)
 	}
-	return PromotionStepResult{Status: PromotionStatusSuccess}, nil
+	return PromotionStepResult{Status: PromotionStatusSucceeded}, nil
 }
 
 func (k *kustomizeBuilder) writeResult(rm resmap.ResMap, outPath string) error {

--- a/internal/directives/kustomize_builder.go
+++ b/internal/directives/kustomize_builder.go
@@ -52,7 +52,7 @@ func (k *kustomizeBuilder) RunPromotionStep(
 	_ context.Context,
 	stepCtx *PromotionStepContext,
 ) (PromotionStepResult, error) {
-	failure := PromotionStepResult{Status: PromotionStatusFailure}
+	failure := PromotionStepResult{Status: PromotionStatusFailed}
 
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
@@ -75,24 +75,24 @@ func (k *kustomizeBuilder) runPromotionStep(
 	// Create a "chrooted" filesystem for the kustomize build.
 	fs, err := securefs.MakeFsOnDiskSecureBuild(stepCtx.WorkDir)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Build the manifests.
 	rm, err := kustomizeBuild(fs, filepath.Join(stepCtx.WorkDir, cfg.Path))
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Prepare the output path.
 	outPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.OutPath)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Write the built manifests to the output path.
 	if err := k.writeResult(rm, outPath); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, fmt.Errorf(
+		return PromotionStepResult{Status: PromotionStatusFailed}, fmt.Errorf(
 			"failed to write built manifests to %q: %w", cfg.OutPath,
 			sanitizePathError(err, stepCtx.WorkDir),
 		)

--- a/internal/directives/kustomize_builder_test.go
+++ b/internal/directives/kustomize_builder_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
 func Test_kustomizeBuilder_runPromotionStep(t *testing.T) {
@@ -38,7 +40,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				assert.FileExists(t, filepath.Join(dir, "output.yaml"))
 				b, err := os.ReadFile(filepath.Join(dir, "output.yaml"))
@@ -68,7 +70,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 
 				assert.DirExists(t, filepath.Join(dir, "output"))
 				b, err := os.ReadFile(filepath.Join(dir, "output", "deployment-test-deployment.yaml"))
@@ -85,7 +87,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "no such file or directory")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},
@@ -101,7 +103,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "invalid Kustomization")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},

--- a/internal/directives/kustomize_builder_test.go
+++ b/internal/directives/kustomize_builder_test.go
@@ -38,7 +38,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				assert.FileExists(t, filepath.Join(dir, "output.yaml"))
 				b, err := os.ReadFile(filepath.Join(dir, "output.yaml"))
@@ -68,7 +68,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSuccess}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusSucceeded}, result)
 
 				assert.DirExists(t, filepath.Join(dir, "output"))
 				b, err := os.ReadFile(filepath.Join(dir, "output", "deployment-test-deployment.yaml"))

--- a/internal/directives/kustomize_builder_test.go
+++ b/internal/directives/kustomize_builder_test.go
@@ -85,7 +85,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "no such file or directory")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},
@@ -101,7 +101,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "invalid Kustomization")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},

--- a/internal/directives/kustomize_builder_test.go
+++ b/internal/directives/kustomize_builder_test.go
@@ -85,7 +85,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "no such file or directory")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},
@@ -101,7 +101,7 @@ metadata:
 			},
 			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "invalid Kustomization")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 
 				assert.NoFileExists(t, filepath.Join(dir, "output.yaml"))
 			},

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -61,13 +61,13 @@ func (k *kustomizeImageSetter) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[KustomizeSetImageConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not convert config into kustomize-set-image config: %w", err)
 	}
 
@@ -82,19 +82,19 @@ func (k *kustomizeImageSetter) runPromotionStep(
 	// Find the Kustomization file.
 	kusPath, err := findKustomization(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure},
+		return PromotionStepResult{Status: PromotionStatusFailed},
 			fmt.Errorf("could not discover kustomization file: %w", err)
 	}
 
 	// Discover image origins and collect target images.
 	targetImages, err := k.buildTargetImages(ctx, stepCtx, cfg.Images)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	// Update the Kustomization file with the new images.
 	if err = updateKustomizationFile(kusPath, targetImages); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailure}, err
+		return PromotionStepResult{Status: PromotionStatusFailed}, err
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -97,7 +97,7 @@ func (k *kustomizeImageSetter) runPromotionStep(
 		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSuccess}
+	result := PromotionStepResult{Status: PromotionStatusSucceeded}
 	if commitMsg := k.generateCommitMessage(cfg.Path, targetImages); commitMsg != "" {
 		result.Output = map[string]any{
 			"commitMessage": commitMsg,

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -61,13 +61,13 @@ func (k *kustomizeImageSetter) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[KustomizeSetImageConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not convert config into kustomize-set-image config: %w", err)
 	}
 
@@ -82,19 +82,19 @@ func (k *kustomizeImageSetter) runPromotionStep(
 	// Find the Kustomization file.
 	kusPath, err := findKustomization(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed},
+		return PromotionStepResult{Status: PromotionStatusErrored},
 			fmt.Errorf("could not discover kustomization file: %w", err)
 	}
 
 	// Discover image origins and collect target images.
 	targetImages, err := k.buildTargetImages(ctx, stepCtx, cfg.Images)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	// Update the Kustomization file with the new images.
 	if err = updateKustomizationFile(kusPath, targetImages); err != nil {
-		return PromotionStepResult{Status: PromotionStatusFailed}, err
+		return PromotionStepResult{Status: PromotionStatusErrored}, err
 	}
 
 	result := PromotionStepResult{Status: PromotionStatusSuccess}

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -61,13 +61,13 @@ func (k *kustomizeImageSetter) RunPromotionStep(
 ) (PromotionStepResult, error) {
 	// Validate the configuration against the JSON Schema.
 	if err := validate(k.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), k.Name()); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Convert the configuration into a typed object.
 	cfg, err := configToStruct[KustomizeSetImageConfig](stepCtx.Config)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not convert config into kustomize-set-image config: %w", err)
 	}
 
@@ -82,22 +82,22 @@ func (k *kustomizeImageSetter) runPromotionStep(
 	// Find the Kustomization file.
 	kusPath, err := findKustomization(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored},
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("could not discover kustomization file: %w", err)
 	}
 
 	// Discover image origins and collect target images.
 	targetImages, err := k.buildTargetImages(ctx, stepCtx, cfg.Images)
 	if err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
 	// Update the Kustomization file with the new images.
 	if err = updateKustomizationFile(kusPath, targetImages); err != nil {
-		return PromotionStepResult{Status: PromotionStatusErrored}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
 
-	result := PromotionStepResult{Status: PromotionStatusSucceeded}
+	result := PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}
 	if commitMsg := k.generateCommitMessage(cfg.Path, targetImages); commitMsg != "" {
 		result.Output = map[string]any{
 			"commitMessage": commitMsg,

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -76,7 +76,7 @@ kind: Kustomization
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSucceeded,
+					Status: kargoapi.PromotionPhaseSucceeded,
 					Output: map[string]any{
 						"commitMessage": "Updated . to use new image\n\n- nginx:1.21.0",
 					},
@@ -111,7 +111,7 @@ kind: Kustomization
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "could not discover kustomization file:")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 			},
 		},
 		{
@@ -151,7 +151,7 @@ images:
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "unable to discover image")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
 			},
 		},
 	}

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -111,7 +111,7 @@ kind: Kustomization
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "could not discover kustomization file:")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 			},
 		},
 		{
@@ -151,7 +151,7 @@ images:
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "unable to discover image")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailure}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
 			},
 		},
 	}

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -76,7 +76,7 @@ kind: Kustomization
 			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, PromotionStepResult{
-					Status: PromotionStatusSuccess,
+					Status: PromotionStatusSucceeded,
 					Output: map[string]any{
 						"commitMessage": "Updated . to use new image\n\n- nginx:1.21.0",
 					},

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -111,7 +111,7 @@ kind: Kustomization
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "could not discover kustomization file:")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 			},
 		},
 		{
@@ -151,7 +151,7 @@ images:
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "unable to discover image")
-				assert.Equal(t, PromotionStepResult{Status: PromotionStatusFailed}, result)
+				assert.Equal(t, PromotionStepResult{Status: PromotionStatusErrored}, result)
 			},
 		},
 	}

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -75,7 +75,7 @@ type PromotionStep struct {
 type PromotionResult struct {
 	// Status is the high-level outcome of the user-defined promotion executed by
 	// the Engine.
-	Status PromotionStatus
+	Status kargoapi.PromotionPhase
 	// Issues aggregates issues encountered during execution of individual
 	// PromotionSteps by their corresponding PromotionStepRunners.
 	Issues []string
@@ -91,31 +91,6 @@ type PromotionResult struct {
 	// State is the current state of the promotion process.
 	State State
 }
-
-// PromotionStatus is a type that represents the high-level outcome of the
-// Engine's execution of a user-defined promotion process or the outcome of a
-// PromotionStepRunner's execution of a single PromotionStep.
-type PromotionStatus string
-
-const (
-	// PromotionStatusErrored is the result of either a user-defined promotion
-	// process executed by the Engine or a single PromotionStep executed by a
-	// PromotionStepRunner which has failed for technical reasons.
-	PromotionStatusErrored PromotionStatus = "Errored"
-	// PromotionStatusFailed is the result of either a user-defined promotion
-	// process executed by the Engine or a single PromotionStep executed by a
-	// PromotionStepRunner which has failed.
-	PromotionStatusFailed PromotionStatus = "Failed"
-	// PromotionStatusRunning is the result of either a user-defined promotion
-	// process executed by the Engine or a single PromotionStep executed by a
-	// PromotionStepRunner which remains in-progress because it is waiting on some
-	// external state (such as waiting for an open PR to be merged or closed).
-	PromotionStatusRunning PromotionStatus = "Running"
-	// PromotionStatusSucceeded is the result of either a user-defined promotion
-	// process executed by the Engine or a single PromotionStep executed by a
-	// PromotionStepRunner which has succeeded.
-	PromotionStatusSucceeded PromotionStatus = "Succeeded"
-)
 
 // PromotionStepContext is a type that represents the context in which a
 // SinglePromotion step is executed by a PromotionStepRunner.
@@ -187,7 +162,7 @@ type PromotionStepContext struct {
 type PromotionStepResult struct {
 	// Status is the high-level outcome a PromotionStep executed by a
 	// PromotionStepRunner.
-	Status PromotionStatus
+	Status kargoapi.PromotionPhase
 	// Output is the opaque output of a PromotionStep executed by a
 	// PromotionStepRunner. The Engine will update shared state with this output,
 	// making it available to subsequent steps.

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -98,6 +98,10 @@ type PromotionResult struct {
 type PromotionStatus string
 
 const (
+	// PromotionStatusErrored is the result of either a user-defined promotion
+	// process executed by the Engine or a single PromotionStep executed by a
+	// PromotionStepRunner which has failed for technical reasons.
+	PromotionStatusErrored PromotionStatus = "Errored"
 	// PromotionStatusFailed is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which has failed.

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -106,12 +106,11 @@ const (
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which has failed.
 	PromotionStatusFailed PromotionStatus = "Failed"
-	// PromotionStatusPending is the result of either a user-defined promotion
+	// PromotionStatusRunning is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
-	// PromotionStepRunner which was unable to complete because it is waiting on
-	// some external state (such as waiting for an open PR to be merged or
-	// closed).
-	PromotionStatusPending PromotionStatus = "Pending"
+	// PromotionStepRunner which remains in-progress because it is waiting on some
+	// external state (such as waiting for an open PR to be merged or closed).
+	PromotionStatusRunning PromotionStatus = "Running"
 	// PromotionStatusSuccess is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which has succeeded.

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -98,10 +98,10 @@ type PromotionResult struct {
 type PromotionStatus string
 
 const (
-	// PromotionStatusFailure is the result of either a user-defined promotion
+	// PromotionStatusFailed is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which has failed.
-	PromotionStatusFailure PromotionStatus = "Failure"
+	PromotionStatusFailed PromotionStatus = "Failed"
 	// PromotionStatusPending is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which was unable to complete because it is waiting on

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -76,9 +76,9 @@ type PromotionResult struct {
 	// Status is the high-level outcome of the user-defined promotion executed by
 	// the Engine.
 	Status kargoapi.PromotionPhase
-	// Issues aggregates issues encountered during execution of individual
-	// PromotionSteps by their corresponding PromotionStepRunners.
-	Issues []string
+	// Message is an optional message that provides additional context about the
+	// outcome of the user-defined promotion executed by the Engine.
+	Message string
 	// HealthCheckSteps collects health check configuration returned from the
 	// execution of individual PromotionSteps by their corresponding
 	// PromotionStepRunners. This configuration can later be used as input to
@@ -163,6 +163,9 @@ type PromotionStepResult struct {
 	// Status is the high-level outcome a PromotionStep executed by a
 	// PromotionStepRunner.
 	Status kargoapi.PromotionPhase
+	// Message is an optional message that provides additional context about the
+	// outcome of a PromotionStep executed by a PromotionStepRunner.
+	Message string
 	// Output is the opaque output of a PromotionStep executed by a
 	// PromotionStepRunner. The Engine will update shared state with this output,
 	// making it available to subsequent steps.

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -111,10 +111,10 @@ const (
 	// PromotionStepRunner which remains in-progress because it is waiting on some
 	// external state (such as waiting for an open PR to be merged or closed).
 	PromotionStatusRunning PromotionStatus = "Running"
-	// PromotionStatusSuccess is the result of either a user-defined promotion
+	// PromotionStatusSucceeded is the result of either a user-defined promotion
 	// process executed by the Engine or a single PromotionStep executed by a
 	// PromotionStepRunner which has succeeded.
-	PromotionStatusSuccess PromotionStatus = "Success"
+	PromotionStatusSucceeded PromotionStatus = "Succeeded"
 )
 
 // PromotionStepContext is a type that represents the context in which a

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -49,7 +49,7 @@ func (e *SimpleEngine) Promote(
 		workDir, err = os.MkdirTemp("", "run-")
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailure,
+					Status:      PromotionStatusFailed,
 					CurrentStep: 0,
 				},
 				fmt.Errorf("temporary working directory creation failed: %w", err)
@@ -69,7 +69,7 @@ func (e *SimpleEngine) Promote(
 		select {
 		case <-ctx.Done():
 			return PromotionResult{
-				Status:      PromotionStatusFailure,
+				Status:      PromotionStatusFailed,
 				CurrentStep: i,
 				State:       state,
 			}, ctx.Err()
@@ -78,7 +78,7 @@ func (e *SimpleEngine) Promote(
 		reg, err := e.registry.GetPromotionStepRunnerRegistration(step.Kind)
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailure,
+					Status:      PromotionStatusFailed,
 					CurrentStep: i,
 					State:       state,
 				},
@@ -114,7 +114,7 @@ func (e *SimpleEngine) Promote(
 		}
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailure,
+					Status:      PromotionStatusFailed,
 					CurrentStep: i,
 					State:       state,
 				},

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -49,7 +49,7 @@ func (e *SimpleEngine) Promote(
 		workDir, err = os.MkdirTemp("", "run-")
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusErrored,
+					Status:      kargoapi.PromotionPhaseErrored,
 					CurrentStep: 0,
 				},
 				fmt.Errorf("temporary working directory creation failed: %w", err)
@@ -69,7 +69,7 @@ func (e *SimpleEngine) Promote(
 		select {
 		case <-ctx.Done():
 			return PromotionResult{
-				Status:      PromotionStatusErrored,
+				Status:      kargoapi.PromotionPhaseErrored,
 				CurrentStep: i,
 				State:       state,
 			}, ctx.Err()
@@ -78,7 +78,7 @@ func (e *SimpleEngine) Promote(
 		reg, err := e.registry.GetPromotionStepRunnerRegistration(step.Kind)
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusErrored,
+					Status:      kargoapi.PromotionPhaseErrored,
 					CurrentStep: i,
 					State:       state,
 				},
@@ -114,14 +114,14 @@ func (e *SimpleEngine) Promote(
 		}
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusErrored,
+					Status:      kargoapi.PromotionPhaseErrored,
 					CurrentStep: i,
 					State:       state,
 				},
 				fmt.Errorf("failed to run step %q: %w", step.Kind, err)
 		}
 
-		if result.Status != PromotionStatusSucceeded {
+		if result.Status != kargoapi.PromotionPhaseSucceeded {
 			return PromotionResult{
 				Status:      result.Status,
 				CurrentStep: i,
@@ -134,7 +134,7 @@ func (e *SimpleEngine) Promote(
 		}
 	}
 	return PromotionResult{
-		Status:           PromotionStatusSucceeded,
+		Status:           kargoapi.PromotionPhaseSucceeded,
 		HealthCheckSteps: healthCheckSteps,
 		CurrentStep:      int64(len(steps)) - 1,
 		State:            state,

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -121,7 +121,7 @@ func (e *SimpleEngine) Promote(
 				fmt.Errorf("failed to run step %q: %w", step.Kind, err)
 		}
 
-		if result.Status != PromotionStatusSuccess {
+		if result.Status != PromotionStatusSucceeded {
 			return PromotionResult{
 				Status:      result.Status,
 				CurrentStep: i,
@@ -134,7 +134,7 @@ func (e *SimpleEngine) Promote(
 		}
 	}
 	return PromotionResult{
-		Status:           PromotionStatusSuccess,
+		Status:           PromotionStatusSucceeded,
 		HealthCheckSteps: healthCheckSteps,
 		CurrentStep:      int64(len(steps)) - 1,
 		State:            state,

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -49,7 +49,7 @@ func (e *SimpleEngine) Promote(
 		workDir, err = os.MkdirTemp("", "run-")
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailed,
+					Status:      PromotionStatusErrored,
 					CurrentStep: 0,
 				},
 				fmt.Errorf("temporary working directory creation failed: %w", err)
@@ -69,7 +69,7 @@ func (e *SimpleEngine) Promote(
 		select {
 		case <-ctx.Done():
 			return PromotionResult{
-				Status:      PromotionStatusFailed,
+				Status:      PromotionStatusErrored,
 				CurrentStep: i,
 				State:       state,
 			}, ctx.Err()
@@ -78,7 +78,7 @@ func (e *SimpleEngine) Promote(
 		reg, err := e.registry.GetPromotionStepRunnerRegistration(step.Kind)
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailed,
+					Status:      PromotionStatusErrored,
 					CurrentStep: i,
 					State:       state,
 				},
@@ -114,7 +114,7 @@ func (e *SimpleEngine) Promote(
 		}
 		if err != nil {
 			return PromotionResult{
-					Status:      PromotionStatusFailed,
+					Status:      PromotionStatusErrored,
 					CurrentStep: i,
 					State:       state,
 				},

--- a/internal/directives/simple_engine_test.go
+++ b/internal/directives/simple_engine_test.go
@@ -22,7 +22,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 		},
 	}
 
-	failureResult := PromotionStepResult{Status: PromotionStatusFailure}
+	failureResult := PromotionStepResult{Status: PromotionStatusFailed}
 	successResult := PromotionStepResult{
 		Status:          PromotionStatusSuccess,
 		HealthCheckStep: &testHealthCheckStep,
@@ -99,7 +99,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: "unknown"}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailure, res.Status)
+				assert.Equal(t, PromotionStatusFailed, res.Status)
 				assert.ErrorContains(t, err, "not found")
 			},
 		},
@@ -108,7 +108,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: failureStepName}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailure, res.Status)
+				assert.Equal(t, PromotionStatusFailed, res.Status)
 				assert.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -127,7 +127,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 				return ctx
 			}(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailure, res.Status)
+				assert.Equal(t, PromotionStatusFailed, res.Status)
 				assert.ErrorIs(t, err, context.Canceled)
 			},
 		},

--- a/internal/directives/simple_engine_test.go
+++ b/internal/directives/simple_engine_test.go
@@ -22,7 +22,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 		},
 	}
 
-	failureResult := PromotionStepResult{Status: PromotionStatusFailed}
+	failureResult := PromotionStepResult{Status: PromotionStatusErrored}
 	successResult := PromotionStepResult{
 		Status:          PromotionStatusSuccess,
 		HealthCheckStep: &testHealthCheckStep,
@@ -99,7 +99,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: "unknown"}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailed, res.Status)
+				assert.Equal(t, PromotionStatusErrored, res.Status)
 				assert.ErrorContains(t, err, "not found")
 			},
 		},
@@ -108,7 +108,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: failureStepName}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailed, res.Status)
+				assert.Equal(t, PromotionStatusErrored, res.Status)
 				assert.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -127,7 +127,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 				return ctx
 			}(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusFailed, res.Status)
+				assert.Equal(t, PromotionStatusErrored, res.Status)
 				assert.ErrorIs(t, err, context.Canceled)
 			},
 		},

--- a/internal/directives/simple_engine_test.go
+++ b/internal/directives/simple_engine_test.go
@@ -24,7 +24,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 
 	failureResult := PromotionStepResult{Status: PromotionStatusErrored}
 	successResult := PromotionStepResult{
-		Status:          PromotionStatusSuccess,
+		Status:          PromotionStatusSucceeded,
 		HealthCheckStep: &testHealthCheckStep,
 	}
 
@@ -72,7 +72,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: successStepName}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusSuccess, res.Status)
+				assert.Equal(t, PromotionStatusSucceeded, res.Status)
 				assert.Equal(t, []HealthCheckStep{testHealthCheckStep}, res.HealthCheckSteps)
 				assert.NoError(t, err)
 			},
@@ -85,7 +85,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			},
 			ctx: context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusSuccess, res.Status)
+				assert.Equal(t, PromotionStatusSucceeded, res.Status)
 				assert.Equal(
 					t,
 					[]HealthCheckStep{testHealthCheckStep, testHealthCheckStep},

--- a/internal/directives/simple_engine_test.go
+++ b/internal/directives/simple_engine_test.go
@@ -22,14 +22,14 @@ func TestSimpleEngine_Promote(t *testing.T) {
 		},
 	}
 
-	failureResult := PromotionStepResult{Status: PromotionStatusErrored}
+	errorResult := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
 	successResult := PromotionStepResult{
-		Status:          PromotionStatusSucceeded,
+		Status:          kargoapi.PromotionPhaseSucceeded,
 		HealthCheckStep: &testHealthCheckStep,
 	}
 
 	const successStepName = "success"
-	const failureStepName = "failure"
+	const errorStepName = "failure"
 	const contextWaiterStep = "waiter"
 	testRegistry := NewStepRunnerRegistry()
 	testRegistry.RegisterPromotionStepRunner(
@@ -41,8 +41,8 @@ func TestSimpleEngine_Promote(t *testing.T) {
 	)
 	testRegistry.RegisterPromotionStepRunner(
 		&mockPromotionStepRunner{
-			name:      failureStepName,
-			runResult: failureResult,
+			name:      errorStepName,
+			runResult: errorResult,
 			runErr:    errors.New("something went wrong"),
 		},
 		nil,
@@ -72,7 +72,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: successStepName}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusSucceeded, res.Status)
+				assert.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 				assert.Equal(t, []HealthCheckStep{testHealthCheckStep}, res.HealthCheckSteps)
 				assert.NoError(t, err)
 			},
@@ -85,7 +85,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			},
 			ctx: context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusSucceeded, res.Status)
+				assert.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 				assert.Equal(
 					t,
 					[]HealthCheckStep{testHealthCheckStep, testHealthCheckStep},
@@ -99,16 +99,16 @@ func TestSimpleEngine_Promote(t *testing.T) {
 			steps: []PromotionStep{{Kind: "unknown"}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusErrored, res.Status)
+				assert.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				assert.ErrorContains(t, err, "not found")
 			},
 		},
 		{
 			name:  "failure: runner returns error",
-			steps: []PromotionStep{{Kind: failureStepName}},
+			steps: []PromotionStep{{Kind: errorStepName}},
 			ctx:   context.Background(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusErrored, res.Status)
+				assert.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				assert.ErrorContains(t, err, "something went wrong")
 			},
 		},
@@ -127,7 +127,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 				return ctx
 			}(),
 			assertions: func(t *testing.T, res PromotionResult, err error) {
-				assert.Equal(t, PromotionStatusErrored, res.Status)
+				assert.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
 				assert.ErrorIs(t, err, context.Canceled)
 			},
 		},


### PR DESCRIPTION
This PR aligns engine/step statues more closely with promotion statuses, in fact it reuses `kargoapi.PromotionPhase`, which eliminates some of the need for mapping engine/step statuses to Promotion phases.

At the same time, it fixes a large discrepancy between Promotion phases and engine/step statuses. Promotions have, for quite some time, used `Errored` for _technical_ failures and `Failed` for non-technical failures.

An example of a non-technical failure would be when a Promotion fails due to user action such as closing a PR without merging.

This PR also updates the `git-wait-for-pr` step to treat that specific scenario as a failure instead of an error.

These changes have been validated end-to-end.