### PR TITLE
refactor(controller): fix slice init length

### DIFF
--- a/internal/argocd/health.go
+++ b/internal/argocd/health.go
@@ -171,14 +171,14 @@ func (h *applicationHealth) GetApplicationHealth(
 	// e.g. the health status result to become unreliable.
 	if errConditions := filterAppConditions(app, healthErrorConditions...); len(errConditions) > 0 {
 		issues := make([]error, len(errConditions))
-		for _, condition := range errConditions {
-			issues = append(issues, fmt.Errorf(
+		for i, condition := range errConditions {
+			issues[i] = fmt.Errorf(
 				"Argo CD Application %q in namespace %q has %q condition: %s",
 				appKey.Name,
 				appKey.Namespace,
 				condition.Type,
 				condition.Message,
-			))
+			)
 		}
 		return kargoapi.HealthStateUnhealthy, healthStatus, syncStatus, errors.Join(issues...)
 	}

--- a/internal/directives/argocd_health.go
+++ b/internal/directives/argocd_health.go
@@ -184,14 +184,14 @@ func (a *argocdUpdater) getApplicationHealth(
 	// e.g. the health status result to become unreliable.
 	if errConditions := a.filterAppConditions(app, healthErrorConditions...); len(errConditions) > 0 {
 		issues := make([]error, len(errConditions))
-		for _, condition := range errConditions {
-			issues = append(issues, fmt.Errorf(
+		for i, condition := range errConditions {
+			issues[i] = fmt.Errorf(
 				"Argo CD Application %q in namespace %q has %q condition: %s",
 				appKey.Name,
 				appKey.Namespace,
 				condition.Type,
 				condition.Message,
-			))
+			)
 		}
 		return kargoapi.HealthStateUnhealthy, appStatus, errors.Join(issues...)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW