### PR TITLE
feat(directives): optional `images` for `kustomize-set-image`

### DIFF
--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -312,7 +312,7 @@ to executing `kustomize edit set image`. This step is commonly followed by a
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a directory containing a `kustomization.yaml` file. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
-| `images` | `[]object` | Y | The details of changes to be applied to the `kustomization.yaml` file. At least one must be specified. |
+| `images` | `[]object` | N | The details of changes to be applied to the `kustomization.yaml` file. When left unspecified, all images from the Freight collection will be set in the Kustomization file. Unless there is an ambiguous image name (for example, due to two Warehouses subscribing to the same repository), which requires manual configuration. |
 | `images[].image` | `string` | Y | Name/URL of the image being updated. |
 | `images[].tag` | `string` | N | A tag naming a specific revision of `image`. Mutually exclusive with `digest` and `useDigest=true`. If none of these are specified, the tag specified by a piece of Freight referencing `image` will be used as the value of this field. |
 | `images[].digest` | `string` | N | A digest naming a specific revision of `image`. Mutually exclusive with `tag` and `useDigest=true`. If none of these are specified, the tag specified by a piece of Freight referencing `image` will be used as the value of `tag`. |

--- a/internal/controller/freight/finder_test.go
+++ b/internal/controller/freight/finder_test.go
@@ -480,6 +480,135 @@ func TestFindImage(t *testing.T) {
 	}
 }
 
+func TestHasAmbiguousImageRequest(t *testing.T) {
+	const testNamespace = "test-namespace"
+	const testRepoURL = "fake-repo-url"
+
+	testOrigin1 := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "test-warehouse",
+	}
+	testOrigin2 := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "some-other-warehouse",
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	testCases := []struct {
+		name       string
+		client     func() client.Client
+		freight    []kargoapi.FreightRequest
+		assertions func(*testing.T, bool, error)
+	}{
+		{
+			name: "no ambiguous image request",
+			client: func() client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+					&kargoapi.Warehouse{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      testOrigin1.Name,
+						},
+						Spec: kargoapi.WarehouseSpec{
+							Subscriptions: []kargoapi.RepoSubscription{{
+								Image: &kargoapi.ImageSubscription{
+									RepoURL: testRepoURL,
+								},
+							}},
+						},
+					},
+				).Build()
+			},
+			freight: []kargoapi.FreightRequest{
+				{
+					Origin: testOrigin1,
+				},
+			},
+			assertions: func(t *testing.T, ambiguous bool, err error) {
+				require.NoError(t, err)
+				require.False(t, ambiguous)
+			},
+		},
+		{
+			name: "ambiguous image request",
+			client: func() client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+					&kargoapi.Warehouse{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      testOrigin1.Name,
+						},
+						Spec: kargoapi.WarehouseSpec{
+							Subscriptions: []kargoapi.RepoSubscription{{
+								Image: &kargoapi.ImageSubscription{
+									RepoURL: testRepoURL,
+								},
+							}},
+						},
+					},
+					&kargoapi.Warehouse{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      testOrigin2.Name,
+						},
+						Spec: kargoapi.WarehouseSpec{
+							Subscriptions: []kargoapi.RepoSubscription{{
+								Image: &kargoapi.ImageSubscription{
+									RepoURL: testRepoURL,
+								},
+							}},
+						},
+					},
+				).Build()
+			},
+			freight: []kargoapi.FreightRequest{
+				{
+					Origin: testOrigin1,
+				},
+				{
+					Origin: testOrigin2,
+				},
+			},
+			assertions: func(t *testing.T, ambiguous bool, err error) {
+				require.True(t, ambiguous)
+				require.ErrorContains(t, err, "multiple requested Freight could potentially provide")
+			},
+		},
+		{
+			name: "origin not found",
+			client: func() client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).Build()
+			},
+			freight: []kargoapi.FreightRequest{
+				{
+					Origin: testOrigin1,
+				},
+			},
+			assertions: func(t *testing.T, _ bool, err error) {
+				require.ErrorContains(t, err, "not found in namespace")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var cl client.Client
+			if testCase.client != nil {
+				cl = testCase.client()
+			}
+			ok, err := HasAmbiguousImageRequest(
+				context.Background(),
+				cl,
+				testNamespace,
+				testCase.freight,
+			)
+			testCase.assertions(t, ok, err)
+		})
+	}
+}
+
 func TestFindChart(t *testing.T) {
 	const testNamespace = "test-namespace"
 	const testRepoURL = "fake-repo-url"

--- a/internal/directives/kustomize_image_setter.go
+++ b/internal/directives/kustomize_image_setter.go
@@ -205,7 +205,17 @@ func (k *kustomizeImageSetter) generateCommitMessage(path string, images map[str
 	}
 	_, _ = commitMsg.WriteString("\n")
 
-	for _, i := range images {
+	// Sort the images by name, in descending order for consistency.
+	imageNames := make([]string, 0, len(images))
+	for name := range images {
+		imageNames = append(imageNames, name)
+	}
+	slices.Sort(imageNames)
+
+	// Append each image to the commit message.
+	for _, name := range imageNames {
+		i := images[name]
+
 		ref := i.Name
 		if i.NewName != "" {
 			ref = i.NewName

--- a/internal/directives/schemas/kustomize-set-image-config.json
+++ b/internal/directives/schemas/kustomize-set-image-config.json
@@ -12,8 +12,7 @@
     },
     "images": {
       "type": "array",
-      "description": "Images is a list of container images to set or update in the Kustomization file.",
-      "minItems": 1,
+      "description": "Images is a list of container images to set or update in the Kustomization file. When left unspecified, all images from the Freight collection will be set in the Kustomization file. Unless there is an ambiguous image name (for example, due to two Warehouses subscribing to the same repository), which requires manual configuration.",
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -378,7 +378,10 @@ type Helm struct {
 }
 
 type KustomizeSetImageConfig struct {
-	// Images is a list of container images to set or update in the Kustomization file.
+	// Images is a list of container images to set or update in the Kustomization file. When
+	// left unspecified, all images from the Freight collection will be set in the Kustomization
+	// file. Unless there is an ambiguous image name (for example, due to two Warehouses
+	// subscribing to the same repository), which requires manual configuration.
 	Images []KustomizeSetImageConfigImage `json:"images"`
 	// Path to the directory containing the Kustomization file.
 	Path string `json:"path"`

--- a/ui/src/gen/directives/kustomize-set-image-config.json
+++ b/ui/src/gen/directives/kustomize-set-image-config.json
@@ -11,7 +11,7 @@
   },
   "images": {
    "type": "array",
-   "description": "Images is a list of container images to set or update in the Kustomization file.",
+   "description": "Images is a list of container images to set or update in the Kustomization file. When left unspecified, all images from the Freight collection will be set in the Kustomization file. Unless there is an ambiguous image name (for example, due to two Warehouses subscribing to the same repository), which requires manual configuration.",
    "items": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
With this pull request, setting `images` for the `kustomize-set-image` step is now optional.

When left unspecified, all images from the Freight collection are automatically set as long as there is no ambiguous target image found (due to e.g. two Warehouses having different selectors for the same image). In case of an ambiguous target image, an error is returned and manual configuration of `images` will still be required.

It is worth noting that the generated commit message describes what's being set in the `kustomization.yaml`, and will thus contain a reference to all images even if they do not appear in any of the Kubernetes manifests which are part of the Kustomization overlay. 

Fixes: #2788 