### PR TITLE
feat: Publish kargo to brew

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -333,6 +333,7 @@ jobs:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
       provenance-name: kargo-cli.intoto.jsonl
+
   update-homebrew-formula:
     if: github.event_name == 'release'
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -347,9 +347,6 @@ jobs:
 
     - name: Setup Git User
       uses: fregante/setup-git-user@v2
-      with:
-        name: ${{ github.actor }}
-        email: ${{ github.actor }}@users.noreply.github.com
 
     - name: Update formula and push
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -341,34 +341,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ publish-image, publish-cli ]
     steps:
-      - name: Checkout bottle Repository
-        uses: actions/checkout@v4
-        with:
-          repository: akuity/homebrew-tap
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: homebrew-tap
+    - name: Checkout tap repository
+      uses: actions/checkout@v4
+      with:
+        repository: akuity/homebrew-tap
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Homebrew formula
-        run: |
-          cd homebrew-tap
-          ./update.sh kargo ${{ github.ref_name }}
+    - name: Setup Git User
+      uses: fregante/setup-git-user@v2
+      with:
+        name: ${{ github.actor }}
+        email: ${{ github.actor }}@users.noreply.github.com
 
-      - name: Configure Git and Commit changes
-        run: |
-          cd homebrew-tap
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git checkout -b update-kargo-${{ github.ref_name }}
-          git add kargo.rb
-          git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"
+    - name: Update formula and push
+      run: |
+        git checkout -b update-kargo-${{ github.ref_name }}
+        ./update.sh kargo ${{ github.ref_name }}
+        git add kargo.rb
+        git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"
+        git push origin update-kargo-${{ github.ref_name }}
 
-      - name: Push changes and open PR
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update Kargo formula to version ${{ github.ref_name }}"
-          branch: update-kargo-${{ github.ref_name }}
-          base: main
-          title: "chore: update Kargo formula to version ${{ github.ref_name }}"
-          body: "This PR updates the Homebrew formula for Kargo to version ${{ github.ref_name }}."
-          delete-branch: 'true'
+    - name: Open PR
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Update Kargo formula to version ${{ github.ref_name }}"
+        branch: update-kargo-${{ github.ref_name }}
+        base: main
+        title: "chore: update Kargo formula to version ${{ github.ref_name }}"
+        body: "This PR updates the Homebrew formula for Kargo to version ${{ github.ref_name }}."
+        delete-branch: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -355,9 +355,9 @@ jobs:
 
       - name: Configure Git and Commit changes
         run: |
+          cd homebrew-tap
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          cd homebrew-tap
           git checkout -b update-kargo-${{ github.ref_name }}
           git add kargo.rb
           git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -335,10 +335,7 @@ jobs:
       provenance-name: kargo-cli.intoto.jsonl
 
   update-homebrew-formula:
-    if: github.event_name == 'release'
-    permissions:
-      contents: write # Needed to push changes
-      pull-requests: write # Needed to create a pull request
+    if: github.event_name == 'release' && github.event.action == 'released' # Runs only for stable releases
     runs-on: ubuntu-latest
     needs: [ publish-image, publish-cli ]
     steps:
@@ -346,7 +343,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: akuity/homebrew-tap
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.TAP_PAT }}
 
     - name: Setup Git User
       uses: fregante/setup-git-user@v2
@@ -365,7 +362,7 @@ jobs:
     - name: Open PR
       uses: peter-evans/create-pull-request@v5
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.TAP_PAT }}
         commit-message: "Update Kargo formula to version ${{ github.ref_name }}"
         branch: update-kargo-${{ github.ref_name }}
         base: main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -333,3 +333,42 @@ jobs:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release
       provenance-name: kargo-cli.intoto.jsonl
+  update-homebrew-formula:
+    if: github.event_name == 'release'
+    permissions:
+      contents: write # Needed to push changes
+      pull-requests: write # Needed to create a pull request
+    runs-on: ubuntu-latest
+    needs: [ publish-image, publish-cli ]
+    steps:
+      - name: Checkout bottle Repository
+        uses: actions/checkout@v4
+        with:
+          repository: akuity/homebrew-tap
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew formula
+        run: |
+          cd homebrew-tap
+          ./update.sh kargo ${{ github.ref_name }}
+
+      - name: Configure Git and Commit changes
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          cd homebrew-tap
+          git checkout -b update-kargo-${{ github.ref_name }}
+          git add kargo.rb
+          git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"
+
+      - name: Push changes and open PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update Kargo formula to version ${{ github.ref_name }}"
+          branch: update-kargo-${{ github.ref_name }}
+          base: main
+          title: "chore: update Kargo formula to version ${{ github.ref_name }}"
+          body: "This PR updates the Homebrew formula for Kargo to version ${{ github.ref_name }}."
+          delete-branch: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -353,8 +353,11 @@ jobs:
 
     - name: Update formula and push
       run: |
+        VERSION_SUFFIX=$(echo "${{ github.ref_name }}" | grep -oP "^v\d+\.\d+" | sed 's/^v/@/')
+        echo "version_suffix=$VERSION_SUFFIX" >> $GITHUB_ENV
+
         git checkout -b update-kargo-${{ github.ref_name }}
