### PR TITLE
refactor: replace helm-update-image with yaml-update

### DIFF
--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -394,6 +394,8 @@ file with new version information which is referenced by the Freight being
 promoted. This step is commonly followed by a [`helm-template`](#helm-template)
 step.
 
+__Deprecated: Use the generic `yaml-update` step instead. Will be removed in v1.2.0.__
+
 ### `helm-update-image` Configuration
 
 | Name | Type | Required | Description |
@@ -435,6 +437,55 @@ steps:
 ```
 
 ### `helm-update-image` Output
+
+| Name | Type | Description |
+|------|------|-------------|
+| `commitMessage` | `string` | A description of the change(s) applied by this step. Typically, a subsequent [`git-commit`](#git-commit) step will reference this output and aggregate this commit message fragment with other like it to build a comprehensive commit message that describes all changes. |
+
+## `yaml-update`
+
+`yaml-update` updates the values of specified keys in any YAML file. This step
+most often used to update image tags or digests in a Helm values and is commonly
+followed by a [`helm-template`](#helm-template) step.
+
+### `yaml-update` Configuration
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Y | Path to a YAML file. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `updates` | `[]object` | Y | The details of changes to be applied to the file. At least one must be specified. |
+| `updates[].key` | `string` | Y | The key to update within the file. For nested values, use a YAML dot notation path. |
+| `updates[].value` | `string` | Y | The new value for the key. Typically specified using an expression. |
+
+### `yaml-update` Example
+
+```yaml
+vars:
+- name: gitRepo
+  value: https://github.com/example/repo.git
+steps:
+- uses: git-clone
+  config:
+    repoURL: ${{ vars.gitRepo }}
+    checkout:
+    - commit: ${{ commitFrom(vars.gitRepo).ID }}
+      path: ./src
+    - branch: stage/${{ ctx.stage }}
+      create: true
+      path: ./out
+- uses: git-clear
+  config:
+    path: ./out
+- uses: yaml-update
+  config:
+    path: ./src/charts/my-chart/values.yaml
+    updates:
+    - key: image.tag
+      value: ${{ imageFrom("my/image").tag }}
+# Render manifests to ./out, commit, push, etc...
+```
+
+### `yaml-update` Output
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -400,10 +400,10 @@ step.
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to Helm values file (e.g. `values.yaml`). This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `images` | `[]object` | Y | The details of changes to be applied to the values file. At least one must be specified. |
-| `images[].image` | `string` | N | Name/URL of the image being updated. <br/><br/>__Deprecated: Use `value` with an expression instead. Will be removed in v1.2.0.__ |
-| `images[].fromOrigin` | `object` | N | See [specifying origins](#specifying-origins). <br/><br/>__Deprecated: Use `value` with an expression instead. Will be removed in v1.2.0.__ |
+| `images[].image` | `string` | Y | Name/URL of the image being updated. The Freight being promoted presumably contains a reference to a revision of this image. |
+| `images[].fromOrigin` | `object` | N | See [specifying origins](#specifying-origins) |
 | `images[].key` | `string` | Y | The key to update within the values file. See Helm documentation on the [format and limitations](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set) of the notation used in this field. |
-| `images[].value` | `string` | Y | Specifies how the value of `key` is to be updated. When `image` is non-empty, possible values for this field are limited to:<ul><li>`ImageAndTag`: Replaces the value of `key` with a string in form `<image url>:<tag>`</li><li>`Tag`: Replaces the value of `key` with the image's tag</li><li>`ImageAndDigest`: Replaces the value of `key` with a string in form `<image url>@<digest>`</li><li>`Digest`: Replaces the value of `key` with the image's digest</li></ul> When `image` is empty, use an expression in this field to describe the new value. |
+| `images[].value` | `string` | Y | Specifies how the value of `key` is to be updated. Possible values for this field are limited to:<ul><li>`ImageAndTag`: Replaces the value of `key` with a string in form `<image url>:<tag>`</li><li>`Tag`: Replaces the value of `key` with the image's tag</li><li>`ImageAndDigest`: Replaces the value of `key` with a string in form `<image url>@<digest>`</li><li>`Digest`: Replaces the value of `key` with the image's digest</li></ul> |
 
 ### `helm-update-image` Example
 
@@ -428,8 +428,9 @@ steps:
   config:
     path: ./src/charts/my-chart/values.yaml
     images:
-    - key: image.tag
-      value: ${{ imageFrom("my/image").tag }}
+    - image: my/image
+      key: image.tag
+      value: Tag
 # Render manifests to ./out, commit, push, etc...
 ```
 

--- a/internal/directives/schemas/helm-update-image-config.json
+++ b/internal/directives/schemas/helm-update-image-config.json
@@ -32,24 +32,12 @@
           },
           "value": {
             "type": "string",
-            "description": "Specifies the new value for the specified key in the Helm values file."
+            "description": "Specifies the new value for the specified key in the Helm values file.",
+            "minLength": 1,
+            "pattern": "^(Digest|ImageAndDigest|ImageAndTag|Tag)$"
           }
         },
