### PR TITLE
fix(controller): fix message that was getting lost beteen step and reconciler

### DIFF
--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -124,6 +124,7 @@ func (e *SimpleEngine) Promote(
 		if result.Status != kargoapi.PromotionPhaseSucceeded {
 			return PromotionResult{
 				Status:      result.Status,
+				Message:     result.Message,
 				CurrentStep: i,
 				State:       state,
 			}, nil


### PR DESCRIPTION
Messages in promotion step results were getting lost because the engine wasn't using them to populate the message field for the overall promotion step result.