### PR TITLE
refactor(controller): fix order of imageFrom() func signatures

### DIFF
--- a/internal/directives/promotions.go
+++ b/internal/directives/promotions.go
@@ -148,8 +148,8 @@ func (s *PromotionStep) GetConfig(
 		expr.Function(
 			"imageFrom",
 			getImageFunc(ctx, cl, promoCtx),
-			new(func(repoURL string) kargoapi.Image),
 			new(func(repoURL string, origin kargoapi.FreightOrigin) kargoapi.Image),
+			new(func(repoURL string) kargoapi.Image),
 		),
 		expr.Function(
 			"chartFrom",


### PR DESCRIPTION
Follow-up to #2998

> ordering the signatures from longest and most complex to shortest and simplest might yield a better signature match

> I applied the same re-ordering to other similar functions

One such change was not saved and thus was not committed and included in the PR.

This small change makes the statement accurate and the tests still pass.