### PR TITLE
fix(controller): fix index out of range on some usage of fromChart()

### DIFF
--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -142,8 +142,8 @@ func (s *PromotionStep) GetConfig(
 		expr.Function(
 			"commitFrom",
 			getCommitFunc(ctx, cl, promoCtx),
-			new(func(repoURL string) kargoapi.GitCommit),
 			new(func(repoURL string, origin kargoapi.FreightOrigin) kargoapi.GitCommit),
+			new(func(repoURL string) kargoapi.GitCommit),
 		),
 		expr.Function(
 			"imageFrom",
@@ -154,10 +154,10 @@ func (s *PromotionStep) GetConfig(
 		expr.Function(
 			"chartFrom",
 			getChartFunc(ctx, cl, promoCtx),
-			new(func(repoURL string) kargoapi.Chart),
+			new(func(repoURL string, chartName string, origin kargoapi.FreightOrigin) kargoapi.Chart),
 			new(func(repoURL string, chartName string) kargoapi.Chart),
 			new(func(repoURL string, origin kargoapi.FreightOrigin) kargoapi.Chart),
-			new(func(repoURL string, chartName string, origin kargoapi.FreightOrigin) kargoapi.Chart),
+			new(func(repoURL string) kargoapi.Chart),
 		),
 	)
 	if err != nil {

--- a/internal/directives/promotions_test.go
+++ b/internal/directives/promotions_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
@@ -81,154 +84,406 @@ func TestPromotionStep_GetMaxAttempts(t *testing.T) {
 }
 
 func TestPromotionStep_GetConfig(t *testing.T) {
-	promoCtx := PromotionContext{
-		Project:   "fake-project",
-		Stage:     "fake-stage",
-		Promotion: "fake-promotion",
-		Vars: []kargoapi.PromotionVariable{
-			{
-				Name:  "strVar",
-				Value: "foo",
+	testScheme := k8sruntime.NewScheme()
+	err := kargoapi.AddToScheme(testScheme)
+	require.NoError(t, err)
+	testClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&kargoapi.Warehouse{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "fake-warehouse",
+				Namespace: "fake-project",
 			},
-			{
-				Name:  "concatStrVar",
-				Value: "${{ vars.strVar }}bar",
-			},
-			{
-				Name:  "boolVar",
-				Value: "true",
-			},
-			{
-				Name: "boolStrVar",
-				// Prove boolVar evaluated as a boolean
-				Value: "${{ quote(!vars.boolVar) }}",
-			},
-			{
-				Name:  "numVar",
-				Value: "42",
-			},
-			{
-				Name: "numStrVar",
-				// Prove numVar evaluated as a number
-				Value: "${{ quote(vars.numVar + 1) }}",
-			},
-		},
-		FreightRequests: []kargoapi.FreightRequest{
-			{
-				Origin: kargoapi.FreightOrigin{
-					Kind: kargoapi.FreightOriginKindWarehouse,
-					Name: "fake-warehouse",
-				},
-				Sources: kargoapi.FreightSources{
-					Direct: true,
+			Spec: kargoapi.WarehouseSpec{
+				Subscriptions: []kargoapi.RepoSubscription{
+					{
+						Git: &kargoapi.GitSubscription{
+							RepoURL: "https://fake-git-repo",
+						},
+					},
+					{
+						Image: &kargoapi.ImageSubscription{
+							RepoURL: "fake-image-repo",
+						},
+					},
+					{
+						Chart: &kargoapi.ChartSubscription{
+							RepoURL: "https://fake-chart-repo",
+							Name:    "fake-chart",
+						},
+					},
+					{
+						Chart: &kargoapi.ChartSubscription{
+							RepoURL: "oci://fake-oci-repo/fake-chart",
+						},
+					},
 				},
 			},
 		},
-		Freight: kargoapi.FreightCollection{
-			Freight: map[string]kargoapi.FreightReference{
-				"Warehouse/fake-warehouse": {
+	).Build()
+
+	testCases := []struct {
+		name        string
+		promoCtx    PromotionContext
+		promoState  State
+		rawCfg      []byte
+		expectedCfg Config
+	}{
+		{
+			name: "test context",
+			// Test that expressions can reference promotion context
+			promoCtx: PromotionContext{
+				Project:   "fake-project",
+				Stage:     "fake-stage",
+				Promotion: "fake-promotion",
+			},
+			rawCfg: []byte(`{
+				"project": "${{ ctx.project }}",
+				"stage": "${{ ctx.stage }}",
+				"promotion": "${{ ctx.promotion }}"
+			}`),
+			expectedCfg: Config{
+				"project":   "fake-project",
+				"stage":     "fake-stage",
+				"promotion": "fake-promotion",
+			},
+		},
+		{
+			name: "test secrets",
+			// Test that expressions can reference secrets
+			promoCtx: PromotionContext{
+				Secrets: map[string]map[string]string{
+					"secret1": {
+						"key1": "value1",
+						"key2": "value2",
+					},
+					"secret2": {
+						"key3": "value3",
+						"key4": "value4",
+					},
+				},
+			},
+			rawCfg: []byte(`{
+				"secret1-1": "${{ secrets.secret1.key1 }}",
+				"secret1-2": "${{ secrets.secret1.key2 }}",
+				"secret2-3": "${{ secrets.secret2.key3 }}",
+				"secret2-4": "${{ secrets.secret2.key4 }}"
+			}`),
+			expectedCfg: Config{
+				"secret1-1": "value1",
+				"secret1-2": "value2",
+				"secret2-3": "value3",
+				"secret2-4": "value4",
+			},
+		},
+		{
+			name: "test vars with literal values",
+			// Test that vars can be assigned literal values
+			promoCtx: PromotionContext{
+				Vars: []kargoapi.PromotionVariable{
+					{
+						Name:  "strVar",
+						Value: "foo",
+					},
+					{
+						Name:  "boolVar",
+						Value: "true",
+					},
+					{
+						Name:  "numVar",
+						Value: "42",
+					},
+				},
+			},
+			rawCfg: []byte(`{
+				"strVar": "${{ vars.strVar }}",
+				"boolVar": "${{ vars.boolVar }}",
+				"numVar": "${{ vars.numVar }}"
+			}`),
+			expectedCfg: Config{
+				"strVar":  "foo",
+				"boolVar": true,
+				"numVar":  42,
+			},
+		},
+		{
+			name: "test vars with expressions",
+			// Test using expressions to define the value of vars
+			promoCtx: PromotionContext{
+				Vars: []kargoapi.PromotionVariable{
+					{
+						Name:  "strVar",
+						Value: "${{ 'f' + 'o' + 'o' }}",
+					},
+					{
+						Name:  "boolVar",
+						Value: "${{ vars.strVar == 'foo' }}",
+					},
+					{
+						Name:  "numVar",
+						Value: "${{ 40 + 2 }}",
+					},
+				},
+			},
+			rawCfg: []byte(`{
+				"strVar": "${{ vars.strVar }}",
+				"boolVar": "${{ vars.boolVar }}",
+				"numVar": "${{ vars.numVar }}"
+			}`),
+			expectedCfg: Config{
+				"strVar":  "foo",
+				"boolVar": true,
+				"numVar":  42,
+			},
+		},
+		{
+			name: "test outputs",
+			// Test that expressions can reference outputs
+			promoState: State{
+				"strOutput":  "foo",
+				"boolOutput": true,
+				"numOutput":  42,
+			},
+			rawCfg: []byte(`{
+				"strOutput": "${{ outputs.strOutput }}",
+				"boolOutput": "${{ outputs.boolOutput }}",
+				"numOutput": "${{ outputs.numOutput }}"
+			}`),
+			expectedCfg: Config{
+				"strOutput":  "foo",
+				"boolOutput": true,
+				"numOutput":  42,
+			},
+		},
+		{
+			name: "test warehouse function",
+			// Test that the warehouse() function can be used to reference freight
+			// origins
+			promoCtx: PromotionContext{
+				Vars: []kargoapi.PromotionVariable{{
+					Name:  "warehouseName",
+					Value: "fake-warehouse",
+				}},
+			},
+			rawCfg: []byte(`{
+				"origin1": "${{ warehouse('fake-warehouse') }}",
+				"origin2": "${{ warehouse(vars.warehouseName) }}"
+			}`),
+			expectedCfg: Config{
+				"origin1": map[string]any{
+					"kind": "Warehouse",
+					"name": "fake-warehouse",
+				},
+				"origin2": map[string]any{
+					"kind": "Warehouse",
+					"name": "fake-warehouse",
+				},
+			},
+		},
+		{
+			name: "test commitFrom function",
+			// Test different ways to use the commitFrom() function
+			promoCtx: PromotionContext{
+				Project: "fake-project",
+				FreightRequests: []kargoapi.FreightRequest{{
 					Origin: kargoapi.FreightOrigin{
 						Kind: kargoapi.FreightOriginKindWarehouse,
 						Name: "fake-warehouse",
 					},
-					Commits: []kargoapi.GitCommit{{
-						RepoURL: "https://fake-git-repo",
-						ID:      "fake-commit-id",
-					}},
-					Images: []kargoapi.Image{{
-						RepoURL: "fake-image-repo",
-						Tag:     "fake-image-tag",
-					}},
-					Charts: []kargoapi.Chart{{
-						RepoURL: "https://fake-chart-repo",
-						Name:    "fake-chart",
-						Version: "fake-chart-version",
-					}},
+					Sources: kargoapi.FreightSources{
+						Direct: true,
+					},
+				}},
+				Freight: kargoapi.FreightCollection{
+					Freight: map[string]kargoapi.FreightReference{
+						"Warehouse/fake-warehouse": {
+							Origin: kargoapi.FreightOrigin{
+								Kind: kargoapi.FreightOriginKindWarehouse,
+								Name: "fake-warehouse",
+							},
+							Commits: []kargoapi.GitCommit{{
+								RepoURL: "https://fake-git-repo",
+								ID:      "fake-commit-id",
+							}},
+						},
+					},
+				},
+				Vars: []kargoapi.PromotionVariable{
+					{
+						Name:  "warehouseName",
+						Value: "fake-warehouse",
+					},
+					{
+						Name:  "repoURL",
+						Value: "https://fake-git-repo",
+					},
 				},
 			},
-		},
-		Secrets: map[string]map[string]string{
-			"secret1": {
-				"key1": "value1",
-				"key2": "value2",
+			// Two ways to use the commitFrom() function:
+			// 1. Pass a git repo URL
+			// 2. Pass a git repo URL and origin
+			rawCfg: []byte(`{
+				"commitID1": "${{ commitFrom('https://fake-git-repo').ID }}",
+				"commitID2": "${{ commitFrom(vars.repoURL).ID }}",
+				"commitID3": "${{ commitFrom('https://fake-git-repo', warehouse('fake-warehouse')).ID }}",
+				"commitID4": "${{ commitFrom(vars.repoURL, warehouse(vars.warehouseName)).ID }}"
+			}`),
+			expectedCfg: Config{
+				"commitID1": "fake-commit-id",
+				"commitID2": "fake-commit-id",
+				"commitID3": "fake-commit-id",
+				"commitID4": "fake-commit-id",
 			},
-			"secret2": {
-				"key3": "value3",
-				"key4": "value4",
+		},
+		{
+			name: "test imageFrom function",
+			// Test different ways to use the imageFrom() function
+			promoCtx: PromotionContext{
+				Project: "fake-project",
+				FreightRequests: []kargoapi.FreightRequest{{
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "fake-warehouse",
+					},
+					Sources: kargoapi.FreightSources{
+						Direct: true,
+					},
+				}},
+				Freight: kargoapi.FreightCollection{
+					Freight: map[string]kargoapi.FreightReference{
+						"Warehouse/fake-warehouse": {
+							Origin: kargoapi.FreightOrigin{
+								Kind: kargoapi.FreightOriginKindWarehouse,
+								Name: "fake-warehouse",
+							},
+							Images: []kargoapi.Image{{
+								RepoURL: "fake-image-repo",
+								Tag:     "fake-image-tag",
+							}},
+						},
+					},
+				},
+				Vars: []kargoapi.PromotionVariable{
+					{
+						Name:  "warehouseName",
+						Value: "fake-warehouse",
+					},
+					{
+						Name:  "repoURL",
+						Value: "fake-image-repo",
+					},
+				},
+			},
+			// Two ways to use the imageFrom() function:
+			// 1. Pass an image repo URL
+			// 2. Pass an image repo URL and origin
+			rawCfg: []byte(`{
+				"imageTag1": "${{ imageFrom('fake-image-repo').Tag }}",
+				"imageTag2": "${{ imageFrom(vars.repoURL).Tag }}",
+				"imageTag3": "${{ imageFrom('fake-image-repo', warehouse('fake-warehouse')).Tag }}",
+				"imageTag4": "${{ imageFrom(vars.repoURL, warehouse(vars.warehouseName)).Tag }}"
+			}`),
+			expectedCfg: Config{
+				"imageTag1": "fake-image-tag",
+				"imageTag2": "fake-image-tag",
+				"imageTag3": "fake-image-tag",
+				"imageTag4": "fake-image-tag",
+			},
+		},
+		{
+			name: "test chartFrom function",
+			// Test different ways to use the chartFrom() function
+			promoCtx: PromotionContext{
+				Project: "fake-project",
+				FreightRequests: []kargoapi.FreightRequest{{
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "fake-warehouse",
+					},
+					Sources: kargoapi.FreightSources{
+						Direct: true,
+					},
+				}},
+				Freight: kargoapi.FreightCollection{
+					Freight: map[string]kargoapi.FreightReference{
+						"Warehouse/fake-warehouse": {
+							Origin: kargoapi.FreightOrigin{
+								Kind: kargoapi.FreightOriginKindWarehouse,
+								Name: "fake-warehouse",
+							},
+							Charts: []kargoapi.Chart{
+								{
+									RepoURL: "https://fake-chart-repo",
+									Name:    "fake-chart",
+									Version: "fake-chart-version",
+								},
+								{
+									RepoURL: "oci://fake-oci-repo/fake-chart",
+									Version: "fake-oci-chart-version",
+								},
+							},
+						},
+					},
+				},
+				Vars: []kargoapi.PromotionVariable{
+					{
+						Name:  "warehouseName",
+						Value: "fake-warehouse",
+					},
+					{
+						Name:  "repoURL",
+						Value: "https://fake-chart-repo",
+					},
+					{
+						Name:  "chartName",
+						Value: "fake-chart",
+					},
+					{
+						Name:  "ociRepoURL",
+						Value: "oci://fake-oci-repo/fake-chart",
+					},
+				},
+			},
+			// Four ways to use the chartFrom() function:
+			// 1. Pass an OCI chart repo URL
+			// 2. Pass an OCI chart repo URL and origin
+			// 3. Pass an HTTPS chart repo URL and chart name
+			// 4. Pass an HTTPS chart repo URL, chart name, and origin
+			// nolint: lll
+			rawCfg: []byte(`{
+				"chartVersion1": "${{ chartFrom('oci://fake-oci-repo/fake-chart').Version }}",
+				"chartVersion2": "${{ chartFrom(vars.ociRepoURL).Version }}",
+				"chartVersion3": "${{ chartFrom('oci://fake-oci-repo/fake-chart', warehouse('fake-warehouse')).Version }}",
+				"chartVersion4": "${{ chartFrom(vars.ociRepoURL, warehouse(vars.warehouseName)).Version }}",
+				"chartVersion5": "${{ chartFrom('https://fake-chart-repo', 'fake-chart').Version }}",
+				"chartVersion6": "${{ chartFrom(vars.repoURL, vars.chartName).Version }}",
+				"chartVersion7": "${{ chartFrom('https://fake-chart-repo', 'fake-chart', warehouse('fake-warehouse')).Version }}",
+				"chartVersion8": "${{ chartFrom(vars.repoURL, vars.chartName, warehouse(vars.warehouseName)).Version }}"
+			}`),
+			expectedCfg: Config{
+				"chartVersion1": "fake-oci-chart-version",
+				"chartVersion2": "fake-oci-chart-version",
+				"chartVersion3": "fake-oci-chart-version",
+				"chartVersion4": "fake-oci-chart-version",
+				"chartVersion5": "fake-chart-version",
+				"chartVersion6": "fake-chart-version",
+				"chartVersion7": "fake-chart-version",
+				"chartVersion8": "fake-chart-version",
 			},
 		},
 	}
-	promoState := State{
-		"strOutput":  "foo",
-		"boolOutput": true,
-		"numOutput":  42,
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			promoStep := PromotionStep{
+				Config: testCase.rawCfg,
+			}
+			stepCfg, err := promoStep.GetConfig(
+				context.Background(),
+				testClient,
+				testCase.promoCtx,
+				testCase.promoState,
+			)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedCfg, stepCfg)
+		})
 	}
-	promoStep := PromotionStep{
-		// nolint: lll
-		Config: []byte(`{
-			"project": "${{ ctx.project }}",
-			"stage": "${{ ctx.stage }}",
-			"promotion": "${{ ctx.promotion }}",
-			"staticStr": "foo",
-			"staticBool": true,
-			"staticNum": 42,
-			"strVar": "${{ vars.strVar }}",
-			"concatStrVar": "${{ vars.concatStrVar }}",
-			"boolVar": "${{ vars.boolVar }}",
-			"boolStrVar": "${{ quote(vars.boolStrVar) }}",
-			"numVar": "${{ vars.numVar }}",
-			"numStrVar": "${{ quote(vars.numStrVar) }}",
-			"commitID": "${{ commitFrom(\"https://fake-git-repo\", warehouse(\"fake-warehouse\")).ID }}",
-			"imageTag": "${{ imageFrom(\"fake-image-repo\", warehouse(\"fake-warehouse\")).Tag }}",
-			"chartVersion": "${{ chartFrom(\"https://fake-chart-repo\", \"fake-chart\", warehouse(\"fake-warehouse\")).Version }}",
-			"secret1-1": "${{ secrets.secret1.key1 }}",
-			"secret1-2": "${{ secrets.secret1.key2 }}",
-			"secret2-3": "${{ secrets.secret2.key3 }}",
-			"secret2-4": "${{ secrets.secret2.key4 }}",
-			"strOutput": "${{ outputs.strOutput }}",
-			"strOutputConcat": "${{ outputs.strOutput }}${{ outputs.strOutput }}",
-			"boolOutput": "${{ outputs.boolOutput }}",
-			"boolStrOutput": "${{ quote(!outputs.boolOutput) }}",
-			"numOutput": "${{ outputs.numOutput }}",
-			"numStrOutput": "${{ quote(outputs.numOutput + 1) }}"
-		}`),
-	}
-	stepCfg, err := promoStep.GetConfig(
-		context.Background(),
-		nil, // We can get away with a nil Kubernetes client because we're specifying origins
-		promoCtx,
-		promoState,
-	)
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		Config{
-			"project":         "fake-project",
-			"stage":           "fake-stage",
-			"promotion":       "fake-promotion",
-			"staticStr":       "foo",
-			"staticBool":      true,
-			"staticNum":       42,
-			"strVar":          "foo",
-			"concatStrVar":    "foobar",
-			"boolVar":         true,
-			"boolStrVar":      "false",
-			"numVar":          42,
-			"numStrVar":       "43",
-			"commitID":        "fake-commit-id",
-			"imageTag":        "fake-image-tag",
-			"chartVersion":    "fake-chart-version",
-			"secret1-1":       "value1",
-			"secret1-2":       "value2",
-			"secret2-3":       "value3",
-			"secret2-4":       "value4",
-			"strOutput":       "foo",
-			"strOutputConcat": "foofoo",
-			"boolOutput":      true,
-			"boolStrOutput":   "false",
-			"numOutput":       42,
-			"numStrOutput":    "43",
-		},
-		stepCfg,
-	)
 }


### PR DESCRIPTION
This fixes the strange issue that @34fathombelow reported through internal channels:

> Having an issue with the `ChartFrom()` function in the `helm-update-chart` promotion step. For some reason the second argument does not work with a variable
`version: ${{ chartFrom(vars.chartRepo, vars.chartName, warehouse(vars.chartName)).Version }}` gives the following error:
>```
>step execution failed: failed to get step config: runtime error: index out of range [1] with >length 1
>```
>However `version: ${{ chartFrom(vars.chartRepo, "kube-prometheus-stack", warehouse(vars.chartName)).Version }}` works as expected.

expr-lang supports function overloading. You register the function signatures you'll accept, and they all get mapped to a common `func(params ...any) (any, error)`. This is what we've done with `chartFrom()`, calls to which can take one of four valid forms:

1. oci chart repo url (string)
4. oci chart repo url, origin (string, origin)
1. http/s chart repo url, chart name (string, string)
2. http/s chart repo url, chart name, origin (string, string origin)

After extensive debugging, I've concluded the order in which these are defined seems to matter. 

More specifically, it matters when a variable from the `vars` map is used since `vars` is a `map[string]any`. This makes the variable values themselves `any` (instead of a string, for instance). This seems to confound expr-lang when iterating over the possible signatures of the function to try and match one to the arguments that were given. An incorrect choice, in turn, leads to an the index out of bounds error as expr-lang attempts to prepare the arguments to be passed to the common `func(params ...any) (any, error)`.

I had a hunch that ordering the signatures from longest and most complex to shortest and simplest might yield a better signature match under these sort of circumstances and that proved to be the case.

I applied the same re-ordering to other similar functions, although they were not prone to this difficulty. (`fromChart()` is the most complex with the widest range of supported usage. The others, being comparatively simple, didn't encounter this difficulty.)

Due in large measure to my inability to _completely_ connect the dots on how expr-lang was picking the wrong function signature, I re-wrote the tests for the affected code to exercise all possible signatures of `fromChart()` and similar functions -- and to do so with string literals as arguments and again with vars (`any`). Everything checks out now.
