### PR TITLE
chore: stop using deprecated setting for cert-manager chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ hack-install-cert-manager: install-helm
 		--install \
 		--create-namespace \
 		--namespace cert-manager \
-		--set installCRDs=true \
+		--set crds.enabled=true \
 		--wait
 
 .PHONY: hack-install-argocd

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -11,7 +11,7 @@ helm install cert-manager cert-manager \
   --version $cert_manager_chart_version \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --wait
 
 helm install argocd argo-cd \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -18,7 +18,7 @@ helm install cert-manager cert-manager \
   --version $cert_manager_chart_version \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --wait
 
 helm install argocd argo-cd \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -32,7 +32,7 @@ helm install cert-manager cert-manager \
   --version $cert_manager_chart_version \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true \
+  --set crds.enabled=true \
   --wait
 
 helm install argocd argo-cd \


### PR DESCRIPTION
Thank you @arober39 for finding.