### PR TITLE
fix(cli): fix flag in login command example

### DIFF
--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -73,7 +73,7 @@ kargo login https://kargo.example.com --admin
 kargo login https://kargo.example.com --kubeconfig
 
 # Log in using the local kubeconfig and ignore cert warnings
-kargo login https://kargo.example.com --kubeconfig --insecure-tls
+kargo login https://kargo.example.com --kubeconfig --insecure-skip-tls-verify
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)


### PR DESCRIPTION
`kargo login -h` says
```
Log in to a Kargo API server

Usage:
  kargo login [SERVER_ADDRESS] (--admin | --kubeconfig | --sso) [flags]

Examples:
  [...]

  # Log in using the local kubeconfig and ignore cert warnings
  kargo login https://kargo.example.com --kubeconfig --insecure-tls

  [...]
```
however `kargo login https://kargo.example.com --kubeconfig --insecure-tls` yields
```
Error: unknown flag: --insecure-tls
```
The correct flag is `--insecure-skip-tls-verify` as also documented in the _Flags_ section of the `kargo login -h` output.