### PR TITLE
fix(api): fix broken bearer token auth

### DIFF
--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -742,7 +742,7 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 
 		// sub is a standard claim. If the user has this claim, we can infer that
 		// they authenticated using OIDC.
-		if userInfo.Claims["sub"] != "" {
+		if _, ok := userInfo.Claims["sub"]; ok {
 			var namespacesToCheck []string
 			if key.Namespace != "" {
 				// This is written the way it is to keep key.Namespace as the first


### PR DESCRIPTION
Fixes #2722

When OIDC claims were generalized by #2315, the `user.Info` struct went from having discrete `Sub`, `Email`, and `Groups` fields to having a `map[string]any` of claims. `any` because claim values can be scalars or vectors.

There was once a check in our authz logic for `userInfo.Sub != ""`. Since `sub` is a standard claim, we could infer the user had authenticated using Kargo's identity provider.

#2315 had an undetected bug. That check became `userInfo.Claims["sub"] != ""` and this is _always_ true because `userInfo.Claims["sub"]` isn't a `string`. It's `any` unless coerced into something else.

When this check was functioning correctly, we'd have inferred that the user who presented the token got it from somewhere _besides_ Kargo's IDP. We'd have guessed it _might_ have come from the cluster itself or from the cluster's own IDP and we'd have simply used it for communication with the k8s API server, which would, of course, let us know if the token were no good.

With that check broken, Kargo was incorrectly inferring that _any_ token presented came from its own IDP -- which means it then went looking ServiceAccount(s) mapped to the user's claims. It would always come up empty-handed, of course, since the user had _no claims_. And this explains the 403s.

The fix is a one-liner.

cc @wmiller112 