### PR TITLE
docs(quickstart): fix appset targetRevision does not exist

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -211,8 +211,8 @@ spec:
       project: default
       source:
         repoURL: ${GITOPS_REPO_URL}
-        targetRevision: stage/{{stage}}
-        path: .
+        targetRevision: main
+        path: stages/{{stage}}
       destination:
         server: https://kubernetes.default.svc
         namespace: kargo-demo-{{stage}}


### PR DESCRIPTION
Was trying out the quickstart example, but it wasn't working since it sets the `targetRevision` to be dynamic. The example repo has the stages path based instead of revision based - https://github.com/akuity/kargo-demo/tree/main/stages