### PR TITLE
fix(directives): log error to surface reason for ArgoCD update

### DIFF
--- a/internal/directives/argocd_updater.go
+++ b/internal/directives/argocd_updater.go
@@ -265,6 +265,12 @@ func (a *argocdUpdater) runPromotionStep(
 			continue
 		}
 
+		// Log the error, as it contains information about why we need to
+		// perform an update.
+		if err != nil {
+			logger.Debug(err.Error())
+		}
+
 		// Perform the update.
 		if err = a.syncApplicationFn(
 			ctx,


### PR DESCRIPTION
Found this while trying to debug an issue with the `argocd-update` step.