### PR TITLE
fix: improve freight availability checks

### DIFF
--- a/api/v1alpha1/freight_helpers_test.go
+++ b/api/v1alpha1/freight_helpers_test.go
@@ -116,54 +116,163 @@ func TestGetFreightByAlias(t *testing.T) {
 }
 
 func TestIsFreightAvailable(t *testing.T) {
-	testFreight := &Freight{
-		Status: FreightStatus{
-			VerifiedIn: map[string]VerifiedStage{
-				"fake-stage-1": {},
-			},
-			ApprovedFor: map[string]ApprovedStage{
-				"fake-stage-2": {},
-			},
-		},
-	}
+	const testNamespace = "fake-namespace"
+	const testWarehouse = "fake-warehouse"
+	const testStage = "fake-stage"
+
 	testCases := []struct {
-		name           string
-		stage          string
-		upstreamStages []string
-		available      bool
+		name     string
+		stage    *Stage
+		Freight  *Freight
+		expected bool
 	}{
 		{
-			name:      "no upstream Stages specified",
-			available: true,
+			name:     "stage is nil",
+			expected: false,
 		},
 		{
-			name:           "verified in an upstream Stage",
-			upstreamStages: []string{"fake-stage-1"},
-			available:      true,
+			name:     "freight is nil",
+			expected: false,
 		},
 		{
-			name:           "approved for Stage",
-			stage:          "fake-stage-2",
-			upstreamStages: []string{"fake-stage-3"},
-			available:      true,
+			name: "stage and freight are in different namespaces",
+			stage: &Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+			},
+			Freight: &Freight{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "wrong-namespace",
+				},
+			},
+			expected: false,
 		},
 		{
-			name:           "unavailable",
-			stage:          "fake-stage-3",
-			upstreamStages: []string{"upstream-stage-2"},
-			available:      false,
+			name: "freight is approved for stage",
+			stage: &Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      testStage,
+				},
+			},
+			Freight: &Freight{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      testStage,
+				},
+				Status: FreightStatus{
+					ApprovedFor: map[string]ApprovedStage{
+						testStage: {},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "stage accepts freight direct from origin",
+			stage: &Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: FreightOrigin{
+							Kind: FreightOriginKindWarehouse,
+							Name: testWarehouse,
+						},
+						Sources: FreightSources{
+							Direct: true,
+						},
+					}},
+				},
+			},
+			Freight: &Freight{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Origin: FreightOrigin{
+					Kind: FreightOriginKindWarehouse,
+					Name: testWarehouse,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "freight is verified in an upstream stage",
+			stage: &Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: FreightOrigin{
+							Kind: FreightOriginKindWarehouse,
+							Name: testWarehouse,
+						},
+						Sources: FreightSources{
+							Stages: []string{"upstream-stage"},
+						},
+					}},
+				},
+			},
+			Freight: &Freight{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Origin: FreightOrigin{
+					Kind: FreightOriginKindWarehouse,
+					Name: testWarehouse,
+				},
+				Status: FreightStatus{
+					VerifiedIn: map[string]VerifiedStage{
+						"upstream-stage": {},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "freight from origin not requested",
+			stage: &Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: FreightOrigin{
+							Kind: FreightOriginKindWarehouse,
+							Name: testWarehouse,
+						},
+						Sources: FreightSources{
+							Stages: []string{"upstream-stage"},
+						},
+					}},
+				},
+			},
+			Freight: &Freight{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Origin: FreightOrigin{
+					Kind: FreightOriginKindWarehouse,
+					Name: "wrong-warehouse",
+				},
+				Status: FreightStatus{
+					VerifiedIn: map[string]VerifiedStage{
+						"upstream-stage": {},
+					},
+				},
+			},
+			expected: false,
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			require.Equal(
 				t,
-				testCase.available,
-				IsFreightAvailable(
-					testFreight,
-					testCase.stage,
-					testCase.upstreamStages,
-				),
+				testCase.expected,
+				IsFreightAvailable(testCase.stage, testCase.Freight),
 			)
 		})
 	}

