### PR TITLE
fix: relax clone step config validation to allow ssh urls

### DIFF
--- a/internal/directives/git_cloner_test.go
+++ b/internal/directives/git_cloner_test.go
@@ -36,7 +36,6 @@ func Test_gitCloner_validate(t *testing.T) {
 			},
 			expectedProblems: []string{
 				"repoURL: String length must be greater than or equal to 1",
-				"repoURL: Does not match format 'uri'",
 			},
 		},
 		{

--- a/internal/directives/schemas/git-clone-config.json
+++ b/internal/directives/schemas/git-clone-config.json
@@ -12,8 +12,7 @@
     "repoURL": {
       "type": "string",
       "description": "The URL of a remote Git repository to clone. Required.",
-      "minLength": 1,
-      "format": "uri"
+      "minLength": 1
     },
     "checkout": {
       "type": "array",


### PR DESCRIPTION
This was too restrictive to permit ssh URLs.

Note that the schemas for `git-open-pr` and `git-wait-for-pr` do not require the same change because you cannot interact with a Git provider's API over ssh, so the http/s URL is _always_ used for those steps.

Part of #2492 