### PR TITLE
fix(stages): auto-promote Freight from other origins

### DIFF
--- a/internal/controller/stages/stages.go
+++ b/internal/controller/stages/stages.go
@@ -906,7 +906,7 @@ func (r *reconciler) syncNormalStage(
 		}
 		if len(promos.Items) > 0 {
 			logger.Debug("Promotion already exists for Freight")
-			return status, nil
+			continue
 		}
 
 		// Auto-promotion of this Freight is permitted.


### PR DESCRIPTION
Found while refactoring the Stage reconciler, and seems important enough to justify a patch for 1.0.x.