### PR TITLE
chore(backport release-1.0): fix(build): use `tini` to reap zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.15 && \
 ####################################################################################################
 FROM alpine:latest AS back-end-dev
 
-RUN apk update && apk add ca-certificates git gpg gpg-agent openssh-client
+RUN apk update && apk add ca-certificates git gpg gpg-agent openssh-client tini
 
 COPY bin/credential-helper /usr/local/bin/credential-helper
 COPY bin/controlplane/kargo /usr/local/bin/kargo
@@ -87,6 +87,7 @@ COPY bin/controlplane/kargo /usr/local/bin/kargo
 RUN adduser -D -H -u 1000 kargo
 USER 1000:0
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/usr/local/bin/kargo"]
 
 ####################################################################################################
@@ -119,4 +120,5 @@ FROM ${BASE_IMAGE}:latest-${TARGETARCH} AS final
 COPY --from=back-end-builder /kargo/bin/ /usr/local/bin/
 COPY --from=tools /tools/ /usr/local/bin/
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/usr/local/bin/kargo"]

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -57,7 +57,8 @@ spec:
       - name: controller
         image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/kargo", "controller"]
+        command: ["/sbin/tini", "--", "/usr/local/bin/kargo"]
+        args: ["controller"]
         {{- with (concat .Values.global.env .Values.controller.env) }}
         env:
           {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -56,7 +56,8 @@ spec:
           - name: garbage-collector
             image: {{ include "kargo.image" . }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            command: ["/usr/local/bin/kargo", "garbage-collector"]
+            command: ["/sbin/tini", "--", "/usr/local/bin/kargo"]
+            args: ["garbage-collector"]
             {{- with (concat .Values.global.env .Values.garbageCollector.env) }}
             env:
               {{- toYaml . | nindent 12 }}

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -57,7 +57,8 @@ spec:
       - name: management-controller
         image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/kargo", "management-controller"]
+        command: ["/sbin/tini", "--", "/usr/local/bin/kargo"]
+        args: ["management-controller"]
         {{- with (concat .Values.global.env .Values.managementController.env) }}
         env:
           {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -57,7 +57,8 @@ spec:
       - name: webhooks-server
         image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/kargo", "webhooks-server"]
+        command: ["/sbin/tini", "--", "/usr/local/bin/kargo"]
+        args: ["webhooks-server"]
         {{- with (concat .Values.global.env .Values.webhooksServer.env) }}
         env:
           {{- toYaml . | nindent 8 }}

--- a/kargo-base.apko.yaml
+++ b/kargo-base.apko.yaml
@@ -11,6 +11,7 @@ contents:
   - gpg-agent~2
   - helm~3 # Required for Kustomize Helm plugin
   - openssh-client~9
+  - tini
 
 accounts:
   groups:


### PR DESCRIPTION
Manual backport of #2959 due to conflicts.