### PR TITLE
refactor(controller): use promotion name when generating branch names

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -477,6 +477,7 @@ func (r *reconciler) promote(
 		WorkDir:         filepath.Join(os.TempDir(), "promotion-"+string(workingPromo.UID)),
 		Project:         stageNamespace,
 		Stage:           stageName,
+		Promotion:       workingPromo.Name,
 		FreightRequests: stage.Spec.RequestedFreight,
 		Freight:         *workingPromo.Status.FreightCollection.DeepCopy(),
 		StartFromStep:   promo.Status.CurrentStep,

--- a/internal/directives/git_pusher.go
+++ b/internal/directives/git_pusher.go
@@ -109,7 +109,7 @@ func (g *gitPushPusher) runPromotionStep(
 	}
 	// If we're supposed to generate a target branch name, do so
 	if cfg.GenerateTargetBranch {
-		pushOpts.TargetBranch = fmt.Sprintf("kargo/%s/%s/promotion", stepCtx.Project, stepCtx.Stage)
+		pushOpts.TargetBranch = fmt.Sprintf("kargo/promotion/%s", stepCtx.Promotion)
 		pushOpts.Force = true
 	}
 	targetBranch := pushOpts.TargetBranch

--- a/internal/directives/git_pusher_test.go
+++ b/internal/directives/git_pusher_test.go
@@ -190,6 +190,7 @@ func Test_gitPusher_runPromotionStep(t *testing.T) {
 		&PromotionStepContext{
 			Project:       "fake-project",
 			Stage:         "fake-stage",
+			Promotion:     "fake-promotion",
 			WorkDir:       workDir,
 			CredentialsDB: &credentials.FakeDB{},
 		},
@@ -201,7 +202,7 @@ func Test_gitPusher_runPromotionStep(t *testing.T) {
 	require.NoError(t, err)
 	branchName, ok := res.Output[branchKey]
 	require.True(t, ok)
-	require.Equal(t, "kargo/fake-project/fake-stage/promotion", branchName)
+	require.Equal(t, "kargo/promotion/fake-promotion", branchName)
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[commitKey]

--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -34,6 +34,8 @@ type PromotionContext struct {
 	Project string
 	// Stage is the Stage that the Promotion is targeting.
 	Stage string
+	// Promotion is the name of the Promotion.
+	Promotion string
 	// FreightRequests is the list of Freight from various origins that is
 	// requested by the Stage targeted by the Promotion. This information is
 	// sometimes useful to PromotionSteps that reference a particular artifact
@@ -114,6 +116,8 @@ type PromotionStepContext struct {
 	Project string
 	// Stage is the Stage that the Promotion is targeting.
 	Stage string
+	// Promotion is the name of the Promotion.
+	Promotion string
 	// FreightRequests is the list of Freight from various origins that is
 	// requested by the Stage targeted by the Promotion. This information is
 	// sometimes useful to PromotionStep that reference a particular artifact and,

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -95,6 +95,7 @@ func (e *SimpleEngine) Promote(
 			Config:          step.Config.DeepCopy(),
 			Project:         promoCtx.Project,
 			Stage:           promoCtx.Stage,
+			Promotion:       promoCtx.Promotion,
 			FreightRequests: promoCtx.FreightRequests,
 			Freight:         promoCtx.Freight,
 		}


### PR DESCRIPTION
Part of #2845

This change creates a more obvious relationship between a Promotion and any PR it may create. This also reduces the likelihood of a Promotion attempting to create a new Promotion-specific branch and finding that branch already exists (having been created by a previous Promotion).