-        "required": ["key", "value"],
-        "oneOf": [
-          {
-            "required": ["image"],
-            "properties": {
-              "image": { "minLength": 1 },
-              "value": { "pattern": "^(Digest|ImageAndDigest|ImageAndTag|Tag)$" }
-            }
-          },
-          {
-            "properties": {
-              "image": { "enum": ["",  null] }
-            }
-          }
-        ]
+        "required": ["image", "key", "value"]
       }
     }
   }

--- a/internal/directives/schemas/yaml-update-config.json
+++ b/internal/directives/schemas/yaml-update-config.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "YAMLUpdateConfig",
+  
+  "definitions": {
+
+    "yamlUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key whose value needs to be updated. For nested values, use a YAML dot notation path.",
+          "minLength": 1
+        },
+        "value": {
+          "type": "string",
+          "description": "The new value for the specified key."
+        }
+      },
+      "required": ["key", "value"]
+    }
+
+  },
+  
+  "type": "object",
+  "required": ["path", "updates"],
+  "additionalProperties": false,
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "The path to a YAML file.",
+      "minLength": 1
+    },
+    "updates": {
+      "type": "array",
+      "description": "A list of updates to apply to the YAML file.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/yamlUpdate"
+      }
+    }
+  }
+}

--- a/internal/directives/yaml_updater.go
+++ b/internal/directives/yaml_updater.go
@@ -1,0 +1,118 @@
+package directives
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/xeipuuv/gojsonschema"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libYAML "github.com/akuity/kargo/internal/yaml"
+)
+
+func init() {
+	builtins.RegisterPromotionStepRunner(newYAMLUpdater(), nil)
+}
+
+// yamlUpdater is an implementation of the PromotionStepRunner interface that
+// updates the values of specified keys in a YAML file.
+type yamlUpdater struct {
+	schemaLoader gojsonschema.JSONLoader
+}
+
+// newYAMLUpdater returns an implementation of the PromotionStepRunner interface
+// that updates the values of specified keys in a YAML file.
+func newYAMLUpdater() PromotionStepRunner {
+	r := &yamlUpdater{}
+	r.schemaLoader = getConfigSchemaLoader(r.Name())
+	return r
+}
+
+// Name implements the PromotionStepRunner interface.
+func (y *yamlUpdater) Name() string {
+	return "yaml-update"
+}
+
+// RunPromotionStep implements the PromotionStepRunner interface.
+func (y *yamlUpdater) RunPromotionStep(
+	ctx context.Context,
+	stepCtx *PromotionStepContext,
+) (PromotionStepResult, error) {
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
+
+	if err := y.validate(stepCtx.Config); err != nil {
+		return failure, err
+	}
+
+	// Convert the configuration into a typed struct
+	cfg, err := ConfigToStruct[YAMLUpdateConfig](stepCtx.Config)
+	if err != nil {
+		return failure, fmt.Errorf("could not convert config into %s config: %w", y.Name(), err)
+	}
+
+	return y.runPromotionStep(ctx, stepCtx, cfg)
+}
+
+// validate validates yamlImageUpdater configuration against a JSON schema.
+func (y *yamlUpdater) validate(cfg Config) error {
+	return validate(y.schemaLoader, gojsonschema.NewGoLoader(cfg), y.Name())
+}
+
+func (y *yamlUpdater) runPromotionStep(
+	_ context.Context,
+	stepCtx *PromotionStepContext,
+	cfg YAMLUpdateConfig,
+) (PromotionStepResult, error) {
+	updates := make(map[string]string, len(cfg.Updates))
+	for _, image := range cfg.Updates {
+		updates[image.Key] = image.Value
+	}
+
+	result := PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}
+	if len(updates) > 0 {
+		if err := y.updateFile(stepCtx.WorkDir, cfg.Path, updates); err != nil {
+			return PromotionStepResult{Status: kargoapi.PromotionPhaseErrored},
+				fmt.Errorf("values file update failed: %w", err)
+		}
+
+		if commitMsg := y.generateCommitMessage(cfg.Path, updates); commitMsg != "" {
+			result.Output = map[string]any{
+				"commitMessage": commitMsg,
+			}
+		}
+	}
+	return result, nil
+}
+
+func (y *yamlUpdater) updateFile(workDir string, path string, changes map[string]string) error {
+	absValuesFile, err := securejoin.SecureJoin(workDir, path)
+	if err != nil {
+		return fmt.Errorf("error joining path %q: %w", path, err)
+	}
+	if err := libYAML.SetStringsInFile(absValuesFile, changes); err != nil {
+		return fmt.Errorf("error updating image references in values file %q: %w", path, err)
+	}
+	return nil
+}
+
+func (y *yamlUpdater) generateCommitMessage(path string, updates map[string]string) string {
+	if len(updates) == 0 {
+		return ""
+	}
+
+	var commitMsg strings.Builder
+	_, _ = commitMsg.WriteString(fmt.Sprintf("Updated %s\n", path))
+	keys := make([]string, 0, len(updates))
+	for key := range updates {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		_, _ = commitMsg.WriteString(fmt.Sprintf("\n- %s: %q", key, updates[key]))
+	}
+
+	return commitMsg.String()
+}

