### PR TITLE
chore(backport release-0.9): feat(directives): enable Helm plugin for `kustomize-build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include $(CURDIR)/hack/tools.mk
 
-SHELL ?= /bin/bash
+SHELL	      ?= /bin/bash
+EXTENDED_PATH ?= $(CURDIR)/hack/bin:$(PATH)
 
 ARGO_CD_CHART_VERSION		:= 6.9.2
 ARGO_ROLLOUTS_CHART_VERSION := 2.35.2
@@ -20,7 +21,7 @@ IMAGE_PUSH 			?= false
 IMAGE_PLATFORMS 	=
 DOCKER_BUILD_OPTS 	=
 
-DOCS_PORT 				?= 3000
+DOCS_PORT ?= 3000
 
 # Intelligently choose to build a multi-arch image if the intent is to push to a
 # container registry (IMAGE_PUSH=true). If not pushing, build an single-arch
@@ -99,8 +100,8 @@ format-ui:
 	pnpm --dir=ui run lint:fix
 
 .PHONY: test-unit
-test-unit:
-	go test \
+test-unit: install-helm
+	PATH=$(EXTENDED_PATH) go test \
 		-v \
 		-timeout=300s \
 		-race \

--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -310,6 +310,8 @@ preceded by a [`git-clear`](#git-clear) step and followed by
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a directory containing a `kustomization.yaml` file. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `outPath` | `string` | Y | Path to the file or directory where rendered manifests are to be written. If the path ends with `.yaml` or `.yml` it is presumed to indicate a file and is otherwise presumed to indicate a directory. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `plugin.helm.apiVersions` | `[]string` | N | Optionally specifies a list of supported API versions to be used when rendering manifests using Kustomize's Helm chart plugin. This is useful for charts that may contain logic specific to different Kubernetes API versions. |
+| `plugin.helm.kubeVersion` | `string` | N | Optionally specifies a Kubernetes version to be assumed when rendering manifests using Kustomize's Helm chart plugin. This is useful for charts that may contain logic specific to different Kubernetes versions. |
 
 ### `kustomize-build` Examples
 

--- a/internal/directives/kustomize_builder.go
+++ b/internal/directives/kustomize_builder.go
@@ -81,7 +81,7 @@ func (k *kustomizeBuilder) runPromotionStep(
 	}
 
 	// Build the manifests.
-	rm, err := kustomizeBuild(fs, filepath.Join(stepCtx.WorkDir, cfg.Path))
+	rm, err := kustomizeBuild(fs, filepath.Join(stepCtx.WorkDir, cfg.Path), cfg.Plugin)
 	if err != nil {
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, err
 	}
@@ -143,7 +143,7 @@ func (k *kustomizeBuilder) writeResult(rm resmap.ResMap, outPath string) error {
 }
 
 // kustomizeBuild builds the manifests in the given directory using Kustomize.
-func kustomizeBuild(fs filesys.FileSystem, path string) (_ resmap.ResMap, err error) {
+func kustomizeBuild(fs filesys.FileSystem, path string, pluginCfg *Plugin) (_ resmap.ResMap, err error) {
 	kustomizeRenderMutex.Lock()
 	defer kustomizeRenderMutex.Unlock()
 
@@ -156,9 +156,25 @@ func kustomizeBuild(fs filesys.FileSystem, path string) (_ resmap.ResMap, err er
 		}
 	}()
 
+	// Disable plugins (i.e. "function based" plugins), but enable builtins
+	// (e.g. transformers, generators).
+	buildPluginCfg := kustypes.DisabledPluginConfig()
+	// Helm plugin builtin requires explicit enabling. Kustomize itself ensures
+	// the further Helm files (e.g. cache, data) are stored in a temporary
+	// directory, AS LONG AS the global configuration is not set.
+	buildPluginCfg.HelmConfig.Enabled = true
+	buildPluginCfg.HelmConfig.Command = "helm"
+
+	if pluginCfg != nil && pluginCfg.Helm != nil {
+		buildPluginCfg.HelmConfig.ApiVersions = pluginCfg.Helm.APIVersions
+		buildPluginCfg.HelmConfig.KubeVersion = pluginCfg.Helm.KubeVersion
+	}
+
 	buildOptions := &krusty.Options{
+		// As we make use of a "chrooted" filesystem, we can safely allow
+		// loading of files from anywhere.
 		LoadRestrictions: kustypes.LoadRestrictionsNone,
-		PluginConfig:     kustypes.DisabledPluginConfig(),
+		PluginConfig:     buildPluginCfg,
 	}
 
 	k := krusty.MakeKustomizer(buildOptions)

--- a/internal/directives/kustomize_builder_test.go
+++ b/internal/directives/kustomize_builder_test.go
@@ -1,12 +1,16 @@
 package directives
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/repo"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
@@ -46,6 +50,63 @@ metadata:
 				b, err := os.ReadFile(filepath.Join(dir, "output.yaml"))
 				require.NoError(t, err)
 				assert.Contains(t, string(b), "test-deployment")
+			},
+		},
+		{
+			name: "successful build with HelmChartInflationGenerator",
+			setupFiles: func(t *testing.T, dir string) {
+				// Create a temporary HTTP server to serve the Helm chart.
+				httpRepositoryRoot := t.TempDir()
+				require.NoError(t, copyFile(
+					"testdata/helm/charts/demo-0.1.0.tgz",
+					filepath.Join(httpRepositoryRoot, "demo-0.1.0.tgz"),
+				))
+				httpRepository := httptest.NewServer(http.FileServer(http.Dir(httpRepositoryRoot)))
+
+				repoIndex, err := repo.IndexDirectory(httpRepositoryRoot, httpRepository.URL)
+				require.NoError(t, err)
+				require.NoError(t, repoIndex.WriteFile(filepath.Join(httpRepositoryRoot, "index.yaml"), 0o600))
+				t.Cleanup(httpRepository.Close)
+
+				// Mock the further files.
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+- chart.yaml
+namespace: demo
+`), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "chart.yaml"), []byte(fmt.Sprintf(`---
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: demo
+name: demo
+releaseName: demo
+repo: %s
+valuesFile: values.yaml
+`, httpRepository.URL)), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte(`---
+replicaCount: 3`), 0o600))
+			},
+			config: KustomizeBuildConfig{
+				Path:    ".",
+				OutPath: "output.yaml",
+			},
+			assertions: func(t *testing.T, dir string, result PromotionStepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
+
+				assert.FileExists(t, filepath.Join(dir, "output.yaml"))
+				b, err := os.ReadFile(filepath.Join(dir, "output.yaml"))
+				require.NoError(t, err)
+
+				// Should be inflated with (part of) the config set.
+				assert.Contains(t, string(b), "namespace: demo")
+				assert.Contains(t, string(b), "helm.sh/chart: demo-0.1.0")
+
+				// The value from the values file should be in the output.
+				assert.Contains(t, string(b), "replicas: 3")
 			},
 		},
 		{

--- a/internal/directives/schemas/kustomize-build-config.json
+++ b/internal/directives/schemas/kustomize-build-config.json
@@ -14,6 +14,33 @@
         "type": "string",
         "description": "OutPath is the file path to write the built manifests to.",
         "minLength": 1
+    },
+    "plugin": {
+      "type": "object",
+      "description": "Plugin contains configuration for customizing the behavior of builtin Kustomize plugins.",
+      "additionalProperties": false,
+      "properties": {
+        "helm": {
+          "type": "object",
+          "description": "Helm contains configuration for inflating a Helm chart.",
+          "additionalProperties": false,
+          "properties": {
+            "apiVersions": {
+              "type": "array",
+              "additionalProperties": false,
+              "description": "APIVersions allows a manual set of supported API versions to be passed when inflating a Helm chart.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "kubeVersion": {
+              "type": "string",
+              "description": "KubeVersion allows for passing a specific Kubernetes version to use when inflating a Helm chart."
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -292,6 +292,24 @@ type KustomizeBuildConfig struct {
 	OutPath string `json:"outPath"`
 	// Path to the directory containing the Kustomization file.
 	Path string `json:"path"`
+	// Plugin contains configuration for customizing the behavior of builtin Kustomize plugins.
+	Plugin *Plugin `json:"plugin,omitempty"`
+}
+
+// Plugin contains configuration for customizing the behavior of builtin Kustomize plugins.
+type Plugin struct {
+	// Helm contains configuration for inflating a Helm chart.
+	Helm *Helm `json:"helm,omitempty"`
+}
+
+// Helm contains configuration for inflating a Helm chart.
+type Helm struct {
+	// APIVersions allows a manual set of supported API versions to be passed when inflating a
+	// Helm chart.
+	APIVersions []string `json:"apiVersions,omitempty"`
+	// KubeVersion allows for passing a specific Kubernetes version to use when inflating a Helm
+	// chart.
+	KubeVersion string `json:"kubeVersion,omitempty"`
 }
 
 type KustomizeSetImageConfig struct {


### PR DESCRIPTION
Manual backport of #2733 to `release-0.9` due to merge conflicts.