### PR TITLE
chore: don't suppress echoing commands of hack-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ hack-codegen: hack-build-dev-tools
 # 	make hack-build IMAGE_PLATFORMS=linux/amd64 DOCKER_BUILD_OPTS=--no-cache
 .PHONY: hack-build
 hack-build: build-base-image
-	@{ \
+	{ \
 		$(CONTAINER_RUNTIME) run -d -p 5000:$(LOCAL_REG_PORT) --name tmp-registry registry:2; \
 		trap '$(CONTAINER_RUNTIME) rm -f tmp-registry' EXIT; \
 		docker push $(BASE_IMAGE):latest-amd64; \
@@ -300,6 +300,7 @@ hack-build: build-base-image
 		$(CONTAINER_RUNTIME) buildx build \
 			$(DOCKER_BUILD_OPTS) \
 			--network host \
+			--platform linux/amd64 \
 			--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 			--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 			--build-arg GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi) \


### PR DESCRIPTION
In #2697 I had not meant to suppress the commands in the `hack-build` target from being echoed. Seeing the commands is helpful for troubleshooting purposes. 