### PR TITLE
fix: update casing to Azure Example in values.yaml unknown connector type "Microsoft"

### DIFF
--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -313,7 +313,7 @@ api:
       ## Azure Example
       # - id: microsoft
       #   name: microsoft
-      #   type: Microsoft
+      #   type: microsoft
       #   config:
       #     clientID: <your client ID>
       #     clientSecret: "$CLIENT_SECRET"


### PR DESCRIPTION
Making a simple change to the values.yaml to fix https://github.com/akuity/kargo/issues/2919