### PR TITLE
fix(controller): do not normalize urls when searching for image creds

### DIFF
--- a/internal/credentials/kubernetes/database_test.go
+++ b/internal/credentials/kubernetes/database_test.go
@@ -34,38 +34,45 @@ func TestGet(t *testing.T) {
 		testProjectNamespace = "fake-namespace"
 		testGlobalNamespace  = "another-fake-namespace"
 
-		testCredType = credentials.TypeGit
-
 		// This deliberately omits the trailing .git to test normalization
-		testRepoURL     = "https://github.com/akuity/kargo"
-		insecureTestURL = "http://github.com/akuity/bogus.git"
+		testGitRepoURL     = "https://github.com/akuity/kargo"
+		testInsecureGitURL = "http://github.com/akuity/bogus.git"
+
+		// This is deliberately an image URL that could be mistaken for an SCP-style
+		// Git URL to verify that Git URL normalization is not applied to image
+		// URLs.
+		testImageURL = "my-registry.io:5000/image"
 	)
 
-	testLabels := map[string]string{
-		kargoapi.CredentialTypeLabelKey: testCredType.String(),
+	testGitLabels := map[string]string{
+		kargoapi.CredentialTypeLabelKey: credentials.TypeGit.String(),
 	}
 
-	projectCredentialWithRepoURL := &corev1.Secret{
+	testImageLabels := map[string]string{
+		kargoapi.CredentialTypeLabelKey: credentials.TypeImage.String(),
+	}
+
+	projectGitCredentialWithRepoURL := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "project-credential-repo-url",
+			Name:      "project-credential-git-repo-url",
 			Namespace: testProjectNamespace,
-			Labels:    testLabels,
+			Labels:    testGitLabels,
 		},
 		Data: map[string][]byte{
-			credentials.FieldRepoURL:  []byte(testRepoURL),
+			credentials.FieldRepoURL:  []byte(testGitRepoURL),
 			credentials.FieldUsername: []byte("project-exact"),
 			credentials.FieldPassword: []byte("fake-password"),
 		},
 	}
 
-	projectCredentialWithRepoURLPattern := &corev1.Secret{
+	projectGitCredentialWithRepoURLPattern := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "project-credential-repo-url-pattern",
+			Name:      "project-credential-git-repo-url-pattern",
 			Namespace: testProjectNamespace,
-			Labels:    testLabels,
+			Labels:    testGitLabels,
 		},
 		Data: map[string][]byte{
-			credentials.FieldRepoURL:        []byte(testRepoURL),
+			credentials.FieldRepoURL:        []byte(testGitRepoURL),
 			credentials.FieldRepoURLIsRegex: []byte("true"),
 			credentials.FieldUsername:       []byte("project-pattern"),
 			credentials.FieldPassword:       []byte("fake-password"),
@@ -76,40 +83,94 @@ func TestGet(t *testing.T) {
 	// Kargo will refuse to look for credentials for insecure URLs. However,
 	// this is a secret that WOULD be matched if not for that check. This helps
 	// us test that the check is working.
-	projectCredentialWithInsecureRepoURL := &corev1.Secret{
+	projectGitCredentialWithInsecureRepoURL := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "project-credential-insecure-repo-url",
+			Name:      "project-credential-git-insecure-repo-url",
 			Namespace: testProjectNamespace,
-			Labels:    testLabels,
+			Labels:    testGitLabels,
 		},
 		Data: map[string][]byte{
-			credentials.FieldRepoURL:  []byte(insecureTestURL),
+			credentials.FieldRepoURL:  []byte(testInsecureGitURL),
 			credentials.FieldUsername: []byte("project-insecure"),
 			credentials.FieldPassword: []byte("fake-password"),
 		},
 	}
 
-	globalCredentialWithRepoURL := &corev1.Secret{
+	globalGitCredentialWithRepoURL := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "global-credential-repo-url",
+			Name:      "global-credential-git-repo-url",
 			Namespace: testGlobalNamespace,
-			Labels:    testLabels,
+			Labels:    testGitLabels,
 		},
 		Data: map[string][]byte{
-			credentials.FieldRepoURL:  []byte(testRepoURL),
+			credentials.FieldRepoURL:  []byte(testGitRepoURL),
 			credentials.FieldUsername: []byte("global-exact"),
 			credentials.FieldPassword: []byte("fake-password"),
 		},
 	}
 