--- a/internal/directives/yaml_updater_test.go
+++ b/internal/directives/yaml_updater_test.go
@@ -1,0 +1,299 @@
+package directives
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func Test_yamlUpdater_validate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		config           Config
+		expectedProblems []string
+	}{
+		{
+			name:   "path is not specified",
+			config: Config{},
+			expectedProblems: []string{
+				"(root): path is required",
+			},
+		},
+		{
+			name: "path is empty",
+			config: Config{
+				"path": "",
+			},
+			expectedProblems: []string{
+				"path: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name:   "updates is null",
+			config: Config{},
+			expectedProblems: []string{
+				"(root): updates is required",
+			},
+		},
+		{
+			name: "updates is empty",
+			config: Config{
+				"updates": []Config{},
+			},
+			expectedProblems: []string{
+				"updates: Array must have at least 1 items",
+			},
+		},
+		{
+			name: "key not specified",
+			config: Config{
+				"updates": []Config{{}},
+			},
+			expectedProblems: []string{
+				"updates.0: key is required",
+			},
+		},
+		{
+			name: "key is empty",
+			config: Config{
+				"updates": []Config{{
+					"key": "",
+				}},
+			},
+			expectedProblems: []string{
+				"updates.0.key: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "value not specified",
+			config: Config{
+				"updates": []Config{{}},
+			},
+			expectedProblems: []string{
+				"updates.0: value is required",
+			},
+		},
+		{
+			name: "valid config",
+			config: Config{
+				"path": "fake-path",
+				"updates": []Config{
+					{
+						"key":   "fake-key",
+						"value": "fake-value",
+					},
+					{
+						"key":   "another-fake-key",
+						"value": "another-fake-value",
+					},
+				},
+			},
+		},
+	}
+
+	r := newYAMLUpdater()
+	runner, ok := r.(*yamlUpdater)
+	require.True(t, ok)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := runner.validate(testCase.config)
+			if len(testCase.expectedProblems) == 0 {
+				require.NoError(t, err)
+			} else {
+				for _, problem := range testCase.expectedProblems {
+					require.ErrorContains(t, err, problem)
+				}
+			}
+		})
+	}
+}
+
+func Test_yamlUpdater_runPromotionStep(t *testing.T) {
+	tests := []struct {
+		name       string
+		stepCtx    *PromotionStepContext
+		cfg        YAMLUpdateConfig
+		files      map[string]string
+		assertions func(*testing.T, string, PromotionStepResult, error)
+	}{
+		{
+			name: "successful run with updates",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: YAMLUpdateConfig{
+				Path: "values.yaml",
+				Updates: []YAMLUpdate{
+					{Key: "image.tag", Value: "fake-tag"},
+				},
+			},
+			files: map[string]string{
+				"values.yaml": "image:\n  tag: oldtag\n",
+			},
+			assertions: func(t *testing.T, workDir string, result PromotionStepResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{
+					Status: kargoapi.PromotionPhaseSucceeded,
+					Output: map[string]any{
+						"commitMessage": "Updated values.yaml\n\n- image.tag: \"fake-tag\"",
+					},
+				}, result)
+				content, err := os.ReadFile(path.Join(workDir, "values.yaml"))
+				require.NoError(t, err)
+				assert.Contains(t, string(content), "tag: fake-tag")
+			},
+		},
+		{
+			name: "failed to update file",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: YAMLUpdateConfig{
+				Path: "non-existent/values.yaml",
+				Updates: []YAMLUpdate{
+					{Key: "image.tag", Value: Tag},
+				},
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+				assert.Contains(t, err.Error(), "values file update failed")
+			},
+		},
+	}
+
+	runner := &yamlUpdater{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepCtx := tt.stepCtx
+
+			stepCtx.WorkDir = t.TempDir()
+			for p, c := range tt.files {
+				require.NoError(t, os.MkdirAll(path.Join(stepCtx.WorkDir, path.Dir(p)), 0o700))
+				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
+			}
+
+			result, err := runner.runPromotionStep(context.Background(), stepCtx, tt.cfg)
+			tt.assertions(t, stepCtx.WorkDir, result, err)
+		})
+	}
+}
+
+func Test_yamlUpdater_updateValuesFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		valuesContent string
+		changes       map[string]string
+		assertions    func(*testing.T, string, error)
+	}{
+		{
+			name:          "successful update",
+			valuesContent: "key: value\n",
+			changes:       map[string]string{"key": "newvalue"},
+			assertions: func(t *testing.T, valuesFilePath string, err error) {
+				require.NoError(t, err)
+
+				require.FileExists(t, valuesFilePath)
+				content, err := os.ReadFile(valuesFilePath)
+				require.NoError(t, err)
+				assert.Contains(t, string(content), "key: newvalue")
+			},
+		},
+		{
+			name:          "file does not exist",
+			valuesContent: "",
+			changes:       map[string]string{"key": "value"},
+			assertions: func(t *testing.T, valuesFilePath string, err error) {
+				require.ErrorContains(t, err, "no such file or directory")
+				require.NoFileExists(t, valuesFilePath)
+			},
+		},
+		{
+			name:          "empty changes",
+			valuesContent: "key: value\n",
+			changes:       map[string]string{},
+			assertions: func(t *testing.T, valuesFilePath string, err error) {
+				require.NoError(t, err)
+				require.FileExists(t, valuesFilePath)
+				content, err := os.ReadFile(valuesFilePath)
+				require.NoError(t, err)
+				assert.Equal(t, "key: value\n", string(content))
+			},
+		},
+	}
+
+	runner := &yamlUpdater{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			valuesFile := path.Join(workDir, "values.yaml")
+
+			if tt.valuesContent != "" {
+				err := os.WriteFile(valuesFile, []byte(tt.valuesContent), 0o600)
+				require.NoError(t, err)
+			}
+
+			err := runner.updateFile(workDir, path.Base(valuesFile), tt.changes)
+			tt.assertions(t, valuesFile, err)
+		})
+	}
+}
+
+func Test_yamlUpdater_generateCommitMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		changes    map[string]string
+		assertions func(*testing.T, string)
+	}{
+		{
+			name: "no changes",
+			path: "values.yaml",
+			assertions: func(t *testing.T, result string) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name:    "single change",
+			path:    "values.yaml",
+			changes: map[string]string{"image": "repo/image:tag1"},
+			assertions: func(t *testing.T, result string) {
+				assert.Equal(t, `Updated values.yaml
+
+- image: "repo/image:tag1"`, result)
+			},
+		},
+		{
+			name: "multiple changes",
+			path: "chart/values.yaml",
+			changes: map[string]string{
+				"image1": "repo1/image1:tag1",
+				"image2": "repo2/image2:tag2",
+			},
+			assertions: func(t *testing.T, result string) {
+				assert.Equal(t, `Updated chart/values.yaml
+
+- image1: "repo1/image1:tag1"
+- image2: "repo2/image2:tag2"`, result)
+			},
+		},
+	}
+
+	runner := &yamlUpdater{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runner.generateCommitMessage(tt.path, tt.changes)
+			tt.assertions(t, result)
+		})
+	}
+}

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -295,7 +295,7 @@ type HelmUpdateImageConfig struct {
 type HelmUpdateImageConfigImage struct {
 	FromOrigin *ChartFromOrigin `json:"fromOrigin,omitempty"`
 	// The container image (without tag) at which the update is targeted.
-	Image string `json:"image,omitempty"`
+	Image string `json:"image"`
 	// The key in the Helm values file of which the value needs to be updated. For nested
 	// values, it takes a YAML dot notation path.
 	Key string `json:"key"`
@@ -353,6 +353,20 @@ type KustomizeSetImageConfigImage struct {
 	Tag string `json:"tag,omitempty"`
 	// UseDigest specifies whether to use the digest of the image instead of the tag.
 	UseDigest bool `json:"useDigest,omitempty"`
+}
+
+type YAMLUpdateConfig struct {
+	// The path to a YAML file.
+	Path string `json:"path"`
+	// A list of updates to apply to the YAML file.
+	Updates []YAMLUpdate `json:"updates"`
+}
+
+type YAMLUpdate struct {
+	// The key whose value needs to be updated. For nested values, use a YAML dot notation path.
+	Key string `json:"key"`
+	// The new value for the specified key.
+	Value string `json:"value"`
 }
 
 // The kind of origin. Currently only 'Warehouse' is supported. Required.

--- a/ui/src/gen/directives/helm-update-image-config.json
+++ b/ui/src/gen/directives/helm-update-image-config.json
@@ -45,7 +45,9 @@
      },
      "value": {
       "type": "string",
-      "description": "Specifies the new value for the specified key in the Helm values file."
+      "description": "Specifies the new value for the specified key in the Helm values file.",
+      "minLength": 1,
+      "pattern": "^(Digest|ImageAndDigest|ImageAndTag|Tag)$"
      }
     }
    }

