### PR TITLE
fix(release-process): fix container networking in release image build process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,8 @@ jobs:
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+      with:
+        driver-opts: network=host
     - name: Install Cosign
       uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
       with:


### PR DESCRIPTION
This setting was missing from the release workflow. The CI workflow already has it.

A million thanks to @34fathombelow for finding this!