### PR TITLE
fix(controller): fix pr already open issue with git-open-pr step

### DIFF
--- a/internal/controller/git/work_tree.go
+++ b/internal/controller/git/work_tree.go
@@ -262,7 +262,7 @@ func (w *workTree) CurrentBranch() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error checking current branch for repo %q: %w", w.url, err)
 	}
-	return string(res), nil
+	return strings.TrimSpace(string(res)), nil
 }
 
 func (w *workTree) DeleteBranch(branch string) error {

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -485,9 +485,10 @@ func (r *reconciler) promote(
 	}
 	if err := os.Mkdir(promoCtx.WorkDir, 0o700); err == nil {
 		// If we're working with a fresh directory, we should start the promotion
-		// process again from the beginning.
+		// process again from the beginning, but we DON'T clear shared state. This
+		// allows individual steps to self-discover that they've run before and
+		// examine the results of their own previous execution.
 		promoCtx.StartFromStep = 0
-		promoCtx.State = nil
 	} else if !os.IsExist(err) {
 		return nil, fmt.Errorf("error creating working directory: %w", err)
 	}

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -3,7 +3,9 @@ package directives
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/xeipuuv/gojsonschema"
 
@@ -70,7 +72,7 @@ func (g *gitPROpener) runPromotionStep(
 	stepCtx *PromotionStepContext,
 	cfg GitOpenPRConfig,
 ) (PromotionStepResult, error) {
-	sourceBranch, err := getSourceBranch(stepCtx.SharedState, cfg)
+	sourceBranch, err := g.getSourceBranch(stepCtx.SharedState, cfg)
 	if err != nil {
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error determining source branch: %w", err)
@@ -127,20 +129,41 @@ func (g *gitPROpener) runPromotionStep(
 			fmt.Errorf("error creating git provider service: %w", err)
 	}
 
-	// Short-circuit if a pull request already exists with the same head commit
-	mustOpen, err := mustOpenPR(
+	// Short-circuit if shared state has output from a previous execution of this
+	// step that contains a PR number.
+	prNumber, err := g.getPRNumber(stepCtx, stepCtx.SharedState)
+	if err != nil {
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
+			fmt.Errorf("error getting PR number from shared state: %w", err)
+	}
+	if prNumber != 0 {
+		return PromotionStepResult{
+			Status: kargoapi.PromotionPhaseSucceeded,
+			Output: map[string]any{
+				prNumberKey: prNumber,
+			},
+		}, nil
+	}
+
+	// Short-circuit if the exact pull request we're about to open already somehow
+	// exists. (It doesn't matter if it's open or closed.)
+	pr, err := g.getExistingPR(
 		ctx,
 		repo,
 		gitProviderSvc,
-		sourceBranch,
 		cfg.TargetBranch,
 	)
 	if err != nil {
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
-			fmt.Errorf("error determining if pull request must be opened: %w", err)
+			fmt.Errorf("error determining if pull request already exists: %w", err)
 	}
-	if !mustOpen {
-		return PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, nil
+	if pr != nil {
+		return PromotionStepResult{
+			Status: kargoapi.PromotionPhaseSucceeded,
+			Output: map[string]any{
+				prNumberKey: pr.Number,
+			},
+		}, nil
 	}
 
 	// Get the title from the commit message of the head of the source branch
@@ -154,7 +177,7 @@ func (g *gitPROpener) runPromotionStep(
 		)
 	}
 
-	if err = ensureRemoteTargetBranch(
+	if err = g.ensureRemoteTargetBranch(
 		repo,
 		cfg.TargetBranch,
 		cfg.CreateTargetBranch,
@@ -177,7 +200,7 @@ func (g *gitPROpener) runPromotionStep(
 		)
 	}
 
-	pr, err := gitProviderSvc.CreatePullRequest(
+	if pr, err = gitProviderSvc.CreatePullRequest(
 		ctx,
 		gitprovider.CreatePullRequestOpts{
 			Head:        sourceBranch,
@@ -185,8 +208,7 @@ func (g *gitPROpener) runPromotionStep(
 			Title:       title,
 			Description: description,
 		},
-	)
-	if err != nil {
+	); err != nil {
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error creating pull request: %w", err)
 	}
@@ -198,7 +220,49 @@ func (g *gitPROpener) runPromotionStep(
 	}, nil
 }
 
-func getSourceBranch(sharedState State, cfg GitOpenPRConfig) (string, error) {
+// getPRNumber checks shared state for output from a previous execution of this
+// step. If any is found and it contains a PR number, that number is returned.
+// 0 is returned if no PR number is found in the shared state. An error is
+// returned if the PR number is found but is neither an int64 nor a float64.
+func (g *gitPROpener) getPRNumber(
+	stepCtx *PromotionStepContext,
+	sharedState State,
+) (int64, error) {
+	stepOutput, exists := sharedState.Get(stepCtx.Alias)
+	if !exists {
+		return 0, nil
+	}
+	stepOutputMap, ok := stepOutput.(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf(
+			"output from step with alias %q is not a map[string]any",
+			stepCtx.Alias,
+		)
+	}
+	prNumberAny, exists := stepOutputMap[prNumberKey]
+	if !exists {
+		return 0, nil
+	}
+	// If the state was rehydrated from PromotionStatus, which makes use of
+	// apiextensions.JSON, the PR number will be a float64. Otherwise, it will be
+	// an int64. We need to handle both cases.
+	switch prNumber := prNumberAny.(type) {
+	case int64:
+		return prNumber, nil
+	case float64:
+		return int64(prNumber), nil
+	default:
+		return 0, fmt.Errorf(
+			"PR number in output from step with alias %q is not an int64",
+			stepCtx.Alias,
+		)
+	}
+}
+
+func (g *gitPROpener) getSourceBranch(
+	sharedState State,
+	cfg GitOpenPRConfig,
+) (string, error) {
 	sourceBranch := cfg.SourceBranch
 	if cfg.SourceBranchFromStep != "" {
 		stepOutput, exists := sharedState.Get(cfg.SourceBranchFromStep)
@@ -235,7 +299,10 @@ func getSourceBranch(sharedState State, cfg GitOpenPRConfig) (string, error) {
 // ensureRemoteTargetBranch ensures the existence of a remote branch. If the
 // branch does not exist, an empty orphaned branch is created and pushed to the
 // remote.
-func ensureRemoteTargetBranch(repo git.Repo, branch string, create bool) error {
+func (g *gitPROpener) ensureRemoteTargetBranch(
+	repo git.Repo,
+	branch string, create bool,
+) error {
 	exists, err := repo.RemoteBranchExists(branch)
 	if err != nil {
 		return fmt.Errorf(
@@ -275,20 +342,22 @@ func ensureRemoteTargetBranch(repo git.Repo, branch string, create bool) error {
 	return nil
 }
 
-// mustOpenPR determines if a pull request must be opened. It returns true if no
-// PR exists for the head commit of the source branch to the target branch.
-// Whether the PR is open or closed is irrelevant as we must NOT create a new PR
-// if one already exists for the same head commit and has already been closed.
-func mustOpenPR(
+// getExistingPR searches for an existing pull request from the head of the
+// repo's current branch to the target branch. If a PR is found, it is returned.
+// If no PR is found, nil is returned.
+func (g *gitPROpener) getExistingPR(
 	ctx context.Context,
 	repo git.Repo,
 	gitProviderSvc gitprovider.GitProviderService,
-	sourceBranch,
 	targetBranch string,
-) (bool, error) {
+) (*gitprovider.PullRequest, error) {
 	commitID, err := repo.LastCommitID()
 	if err != nil {
-		return false, fmt.Errorf("error getting last commit ID: %w", err)
+		return nil, fmt.Errorf("error getting last commit ID: %w", err)
+	}
+	sourceBranch, err := repo.CurrentBranch()
+	if err != nil {
+		return nil, fmt.Errorf("error getting current branch: %w", err)
 	}
 	prs, err := gitProviderSvc.ListPullRequests(
 		ctx,
@@ -298,15 +367,38 @@ func mustOpenPR(
 		},
 	)
 	if err != nil {
-		return false, fmt.Errorf("error listing pull requests: %w", err)
+		return nil, fmt.Errorf("error listing pull requests: %w", err)
 	}
 	if len(prs) == 0 {
-		return true, nil
+		return nil, nil
 	}
+	// If promotion names are incorporated into PR source branches, it's highly
+	// unlikely that we would have found more than one PR matching the search
+	// criteria. Accounting for the possibility of users specifying their own
+	// source branch names using an expression, there is somewhat more of a
+	// possibility of multiple PRs being found. We sort descending by creation
+	// time before narrowing the list down to the PR with the correct head SHA.
+	// Multiple PRs with the same head SHA may be possible with some providers if
+	// a PR was closed and one exactly like it was then opened (instead of
+	// re-opening the original). Others may not allow this.
+	//
+	// In summary: We're looking for the most recent of any PRs that exactly match
+	// the PR we might otherwise open.
+	slices.SortFunc(prs, func(lhs, rhs *gitprovider.PullRequest) int {
+		var ltime time.Time
+		if lhs.CreatedAt != nil {
+			ltime = *lhs.CreatedAt
+		}
+		var rtime time.Time
+		if rhs.CreatedAt != nil {
+			rtime = *rhs.CreatedAt
+		}
+		return rtime.Compare(ltime)
+	})
 	for _, pr := range prs {
 		if pr.HeadSHA == commitID {
-			return false, nil
+			return pr, nil
 		}
 	}
-	return true, nil
+	return nil, nil
 }

--- a/internal/directives/git_pr_opener.go
+++ b/internal/directives/git_pr_opener.go
@@ -136,7 +136,7 @@ func (g *gitPROpener) runPromotionStep(
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
 			fmt.Errorf("error getting PR number from shared state: %w", err)
 	}
-	if prNumber != 0 {
+	if prNumber != -1 {
 		return PromotionStepResult{
 			Status: kargoapi.PromotionPhaseSucceeded,
 			Output: map[string]any{
@@ -230,18 +230,18 @@ func (g *gitPROpener) getPRNumber(
 ) (int64, error) {
 	stepOutput, exists := sharedState.Get(stepCtx.Alias)
 	if !exists {
-		return 0, nil
+		return -1, nil
 	}
 	stepOutputMap, ok := stepOutput.(map[string]any)
 	if !ok {
-		return 0, fmt.Errorf(
+		return -1, fmt.Errorf(
 			"output from step with alias %q is not a map[string]any",
 			stepCtx.Alias,
 		)
 	}
 	prNumberAny, exists := stepOutputMap[prNumberKey]
 	if !exists {
-		return 0, nil
+		return -1, nil
 	}
 	// If the state was rehydrated from PromotionStatus, which makes use of
 	// apiextensions.JSON, the PR number will be a float64. Otherwise, it will be
@@ -252,7 +252,7 @@ func (g *gitPROpener) getPRNumber(
 	case float64:
 		return int64(prNumber), nil
 	default:
-		return 0, fmt.Errorf(
+		return -1, fmt.Errorf(
 			"PR number in output from step with alias %q is not an int64",
 			stepCtx.Alias,
 		)

--- a/internal/directives/git_pr_opener_test.go
+++ b/internal/directives/git_pr_opener_test.go
@@ -158,25 +158,25 @@ func Test_gitPROpener_runPromotionStep(t *testing.T) {
 	// Set up a fake git provider
 	const fakeGitProviderName = "fake"
 	const testPRNumber int64 = 42
-	gitprovider.RegisterProvider(
+	gitprovider.Register(
 		fakeGitProviderName,
-		gitprovider.ProviderRegistration{
-			NewService: func(
+		gitprovider.Registration{
+			NewProvider: func(
 				string,
-				*gitprovider.GitProviderOptions,
-			) (gitprovider.GitProviderService, error) {
-				return &gitprovider.FakeGitProviderService{
+				*gitprovider.Options,
+			) (gitprovider.Interface, error) {
+				return &gitprovider.Fake{
 					ListPullRequestsFn: func(
 						context.Context,
-						gitprovider.ListPullRequestOpts,
-					) ([]*gitprovider.PullRequest, error) {
+						*gitprovider.ListPullRequestOptions,
+					) ([]gitprovider.PullRequest, error) {
 						// Avoid opening of a PR being short-circuited by simulating
 						// conditions where the PR in question doesn't already exist.
 						return nil, nil
 					},
 					CreatePullRequestFn: func(
 						context.Context,
-						gitprovider.CreatePullRequestOpts,
+						*gitprovider.CreatePullRequestOpts,
 					) (*gitprovider.PullRequest, error) {
 						return &gitprovider.PullRequest{Number: testPRNumber}, nil
 					},

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -64,10 +64,10 @@ func (g *gitPRWaiter) runPromotionStep(
 	stepCtx *PromotionStepContext,
 	cfg GitWaitForPRConfig,
 ) (PromotionStepResult, error) {
-	prNumber, err := getPRNumber(stepCtx.SharedState, cfg)
+	prNumber, err := g.getPRNumber(stepCtx.SharedState, cfg)
 	if err != nil {
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
-			fmt.Errorf("error getting PR number: %w", err)
+			fmt.Errorf("error getting PR number from shared state: %w", err)
 	}
 
 	var repoCreds *git.RepoCredentials
@@ -133,7 +133,14 @@ func (g *gitPRWaiter) runPromotionStep(
 	}, nil
 }
 
-func getPRNumber(sharedState State, cfg GitWaitForPRConfig) (int64, error) {
+// getPRNumber checks shared state for output from a previous step and returns
+// any PR number from that output. If no such output is found, the output
+// contains no PR number, or the PR number is not an int64 or float64, then an
+// error is returned.
+func (g *gitPRWaiter) getPRNumber(
+	sharedState State,
+	cfg GitWaitForPRConfig,
+) (int64, error) {
 	if cfg.PRNumberFromStep == "" {
 		return cfg.PRNumber, nil
 	}

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -100,12 +100,12 @@ func Test_gitPRWaiter_validate(t *testing.T) {
 func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 	testCases := []struct {
 		name       string
-		provider   gitprovider.GitProviderService
+		provider   gitprovider.Interface
 		assertions func(*testing.T, PromotionStepResult, error)
 	}{
 		{
 			name: "error finding PR",
-			provider: &gitprovider.FakeGitProviderService{
+			provider: &gitprovider.Fake{
 				GetPullRequestFn: func(
 					context.Context,
 					int64,
@@ -121,13 +121,13 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 		},
 		{
 			name: "PR is open",
-			provider: &gitprovider.FakeGitProviderService{
+			provider: &gitprovider.Fake{
 				GetPullRequestFn: func(
 					context.Context,
 					int64,
 				) (*gitprovider.PullRequest, error) {
 					return &gitprovider.PullRequest{
-						State: gitprovider.PullRequestStateOpen,
+						Open: true,
 					}, nil
 				},
 			},
@@ -137,40 +137,16 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			},
 		},
 		{
-			name: "error checking if PR was merged",
-			provider: &gitprovider.FakeGitProviderService{
-				GetPullRequestFn: func(
-					context.Context,
-					int64,
-				) (*gitprovider.PullRequest, error) {
-					return &gitprovider.PullRequest{
-						State: gitprovider.PullRequestStateClosed,
-					}, nil
-				},
-				IsPullRequestMergedFn: func(context.Context, int64) (bool, error) {
-					return false, errors.New("something went wrong")
-				},
-			},
-			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.ErrorContains(t, err, "error checking if pull request")
-				require.ErrorContains(t, err, "was merged")
-				require.ErrorContains(t, err, "something went wrong")
-				require.Equal(t, kargoapi.PromotionPhaseErrored, res.Status)
-			},
-		},
-		{
 			name: "PR is closed and not merged",
-			provider: &gitprovider.FakeGitProviderService{
+			provider: &gitprovider.Fake{
 				GetPullRequestFn: func(
 					context.Context,
 					int64,
 				) (*gitprovider.PullRequest, error) {
 					return &gitprovider.PullRequest{
-						State: gitprovider.PullRequestStateClosed,
+						Open:   false,
+						Merged: false,
 					}, nil
-				},
-				IsPullRequestMergedFn: func(context.Context, int64) (bool, error) {
-					return false, nil
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
@@ -181,17 +157,15 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 		},
 		{
 			name: "PR is closed and merged",
-			provider: &gitprovider.FakeGitProviderService{
+			provider: &gitprovider.Fake{
 				GetPullRequestFn: func(
 					context.Context,
 					int64,
 				) (*gitprovider.PullRequest, error) {
 					return &gitprovider.PullRequest{
-						State: gitprovider.PullRequestStateClosed,
+						Open:   false,
+						Merged: true,
 					}, nil
-				},
-				IsPullRequestMergedFn: func(context.Context, int64) (bool, error) {
-					return true, nil
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
@@ -211,13 +185,13 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 			// care of that problem
 			testGitProviderName := uuid.NewString()
 
-			gitprovider.RegisterProvider(
+			gitprovider.Register(
 				testGitProviderName,
-				gitprovider.ProviderRegistration{
-					NewService: func(
+				gitprovider.Registration{
+					NewProvider: func(
 						string,
-						*gitprovider.GitProviderOptions,
-					) (gitprovider.GitProviderService, error) {
+						*gitprovider.Options,
+					) (gitprovider.Interface, error) {
 						return testCase.provider, nil
 					},
 				},

--- a/internal/gitprovider/github/github.go
+++ b/internal/gitprovider/github/github.go
@@ -152,7 +152,7 @@ func convertGithubPR(ghPR *github.PullRequest) *gitprovider.PullRequest {
 	case "closed":
 		prState = gitprovider.PullRequestStateClosed
 	}
-	return &gitprovider.PullRequest{
+	pr := &gitprovider.PullRequest{
 		Number:         int64(ptr.Deref(ghPR.Number, 0)),
 		URL:            ptr.Deref(ghPR.HTMLURL, ""),
 		State:          prState,
@@ -160,6 +160,10 @@ func convertGithubPR(ghPR *github.PullRequest) *gitprovider.PullRequest {
 		Object:         ghPR,
 		HeadSHA:        ptr.Deref(ghPR.Head.SHA, ""),
 	}
+	if ghPR.CreatedAt != nil {
+		pr.CreatedAt = &ghPR.CreatedAt.Time
+	}
+	return pr
 }
 
 func parseGitHubURL(repoURL string) (string, string, string, error) {

--- a/internal/gitprovider/github/github_test.go
+++ b/internal/gitprovider/github/github_test.go
@@ -45,7 +45,7 @@ func TestParseGitHubURL(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {
-			host, owner, repo, err := parseGitHubURL(testCase.url)
+			host, owner, repo, err := parseRepoURL(testCase.url)
 			if testCase.errExpected {
 				require.Error(t, err)
 			} else {

--- a/internal/gitprovider/gitlab/gitlab.go
+++ b/internal/gitprovider/gitlab/gitlab.go
@@ -185,6 +185,7 @@ func convertGitlabMR(glMR *gitlab.MergeRequest) *gitprovider.PullRequest {
 		MergeCommitSHA: glMR.MergeCommitSHA,
 		Object:         glMR,
 		HeadSHA:        glMR.SHA,
+		CreatedAt:      glMR.CreatedAt,
 	}
 }
 

--- a/internal/gitprovider/gitlab/gitlab.go
+++ b/internal/gitprovider/gitlab/gitlab.go
@@ -14,34 +14,30 @@ import (
 	"github.com/akuity/kargo/internal/gitprovider"
 )
 
-const (
-	GitProviderServiceName = "gitlab"
-)
+const ProviderName = "gitlab"
 
-var (
-	registration = gitprovider.ProviderRegistration{
-		Predicate: func(repoURL string) bool {
-			u, err := url.Parse(repoURL)
-			if err != nil {
-				return false
-			}
-			// We assume that any hostname with the word "gitlab" in the hostname,
-			// can use this provider. NOTE: we will miss cases where the host is
-			// Gitlab but doesn't incorporate the word "gitlab" in the hostname.
-			// e.g. 'git.mycompany.com'
-			return strings.Contains(u.Host, GitProviderServiceName)
-		},
-		NewService: func(
-			repoURL string,
-			opts *gitprovider.GitProviderOptions,
-		) (gitprovider.GitProviderService, error) {
-			return NewGitLabProvider(repoURL, opts)
-		},
-	}
-)
+var registration = gitprovider.Registration{
+	Predicate: func(repoURL string) bool {
+		u, err := url.Parse(repoURL)
+		if err != nil {
+			return false
+		}
+		// We assume that any hostname with the word "gitlab" in it, can use this
+		// provider. NOTE: We will miss cases where the host is self-hosted Gitlab
+		// but doesn't incorporate the word "gitlab" in the hostname. e.g.
+		// 'git.mycompany.com'
+		return strings.Contains(u.Host, ProviderName)
+	},
+	NewProvider: func(
+		repoURL string,
+		opts *gitprovider.Options,
+	) (gitprovider.Interface, error) {
+		return NewProvider(repoURL, opts)
+	},
+}
 
 func init() {
-	gitprovider.RegisterProvider(GitProviderServiceName, registration)
+	gitprovider.Register(ProviderName, registration)
 }
 
 type mergeRequestClient interface {
@@ -65,23 +61,21 @@ type mergeRequestClient interface {
 	) (*gitlab.MergeRequest, *gitlab.Response, error)
 }
 
-type gitLabClient struct { // nolint: revive
-	mergeRequests mergeRequestClient
-}
-
-type gitLabProvider struct { // nolint: revive
+// provider is a GitLab-based implementation of gitprovider.Interface.
+type provider struct { // nolint: revive
 	projectName string
-	client      *gitLabClient
+	client      mergeRequestClient
 }
 
-func NewGitLabProvider(
+// NewProvider returns a GitLab-based implementation of gitprovider.Interface.
+func NewProvider(
 	repoURL string,
-	opts *gitprovider.GitProviderOptions,
-) (gitprovider.GitProviderService, error) {
+	opts *gitprovider.Options,
+) (gitprovider.Interface, error) {
 	if opts == nil {
-		opts = &gitprovider.GitProviderOptions{}
+		opts = &gitprovider.Options{}
 	}
-	host, projectName, err := parseGitLabURL(repoURL)
+	host, projectName, err := parseRepoURL(repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -108,17 +102,21 @@ func NewGitLabProvider(
 	if err != nil {
 		return nil, err
 	}
-	return &gitLabProvider{
+	return &provider{
 		projectName: projectName,
-		client:      &gitLabClient{mergeRequests: client.MergeRequests},
+		client:      client.MergeRequests,
 	}, nil
 }
 
-func (g *gitLabProvider) CreatePullRequest(
+// CreatePullRequest implements gitprovider.Interface.
+func (p *provider) CreatePullRequest(
 	_ context.Context,
-	opts gitprovider.CreatePullRequestOpts,
+	opts *gitprovider.CreatePullRequestOpts,
 ) (*gitprovider.PullRequest, error) {
-	glMR, _, err := g.client.mergeRequests.CreateMergeRequest(g.projectName, &gitlab.CreateMergeRequestOptions{
+	if opts == nil {
+		opts = &gitprovider.CreatePullRequestOpts{}
+	}
+	glMR, _, err := p.client.CreateMergeRequest(p.projectName, &gitlab.CreateMergeRequestOptions{
 		Title:              &opts.Title,
 		Description:        &opts.Description,
 		SourceBranch:       &opts.Head,
@@ -128,60 +126,82 @@ func (g *gitLabProvider) CreatePullRequest(
 	if err != nil {
 		return nil, err
 	}
-	return convertGitlabMR(glMR), nil
+	if glMR == nil {
+		return nil, fmt.Errorf("unexpected nil merge request")
+	}
+	pr := convertGitlabMR(*glMR)
+	return &pr, nil
 }
 
-func (g *gitLabProvider) GetPullRequest(
+// GetPullRequest implements gitprovider.Interface.
+func (p *provider) GetPullRequest(
 	_ context.Context,
 	id int64,
 ) (*gitprovider.PullRequest, error) {
-	glMR, err := g.getMergeRequest(id)
+	glMR, _, err := p.client.GetMergeRequest(p.projectName, int(id), nil)
 	if err != nil {
 		return nil, err
 	}
-	return convertGitlabMR(glMR), nil
+	if glMR == nil {
+		return nil, fmt.Errorf("unexpected nil merge request")
+	}
+	pr := convertGitlabMR(*glMR)
+	return &pr, nil
 }
 
-func (g *gitLabProvider) ListPullRequests(
+// ListPullRequests implements gitprovider.Interface.
+func (p *provider) ListPullRequests(
 	_ context.Context,
-	opts gitprovider.ListPullRequestOpts,
-) ([]*gitprovider.PullRequest, error) {
+	opts *gitprovider.ListPullRequestOptions,
+) ([]gitprovider.PullRequest, error) {
+	if opts == nil {
+		opts = &gitprovider.ListPullRequestOptions{}
+	}
+	if opts.State == "" {
+		opts.State = gitprovider.PullRequestStateOpen
+	}
+	switch opts.State {
+	case gitprovider.PullRequestStateAny, gitprovider.PullRequestStateClosed,
+		gitprovider.PullRequestStateOpen:
+	default:
+		return nil, fmt.Errorf("unknown pull request state %q", opts.State)
+	}
 	listOpts := &gitlab.ListProjectMergeRequestsOptions{
-		SourceBranch: &opts.Head,
-		TargetBranch: &opts.Base,
+		SourceBranch: &opts.HeadBranch,
+		TargetBranch: &opts.BaseBranch,
+		ListOptions: gitlab.ListOptions{
+			// The max isn't documented, but this doesn't produce an error.
+			PerPage: 100,
+		},
 	}
-	glMRs, _, err := g.client.mergeRequests.ListProjectMergeRequests(g.projectName, listOpts)
-	if err != nil {
-		return nil, err
-	}
-	prs := make([]*gitprovider.PullRequest, 0, len(glMRs))
-	for _, glMR := range glMRs {
-		if (opts.State == gitprovider.PullRequestStateOpen) == isMROpen(glMR) {
-			prs = append(prs, convertGitlabMR(glMR))
+	prs := []gitprovider.PullRequest{}
+	for {
+		glMRs, res, err := p.client.ListProjectMergeRequests(p.projectName, listOpts)
+		if err != nil {
+			return nil, err
 		}
+		for _, glMR := range glMRs {
+			if (opts.State == gitprovider.PullRequestStateAny ||
+				((opts.State == gitprovider.PullRequestStateOpen) == isMROpen(*glMR))) &&
+				(opts.HeadCommit == "" || glMR.SHA == opts.HeadCommit) {
+				prs = append(prs, convertGitlabMR(*glMR))
+			}
+		}
+		if res == nil || res.NextPage == 0 {
+			break
+		}
+		listOpts.Page = res.NextPage
 	}
 	return prs, nil
 }
 
-func (g *gitLabProvider) IsPullRequestMerged(_ context.Context, id int64) (bool, error) {
-	glMR, err := g.getMergeRequest(id)
-	if err != nil {
-		return false, err
-	}
-	return glMR.State == "merged", nil
-}
-
-func convertGitlabMR(glMR *gitlab.MergeRequest) *gitprovider.PullRequest {
-	var prState gitprovider.PullRequestState
-	if isMROpen(glMR) {
-		prState = gitprovider.PullRequestStateOpen
-	} else {
-		prState = gitprovider.PullRequestStateClosed
-	}
-	return &gitprovider.PullRequest{
+func convertGitlabMR(glMR gitlab.MergeRequest) gitprovider.PullRequest {
+	fmt.Println(glMR.MergeCommitSHA)
+	return gitprovider.PullRequest{
 		Number:         int64(glMR.IID),
 		URL:            glMR.WebURL,
-		State:          prState,
+		Open:           isMROpen(glMR),
+		Merged:         glMR.State == "merged",
 		MergeCommitSHA: glMR.MergeCommitSHA,
 		Object:         glMR,
 		HeadSHA:        glMR.SHA,
@@ -189,16 +209,11 @@ func convertGitlabMR(glMR *gitlab.MergeRequest) *gitprovider.PullRequest {
 	}
 }
 
-func isMROpen(glMR *gitlab.MergeRequest) bool {
+func isMROpen(glMR gitlab.MergeRequest) bool {
 	return glMR.State == "opened" || glMR.State == "locked"
 }
 
-func (g *gitLabProvider) getMergeRequest(id int64) (*gitlab.MergeRequest, error) {
-	glMR, _, err := g.client.mergeRequests.GetMergeRequest(g.projectName, int(id), nil)
-	return glMR, err
-}
-
-func parseGitLabURL(repoURL string) (string, string, error) {
+func parseRepoURL(repoURL string) (string, string, error) {
 	u, err := url.Parse(git.NormalizeURL(repoURL))
 	if err != nil {
 		return "", "", fmt.Errorf("error parsing gitlab repository URL %q: %w", u, err)

--- a/internal/gitprovider/gitprovider.go
+++ b/internal/gitprovider/gitprovider.go
@@ -2,6 +2,7 @@ package gitprovider
 
 import (
 	"context"
+	"time"
 )
 
 // GitProviderOptions contains the options for a GitProvider.
@@ -68,6 +69,8 @@ type PullRequest struct {
 	Object any `json:"-"`
 	// HeadSHA is the SHA of the head commit
 	HeadSHA string `json:"headSHA"`
+	// CreatedAt is the time the pull request was created
+	CreatedAt *time.Time `json:"createdAt"`
 }
 
 func (pr *PullRequest) IsOpen() bool {

--- a/internal/gitprovider/gitprovider.go
+++ b/internal/gitprovider/gitprovider.go
@@ -5,8 +5,26 @@ import (
 	"time"
 )
 
-// GitProviderOptions contains the options for a GitProvider.
-type GitProviderOptions struct { // nolint: revive
+// PullRequestState represents the state of a pull request. e.g. Closed, Open,
+// etc.
+type PullRequestState string
+
+const (
+	// PullRequestStateAny represents all pull requests, regardless of state.
+	PullRequestStateAny PullRequestState = "Any"
+	// PullRequestStateClosed represents pull requests that are (logically)
+	// closed. Depending on the underlying provider, this may encompass pull
+	// requests in other states such as "merged" or "declined".
+	PullRequestStateClosed PullRequestState = "Closed"
+	// PullRequestStateOpen represents pull requests that are (logically) open.
+	// Depending on the underlying provider, this may encompass pull requests in
+	// other states such as "draft" or "ready for review".
+	PullRequestStateOpen PullRequestState = "Open"
+)
+
+// Options encapsulates options used in instantiating any implementation
+// of Interface.
+type Options struct {
 	// Name specifies which Git provider to use when that information cannot be
 	// inferred from the repository URL.
 	Name string
@@ -18,102 +36,116 @@ type GitProviderOptions struct { // nolint: revive
 	InsecureSkipTLSVerify bool
 }
 
-// GitProviderService is an abstracted interface for a git providers (GitHub, GitLab, BitBucket)
-// when interacting against a single git repository (e.g. managing pull requests).
-type GitProviderService interface { // nolint: revive
-	// CreatePullRequest creates a pull request
-	CreatePullRequest(ctx context.Context, opts CreatePullRequestOpts) (*PullRequest, error)
+// Interface is an abstracted interface for interacting with a single repository
+// hosted by some a Git hosting provider (e.g. GitHub, GitLab, BitBucket,
+// etc.).
+type Interface interface {
+	// CreatePullRequest creates a pull request.
+	CreatePullRequest(context.Context, *CreatePullRequestOpts) (*PullRequest, error)
 
 	// Get gets an existing pull request by ID
-	GetPullRequest(ctx context.Context, number int64) (*PullRequest, error)
+	GetPullRequest(context.Context, int64) (*PullRequest, error)
 
-	// ListPullRequests lists pull requests by the given options
-	ListPullRequests(ctx context.Context, opts ListPullRequestOpts) ([]*PullRequest, error)
-
-	// IsPullRequestMerged returns whether or not the pull request was merged
-	IsPullRequestMerged(ctx context.Context, number int64) (bool, error)
+	// ListPullRequests lists pull requests by the given options. Implementations
+	// have no obligation to sort the results in any particular order, due mainly
+	// to differences in the underlying provider APIs. It is the responsibility of
+	// the caller to sort the results as needed.
+	ListPullRequests(context.Context, *ListPullRequestOptions) ([]PullRequest, error)
 }
 
+// CreatePullRequestOpts encapsulates the options used when creating a pull
+// request.
 type CreatePullRequestOpts struct {
-	Head        string
-	Base        string
-	Title       string
+	// Title is the title of the pull request.
+	Title string
+	// Description is the body of the pull request.
 	Description string
+	// Head is the name of the source branch.
+	Head string
+	// Base is the name of the target branch.
+	Base string
 }
 
-type ListPullRequestOpts struct {
-	// State is the pull request state (one of: Open, Closed). Defaults to Open
+// ListPullRequestOptions encapsulates the options used when listing pull
+// requests.
+type ListPullRequestOptions struct {
+	// State is the pull request state (one of: Any, Closed, or Open).
 	State PullRequestState
-	Head  string
-	Base  string
+	// HeadBranch is the name of the source branch. A non-empty value will limit
+	// results to pull requests with the given source branch.
+	HeadBranch string
+	// HeadCommit is the SHA of the commit at the head of the source branch. A
+	// non-empty value will limit results to pull requests with the given head
+	// commit.
+	HeadCommit string
+	// BaseBranch is the name of the target branch. A non-empty value will limit
+	// results to pull requests with the given target branch.
+	BaseBranch string
 }
 
-type PullRequestState string
-
-const (
-	PullRequestStateOpen   PullRequestState = "Open"
-	PullRequestStateClosed PullRequestState = "Closed"
-)
-
+// PullRequest is an abstracted representation of a Git hosting provider's pull
+// request object (or equivalent; e.g. a GitLab merge request).
 type PullRequest struct {
-	// Number is the numeric pull request number (not an ID)
-	// Pull requests numbers are unique only within a repository
+	// Number is the pull request number, which is unique only within a single
+	// repository.
 	Number int64 `json:"id"`
-	// URL is the url to the pull request
+	// URL is the URL to the pull request.
 	URL string `json:"url"`
-	// State is the pull request state (one of: Open, Closed)
-	State PullRequestState `json:"state"`
-	// MergeCommitSHA is the SHA of the merge commit
+	// Open is true if the pull request is logically open. Depending on the
+	// underlying Git hosting provider, this may encompass pull requests in other
+	// states such as "draft" or "ready for review".
+	Open bool `json:"open"`
+	// Merged is true if the pull request was merged.
+	Merged bool `json:"merged"`
+	// MergeCommitSHA is the SHA of the merge commit.
 	MergeCommitSHA string `json:"mergeCommitSHA"`
-	// Object is the underlying object from the provider
+	// Object is the underlying object from the Git hosting provider.
 	Object any `json:"-"`
-	// HeadSHA is the SHA of the head commit
+	// HeadSHA is the SHA of the commit at the head of the source branch.
 	HeadSHA string `json:"headSHA"`
-	// CreatedAt is the time the pull request was created
+	// CreatedAt is the time the pull request was created.
 	CreatedAt *time.Time `json:"createdAt"`
 }
 
-func (pr *PullRequest) IsOpen() bool {
-	return pr.State == PullRequestStateOpen
-}
-
-type FakeGitProviderService struct {
+// Fake is a fake implementation of the provider Interface used to facilitate
+// testing.
+type Fake struct {
+	// CreatePullRequestFn defines the functionality of the CreatePullRequest
+	// method.
 	CreatePullRequestFn func(
 		context.Context,
-		CreatePullRequestOpts,
+		*CreatePullRequestOpts,
 	) (*PullRequest, error)
-	GetPullRequestFn   func(context.Context, int64) (*PullRequest, error)
+	// GetPullRequestFn defines the functionality of the GetPullRequest method.
+	GetPullRequestFn func(context.Context, int64) (*PullRequest, error)
+	// ListPullRequestsFn defines the functionality of the ListPullRequests
+	// method.
 	ListPullRequestsFn func(
 		context.Context,
-		ListPullRequestOpts,
-	) ([]*PullRequest, error)
-	IsPullRequestMergedFn func(context.Context, int64) (bool, error)
+		*ListPullRequestOptions,
+	) ([]PullRequest, error)
 }
 
-func (f *FakeGitProviderService) CreatePullRequest(
+// CreatePullRequest implements gitprovider.Interface.
+func (f *Fake) CreatePullRequest(
 	ctx context.Context,
-	opts CreatePullRequestOpts,
+	opts *CreatePullRequestOpts,
 ) (*PullRequest, error) {
 	return f.CreatePullRequestFn(ctx, opts)
 }
 
-func (f *FakeGitProviderService) GetPullRequest(
+// GetPullRequest implements gitprovider.Interface.
+func (f *Fake) GetPullRequest(
 	ctx context.Context,
 	number int64,
 ) (*PullRequest, error) {
 	return f.GetPullRequestFn(ctx, number)
 }
 
-func (f *FakeGitProviderService) ListPullRequests(
+// ListPullRequests implements gitprovider.Interface.
+func (f *Fake) ListPullRequests(
 	ctx context.Context,
-	opts ListPullRequestOpts,
-) ([]*PullRequest, error) {
+	opts *ListPullRequestOptions,
+) ([]PullRequest, error) {
 	return f.ListPullRequestsFn(ctx, opts)
-}
-
-func (f *FakeGitProviderService) IsPullRequestMerged(
-	ctx context.Context,
-	number int64,
-) (bool, error) {
-	return f.IsPullRequestMergedFn(ctx, number)
 }


### PR DESCRIPTION
Fixes #2845

Follows up on #2878 and #2881 

This makes the `git-open-pr` step's short-circuiting a little more resilient.

Prior to this trio of related fixes, if the controller restarted while a Promotion was still in-progress waiting for a PR to be merged, when the controller came back up and found the Promotion's state gone from the ephemeral disk, it would start the entire user-defined Promotion process over again from step 0, potentially getting into trouble when it came time to open a PR, since a PR identical to the one it would otherwise open already exists. (Same source branch, same commit at the head of that branch, same base branch.)

This PR, the final component of the fix, uses a two-phased approach for the `git-open-pr` step to determine if a PR actually needs to be opened or not:

* Looks at state that may have been left behind by a previous successful execution. If a PR number is found therein, short-circuit as if successful and continue on to the next step.

* For good measure, looks for a PR identical to the one it may open. If found, it will short-circuit as described above. This makes the step more resilient to the remote possibility that _somehow_ a PR identical to the one it would otherwise open was created through other means. It will work with that PR  as if it had opened it itself.

  __Edit:__ This second check is also helpful in the case that someone's got unmerged PRs open when they upgrade from an existing v1.0.x to v1.1.0.

Both of these are resilient to the possibility of an existing PR having been merged or closed while the controller was down/restarting, as they do not even check if it is open, merged, closed, etc. (It is a subsequent `git-wait-for-pr` step's job to worry about that.)