### PR TITLE
refactor: move shard filtering to cache level

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -17,6 +18,7 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api/kubernetes"
 	libargocd "github.com/akuity/kargo/internal/argocd"
+	"github.com/akuity/kargo/internal/controller"
 	argocd "github.com/akuity/kargo/internal/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/promotions"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
@@ -168,6 +170,12 @@ func (o *controllerOptions) setupKargoManager(
 		}
 	}
 
+	shardReq, err := controller.GetShardRequirement(stagesReconcilerCfg.ShardName)
+	if err != nil {
+		return nil, stagesReconcilerCfg, fmt.Errorf("error getting shard requirement: %w", err)
+	}
+	shardSelector := labels.NewSelector().Add(*shardReq)
+
 	mgr, err := ctrl.NewManager(
 		restCfg,
 		ctrl.Options{
@@ -183,6 +191,15 @@ func (o *controllerOptions) setupKargoManager(
 					// here since the underlying informer will not be able to watch
 					// Secrets in all namespaces.
 					DisableFor: []client.Object{&corev1.Secret{}},
+				},
+			},
+			Cache: cache.Options{
+				// Ensure that the controller only watches resources in the shard
+				// it is responsible for.
+				ByObject: map[client.Object]cache.ByObject{
+					&kargoapi.Warehouse{}: {Label: shardSelector},
+					&kargoapi.Stage{}:     {Label: shardSelector},
+					&kargoapi.Promotion{}: {Label: shardSelector},
 				},
 			},
 		},
