### PR TITLE
fix(chart): add patchs on promos to kargo-admin clusterrole

### DIFF
--- a/charts/kargo/templates/users/cluster-roles.yaml
+++ b/charts/kargo/templates/users/cluster-roles.yaml
@@ -50,6 +50,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - kargo.akuity.io


### PR DESCRIPTION
Fixes #2790 

Follows up on #2749 and #2760

cc @shmargum. Thanks for reporting.