### PR TITLE
refactor(chart): resume using official kargo image for cabundle init containers

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       {{- if or .Values.api.cabundle.configMapName .Values.api.cabundle.secretName }}
       initContainers:
       - name: parse-cabundle
-        image: alpine/curl:latest
+        image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -94,7 +94,7 @@ spec:
       {{- if or .Values.controller.cabundle.configMapName .Values.controller.cabundle.secretName }}
       initContainers:
       - name: parse-cabundle
-        image: alpine/curl:latest
+        image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/kargo-base.apko.yaml
+++ b/kargo-base.apko.yaml
@@ -5,6 +5,7 @@ contents:
   - https://packages.wolfi.dev/os
   packages:
   - busybox # TODO: Remove this if we can figure out how to get by without a shell
+  - ca-certificates
   - git~2
   - gpg~2
   - gpg-agent~2


### PR DESCRIPTION
In #2697 we went distroless _and_ shell-less. At that time, lack of a shell forced us to stop using the official Kargo image for the init container that preps any custom CA bundles. We fell back on using `alpine/curl:latest`

In #2709, for unrelated reasons, we added a minimal shell env (busybox).

As we've discussed offline, now that we've done this, we can resume using the official kargo image as the init container and it shrinks Kargo's overall footprint a tad by eliminating a dependency on an image we're not in control of.

cc @gdsoumya 