### PR TITLE
fix(controller): fix gitlab provider not found

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -29,8 +29,6 @@ import (
 	"github.com/akuity/kargo/internal/os"
 	"github.com/akuity/kargo/internal/types"
 	versionpkg "github.com/akuity/kargo/internal/version"
-
-	_ "github.com/akuity/kargo/internal/gitprovider/github"
 )
 
 type controllerOptions struct {

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -11,6 +11,9 @@ import (
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/gitprovider"
+
+	_ "github.com/akuity/kargo/internal/gitprovider/github" // GitHub provider registration
+	_ "github.com/akuity/kargo/internal/gitprovider/gitlab" // GitLab provider registration
 )
 
 const prNumberKey = "prNumber"


### PR DESCRIPTION
Fixes #2792

The only reference to the `gitlab` package, ensuring it got registered as a provider, was removed along with the legacy promo mechs.

It probably should have been side-by-side with the `github` provider registration.

This fixes it. This also handles both provider registrations closer to where they're used, which makes things easier to understand.

N.B.: Longer term, I might like to see the Provider interface and registry go away. Instead of updating Kargo to register a lot of new, built-in Provider implementations over time, Kargo can just use third-party steps that integrate with with different git providers.