@@ -294,7 +311,6 @@ func (o *controllerOptions) setupReconcilers(
 	if err := warehouses.SetupReconcilerWithManager(
 		kargoMgr,
 		credentialsDB,
-		o.ShardName,
 	); err != nil {
 		return fmt.Errorf("error setting up Warehouses reconciler: %w", err)
 	}

--- a/internal/controller/promotions/watches.go
+++ b/internal/controller/promotions/watches.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,8 +20,7 @@ import (
 // UpdatedArgoCDAppHandler is an event handler that enqueues Promotions for
 // reconciliation when an associated ArgoCD Application is updated.
 type UpdatedArgoCDAppHandler[T any] struct {
-	kargoClient   client.Client
-	shardSelector labels.Selector
+	kargoClient client.Client
 }
 
 // Create implements TypedEventHandler.
@@ -79,7 +77,6 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 				indexer.RunningPromotionsByArgoCDApplicationsIndexField,
 				fmt.Sprintf("%s:%s", newApp.Namespace, newApp.Name),
 			),
-			LabelSelector: u.shardSelector,
 		},
 	); err != nil {
 		logger.Error(

--- a/internal/controller/promotions/watches_test.go
+++ b/internal/controller/promotions/watches_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -26,13 +25,12 @@ import (
 
 func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 	tests := []struct {
-		name          string
-		applications  []client.Object
-		indexer       client.IndexerFunc
-		interceptor   interceptor.Funcs
-		shardSelector labels.Selector
-		e             event.TypedUpdateEvent[*argocd.Application]
-		assertions    func(*testing.T, workqueue.TypedRateLimitingInterface[reconcile.Request])
+		name         string
+		applications []client.Object
+		indexer      client.IndexerFunc
+		interceptor  interceptor.Funcs
+		e            event.TypedUpdateEvent[*argocd.Application]
+		assertions   func(*testing.T, workqueue.TypedRateLimitingInterface[reconcile.Request])
 	}{
 		{
 			name: "Event without new object",
@@ -162,64 +160,6 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 			},
 		},
 		{
-			name: "Event object with indexed Promotion and shard selector",
-			applications: []client.Object{
-				&kargoapi.Promotion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "matching-promotion",
-						Namespace: "fake-namespace",
-						Labels: map[string]string{
-							"shard-label": "shard-value",
-						},
-					},
-				},
-				&kargoapi.Promotion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "matching-promotion-without-shard-label",
-						Namespace: "fake-namespace",
-					},
-				},
-				&kargoapi.Promotion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "other-promotion-with-shard-label",
-						Namespace: "fake-namespace",
-						Labels: map[string]string{
-							"shard-label": "other-shard-value",
-						},
-					},
-				},
-			},
-			indexer: func(obj client.Object) []string {
-				if strings.HasPrefix(obj.GetName(), "matching-promotion") {
-					return []string{"fake-application-namespace:fake-application-name"}
-				}
-				return nil
-			},
-			shardSelector: labels.SelectorFromSet(labels.Set{
-				"shard-label": "shard-value",
-			}),
-			e: event.TypedUpdateEvent[*argocd.Application]{
-				ObjectOld: &argocd.Application{},
-				ObjectNew: &argocd.Application{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "fake-application-name",
-						Namespace: "fake-application-namespace",
-					},
-				},
-			},
-			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-				require.Equal(t, 1, wq.Len())
-
-				item, _ := wq.Get()
-				require.Equal(t, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: "fake-namespace",
-						Name:      "matching-promotion",
-					},
-				}, item)
-			},
-		},
-		{
 			name: "Event object has no indexed Promotion",
 			applications: []client.Object{
 				&kargoapi.Promotion{
@@ -293,8 +233,7 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 				WithInterceptorFuncs(tt.interceptor)
 
 			u := &UpdatedArgoCDAppHandler[*argocd.Application]{
-				kargoClient:   c.Build(),
-				shardSelector: tt.shardSelector,
+				kargoClient: c.Build(),
 			}
 
 			wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())

--- a/internal/controller/stages/stages_test.go
+++ b/internal/controller/stages/stages_test.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
-	"github.com/akuity/kargo/internal/controller"
 	rollouts "github.com/akuity/kargo/internal/controller/rollouts/api/v1alpha1"
 	"github.com/akuity/kargo/internal/directives"
 	"github.com/akuity/kargo/internal/indexer"
@@ -34,8 +33,6 @@ func TestNewReconciler(t *testing.T) {
 		RolloutsControllerInstanceID: "fake-instance-id",
 	}
 	kubeClient := fake.NewClientBuilder().Build()
-	requirement, err := controller.GetShardRequirement(testCfg.ShardName)
-	require.NoError(t, err)
 	directivesEngine := &directives.FakeEngine{}
 	recorder := &fakeevent.EventRecorder{Events: nil}
 	r := newReconciler(
@@ -43,7 +40,6 @@ func TestNewReconciler(t *testing.T) {
 		directivesEngine,
 		recorder,
 		testCfg,
-		requirement,
 	)
 	require.Equal(t, testCfg, r.cfg)
 	require.NotNil(t, r.kargoClient)

--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -69,14 +69,7 @@ type reconciler struct {
 func SetupReconcilerWithManager(
 	mgr manager.Manager,
 	credentialsDB credentials.Database,
-	shardName string,
 ) error {
-
-	shardPredicate, err := controller.GetShardPredicate(shardName)
-	if err != nil {
-		return fmt.Errorf("error creating shard selector predicate: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&kargoapi.Warehouse{}).
 		WithEventFilter(
@@ -93,7 +86,6 @@ func SetupReconcilerWithManager(
 				kargo.RefreshRequested{},
 			),
 		).
-		WithEventFilter(shardPredicate).
 		WithOptions(controller.CommonOptions()).
 		Complete(newReconciler(mgr.GetClient(), credentialsDB)); err != nil {
 		return fmt.Errorf("error building Warehouse reconciler: %w", err)


### PR DESCRIPTION
Move shard-based resource filtering from individual controllers (Promotions, Stages, Warehouses) to the controller-manager cache configuration. This simplifies the controllers by removing duplicated shard filtering logic while maintaining the same behavior at the cache level.

This should forever help prevent issues like #2791.