### PR TITLE
fix(stage): wait for running verification to finish before next Promotion

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -22,6 +22,9 @@ const (
 	StagePhasePromoting StagePhase = "Promoting"
 	// StagePhaseVerifying denotes a Stage that is currently being verified.
 	StagePhaseVerifying StagePhase = "Verifying"
+	// StagePhaseFailed denotes a Stage that is in a failed state. For example,
+	// the Stage may have failed to promote or verify its Freight.
+	StagePhaseFailed StagePhase = "Failed"
 )
 
 type VerificationPhase string

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 			name:                  "stage not awaiting promo",
 			expectPromoteFnCalled: false,
 			promoToReconcile:      &types.NamespacedName{Namespace: "fake-namespace", Name: "fake-promo"},
-			expectedPhase:         kargoapi.PromotionPhaseRunning,
+			expectedPhase:         kargoapi.PromotionPhasePending,
 			expectedEventRecorded: false,
 			promos: []client.Object{
 				&kargoapi.Stage{

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -295,7 +295,7 @@ func (u *PromotionAcknowledgedByStageHandler[T]) Update(
 	}
 
 	if oldStage.Status.CurrentPromotion == nil ||
-		oldStage.Status.CurrentPromotion.Name == newStage.Status.CurrentPromotion.Name {
+		oldStage.Status.CurrentPromotion.Name != newStage.Status.CurrentPromotion.Name {
 		wq.Add(reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: newStage.Namespace,

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -239,3 +239,78 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		)
 	}
 }
+
+// PromotionAcknowledgedByStageHandler is an event handler that enqueues a
+// Promotion for reconciliation when it has been acknowledged by the Stage\
+// it is for.
+type PromotionAcknowledgedByStageHandler[T any] struct{}
+
+// Create implements TypedEventHandler.
+func (u *PromotionAcknowledgedByStageHandler[T]) Create(
+	context.Context,
+	event.TypedCreateEvent[T],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// No-op
+}
+
+// Delete implements TypedEventHandler.
+func (u *PromotionAcknowledgedByStageHandler[T]) Delete(
+	context.Context,
+	event.TypedDeleteEvent[T],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// No-op
+}
+
+// Generic implements TypedEventHandler.
+func (u *PromotionAcknowledgedByStageHandler[T]) Generic(
+	context.Context,
+	event.TypedGenericEvent[T],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// No-op
+}
+
+// Update implements TypedEventHandler.
+func (u *PromotionAcknowledgedByStageHandler[T]) Update(
+	ctx context.Context,
+	e event.TypedUpdateEvent[T],
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := logging.LoggerFromContext(ctx)
+
+	oldStage := any(e.ObjectOld).(*kargoapi.Stage) // nolint: forcetypeassert
+	newStage := any(e.ObjectNew).(*kargoapi.Stage) // nolint: forcetypeassert
+	if newStage == nil || oldStage == nil {
+		logger.Error(
+			nil, "Update event has no new or old object",
+			"event", e,
+		)
+		return
+	}
+
+	if oldStage.Status.CurrentPromotion == nil && newStage.Status.CurrentPromotion == nil {
+		return
+	}
+
+	if oldStage.Status.CurrentPromotion != nil && newStage.Status.CurrentPromotion == nil {
+		return
+	}
+
+	if oldStage.Status.CurrentPromotion == nil ||
+		oldStage.Status.CurrentPromotion.Name == newStage.Status.CurrentPromotion.Name {
+		wq.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: newStage.Namespace,
+				Name:      newStage.Status.CurrentPromotion.Name,
+			},
+		})
+		logger.Debug(
+			"enqueued Promotion for reconciliation",
+			"namespace", newStage.Namespace,
+			"promotion", newStage.Status.CurrentPromotion.Name,
+			"stage", newStage.Name,
+		)
+	}
+}

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -290,11 +290,7 @@ func (u *PromotionAcknowledgedByStageHandler[T]) Update(
 		return
 	}
 
