### PR TITLE
fix: fix for deciding to wait for verification or skip to next promo

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -1124,7 +1124,7 @@ func (r *reconciler) syncPromotions(
 	if (status.Phase == kargoapi.StagePhaseSteady || status.Phase == kargoapi.StagePhaseVerifying) &&
 		status.FreightHistory.Current() != nil &&
 		len(status.FreightHistory.Current().VerificationHistory) == 0 &&
-		status.Health != nil && status.Health.Status != kargoapi.HealthStateUnhealthy {
+		(status.Health == nil || status.Health.Status != kargoapi.HealthStateUnhealthy) {
 		logger.WithValues().Debug("Stage is waiting for verification to start")
 		return status, nil
 	}


### PR DESCRIPTION
It's a bit of a flaw that we're potentially making some decisions here based on health assessed in a _previous_ reconciliation loop. That being said, we can sort of get away with it because we only decide to _not_ wait for verification when we see "unhealthy," which means we are already in dire circumstances and the next promo may be what fixes it... turns out, we should handle nil health the same way.

Strategically, @hiddeco and I are in agreement that we need bigger modifications to the stage reconciliation loop to assess health at a different point in that loop so it's ideally never nil and also more up-to-date.

I'll be opening a separate issue for this refactoring.