### PR TITLE
chore: release chores 1.0

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -47,7 +47,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -66,7 +66,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -78,7 +78,7 @@ just for this quickstart using
 [kind](https://kind.sigs.k8s.io/#installation-and-usage).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/kind.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/kind.sh | sh
 ```
 
 :::info
@@ -96,7 +96,7 @@ Docker, Docker Desktop, or OrbStack), you can easily launch a disposable cluster
 just for this quickstart using [k3d](https://k3d.io).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/k3d.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/k3d.sh | sh
 ```
 
 :::info
@@ -491,7 +491,7 @@ the previous section.
     ```shell
     arch=$(uname -m)
     [ "$arch" = "x86_64" ] && arch=amd64
-    curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
+    curl -L -o kargo https://github.com/akuity/kargo/releases/v1.0.4/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
     chmod +x kargo
     ```
 
@@ -502,7 +502,7 @@ the previous section.
     <TabItem value="windows" label="Windows Powershell">
 
     ```shell
-    Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+    Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/v1.0.4/download/kargo-windows-amd64.exe -OutFile kargo.exe
     ```
 
     Then move `kargo.exe` to a location in your file system that is included in the value
@@ -883,7 +883,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>
@@ -901,7 +901,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.0/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>

--- a/docs/docs/30-how-to-guides/10-installing-kargo.md
+++ b/docs/docs/30-how-to-guides/10-installing-kargo.md
@@ -45,6 +45,7 @@ user-specified admin password:
 ```shell
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 1.0.4 \
   --namespace kargo \
   --create-namespace \
   --set api.adminAccount.passwordHash='$2a$10$Zrhhie4vLz5ygtVSaif6o.qN36jgs6vjtMBdM6yrU1FOeiAAMMxOm' \
@@ -83,6 +84,7 @@ following:
    ```shell
    helm install kargo \
      oci://ghcr.io/akuity/kargo-charts/kargo \
+     --version 1.0.4 \
      --namespace kargo \
      --create-namespace \
      --values ~/kargo-values.yaml \

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -39,6 +39,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 1.0.4 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -46,6 +46,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 1.0.4 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -60,6 +60,7 @@ helm install argo-rollouts argo-rollouts \
 # Password is 'admin'
 helm install kargo \
   oci://ghcr.io/akuity/kargo-charts/kargo \
+  --version 1.0.4 \
   --namespace kargo \
   --create-namespace \
   --set api.service.type=NodePort \


### PR DESCRIPTION
This PR locks the docs in `release-1.0` (the current production docs) into v1.0.4 of the chart and quickstart scripts from the `release-1.0` branch.

This allows us to switch to the soon-to-be-published `release-1.1` production docs without breaking the documentation for 1.0.