### PR TITLE
fix(docs): fix targetRevision & path in quickstart guide

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -245,8 +245,8 @@ spec:
       project: default
       source:
         repoURL: ${GITOPS_REPO_URL}
-        targetRevision: stage/{{stage}}
-        path: .
+        targetRevision: HEAD
+        path: stages/{{stage}}
       destination:
         server: https://kubernetes.default.svc
         namespace: kargo-demo-{{stage}}


### PR DESCRIPTION
Currently, kargo-demo repo has only main branch -> change targetRevision to HEAD and path to stage