### PR TITLE
fix: Clicking multiple times on same freight not working

### DIFF
--- a/ui/src/features/freight-timeline/freight-content-item.tsx
+++ b/ui/src/features/freight-timeline/freight-content-item.tsx
@@ -16,33 +16,35 @@ export const FreightContentItem = (props: {
   highlighted: boolean;
   linkClass: string;
 }) => {
-  const { horizontal, dark, highlighted, overlay, title, icon, href, children, linkClass} = props
-  return <Tooltip
-    className={classNames('min-w-0 flex items-center justify-center my-1 rounded', {
-      'flex-col p-1 w-full': !horizontal,
-      'mr-2 p-2 max-w-60 flex-shrink': horizontal,
-      'bg-black text-white': dark,
-      'bg-white': !dark && highlighted && !horizontal,
-      'border border-solid border-gray-200': !dark && !highlighted && !horizontal,
-      'bg-gray-200': !dark && horizontal
-    })}
-    overlay={overlay}
-    title={title}
-  >
-    <FontAwesomeIcon
-      icon={icon}
-      style={{ fontSize: '14px' }}
-      className={classNames('px-1', {
-        'mb-2': !horizontal,
-        'mr-2': horizontal
+  const { horizontal, dark, highlighted, overlay, title, icon, href, children, linkClass } = props;
+  return (
+    <Tooltip
+      className={classNames('min-w-0 flex items-center justify-center my-1 rounded', {
+        'flex-col p-1 w-full': !horizontal,
+        'mr-2 p-2 max-w-60 flex-shrink': horizontal,
+        'bg-black text-white': dark,
+        'bg-white': !dark && highlighted && !horizontal,
+        'border border-solid border-gray-200': !dark && !highlighted && !horizontal,
+        'bg-gray-200': !dark && horizontal
       })}
-    />
-    {href ? (
-      <a target='_blank' className={linkClass}>
+      overlay={overlay}
+      title={title}
+    >
+      <FontAwesomeIcon
+        icon={icon}
+        style={{ fontSize: '14px' }}
+        className={classNames('px-1', {
+          'mb-2': !horizontal,
+          'mr-2': horizontal
+        })}
+      />
+      {href ? (
+        <a target='_blank' className={linkClass}>
+          <TruncateMiddle>{children || ''}</TruncateMiddle>
+        </a>
+      ) : (
         <TruncateMiddle>{children || ''}</TruncateMiddle>
-      </a>
-    ) : (
-      <TruncateMiddle>{children || ''}</TruncateMiddle>
-    )}
-  </Tooltip>
+      )}
+    </Tooltip>
+  );
 };

--- a/ui/src/features/freight-timeline/freight-content-item.tsx
+++ b/ui/src/features/freight-timeline/freight-content-item.tsx
@@ -1,0 +1,48 @@
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Tooltip } from 'antd';
+import classNames from 'classnames';
+
+import { TruncateMiddle } from '../common/truncate-middle';
+
+export const FreightContentItem = (props: {
+  icon: IconDefinition;
+  overlay?: React.ReactNode;
+  title?: string;
+  href?: string;
+  children?: string;
+  horizontal?: boolean;
+  dark?: boolean;
+  highlighted: boolean;
+  linkClass: string;
+}) => {
+  const { horizontal, dark, highlighted, overlay, title, icon, href, children, linkClass} = props
+  return <Tooltip
+    className={classNames('min-w-0 flex items-center justify-center my-1 rounded', {
+      'flex-col p-1 w-full': !horizontal,
+      'mr-2 p-2 max-w-60 flex-shrink': horizontal,
+      'bg-black text-white': dark,
+      'bg-white': !dark && highlighted && !horizontal,
+      'border border-solid border-gray-200': !dark && !highlighted && !horizontal,
+      'bg-gray-200': !dark && horizontal
+    })}
+    overlay={overlay}
+    title={title}
+  >
+    <FontAwesomeIcon
+      icon={icon}
+      style={{ fontSize: '14px' }}
+      className={classNames('px-1', {
+        'mb-2': !horizontal,
+        'mr-2': horizontal
+      })}
+    />
+    {href ? (
+      <a target='_blank' className={linkClass}>
+        <TruncateMiddle>{children || ''}</TruncateMiddle>
+      </a>
+    ) : (
+      <TruncateMiddle>{children || ''}</TruncateMiddle>
+    )}
+  </Tooltip>
+};

--- a/ui/src/features/freight-timeline/freight-contents.tsx
+++ b/ui/src/features/freight-timeline/freight-contents.tsx
@@ -6,6 +6,7 @@ import { Freight } from '@ui/gen/v1alpha1/generated_pb';
 import { urlForImage } from '@ui/utils/url';
 
 import { CommitInfo } from '../common/commit-info';
+
 import { FreightContentItem } from './freight-content-item';
 
 export const FreightContents = (props: {

--- a/ui/src/features/freight-timeline/freight-contents.tsx
+++ b/ui/src/features/freight-timeline/freight-contents.tsx
@@ -1,14 +1,12 @@
 import { faDocker, faGitAlt } from '@fortawesome/free-brands-svg-icons';
-import { IconDefinition, faAnchor } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Tooltip } from 'antd';
+import { faAnchor } from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 
 import { Freight } from '@ui/gen/v1alpha1/generated_pb';
 import { urlForImage } from '@ui/utils/url';
 
 import { CommitInfo } from '../common/commit-info';
-import { TruncateMiddle } from '../common/truncate-middle';
+import { FreightContentItem } from './freight-content-item';
 
 export const FreightContents = (props: {
   freight?: Freight;
@@ -18,43 +16,6 @@ export const FreightContents = (props: {
 }) => {
   const { freight, highlighted, horizontal, dark } = props;
   const linkClass = `${highlighted ? 'text-blue-500' : 'text-gray-400'} hover:text-blue-400 hover:underline max-w-full min-w-0 flex-shrink`;
-
-  const FreightContentItem = (props: {
-    icon: IconDefinition;
-    overlay?: React.ReactNode;
-    title?: string;
-    href?: string;
-    children?: string;
-  }) => (
-    <Tooltip
-      className={classNames('min-w-0 flex items-center justify-center my-1 rounded', {
-        'flex-col p-1 w-full': !horizontal,
-        'mr-2 p-2 max-w-60 flex-shrink': horizontal,
-        'bg-black text-white': dark,
-        'bg-white': !dark && highlighted && !horizontal,
-        'border border-solid border-gray-200': !dark && !highlighted && !horizontal,
-        'bg-gray-200': !dark && horizontal
-      })}
-      overlay={props.overlay}
-      title={props.title}
-    >
-      <FontAwesomeIcon
-        icon={props.icon}
-        style={{ fontSize: '14px' }}
-        className={classNames('px-1', {
-          'mb-2': !horizontal,
-          'mr-2': horizontal
-        })}
-      />
-      {props.href ? (
-        <a target='_blank' className={linkClass}>
-          <TruncateMiddle>{props.children || ''}</TruncateMiddle>
-        </a>
-      ) : (
-        <TruncateMiddle>{props.children || ''}</TruncateMiddle>
-      )}
-    </Tooltip>
-  );
 
   return (
     <div
@@ -69,6 +30,10 @@ export const FreightContents = (props: {
     >
       {(freight?.commits || []).map((c) => (
         <FreightContentItem
+          dark={dark}
+          horizontal={horizontal}
+          linkClass={linkClass}
+          highlighted={highlighted}
           key={c.id}
           overlay={<CommitInfo commit={c} />}
           icon={faGitAlt}
@@ -81,6 +46,10 @@ export const FreightContents = (props: {
       ))}
       {(freight?.images || []).map((i) => (
         <FreightContentItem
+          dark={dark}
+          horizontal={horizontal}
+          linkClass={linkClass}
+          highlighted={highlighted}
           key={`${i.repoURL}:${i.tag}`}
           title={`${i.repoURL}:${i.tag}`}
           icon={faDocker}
@@ -91,6 +60,10 @@ export const FreightContents = (props: {
       ))}
       {(freight?.charts || []).map((c) => (
         <FreightContentItem
+          dark={dark}
+          horizontal={horizontal}
+          linkClass={linkClass}
+          highlighted={highlighted}
           key={`${c.repoURL}:${c.version}`}
           title={`${c.repoURL}:${c.version}`}
           icon={faAnchor}


### PR DESCRIPTION
Fix: Clicking multiple times on same freight not working

Having components defined inside another components is not the best practice especially without useMemo or something similar since it is quite easy to trigger a lot of re-renders.

In this instance it was triggering loop somehow (not sure 100% what it was causing, my tip is that tooltip) which ends up in:
<img width="1507" alt="Screenshot 2024-10-25 at 21 12 56" src="https://github.com/user-attachments/assets/1549e16a-fdc4-4fb5-81fd-1501a2d9aa46">

Since there is no really good reason to have it (FreightContentItem) defined inside another component I extracted it as separate component which fixes the issue.

You can replicate the issue by clicking on highlighted area multiple times:
<img width="637" alt="Screenshot 2024-10-25 at 21 45 25" src="https://github.com/user-attachments/assets/517d2d01-8ab1-4dc0-8c9a-0c3940c765e9">

Note that after first click it will open details of Freight, after second click it will close it and on third click it will do nothing (it should open details again but it does not)... This happens only if you keep mouse in highlighted area. If you go up and down (git / docker) then it kind of works....


With this commit you can click as many times you want on the same spot and it will keep opening and closing those details without hitting:
```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```