-        ./update.sh kargo ${{ github.ref_name }}
+        ./update.sh kargo ${{ github.ref_name }} ${{ env.version_suffix }}
         git add kargo.rb
         git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"
         git push origin update-kargo-${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -345,17 +345,33 @@ jobs:
         repository: akuity/homebrew-tap
         token: ${{ secrets.TAP_PAT }}
 
+    - name: Export LATEST_TAG and VERSION_SUFFIX
+      run: |
+        LATEST_TAG=$(curl -qsSL \
+          -H 'Accept: application/vnd.github+json' \
+          -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          -H 'X-GitHub-Api-Version: 2022-11-28' \
+          '${{ github.api_url }}/repos/${{ github.repository }}/releases/latest' \
+        | jq -r .tag_name)
+        echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+        VERSION_SUFFIX=$(echo "${{ github.ref_name }}" | grep -oP "^v\d+\.\d+" | sed 's/^v/@/')
+        echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
+
     - name: Setup Git User
       uses: fregante/setup-git-user@v2
 
-    - name: Update formula and push
+    - name: Update formula and push changes
       run: |
-        VERSION_SUFFIX=$(echo "${{ github.ref_name }}" | grep -oP "^v\d+\.\d+" | sed 's/^v/@/')
-        echo "version_suffix=$VERSION_SUFFIX" >> $GITHUB_ENV
-
         git checkout -b update-kargo-${{ github.ref_name }}
-        ./update.sh kargo ${{ github.ref_name }} ${{ env.version_suffix }}
-        git add kargo.rb
+ 
+        if [[ ${{ github.ref_name }} == ${{ env.LATEST_TAG }} ]]; then
+          ./update.sh kargo ${{ github.ref_name }}
+          git add kargo.rb
+        fi
+        
+        ./update.sh kargo ${{ github.ref_name }} ${{ env.VERSION_SUFFIX }}
+        git add kargo${{ env.VERSION_SUFFIX }}.rb
         git commit -m "chore: update Kargo cli to version ${{ github.ref_name }}"
         git push origin update-kargo-${{ github.ref_name }}
 

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-cli:
 		./cmd/cli
 
 ################################################################################
-# Used for Nighty/Unstable builds                                              #
+# Used for Nightly/Unstable builds                                              #
 ################################################################################
 
 .PHONY: build-nightly-cli

--- a/docs/docs/40-contributor-guide/15-release-procedures.md
+++ b/docs/docs/40-contributor-guide/15-release-procedures.md
@@ -154,7 +154,7 @@ release date -- which is always a Friday.
       [automated release process](https://github.com/akuity/kargo/actions/workflows/release.yaml)
       to complete.
 
-1. Update Homebrew Formula.
+1. Update [Homebrew Formula](https://github.com/akuity/homebrew-tap).
 
     * Clone the Homebrew tap repository:
         ```bash

--- a/docs/docs/40-contributor-guide/15-release-procedures.md
+++ b/docs/docs/40-contributor-guide/15-release-procedures.md
@@ -154,6 +154,29 @@ release date -- which is always a Friday.
       [automated release process](https://github.com/akuity/kargo/actions/workflows/release.yaml)
       to complete.
 
+1. Update Homebrew Formula.
+
+    * Clone the Homebrew tap repository:
+        ```bash
+        git clone https://github.com/akuity/homebrew-tap.git
+        cd homebrew-tap
+        ```
+    * Run the update script with the new version:
+        ```bash
+        ./update.sh kargo vM.m.0
+        ```
+    * Verify the updated formula:
+        ```bash
+        brew install --build-from-source ./kargo.rb
+        kargo --version
+        ```
+    * Commit and push the changes to the Homebrew tap repository:
+        ```bash
+        git add kargo.rb
+        git commit -m "Update Kargo formula to version vM.m.0"
+        git push origin main
+        ```
+
 1. Mark the release branch (`release-M.m`) as the __"Production branch"__
    [in Netlify](https://app.netlify.com/sites/docs-kargo-akuity-io/configuration/deploys#branches-and-deploy-contexts).
 

--- a/docs/docs/40-contributor-guide/15-release-procedures.md
+++ b/docs/docs/40-contributor-guide/15-release-procedures.md
@@ -154,29 +154,6 @@ release date -- which is always a Friday.
       [automated release process](https://github.com/akuity/kargo/actions/workflows/release.yaml)
       to complete.
 
-1. Update [Homebrew Formula](https://github.com/akuity/homebrew-tap).
-
-    * Clone the Homebrew tap repository:
-        ```bash
-        git clone https://github.com/akuity/homebrew-tap.git
-        cd homebrew-tap
-        ```
-    * Run the update script with the new version:
-        ```bash
-        ./update.sh kargo vM.m.0
-        ```
-    * Verify the updated formula:
-        ```bash
-        brew install --build-from-source ./kargo.rb
-        kargo --version
-        ```
-    * Commit and push the changes to the Homebrew tap repository:
-        ```bash
-        git add kargo.rb
-        git commit -m "Update Kargo formula to version vM.m.0"
-        git push origin main
-        ```
-
 1. Mark the release branch (`release-M.m`) as the __"Production branch"__
    [in Netlify](https://app.netlify.com/sites/docs-kargo-akuity-io/configuration/deploys#branches-and-deploy-contexts).
 


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/2514

Added the Kargo CLI to Homebrew. The formula supports macOS (Intel and ARM) and Linux (Intel and ARM) with architecture-specific binaries for version `v1.0.3` currently.
Formula can be found here: https://github.com/akuity/homebrew-tap

TODO: Give Permission to access `akuity/homebrew-tap.git` (for creating a pull request) to github-actions[bot] (`GITHUB_TOKEN`)