-	if oldStage.Status.CurrentPromotion == nil && newStage.Status.CurrentPromotion == nil {
-		return
-	}
-
-	if oldStage.Status.CurrentPromotion != nil && newStage.Status.CurrentPromotion == nil {
+	if newStage.Status.CurrentPromotion == nil {
 		return
 	}
 

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1031,7 +1031,8 @@ func (r *reconciler) syncPromotions(
 		}
 	}
 
-	// If the latest Promotion is in a running phase, the Stage is promoting.
+	// If the highest priority Promotion is in a running phase, the Stage is
+	// promoting.
 	if !highestPrioPromo.Status.Phase.IsTerminal() {
 		logger.WithValues("promotion", highestPrioPromo.Name).Debug("Stage has a running Promotion")
 		status.Phase = kargoapi.StagePhasePromoting

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1011,7 +1011,6 @@ func (r *reconciler) syncPromotions(
 
 	// If the highest priority Promotion does not match the current Promotion, or
 	// is in a terminal phase, then the current Promotion is no longer valid.
-	// terminal phase, then the current Promotion is no longer valid.
 	if curPromotion := status.CurrentPromotion; curPromotion != nil {
 		if curPromotion.Name != highestPrioPromo.Name || highestPrioPromo.Status.Phase.IsTerminal() {
 			status.CurrentPromotion = nil

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -778,7 +778,7 @@ func (r *reconciler) syncNormalStage(
 		// THEN
 		// Mark the Freight as verified in this Stage
 		if (status.Health == nil || status.Health.Status == kargoapi.HealthStateHealthy) &&
-			currentVI.Phase == kargoapi.VerificationPhaseSuccessful {
+			(currentVI != nil && currentVI.Phase == kargoapi.VerificationPhaseSuccessful) {
 			for _, freight := range currentFC.Freight {
 				updated, err := r.verifyFreightInStageFn(
 					ctx,

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1084,11 +1084,16 @@ func (r *reconciler) syncPromotions(
 	for _, p := range newPromotions {
 		promo := p
 		status.LastPromotion = &promo
-		if promo.Status.Phase == kargoapi.PromotionPhaseSucceeded {
-			status.FreightHistory.Record(status.LastPromotion.Status.FreightCollection)
+		switch promo.Status.Phase {
+		case kargoapi.PromotionPhaseSucceeded:
+			status.FreightHistory.Record(promo.Status.FreightCollection)
 			if status.CurrentPromotion == nil {
 				status.Phase = kargoapi.StagePhaseSteady
 			}
+		case kargoapi.PromotionPhasePending, kargoapi.PromotionPhaseRunning:
+			// No-op for safety in case the surrounding logic ever changes
+		default:
+			status.Phase = kargoapi.StagePhaseFailed
 		}
 	}
 

--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1009,7 +1009,8 @@ func (r *reconciler) syncPromotions(
 	// is the one that we will consider for the current state of the Stage.
 	highestPrioPromo := promotions[0]
 
-	// If the latest Promotion does not match the current Promotion, or is in a
+	// If the highest priority Promotion does not match the current Promotion, or
+	// is in a terminal phase, then the current Promotion is no longer valid.
 	// terminal phase, then the current Promotion is no longer valid.
 	if curPromotion := status.CurrentPromotion; curPromotion != nil {
 		if curPromotion.Name != highestPrioPromo.Name || highestPrioPromo.Status.Phase.IsTerminal() {

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -2275,7 +2275,8 @@ func TestReconciler_syncPromotions(t *testing.T) {
 			assertions: func(t *testing.T, status kargoapi.StageStatus, err error) {
 				require.NoError(t, err)
 
-				require.Equal(t, kargoapi.StagePhaseSteady, status.Phase)
+				// Phase should be Failed because the last Promotion failed.
+				require.Equal(t, kargoapi.StagePhaseFailed, status.Phase)
 				require.Nil(t, status.CurrentPromotion)
 
 				status.LastPromotion.FinishedAt = nil


### PR DESCRIPTION
Fixes: #2152
Fixes: #2128 
Fixes: #2693

💡With the Stage mechanism determining what Promotion should be allowed to be processed next, we can get rid of the prioritized queue sometime in the future.