### PR TITLE
fix: add busybox to base image

### DIFF
--- a/kargo-base.apko.yaml
+++ b/kargo-base.apko.yaml
@@ -4,6 +4,7 @@ contents:
   repositories:
   - https://packages.wolfi.dev/os
   packages:
+  - busybox # TODO: Remove this if we can figure out how to get by without a shell
   - git~2
   - gpg~2
   - gpg-agent~2


### PR DESCRIPTION
Went a bit overboard in #2697.

While I would _love_ not having a shell in the image, I can't get interactions with a remote repo over ssh to work without one.

This is part of #2492 