### PR TITLE
docs: fix docs site redirect rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@
   ignore = "git diff --quiet main -- docs"
 
 [[redirects]]
-  from = "https://kargo.akuity.io"
+  from = "https://kargo.akuity.io/*"
   to = "https://kargo.io"
   status = 301
+  force = true


### PR DESCRIPTION
This is a "forward port." The `release-1.0` branch, which is the production docs branch, already has this fix.

I want it in `main` now so we don't lose the fix when we create a `release-1.1` branch in a few weeks.