### PR TITLE
fix(controller): git-push step: pull --rebase before push

### DIFF
--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -924,7 +924,24 @@ steps:
 ### `git-push`
 
 `git-push` pushes the committed changes in a specified working tree to a
-specified branch in the remote repository. This step typically follows a `git-commit` step and is often followed by a `git-open-pr` step.
+specified branch in the remote repository. This step typically follows a
+`git-commit` step and is often followed by a `git-open-pr` step.
+
+This step also implements its own, internal retry logic. If a push fails, with
+the cause determined to be the presence of new commits in the remote branch that
+are not present in the local branch, the step will attempt to rebase before
+retrying the push. Any merge conflict requiring manual resolution will
+immediately halt further attempts.
+
+:::info
+This step's internal retry logic is helpful in scenarios when concurrent
+Promotions to multiple Stages may all write to the same branch of the same
+repository.
+
+Because conflicts requiring manual resolution will halt further attempts, it is
+recommended to design your Promotion processes such that Promotions to multiple
+Stages that write to the same branch do not write to the same files.
+:::
 
 #### `git-push` Configuration
 
@@ -932,6 +949,7 @@ specified branch in the remote repository. This step typically follows a `git-co
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing committed changes. |
 | `targetBranch` | `string` | N | The branch to push to in the remote repository. Mutually exclusive with `generateTargetBranch=true`. If neither of these is provided, the target branch will be the same as the branch currently checked out in the working tree. |
+| `maxAttempts` | `int32` | N | The maximum number of attempts to make when pushing to the remote repository. Default is 50. |
 | `generateTargetBranch` | `boolean` | N | Whether to push to a remote branch named like `kargo/<project>/<stage>/promotion`. If such a branch does not already exist, it will be created. A value of 'true' is mutually exclusive with `targetBranch`. If neither of these is provided, the target branch will be the currently checked out branch. This option is useful when a subsequent promotion step will open a pull request against a Stage-specific branch. In such a case, the generated target branch pushed to by the `git-push` step can later be utilized as the source branch of the pull request. |
 
 #### `git-push` Examples

--- a/internal/controller/git/errors.go
+++ b/internal/controller/git/errors.go
@@ -1,0 +1,14 @@
+package git
+
+import (
+	"errors"
+)
+
+// ErrMergeConflict is returned when a merge conflict occurs.
+var ErrMergeConflict = errors.New("merge conflict")
+
+// IsMergeConflict returns true if the error is a merge conflict or wraps one
+// and false otherwise.
+func IsMergeConflict(err error) bool {
+	return errors.Is(err, ErrMergeConflict)
+}

--- a/internal/controller/git/errors.go
+++ b/internal/controller/git/errors.go
@@ -12,3 +12,13 @@ var ErrMergeConflict = errors.New("merge conflict")
 func IsMergeConflict(err error) bool {
 	return errors.Is(err, ErrMergeConflict)
 }
+
+// ErrNonFastForward is returned when a push is rejected because it is not a
+// fast-forward or needs to be fetched first.
+var ErrNonFastForward = errors.New("non-fast-forward")
+
+// IsNonFastForward returns true if the error is a non-fast-forward or wraps one
+// and false otherwise.
+func IsNonFastForward(err error) bool {
+	return errors.Is(err, ErrNonFastForward)
+}

--- a/internal/controller/git/errors_test.go
+++ b/internal/controller/git/errors_test.go
@@ -20,7 +20,7 @@ func TestIsMergeConflict(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "not a a merge conflict",
+			name:     "not a merge conflict",
 			err:      errors.New("something went wrong"),
 			expected: false,
 		},
@@ -38,6 +38,41 @@ func TestIsMergeConflict(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := IsMergeConflict(testCase.err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestIsNonFastForward(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "not a non-fast-forward error",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+		{
+			name:     "a non-fast-forward error",
+			err:      ErrNonFastForward,
+			expected: true,
+		},
+		{
+			name:     "a wrapped fast forward error",
+			err:      fmt.Errorf("an error occurred: %w", ErrNonFastForward),
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := IsNonFastForward(testCase.err)
 			require.Equal(t, testCase.expected, actual)
 		})
 	}

--- a/internal/controller/git/errors_test.go
+++ b/internal/controller/git/errors_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMergeConflict(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "not a a merge conflict",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+		{
+			name:     "a merge conflict",
+			err:      ErrMergeConflict,
+			expected: true,
+		},
+		{
+			name:     "a wrapped merge conflict",
+			err:      fmt.Errorf("an error occurred: %w", ErrMergeConflict),
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := IsMergeConflict(testCase.err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/internal/controller/git/work_tree.go
+++ b/internal/controller/git/work_tree.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -57,6 +58,9 @@ type WorkTree interface {
 	GetDiffPathsForCommitID(commitID string) ([]string, error)
 	// IsAncestor returns true if parent branch is an ancestor of child
 	IsAncestor(parent string, child string) (bool, error)
+	// IsRebasing returns a bool indicating whether the working tree is currently
+	// in the middle of a rebase operation.
+	IsRebasing() (bool, error)
 	// LastCommitID returns the ID (sha) of the most recent commit to the current
 	// branch.
 	LastCommitID() (string, error)
@@ -316,6 +320,25 @@ func (w *workTree) IsAncestor(parent string, child string) (bool, error) {
 	return false, fmt.Errorf("error testing ancestry of branches %q, %q: %w", parent, child, err)
 }
 
+func (w *workTree) IsRebasing() (bool, error) {
+	res, err := libExec.Exec(w.buildGitCommand("rev-parse", "--git-path", "rebase-merge"))
+	if err != nil {
+		return false, fmt.Errorf("error determining rebase status: %w", err)
+	}
+	rebaseMerge := filepath.Join(w.dir, strings.TrimSpace(string(res)))
+	if _, err = os.Stat(rebaseMerge); err == nil {
+		return true, nil
+	}
+	if res, err = libExec.Exec(w.buildGitCommand("rev-parse", "--git-path", "rebase-apply")); err != nil {
+		return false, fmt.Errorf("error determining rebase status: %w", err)
+	}
+	rebaseApply := filepath.Join(w.dir, strings.TrimSpace(string(res)))
+	if _, err = os.Stat(rebaseApply); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (w *workTree) LastCommitID() (string, error) {
 	shaBytes, err := libExec.Exec(w.buildGitCommand("rev-parse", "HEAD"))
 	if err != nil {
@@ -481,18 +504,44 @@ type PushOptions struct {
 	// TargetBranch specifies the branch to push to. If empty, the current branch
 	// will be pushed to a remote branch by the same name.
 	TargetBranch string
+	// PullRebase indicates whether to pull and rebase before pushing. This can
+	// be useful when pushing changes to a remote branch that has been updated
+	// in the time since the local branch was last pulled.
+	PullRebase bool
 }
 
 func (w *workTree) Push(opts *PushOptions) error {
 	if opts == nil {
 		opts = &PushOptions{}
 	}
-	args := []string{"push", "origin"}
-	if opts.TargetBranch != "" {
-		args = append(args, fmt.Sprintf("HEAD:%s", opts.TargetBranch))
-	} else {
-		args = append(args, "HEAD")
+	targetBranch := opts.TargetBranch
+	if targetBranch == "" {
+		var err error
+		if targetBranch, err = w.CurrentBranch(); err != nil {
+			return err
+		}
 	}
+	if opts.PullRebase {
+		exists, err := w.RemoteBranchExists(targetBranch)
+		if err != nil {
+			return err
+		}
+		// We only want to pull and rebase if the remote branch exists.
+		if exists {
+			if _, err = libExec.Exec(w.buildGitCommand("pull", "--rebase", "origin", targetBranch)); err != nil {
+				// The error we're most concerned with is a merge conflict requiring
+				// manual resolution, because it's an error that no amount of retries
+				// will fix. If we find that a rebase is in progress, this is what
+				// has happened.
+				if isRebasing, isRebasingErr := w.IsRebasing(); isRebasingErr == nil && isRebasing {
+					return ErrMergeConflict
+				}
+				// If we get to here, the error isn't a merge conflict.
+				return fmt.Errorf("error pulling and rebasing branch: %w", err)
+			}
+		}
+	}
+	args := []string{"push", "origin", fmt.Sprintf("HEAD:%s", targetBranch)}
 	if opts.Force {
 		args = append(args, "--force")
 	}

--- a/internal/controller/git/work_tree.go
+++ b/internal/controller/git/work_tree.go
@@ -326,14 +326,20 @@ func (w *workTree) IsRebasing() (bool, error) {
 		return false, fmt.Errorf("error determining rebase status: %w", err)
 	}
 	rebaseMerge := filepath.Join(w.dir, strings.TrimSpace(string(res)))
-	if _, err = os.Stat(rebaseMerge); err == nil {
+	if _, err = os.Stat(rebaseMerge); !os.IsNotExist(err) {
+		if err != nil {
+			return false, err
+		}
 		return true, nil
 	}
 	if res, err = libExec.Exec(w.buildGitCommand("rev-parse", "--git-path", "rebase-apply")); err != nil {
 		return false, fmt.Errorf("error determining rebase status: %w", err)
 	}
 	rebaseApply := filepath.Join(w.dir, strings.TrimSpace(string(res)))
-	if _, err = os.Stat(rebaseApply); err == nil {
+	if _, err = os.Stat(rebaseApply); !os.IsNotExist(err) {
+		if err != nil {
+			return false, err
+		}
 		return true, nil
 	}
 	return false, nil

--- a/internal/directives/errors.go
+++ b/internal/directives/errors.go
@@ -1,0 +1,24 @@
+package directives
+
+import "errors"
+
+// terminalError wraps another error to indicate to the step execution engine
+// that the step that produced the error should not be retried.
+type terminalError struct {
+	err error
+}
+
+// Error implements the error interface.
+func (e *terminalError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+// isTerminal returns true if the error is a terminal error or wraps one and
+// false otherwise.
+func isTerminal(err error) bool {
+	te := &terminalError{}
+	return errors.As(err, &te)
+}

--- a/internal/directives/errors_test.go
+++ b/internal/directives/errors_test.go
@@ -1,0 +1,47 @@
+package directives
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTerminal(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "not a terminal error",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+		{
+			name:     "a terminal error",
+			err:      &terminalError{err: errors.New("something went wrong")},
+			expected: true,
+		},
+		{
+			name: "a wrapped terminal error",
+			err: fmt.Errorf(
+				"an error occurred: %w",
+				&terminalError{err: errors.New("something went wrong")},
+			),
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := isTerminal(testCase.err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/internal/directives/git_pr_waiter.go
+++ b/internal/directives/git_pr_waiter.go
@@ -114,10 +114,8 @@ func (g *gitPRWaiter) runPromotionStep(
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseRunning}, nil
 	}
 	if !pr.Merged {
-		return PromotionStepResult{
-			Status:  kargoapi.PromotionPhaseFailed,
-			Message: fmt.Sprintf("pull request %d was closed without being merged", prNumber),
-		}, err
+		return PromotionStepResult{Status: kargoapi.PromotionPhaseFailed},
+			&terminalError{err: fmt.Errorf("pull request %d was closed without being merged", prNumber)}
 	}
 	return PromotionStepResult{
 		Status: kargoapi.PromotionPhaseSucceeded,

--- a/internal/directives/git_pr_waiter_test.go
+++ b/internal/directives/git_pr_waiter_test.go
@@ -150,8 +150,8 @@ func Test_gitPRWaiter_runPromotionStep(t *testing.T) {
 				},
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
-				require.NoError(t, err)
-				require.Contains(t, res.Message, "closed without being merged")
+				require.ErrorContains(t, err, "closed without being merged")
+				require.True(t, isTerminal(err))
 				require.Equal(t, kargoapi.PromotionPhaseFailed, res.Status)
 			},
 		},

--- a/internal/directives/git_pusher_test.go
+++ b/internal/directives/git_pusher_test.go
@@ -203,6 +203,7 @@ func Test_gitPusher_runPromotionStep(t *testing.T) {
 	r := newGitPusher()
 	runner, ok := r.(*gitPushPusher)
 	require.True(t, ok)
+	require.NotNil(t, runner.branchMus)
 
 	res, err := runner.runPromotionStep(
 		context.Background(),

--- a/internal/directives/git_pusher_test.go
+++ b/internal/directives/git_pusher_test.go
@@ -3,6 +3,7 @@ package directives
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -35,6 +36,24 @@ func Test_gitPusher_validate(t *testing.T) {
 			},
 			expectedProblems: []string{
 				"path: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "maxAttempts < 1",
+			config: Config{
+				"maxAttempts": 0,
+			},
+			expectedProblems: []string{
+				"maxAttempts: Must be greater than or equal to 1",
+			},
+		},
+		{
+			name: fmt.Sprintf("maxAttempts > %d", math.MaxInt32),
+			config: Config{
+				"maxAttempts": math.MaxInt32 + 1,
+			},
+			expectedProblems: []string{
+				fmt.Sprintf("maxAttempts: Must be less than or equal to %.9e", float64(math.MaxInt32)),
 			},
 		},
 		{

--- a/internal/directives/http_requester.go
+++ b/internal/directives/http_requester.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -115,7 +116,7 @@ func (h *httpRequester) runPromotionStep(
 		}, nil
 	case failure:
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseFailed},
-			fmt.Errorf("HTTP response met failure criteria")
+			&terminalError{err: errors.New("HTTP response met failure criteria")}
 	default:
 		return PromotionStepResult{Status: kargoapi.PromotionPhaseRunning}, nil
 	}

--- a/internal/directives/http_requester_test.go
+++ b/internal/directives/http_requester_test.go
@@ -334,6 +334,7 @@ func Test_httpRequester_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "HTTP response met failure criteria")
+				require.True(t, isTerminal(err))
 				require.Equal(t, kargoapi.PromotionPhaseFailed, res.Status)
 			},
 		},
@@ -346,6 +347,7 @@ func Test_httpRequester_runPromotionStep(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res PromotionStepResult, err error) {
 				require.ErrorContains(t, err, "HTTP response met failure criteria")
+				require.True(t, isTerminal(err))
 				require.Equal(t, kargoapi.PromotionPhaseFailed, res.Status)
 			},
 		},

--- a/internal/directives/schemas/git-push-config.json
+++ b/internal/directives/schemas/git-push-config.json
@@ -9,6 +9,12 @@
       "type": "boolean",
       "description": "Indicates whether to push to a new remote branch. A value of 'true' is mutually exclusive with 'targetBranch'. If neither of these is provided, the target branch will be the currently checked out branch."
     },
+    "maxAttempts": {
+      "type": "integer",
+      "description": "This step implements its own internal retry logic for cases where a push is determined to have failed due to the remote branch having commits that that are not present locally. Each attempt, including the first, rebases prior to pushing. This field configures the maximum number of attempts to push to the remote repository. If not specified, the default is 50.",
+      "minimum": 1,
+      "maximum": 2147483647
+    },
     "path": {
       "type": "string",
       "description": "The path to a working directory of a local repository.",

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -211,6 +211,12 @@ type GitPushConfig struct {
 	// with 'targetBranch'. If neither of these is provided, the target branch will be the
 	// currently checked out branch.
 	GenerateTargetBranch bool `json:"generateTargetBranch,omitempty"`
+	// This step implements its own internal retry logic for cases where a push is determined to
+	// have failed due to the remote branch having commits that that are not present locally.
+	// Each attempt, including the first, rebases prior to pushing. This field configures the
+	// maximum number of attempts to push to the remote repository. If not specified, the
+	// default is 50.
+	MaxAttempts *int64 `json:"maxAttempts,omitempty"`
 	// The path to a working directory of a local repository.
 	Path string `json:"path"`
 	// The target branch to push to. Mutually exclusive with 'generateTargetBranch=true'. If

--- a/ui/src/gen/directives/git-push-config.json
+++ b/ui/src/gen/directives/git-push-config.json
@@ -8,6 +8,12 @@
    "type": "boolean",
    "description": "Indicates whether to push to a new remote branch. A value of 'true' is mutually exclusive with 'targetBranch'. If neither of these is provided, the target branch will be the currently checked out branch."
   },
+  "maxAttempts": {
+   "type": "integer",
+   "description": "This step implements its own internal retry logic for cases where a push is determined to have failed due to the remote branch having commits that that are not present locally. Each attempt, including the first, rebases prior to pushing. This field configures the maximum number of attempts to push to the remote repository. If not specified, the default is 50.",
+   "minimum": 1,
+   "maximum": 2147483647
+  },
   "path": {
    "type": "string",
    "description": "The path to a working directory of a local repository.",


### PR DESCRIPTION
Fixes #3071 

Although this is WIP 👀 would still be helpful, @hiddeco. 🙏 

Apart from the git bits of this, this PR is the catalyst for the step execution engine to start distinguishing between errors/failures that are terminal and ones that can be retried. This seemed like the time, because once a merge conflict that requires manual resolution has been detected, there is no point in performing any retries, no matter what the retry policy says.

I tried to implement what we discussed offline, but I think you'll have some good constructive feedback on this.

r4r