--- a/internal/api/promote_downstream_v1alpha1.go
+++ b/internal/api/promote_downstream_v1alpha1.go
@@ -92,22 +92,26 @@ func (s *server) PromoteDownstream(
 		}
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
-	if !s.isFreightAvailableFn(
-		freight,
-		"",                  // approved for not considered
-		[]string{stageName}, // verified in
-	) {
+
+	var directAllowed bool
+	for _, req := range stage.Spec.RequestedFreight {
+		if req.Origin.Equals(&freight.Origin) && req.Sources.Direct {
+			directAllowed = true
+			break
+		}
+	}
+	if _, verified := freight.Status.VerifiedIn[stage.Name]; !verified && !directAllowed {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,
 			fmt.Errorf(
-				"Freight %q is not available to Stage %q",
+				"Freight %q is not available to Stages down stream from %q",
 				freightName,
 				stageName,
 			),
 		)
 	}
 
-	downstreams, err := s.findDownstreamStagesFn(ctx, stage)
+	downstreams, err := s.findDownstreamStagesFn(ctx, stage, freight.Origin)
 	if err != nil {
 		return nil, fmt.Errorf("find downstream stages: %w", err)
 	}
@@ -160,9 +164,13 @@ func (s *server) PromoteDownstream(
 }
 
 // findDownstreamStages returns a list of Stages that are immediately downstream
-// from the given Stage.
+// from the given Stage and request Freight from the given origin.
 // TODO: this could be powered by an index.
