### PR TITLE
chore: preview the docs in container as the host user to avoid permission denied error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ start-controller-local:
 
 .PHONY: hack-serve-docs
 hack-serve-docs: hack-build-dev-tools
-	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) -p $(DOCS_PORT):$(DOCS_PORT) kargo:dev-tools make serve-docs
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) --user $(id -u):$(id -g) -p $(DOCS_PORT):$(DOCS_PORT) kargo:dev-tools make serve-docs
 
 .PHONY: serve-docs
 serve-docs:

--- a/docs/docs/30-how-to-guides/10-installing-kargo.md
+++ b/docs/docs/30-how-to-guides/10-installing-kargo.md
@@ -74,7 +74,7 @@ following:
 1. Edit and save the values.
 
    :::info
-   You will find this configuration file contains helpful comments for every
+   You will find that this configuration file (kargo-values.yaml) contains helpful comments for every
    option, so specific options are not covered in detail here.
    :::
 

--- a/docs/docs/40-contributor-guide/10-hacking-on-kargo.md
+++ b/docs/docs/40-contributor-guide/10-hacking-on-kargo.md
@@ -455,13 +455,11 @@ make hack-serve-docs
 ```
 
 :::info
-If you wish to opt-out of executing code-generation within a container (for
-performance reasons, perhaps), drop the `hack-` prefix from the target to run the docs natively on your system:
+If you want to build and serve the docs on your local machine, run the following command:
 
 ```shell
 make serve-docs
 ```
 
-This will require quite a variety of tools to be installed locally, so we do not
-recommend this if you can avoid it.
+This will require you to install the [`pnpm`](https://pnpm.io/installation) tool locally on your machine.
 :::


### PR DESCRIPTION
This PR serves couple of things:

1. Make sure to run the container for serving docs as the host user otherwise you'll get the `Permission Denied Error` 
```
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
docker run -it --rm -e GOFLAGS="-buildvcs=false" -v gomodcache:/home/user/gocache -v /home/nitish/Documents/Work/Open-Source/kargo/:/workspaces/kargo -v /workspaces/kargo/ui/node_modules -w /workspaces/kargo -p 3000:3000 kargo:dev-tools make serve-docs
cd docs && pnpm install && pnpm start
 EACCES  EACCES: permission denied, open '/workspaces/kargo/docs/_tmp_61_f8a007a35b8c63922ca99b1fba2579a9'


make: *** [Makefile:418: serve-docs] Error 243
make: *** [Makefile:414: hack-serve-docs] Error 2
```

2. Modify the instructions on how to build the docs locally - all it requires you to install is the `pnpm` tool locally and not any other variety of tools. 