### PR TITLE
fix(docs): consistent title case

### DIFF
--- a/docs/docs/30-how-to-guides/15-working-with-freight.md
+++ b/docs/docs/30-how-to-guides/15-working-with-freight.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to work effectively with freight
-sidebar_label: Working with freight
+sidebar_label: Working with Freight
 ---
 
 # Working With Freight

--- a/docs/docs/30-how-to-guides/20-managing-credentials.md
+++ b/docs/docs/30-how-to-guides/20-managing-credentials.md
@@ -1,6 +1,6 @@
 ---
 description: Find out how to manage repository credentials for use by Kargo
-sidebar_label: Managing credentials
+sidebar_label: Managing Credentials
 ---
 
 # Managing Credentials

--- a/docs/docs/30-how-to-guides/30-managing-user-permissions.md
+++ b/docs/docs/30-how-to-guides/30-managing-user-permissions.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to manage user permissions
-sidebar_label: Managing user permissions
+sidebar_label: Managing User Permissions
 ---
 
 # Managing User Permissions

--- a/docs/docs/30-how-to-guides/_category_.json
+++ b/docs/docs/30-how-to-guides/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "How-to guides",
+  "label": "How-to Guides",
   "link":  null
 }

--- a/docs/docs/35-references/_category_.json
+++ b/docs/docs/35-references/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Reference docs",
+  "label": "Reference Docs",
   "link":  null
 }

--- a/docs/docs/40-contributor-guide/20-signing-commits.md
+++ b/docs/docs/40-contributor-guide/20-signing-commits.md
@@ -1,6 +1,6 @@
 ---
 description: Find out how to sign commits when contributing to Kargo
-sidebar_label: Signing commits
+sidebar_label: Signing Commits
 ---
 
 # Signing Commits

--- a/docs/docs/40-contributor-guide/30-code-of-conduct.md
+++ b/docs/docs/40-contributor-guide/30-code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Code of conduct
+sidebar_label: Code of Conduct
 description: Contributor Code of Conduct for the open source Kargo project
 ---
 

--- a/docs/docs/40-contributor-guide/index.md
+++ b/docs/docs/40-contributor-guide/index.md
@@ -11,6 +11,6 @@ Kargo project.
 
 This guide is decomposed into the following, high-level topics:
 
-* [Hacking on Kargo](./10-hacking-on-kargo.md)
-* [Signing commits](./20-signing-commits.md)
-* [Code of conduct](./30-code-of-conduct.md)
+* [Hacking On Kargo](./10-hacking-on-kargo.md)
+* [Signing Commits](./20-signing-commits.md)
+* [Code Of Conduct](./30-code-of-conduct.md)

--- a/docs/docs/40-contributor-guide/index.md
+++ b/docs/docs/40-contributor-guide/index.md
@@ -1,6 +1,6 @@
 ---
 description: A comprehensive introduction for developers who are looking to get involved with contributing directly to the Kargo project
-sidebar_label: Contributor guide
+sidebar_label: Contributor Guide
 ---
 
 # Kargo Contributor Guide

--- a/docs/docs/40-contributor-guide/index.md
+++ b/docs/docs/40-contributor-guide/index.md
@@ -11,6 +11,6 @@ Kargo project.
 
 This guide is decomposed into the following, high-level topics:
 
-* [Hacking On Kargo](./10-hacking-on-kargo.md)
+* [Hacking on Kargo](./10-hacking-on-kargo.md)
 * [Signing Commits](./20-signing-commits.md)
-* [Code Of Conduct](./30-code-of-conduct.md)
+* [Code of Conduct](./30-code-of-conduct.md)


### PR DESCRIPTION
closes #2902

The current state of the docs adopts the label for each item in the following order of precedence

1. From the `sidebar_label` field in the frontmatter of the `.md` file (if explicitly provided)
2. From the first `# heading` in the `.md` file (if `sidebar_label` is absent)
3. From the filename of the `.md` file (if neither `sidebar_label` nor a `# heading` is present)

Given this behavior I have tried to address the issue by updating the markdown files to explicitly include titlecase in the `sidebar_label` field where it was missing. 

Do we need to add further changes, like automating this process or handling additional edge cases?
Also, should we add monotype texts for kargo resources?