### PR TITLE
feat(controller)!: assign a default alias to promotion steps that have none

### DIFF
--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"regexp"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -34,10 +32,6 @@ const (
 	// user.
 	PromotionPhaseAborted PromotionPhase = "Aborted"
 )
-
-// ReservedStepAliasRegex is a regular expression that matches step aliases that
-// are reserved for internal use.
-var ReservedStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 // IsTerminal returns true if the PromotionPhase is a terminal one.
 func (p *PromotionPhase) IsTerminal() bool {

--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"regexp"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -32,6 +34,10 @@ const (
 	// user.
 	PromotionPhaseAborted PromotionPhase = "Aborted"
 )
+
+// ReservedStepAliasRegex is a regular expression that matches step aliases that
+// are reserved for internal use.
+var ReservedStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 // IsTerminal returns true if the PromotionPhase is a terminal one.
 func (p *PromotionPhase) IsTerminal() bool {

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -12,6 +14,8 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 )
+
+var forbiddenStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 // SimpleEngine is a simple engine that executes a list of PromotionSteps in
 // sequence.
@@ -87,6 +91,20 @@ func (e *SimpleEngine) Promote(
 
 		stateCopy := state.DeepCopy()
 
+		step.Alias = strings.TrimSpace(step.Alias)
+		if step.Alias == "" {
+			step.Alias = fmt.Sprintf("step-%d", i)
+		} else if forbiddenStepAliasRegex.MatchString(step.Alias) {
+			// A webhook enforces this regex as well, but we're checking here to
+			// account for the possibility of EXISTING Stages with a promotionTemplate
+			// containing a step with a now-reserved alias.
+			return PromotionResult{
+				Status:      kargoapi.PromotionPhaseErrored,
+				CurrentStep: i,
+				State:       state,
+			}, fmt.Errorf("step alias %q is forbidden", step.Alias)
+		}
+
 		stepCtx := &PromotionStepContext{
 			UIBaseURL:       promoCtx.UIBaseURL,
 			WorkDir:         workDir,
@@ -110,9 +128,7 @@ func (e *SimpleEngine) Promote(
 		}
 
 		result, err := reg.Runner.RunPromotionStep(ctx, stepCtx)
-		if step.Alias != "" {
-			state[step.Alias] = result.Output
-		}
+		state[step.Alias] = result.Output
 		if err != nil {
 			return PromotionResult{
 					Status:      kargoapi.PromotionPhaseErrored,

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -13,6 +14,10 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 )
+
+// ReservedStepAliasRegex is a regular expression that matches step aliases that
+// are reserved for internal use.
+var ReservedStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 // SimpleEngine is a simple engine that executes a list of PromotionSteps in
 // sequence.
@@ -91,7 +96,7 @@ func (e *SimpleEngine) Promote(
 		step.Alias = strings.TrimSpace(step.Alias)
 		if step.Alias == "" {
 			step.Alias = fmt.Sprintf("step-%d", i)
-		} else if kargoapi.ReservedStepAliasRegex.MatchString(step.Alias) {
+		} else if ReservedStepAliasRegex.MatchString(step.Alias) {
 			// A webhook enforces this regex as well, but we're checking here to
 			// account for the possibility of EXISTING Stages with a promotionTemplate
 			// containing a step with a now-reserved alias.

--- a/internal/directives/simple_engine.go
+++ b/internal/directives/simple_engine.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -14,8 +13,6 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/credentials"
 )
-
-var forbiddenStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 // SimpleEngine is a simple engine that executes a list of PromotionSteps in
 // sequence.
@@ -94,7 +91,7 @@ func (e *SimpleEngine) Promote(
 		step.Alias = strings.TrimSpace(step.Alias)
 		if step.Alias == "" {
 			step.Alias = fmt.Sprintf("step-%d", i)
-		} else if forbiddenStepAliasRegex.MatchString(step.Alias) {
+		} else if kargoapi.ReservedStepAliasRegex.MatchString(step.Alias) {
 			// A webhook enforces this regex as well, but we're checking here to
 			// account for the possibility of EXISTING Stages with a promotionTemplate
 			// containing a step with a now-reserved alias.

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -3,6 +3,8 @@ package stage
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +25,8 @@ var (
 		Kind:  "Stage",
 	}
 )
+
+var forbiddenStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 type webhook struct {
 	client  client.Client
@@ -194,7 +198,11 @@ func (w *webhook) validateSpec(
 	if spec == nil { // nil spec is caught by declarative validations
 		return nil
 	}
-	return w.validateRequestedFreight(f.Child("requestedFreight"), spec.RequestedFreight)
+	errs := w.validateRequestedFreight(f.Child("requestedFreight"), spec.RequestedFreight)
+	return append(
+		errs,
+		w.ValidatePromotionTemplate(f.Child("promotionTemplate"), spec.PromotionTemplate)...,
+	)
 }
 
 func (w *webhook) validateRequestedFreight(
@@ -220,4 +228,25 @@ func (w *webhook) validateRequestedFreight(
 		seenOrigins[req.Origin.String()] = struct{}{}
 	}
 	return nil
+}
+
+func (w *webhook) ValidatePromotionTemplate(
+	f *field.Path,
+	promoTemplate *kargoapi.PromotionTemplate,
+) field.ErrorList {
+	if promoTemplate == nil {
+		return nil
+	}
+	errs := field.ErrorList{}
+	for i, step := range promoTemplate.Spec.Steps {
+		stepAlias := strings.TrimSpace(step.As)
+		if forbiddenStepAliasRegex.MatchString(stepAlias) {
+			errs = append(errs, field.Invalid(
+				f.Child("spec", "steps").Index(i).Child("as"),
+				stepAlias,
+				"step alias is reserved",
+			))
+		}
+	}
+	return errs
 }

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/directives"
 	libWebhook "github.com/akuity/kargo/internal/webhook"
 )
 
@@ -237,7 +238,7 @@ func (w *webhook) ValidatePromotionTemplate(
 	errs := field.ErrorList{}
 	for i, step := range promoTemplate.Spec.Steps {
 		stepAlias := strings.TrimSpace(step.As)
-		if kargoapi.ReservedStepAliasRegex.MatchString(stepAlias) {
+		if directives.ReservedStepAliasRegex.MatchString(stepAlias) {
 			errs = append(errs, field.Invalid(
 				f.Child("spec", "steps").Index(i).Child("as"),
 				stepAlias,

--- a/internal/webhook/stage/webhook.go
+++ b/internal/webhook/stage/webhook.go
@@ -3,7 +3,6 @@ package stage
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -25,8 +24,6 @@ var (
 		Kind:  "Stage",
 	}
 )
-
-var forbiddenStepAliasRegex = regexp.MustCompile(`^step-\d+$`)
 
 type webhook struct {
 	client  client.Client
@@ -240,7 +237,7 @@ func (w *webhook) ValidatePromotionTemplate(
 	errs := field.ErrorList{}
 	for i, step := range promoTemplate.Spec.Steps {
 		stepAlias := strings.TrimSpace(step.As)
-		if forbiddenStepAliasRegex.MatchString(stepAlias) {
+		if kargoapi.ReservedStepAliasRegex.MatchString(stepAlias) {
 			errs = append(errs, field.Invalid(
 				f.Child("spec", "steps").Index(i).Child("as"),
 				stepAlias,


### PR DESCRIPTION
Part of #2845 

This PR make the step execution engine assign a default alias to any promotion step that doesn't explicitly have an alias specified.

This makes it such that _all_ steps leave behind outputs in the shared state map where that was only possible before for steps that had explicitly been assigned an alias.

This creates the possibility of modifying some step implementations, in a follow-up, to consult any output they themselves may have produced in a previous execution.

This is braking only insofar as it reserves step aliases of the form `^step-\d+$` for system use.