-func (s *server) findDownstreamStages(ctx context.Context, stage *kargoapi.Stage) ([]kargoapi.Stage, error) {
+func (s *server) findDownstreamStages(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+	origin kargoapi.FreightOrigin,
+) ([]kargoapi.Stage, error) {
 	var allStages kargoapi.StageList
 	if err := s.client.List(ctx, &allStages, client.InNamespace(stage.Namespace)); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -170,6 +178,9 @@ func (s *server) findDownstreamStages(ctx context.Context, stage *kargoapi.Stage
 	var downstreams []kargoapi.Stage
 	for _, s := range allStages.Items {
 		for _, req := range s.Spec.RequestedFreight {
+			if !req.Origin.Equals(&origin) {
+				continue
+			}
 			for _, upstream := range req.Sources.Stages {
 				if upstream == stage.Name {
 					downstreams = append(downstreams, s)

--- a/internal/api/promote_downstream_v1alpha1_test.go
+++ b/internal/api/promote_downstream_v1alpha1_test.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,9 +247,6 @@ func TestPromoteDownstream(t *testing.T) {
 				) (*kargoapi.Freight, error) {
 					return &kargoapi.Freight{}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return false
-				},
 			},
 			assertions: func(
 				t *testing.T,
@@ -281,6 +279,10 @@ func TestPromoteDownstream(t *testing.T) {
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
 					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-project",
+							Name:      "fake-stage",
+						},
 						Spec: testStageSpec,
 					}, nil
 				},
@@ -289,12 +291,19 @@ func TestPromoteDownstream(t *testing.T) {
 					client.Client,
 					string, string, string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{
+						Status: kargoapi.FreightStatus{
+							VerifiedIn: map[string]kargoapi.VerifiedStage{
+								"fake-stage": {},
+							},
+						},
+					}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return true
-				},
-				findDownstreamStagesFn: func(context.Context, *kargoapi.Stage) ([]kargoapi.Stage, error) {
+				findDownstreamStagesFn: func(
+					context.Context,
+					*kargoapi.Stage,
+					kargoapi.FreightOrigin,
+				) ([]kargoapi.Stage, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -325,6 +334,10 @@ func TestPromoteDownstream(t *testing.T) {
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
 					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-project",
+							Name:      "fake-stage",
+						},
 						Spec: testStageSpec,
 					}, nil
 				},
@@ -333,12 +346,19 @@ func TestPromoteDownstream(t *testing.T) {
 					client.Client,
 					string, string, string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{
+						Status: kargoapi.FreightStatus{
+							VerifiedIn: map[string]kargoapi.VerifiedStage{
+								"fake-stage": {},
+							},
+						},
+					}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return true
-				},
-				findDownstreamStagesFn: func(context.Context, *kargoapi.Stage) ([]kargoapi.Stage, error) {
+				findDownstreamStagesFn: func(
+					context.Context,
+					*kargoapi.Stage,
+					kargoapi.FreightOrigin,
+				) ([]kargoapi.Stage, error) {
 					return nil, nil
 				},
 			},
@@ -373,6 +393,10 @@ func TestPromoteDownstream(t *testing.T) {
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
 					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-project",
+							Name:      "fake-stage",
+						},
 						Spec: testStageSpec,
 					}, nil
 				},
@@ -383,12 +407,19 @@ func TestPromoteDownstream(t *testing.T) {
 					string,
 					string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{
+						Status: kargoapi.FreightStatus{
+							VerifiedIn: map[string]kargoapi.VerifiedStage{
+								"fake-stage": {},
+							},
+						},
+					}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return true
-				},
-				findDownstreamStagesFn: func(context.Context, *kargoapi.Stage) ([]kargoapi.Stage, error) {
+				findDownstreamStagesFn: func(
+					context.Context,
+					*kargoapi.Stage,
+					kargoapi.FreightOrigin,
+				) ([]kargoapi.Stage, error) {
 					return []kargoapi.Stage{{}}, nil
 				},
 				authorizeFn: func(
@@ -428,6 +459,10 @@ func TestPromoteDownstream(t *testing.T) {
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
 					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-project",
+							Name:      "fake-stage",
+						},
 						Spec: testStageSpec,
 					}, nil
 				},
@@ -436,12 +471,19 @@ func TestPromoteDownstream(t *testing.T) {
 					client.Client,
 					string, string, string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{
+						Status: kargoapi.FreightStatus{
+							VerifiedIn: map[string]kargoapi.VerifiedStage{
+								"fake-stage": {},
+							},
+						},
+					}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return true
-				},
-				findDownstreamStagesFn: func(context.Context, *kargoapi.Stage) ([]kargoapi.Stage, error) {
+				findDownstreamStagesFn: func(
+					context.Context,
+					*kargoapi.Stage,
+					kargoapi.FreightOrigin,
+				) ([]kargoapi.Stage, error) {
 					return []kargoapi.Stage{
 						{
 							Spec: kargoapi.StageSpec{
@@ -501,6 +543,10 @@ func TestPromoteDownstream(t *testing.T) {
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
 					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "fake-project",
+							Name:      "fake-stage",
+						},
 						Spec: testStageSpec,
 					}, nil
 				},
@@ -509,12 +555,19 @@ func TestPromoteDownstream(t *testing.T) {
 					client.Client,
 					string, string, string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{
+						Status: kargoapi.FreightStatus{
+							VerifiedIn: map[string]kargoapi.VerifiedStage{
+								"fake-stage": {},
+							},
+						},
+					}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
-					return true
-				},
-				findDownstreamStagesFn: func(context.Context, *kargoapi.Stage) ([]kargoapi.Stage, error) {
+				findDownstreamStagesFn: func(
+					context.Context,
+					*kargoapi.Stage,
+					kargoapi.FreightOrigin,
+				) ([]kargoapi.Stage, error) {
 					return []kargoapi.Stage{
 						{
 							Spec: kargoapi.StageSpec{

--- a/internal/api/promote_to_stage_v1alpha1.go
+++ b/internal/api/promote_to_stage_v1alpha1.go
@@ -86,14 +86,7 @@ func (s *server) PromoteToStage(
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	var upstreamStages []string
-	for _, req := range stage.Spec.RequestedFreight {
-		if req.Origin.Equals(&freight.Origin) {
-			upstreamStages = req.Sources.Stages
-			break
-		}
-	}
-	if !s.isFreightAvailableFn(freight, stage.Name, upstreamStages) {
+	if !s.isFreightAvailableFn(stage, freight) {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,
 			fmt.Errorf(

--- a/internal/api/promote_to_stage_v1alpha1_test.go
+++ b/internal/api/promote_to_stage_v1alpha1_test.go
@@ -247,7 +247,7 @@ func TestPromoteToStage(t *testing.T) {
 				) (*kargoapi.Freight, error) {
 					return &kargoapi.Freight{}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
+				isFreightAvailableFn: func(*kargoapi.Stage, *kargoapi.Freight) bool {
 					return false
 				},
 			},
@@ -294,7 +294,7 @@ func TestPromoteToStage(t *testing.T) {
 				) (*kargoapi.Freight, error) {
 					return &kargoapi.Freight{}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
+				isFreightAvailableFn: func(*kargoapi.Stage, *kargoapi.Freight) bool {
 					return true
 				},
 				authorizeFn: func(
@@ -344,7 +344,7 @@ func TestPromoteToStage(t *testing.T) {
 				) (*kargoapi.Freight, error) {
 					return &kargoapi.Freight{}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
+				isFreightAvailableFn: func(*kargoapi.Stage, *kargoapi.Freight) bool {
 					return true
 				},
 				authorizeFn: func(
@@ -401,7 +401,7 @@ func TestPromoteToStage(t *testing.T) {
 				) (*kargoapi.Freight, error) {
 					return &kargoapi.Freight{}, nil
 				},
-				isFreightAvailableFn: func(*kargoapi.Freight, string, []string) bool {
+				isFreightAvailableFn: func(*kargoapi.Stage, *kargoapi.Freight) bool {
 					return true
 				},
 				authorizeFn: func(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,11 +76,7 @@ type server struct {
 		name string,
 		alias string,
 	) (*kargoapi.Freight, error)
-	isFreightAvailableFn func(
-		freight *kargoapi.Freight,
-		stage string,
-		upstreamStages []string,
-	) bool
+	isFreightAvailableFn func(*kargoapi.Stage, *kargoapi.Freight) bool
 
 	// Common Promotions:
 	createPromotionFn func(
@@ -90,7 +86,11 @@ type server struct {
 	) error
 
 	// Promote downstream:
-	findDownstreamStagesFn func(ctx context.Context, stage *kargoapi.Stage) ([]kargoapi.Stage, error)
+	findDownstreamStagesFn func(
+		context.Context,
+		*kargoapi.Stage,
+		kargoapi.FreightOrigin,
+	) ([]kargoapi.Stage, error)
 
 	// QueryFreight API:
 	listFreightFn func(

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -466,15 +465,8 @@ func (r *reconciler) promote(
 	if targetFreight == nil {
 		return nil, fmt.Errorf("Freight %q not found in namespace %q", promo.Spec.Freight, promo.Namespace)
 	}
-	var upstreams []string
-	for _, req := range stage.Spec.RequestedFreight {
-		upstreams = append(upstreams, req.Sources.Stages...)
-	}
-	// De-dupe upstreams
-	slices.Sort(upstreams)
-	upstreams = slices.Compact(upstreams)
 
-	if !kargoapi.IsFreightAvailable(targetFreight, stageName, upstreams) {
+	if !kargoapi.IsFreightAvailable(stage, targetFreight) {
 		return nil, fmt.Errorf(
 			"Freight %q is not available to Stage %q in namespace %q",
 			promo.Spec.Freight,


### PR DESCRIPTION
Fixes #2365 

After approaching this problem a few different ways, the thing that came out cleanest was treating the question of whether a piece of Freight is _wanted_ by a given Stage as just another dimension of whether that Freight is _available_ to that Stage.

1b3d577e491eddf6e91b7e463a41ae8c02399419 is some pre-requisite refactoring that made the more prescient refactoring and enhancements in 75d6fcc7d66da56006be5fc371e8c15f965d0de9 a bit easier.

6753bad5a0cb046e891e320508acce410a00356b just updates existing usage of the refactored availability check accordingly.

2559c0c2323e5c544966df8361267e1580e1bc4b adds the availability check to the Promo creation webhook so that availability checks aren't bypassed when using `kubectl` instead of `kargo` or the UI.