### PR TITLE
fix: use mkdirall when creating ~/.ssh dir to allow for the case where it already exists

### DIFF
--- a/internal/controller/git/base_repo.go
+++ b/internal/controller/git/base_repo.go
@@ -126,7 +126,7 @@ func (b *baseRepo) setupAuth() error {
 	// If an SSH key was provided, use that.
 	if b.creds.SSHPrivateKey != "" {
 		sshPath := filepath.Join(b.homeDir, ".ssh")
-		if err := os.Mkdir(sshPath, 0700); err != nil {
+		if err := os.MkdirAll(sshPath, 0700); err != nil {
 			return fmt.Errorf("error creating SSH directory %q: %w", sshPath, err)
 		}
 		sshConfigPath := filepath.Join(sshPath, "config")


### PR DESCRIPTION
This fixes a problem that only occurs when using ssh to interact with a remote repo.

We re-setup auth mechanisms every time we load an already-cloned repo from disk because the possibility always exists that for a long-running promotion step, credentials for the repo have been updated between two executions of that step. I am confident this is the right thing to do, however, when using SSH, there is an `os.Mkdir()` call that can fail because the directory it attempts to create would have been created by the previous execution of the auth setup logic.

This PR solves that problem by using `os.MkdirAll()` instead, as that will not error if the directory already exists.

Part of #2492 