-	globalCredentialWithRepoURLPattern := &corev1.Secret{
+	globalGitCredentialWithRepoURLPattern := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "global-credential-repo-url-pattern",
+			Name:      "global-credential-git-repo-url-pattern",
 			Namespace: testGlobalNamespace,
-			Labels:    testLabels,
+			Labels:    testGitLabels,
 		},
 		Data: map[string][]byte{
-			credentials.FieldRepoURL:        []byte(testRepoURL),
+			credentials.FieldRepoURL:        []byte(testGitRepoURL),
+			credentials.FieldRepoURLIsRegex: []byte("true"),
+			credentials.FieldUsername:       []byte("global-pattern"),
+			credentials.FieldPassword:       []byte("fake-password"),
+		},
+	}
+
+	projectImageCredentialWithRepoURL := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "project-credential-image-repo-url",
+			Namespace: testProjectNamespace,
+			Labels:    testImageLabels,
+		},
+		Data: map[string][]byte{
+			credentials.FieldRepoURL:  []byte(testImageURL),
+			credentials.FieldUsername: []byte("project-exact"),
+			credentials.FieldPassword: []byte("fake-password"),
+		},
+	}
+
+	projectImageCredentialWithRepoURLPattern := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "project-credential-image-repo-url-pattern",
+			Namespace: testProjectNamespace,
+			Labels:    testImageLabels,
+		},
+		Data: map[string][]byte{
+			credentials.FieldRepoURL:        []byte(testImageURL),
+			credentials.FieldRepoURLIsRegex: []byte("true"),
+			credentials.FieldUsername:       []byte("project-pattern"),
+			credentials.FieldPassword:       []byte("fake-password"),
+		},
+	}
+
+	globalImageCredentialWithRepoURL := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-credential-image-repo-url",
+			Namespace: testGlobalNamespace,
+			Labels:    testImageLabels,
+		},
+		Data: map[string][]byte{
+			credentials.FieldRepoURL:  []byte(testImageURL),
+			credentials.FieldUsername: []byte("global-exact"),
+			credentials.FieldPassword: []byte("fake-password"),
+		},
+	}
+
+	globalImageCredentialWithRepoURLPattern := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-credential-image-repo-url-pattern",
+			Namespace: testGlobalNamespace,
+			Labels:    testImageLabels,
+		},
+		Data: map[string][]byte{
+			credentials.FieldRepoURL:        []byte(testImageURL),
 			credentials.FieldRepoURLIsRegex: []byte("true"),
 			credentials.FieldUsername:       []byte("global-pattern"),
 			credentials.FieldPassword:       []byte("fake-password"),
@@ -119,76 +180,120 @@ func TestGet(t *testing.T) {
 	testCases := []struct {
 		name     string
 		secrets  []client.Object
+		credType credentials.Type
 		repoURL  string
 		expected *corev1.Secret
 	}{
 		{
-			name:     "exact match in project namespace",
-			secrets:  []client.Object{projectCredentialWithRepoURL},
-			repoURL:  testRepoURL,
-			expected: projectCredentialWithRepoURL,
+			name:     "git URL exact match in project namespace",
+			secrets:  []client.Object{projectGitCredentialWithRepoURL},
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: projectGitCredentialWithRepoURL,
 		},
 		{
-			name:     "pattern match in project namespace",
-			secrets:  []client.Object{projectCredentialWithRepoURLPattern},
-			repoURL:  testRepoURL,
-			expected: projectCredentialWithRepoURLPattern,
+			name:     "git URL pattern match in project namespace",
+			secrets:  []client.Object{projectGitCredentialWithRepoURLPattern},
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: projectGitCredentialWithRepoURLPattern,
 		},
 		{
-			name:     "exact match in global namespace",
-			secrets:  []client.Object{globalCredentialWithRepoURL},
-			repoURL:  testRepoURL,
-			expected: globalCredentialWithRepoURL,
+			name:     "git URL exact match in global namespace",
+			secrets:  []client.Object{globalGitCredentialWithRepoURL},
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: globalGitCredentialWithRepoURL,
 		},
 		{
-			name:     "pattern match in global namespace",
-			secrets:  []client.Object{globalCredentialWithRepoURLPattern},
-			repoURL:  testRepoURL,
-			expected: globalCredentialWithRepoURLPattern,
+			name:     "git URL pattern match in global namespace",
+			secrets:  []client.Object{globalGitCredentialWithRepoURLPattern},
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: globalGitCredentialWithRepoURLPattern,
 		},
+		// Image URLs of the form host:port/image can be mistaken for SCP-style Git
+		// URLs. The next several test cases verify that Git URL normalization is
+		// not being applied to image URLs and incorrectly normalizing
+		// host:port/image as ssh://host:port/image.
+		{
+			name:     "image URL exact match in project namespace",
+			secrets:  []client.Object{projectImageCredentialWithRepoURL},
+			credType: credentials.TypeImage,
+			repoURL:  testImageURL,
+			expected: projectImageCredentialWithRepoURL,
+		},
+		{
+			name:     "image URL pattern match in project namespace",
+			secrets:  []client.Object{projectImageCredentialWithRepoURLPattern},
+			credType: credentials.TypeImage,
+			repoURL:  testImageURL,
+			expected: projectImageCredentialWithRepoURLPattern,
+		},
+		{
+			name:     "image URL exact match in global namespace",
+			secrets:  []client.Object{globalImageCredentialWithRepoURL},
+			credType: credentials.TypeImage,
+			repoURL:  testImageURL,
+			expected: globalImageCredentialWithRepoURL,
+		},
+		{
+			name:     "image URL pattern match in global namespace",
+			secrets:  []client.Object{globalImageCredentialWithRepoURLPattern},
+			credType: credentials.TypeImage,
+			repoURL:  testImageURL,
+			expected: globalImageCredentialWithRepoURLPattern,
+		},
+		// The next several tests cases confirm the precedence rules for credential
+		// matching.
 		{
 			name: "precedence: exact match in project namespace over pattern match",
 			secrets: []client.Object{
-				projectCredentialWithRepoURL,
-				projectCredentialWithRepoURLPattern,
+				projectGitCredentialWithRepoURL,
+				projectGitCredentialWithRepoURLPattern,
 			},
-			repoURL:  testRepoURL,
-			expected: projectCredentialWithRepoURL,
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: projectGitCredentialWithRepoURL,
 		},
 		{
 			name: "precedence: exact match in global namespace over pattern match",
 			secrets: []client.Object{
-				globalCredentialWithRepoURL,
-				globalCredentialWithRepoURLPattern,
+				globalGitCredentialWithRepoURL,
+				globalGitCredentialWithRepoURLPattern,
 			},
-			repoURL:  testRepoURL,
-			expected: globalCredentialWithRepoURL,
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: globalGitCredentialWithRepoURL,
 		},
 		{
 			name: "precedence: match in project namespace over match in global namespace",
 			secrets: []client.Object{
-				projectCredentialWithRepoURL,
-				globalCredentialWithRepoURL,
+				projectGitCredentialWithRepoURL,
+				globalGitCredentialWithRepoURL,
 			},
-			repoURL:  testRepoURL,
-			expected: projectCredentialWithRepoURL,
+			credType: credentials.TypeGit,
+			repoURL:  testGitRepoURL,
+			expected: projectGitCredentialWithRepoURL,
 		},
 		{
 			name: "no match",
 			secrets: []client.Object{
-				projectCredentialWithRepoURL,
-				projectCredentialWithRepoURLPattern,
-				globalCredentialWithRepoURL,
-				globalCredentialWithRepoURLPattern,
+				projectGitCredentialWithRepoURL,
+				projectGitCredentialWithRepoURLPattern,
+				globalGitCredentialWithRepoURL,
+				globalGitCredentialWithRepoURLPattern,
 			},
+			credType: credentials.TypeGit,
 			repoURL:  "http://github.com/no/secrets/should/match/this.git",
 			expected: nil,
 		},
 		{
 			name: "insecure HTTP endpoint",
 			// Would match if not for the insecure URL check
-			secrets:  []client.Object{projectCredentialWithInsecureRepoURL},
-			repoURL:  insecureTestURL,
+			secrets:  []client.Object{projectGitCredentialWithInsecureRepoURL},
+			credType: credentials.TypeGit,
+			repoURL:  testInsecureGitURL,
 			expected: nil,
 		},
 	}
@@ -204,7 +309,7 @@ func TestGet(t *testing.T) {
 			).Get(
 				context.Background(),
 				testProjectNamespace,
-				testCredType,
+				testCase.credType,
 				testCase.repoURL,
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #2928

We formerly applied git repo URL and chart repo URL normalization to _all_ repo URLs when searching for credentials because we believed it to be safe.

An edge case we'd not previously identified involved that fact that an image repo URL of the form `host:port/name` can be mistaken for an SCP-style Git URL and would thus be normalized as `host:port/name` 😬 and would prevent a successful match.

This PR causes us to selectively normalize based on the type of credential we're searching for.