### PR TITLE
fix: sharded Warehouse cross-controller access

### DIFF
--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -69,7 +69,13 @@ type reconciler struct {
 func SetupReconcilerWithManager(
 	mgr manager.Manager,
 	credentialsDB credentials.Database,
+	shardName string,
 ) error {
+	shardPredicate, err := controller.GetShardPredicate(shardName)
+	if err != nil {
+		return fmt.Errorf("error creating shard selector predicate: %w", err)
+	}
+
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&kargoapi.Warehouse{}).
 		WithEventFilter(
@@ -86,6 +92,7 @@ func SetupReconcilerWithManager(
 				kargo.RefreshRequested{},
 			),
 		).
+		WithEventFilter(shardPredicate).
 		WithOptions(controller.CommonOptions()).
 		Complete(newReconciler(mgr.GetClient(), credentialsDB)); err != nil {
 		return fmt.Errorf("error building Warehouse reconciler: %w", err)


### PR DESCRIPTION
Allow Warehouse resources to be accessible by all controllers in a sharded setup, while still being handled by one controller at a time.

**Note:** This assumes that only other controller instances desire to access Warehouses. If there is another case of sharding where other kinds are expected to be handled by shard X but able to be "seen" by shard Z, this will still not work.