--- a/ui/src/gen/directives/yaml-update-config.json
+++ b/ui/src/gen/directives/yaml-update-config.json
@@ -1,0 +1,49 @@
+{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "YAMLUpdateConfig",
+ "definitions": {
+  "yamlUpdate": {
+   "type": "object",
+   "additionalProperties": false,
+   "properties": {
+    "key": {
+     "type": "string",
+     "description": "The key whose value needs to be updated. For nested values, use a YAML dot notation path.",
+     "minLength": 1
+    },
+    "value": {
+     "type": "string",
+     "description": "The new value for the specified key."
+    }
+   }
+  }
+ },
+ "type": "object",
+ "additionalProperties": false,
+ "properties": {
+  "path": {
+   "type": "string",
+   "description": "The path to a YAML file.",
+   "minLength": 1
+  },
+  "updates": {
+   "type": "array",
+   "description": "A list of updates to apply to the YAML file.",
+   "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "The key whose value needs to be updated. For nested values, use a YAML dot notation path.",
+      "minLength": 1
+     },
+     "value": {
+      "type": "string",
+      "description": "The new value for the specified key."
+     }
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
Fixes #2939

This PR:

* Reverts most of what #2925 did to the `helm-update-image` step. _There is no sense improving that step and deprecating individual fields if the entire step is going to be deprecated and replaced. This would only have led to confusion._

* Deprecates `helm-update-image`.

* Adds a new, generic `yaml-update` step that is essentially an improved/stripped down version of the `helm-update-image` step.