### PR TITLE
chore: release chores 1.1

### DIFF
--- a/docs/docs/20-quickstart.md
+++ b/docs/docs/20-quickstart.md
@@ -47,7 +47,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -66,7 +66,7 @@ remove not just Kargo-related resources, but _all_ your workloads and data.
 :::
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/install.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/install.sh | sh
 ```
 
 </TabItem>
@@ -78,7 +78,7 @@ just for this quickstart using
 [kind](https://kind.sigs.k8s.io/#installation-and-usage).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/kind.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/kind.sh | sh
 ```
 
 :::info
@@ -96,7 +96,7 @@ Docker, Docker Desktop, or OrbStack), you can easily launch a disposable cluster
 just for this quickstart using [k3d](https://k3d.io).
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/k3d.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/k3d.sh | sh
 ```
 
 :::info
@@ -937,7 +937,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>
@@ -955,7 +955,7 @@ If, instead, you wish to preserve non-Kargo-related workloads and data, you
 will need to manually uninstall Kargo and its prerequisites:
 
 ```shell
-curl -L https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/uninstall.sh | sh
+curl -L https://raw.githubusercontent.com/akuity/kargo/release-1.1/hack/quickstart/uninstall.sh | sh
 ```
 
 </TabItem>


### PR DESCRIPTION
While this is not part of the currently documented [release procedure](https://docs.kargo.io/contributor-guide/release-procedures), I believe this is the correct way to handle this.

The reason is that `main` may contain changes that are not relevant to the current production release range, which could then cause issues. Instead, the documentation should be locked to scripts from the release branch, and any changes relevant to this SemVer range should be backported instead.

Note that this does not include setting the version for the chart as is being done in e.g. #3078, as the "latest" published version is correctly detected by Helm itself.