### PR TITLE
chore(ci): handle deprecation of Go linter format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
       run: git config --global --add safe.directory '*'
     - name: Run linter
       env:
-        GO_LINT_ERROR_FORMAT: github-actions
+        GO_LINT_ERROR_FORMAT: colored-line-number
       run: make lint-go
 
   lint-charts:


### PR DESCRIPTION
Deals with error that I had noticed a couple of times in CI:

```
level=warning msg="[config_reader] The output format `github-actions` is deprecated, please use `colored-line-number`"
```