### PR TITLE
fix(docs): kustomize build folder of uat & prod

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -401,7 +401,7 @@ the previous section.
               - image: public.ecr.aws/nginx/nginx
           - uses: kustomize-build
             config:
-              path: ./src/stages/test
+              path: ./src/stages/uat
               outPath: ./out/manifests.yaml
           - uses: git-commit
             as: commit
@@ -457,7 +457,7 @@ the previous section.
               - image: public.ecr.aws/nginx/nginx
           - uses: kustomize-build
             config:
-              path: ./src/stages/test
+              path: ./src/stages/prod
               outPath: ./out/manifests.yaml
           - uses: git-commit
             as: commit
@@ -645,7 +645,7 @@ the previous section.
               - image: public.ecr.aws/nginx/nginx
           - uses: kustomize-build
             config:
-              path: ./src/stages/test
+              path: ./src/stages/uat
               outPath: ./out/manifests.yaml
           - uses: git-commit
             as: commit
@@ -701,7 +701,7 @@ the previous section.
               - image: public.ecr.aws/nginx/nginx
           - uses: kustomize-build
             config:
-              path: ./src/stages/test
+              path: ./src/stages/prod
               outPath: ./out/manifests.yaml
           - uses: git-commit
             as: commit


### PR DESCRIPTION
Currently, when make a promotion from test to uat or uat to prod, the kustomize still build the manifest of test stage, it makes the application cannot start because of the same nodePort, and the html content is not correct