### PR TITLE
feat(ui): PR deep links in Promotion steps and in Promotion lists

### DIFF
--- a/ui/src/features/common/manifest-preview.tsx
+++ b/ui/src/features/common/manifest-preview.tsx
@@ -12,6 +12,10 @@ export const ManifestPreview = ({
   height?: string;
 }) => {
   const encodedObject = yaml.stringify(object.toJson(), (_, v) => {
+    if (!v) {
+      return;
+    }
+
     if (typeof v === 'string' && v === '') {
       return;
     }

--- a/ui/src/features/promotion-directives/registry/types.ts
+++ b/ui/src/features/promotion-directives/registry/types.ts
@@ -15,6 +15,6 @@ export type Runner = {
   identifier: string;
   // UI helper
   // this accepts font-awesome icon
-  unstable_icons: IconDefinition[];
+  unstable_icons?: IconDefinition[];
   config: JSONSchema7;
 };

--- a/ui/src/features/promotion-directives/registry/use-discover-registries.ts
+++ b/ui/src/features/promotion-directives/registry/use-discover-registries.ts
@@ -1,29 +1,3 @@
-import {
-  faArrowUp,
-  faChartLine,
-  faCheck,
-  faClock,
-  faClone,
-  faCloudUploadAlt,
-  faCodeBranch,
-  faCodePullRequest,
-  faCopy,
-  faDraftingCompass,
-  faEdit,
-  faExchangeAlt,
-  faFileCode,
-  faFileEdit,
-  faFileImage,
-  faGlobe,
-  faHammer,
-  faHeart,
-  faNetworkWired,
-  faRedoAlt,
-  faSyncAlt,
-  faUpDown,
-  faUpload,
-  faWrench
-} from '@fortawesome/free-solid-svg-icons';
 import { JSONSchema7 } from 'json-schema';
 
 // IMPORTANT(Marvin9): this must be replaced with proper discovery mechanism
@@ -53,82 +27,66 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
     runners: [
       {
         identifier: 'argocd-update',
-        unstable_icons: [faUpDown, faHeart],
         config: argocdUpdateConfig as JSONSchema7
       },
       {
         identifier: 'copy',
-        unstable_icons: [faCopy],
         config: copyConfig as JSONSchema7
       },
       {
         identifier: 'git-clone',
-        unstable_icons: [faCodeBranch, faClone],
         config: gitCloneConfig as JSONSchema7
       },
       {
         identifier: 'git-push',
-        unstable_icons: [faArrowUp, faCloudUploadAlt, faUpload],
         config: gitPushConfig as JSONSchema7
       },
       {
         identifier: 'git-commit',
-        unstable_icons: [faCheck, faCodeBranch],
         config: gitCommitConfig as unknown as JSONSchema7
       },
       {
         identifier: 'git-open-pr',
-        unstable_icons: [faCodePullRequest, faFileCode],
         config: gitOpenPR as unknown as JSONSchema7
       },
       {
         identifier: 'git-wait-for-pr',
-        unstable_icons: [faClock, faCodePullRequest],
         config: gitWaitForPR as unknown as JSONSchema7
       },
       {
         identifier: 'yaml-update',
-        config: yamlUpdateConfig as unknown as JSONSchema7,
-        unstable_icons: [faFileCode, faSyncAlt, faEdit]
+        config: yamlUpdateConfig as unknown as JSONSchema7
       },
       {
         identifier: 'git-push',
-        unstable_icons: [faArrowUp, faCloudUploadAlt],
         config: gitPushConfig as unknown as JSONSchema7
       },
       {
         identifier: 'git-clear',
-        unstable_icons: [faRedoAlt, faCodeBranch],
         config: gitOverwriteConfig as JSONSchema7
       },
       {
         identifier: 'helm-update-chart',
-        unstable_icons: [faSyncAlt, faChartLine],
         config: helmUpdateChartConfig as JSONSchema7
       },
       {
         identifier: 'helm-update-image',
-        unstable_icons: [faSyncAlt, faFileImage],
         config: helmUpdateImageConfig as JSONSchema7
       },
       {
         identifier: 'helm-template',
-        unstable_icons: [faFileCode, faDraftingCompass],
         config: helmTemplateConfig as JSONSchema7
       },
       {
         identifier: 'kustomize-build',
-        unstable_icons: [faWrench, faHammer],
         config: kustomizeBuildConfig as JSONSchema7
       },
       {
         identifier: 'kustomize-set-image',
-        unstable_icons: [faFileImage, faFileEdit],
         config: kustomizeSetImageConfig as JSONSchema7
       },
       {
         identifier: 'http',
-        unstable_icons: [faGlobe, faNetworkWired, faExchangeAlt],
         config: httpConfig as JSONSchema7
       }
     ]

--- a/ui/src/features/stage/create-stage.tsx
+++ b/ui/src/features/stage/create-stage.tsx
@@ -23,6 +23,7 @@ import { FieldContainer } from '@ui/features/common/form/field-container';
 import schema from '@ui/gen/schema/stages.kargo.akuity.io_v1alpha1.json';
 import { createResource } from '@ui/gen/service/v1alpha1/service-KargoService_connectquery';
 import { PromotionStep, Stage } from '@ui/gen/v1alpha1/generated_pb';
+import { cleanEmptyObjectValues } from '@ui/utils/helpers';
 import { zodValidators } from '@ui/utils/validators';
 
 import { getStageYAMLExample } from '../project/pipelines/utils/stage-yaml-example';
@@ -67,7 +68,8 @@ const stageFormToYAML = (
     spec: {
       requestedFreight: data.requestedFreight,
       ...(promotionTemplateSteps?.length > 0 && {
-        promotionTemplate: { spec: { steps: promotionTemplateSteps } }
+        // IMPORTANT TO CLEANUP EMPTY VALUES OR UNEXPECTED CONFIG FOR PROMOTION STEP WOULD HAPPEN
+        promotionTemplate: { spec: cleanEmptyObjectValues({ steps: promotionTemplateSteps }) }
       })
     }
   });

--- a/ui/src/features/stage/promotion-details-modal.tsx
+++ b/ui/src/features/stage/promotion-details-modal.tsx
@@ -106,8 +106,8 @@ const Step = ({
   };
 
   const UiPlugins = uiPlugins
-    .filter((plugin) => plugin.DeepLinkPlugin.PromotionStep.shouldRender({ step, result }))
-    .map((plugin) => plugin.DeepLinkPlugin.PromotionStep.render);
+    .filter((plugin) => plugin.DeepLinkPlugin?.PromotionStep?.shouldRender({ step, result }))
+    .map((plugin) => plugin.DeepLinkPlugin?.PromotionStep?.render);
 
   return {
     className: classNames('', {
@@ -130,14 +130,17 @@ const Step = ({
           <span className='font-semibold text-base '>{meta.spec.identifier}</span>
           {UiPlugins.length > 0 && (
             <UiPluginHoles.DeepLinks.PromotionStep className='ml-2'>
-              {UiPlugins.map((ApplyPlugin, idx) => (
-                <ApplyPlugin
-                  result={result}
-                  step={step}
-                  output={output as Record<string, unknown>}
-                  key={idx}
-                />
-              ))}
+              {UiPlugins.map(
+                (ApplyPlugin, idx) =>
+                  ApplyPlugin && (
+                    <ApplyPlugin
+                      result={result}
+                      step={step}
+                      output={output as Record<string, unknown>}
+                      key={idx}
+                    />
+                  )
+              )}
             </UiPluginHoles.DeepLinks.PromotionStep>
           )}
           {!!step?.as && (

--- a/ui/src/features/stage/promotion-details-modal.tsx
+++ b/ui/src/features/stage/promotion-details-modal.tsx
@@ -28,16 +28,18 @@ import { Runner } from '@ui/features/promotion-directives/registry/types';
 import { canAbortPromotion } from '@ui/features/stage/utils/promotion';
 import { abortPromotion } from '@ui/gen/service/v1alpha1/service-KargoService_connectquery';
 import { Promotion, PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
+import uiPlugins from '@ui/plugins';
+import { UiPluginHoles } from '@ui/plugins/ui-plugin-hole/ui-plugin-holes';
 import { decodeRawData } from '@ui/utils/decode-raw-data';
 
 const Step = ({
   step,
   result,
-  logs
+  output
 }: {
   step: PromotionStep;
   result: PromotionDirectiveStepStatus;
-  logs?: object;
+  output?: object;
 }) => {
   const [showDetails, setShowDetails] = useState(false);
 
@@ -75,7 +77,7 @@ const Step = ({
 
   const opts: SegmentedOptions<string> = [];
 
-  if (logs) {
+  if (output) {
     opts.push({
       label: 'Output',
       value: 'output',
@@ -100,8 +102,12 @@ const Step = ({
 
   const yamlView = {
     config: meta?.config,
-    output: logs ? JSON.stringify(logs || {}, null, ' ') : ''
+    output: output ? JSON.stringify(output || {}, null, ' ') : ''
   };
+
+  const UiPlugins = uiPlugins
+    .filter((plugin) => plugin.DeepLinkPlugin.PromotionStep.shouldRender({ step, result }))
+    .map((plugin) => plugin.DeepLinkPlugin.PromotionStep.render);
 
   return {
     className: classNames('', {
@@ -120,23 +126,25 @@ const Step = ({
           {success && <FontAwesomeIcon icon={faCheck} className='text-green-500' />}
           {failed && <FontAwesomeIcon icon={faTimes} className='text-red-500' />}
         </Flex>
-        <Flex className={'font-semibold text-base w-full'} align='center'>
-          {meta.spec.identifier}
+        <Flex className={'w-full'} align='center'>
+          <span className='font-semibold text-base '>{meta.spec.identifier}</span>
+          {UiPlugins.length > 0 && (
+            <UiPluginHoles.DeepLinks.PromotionStep className='ml-2'>
+              {UiPlugins.map((ApplyPlugin, idx) => (
+                <ApplyPlugin
+                  result={result}
+                  step={step}
+                  output={output as Record<string, unknown>}
+                  key={idx}
+                />
+              ))}
+            </UiPluginHoles.DeepLinks.PromotionStep>
+          )}
           {!!step?.as && (
             <Tag className='text-xs ml-auto mr-5' color='blue'>
               {step.as}
             </Tag>
           )}
-          <Flex className={classNames({ 'ml-auto': !step?.as })} align='center'>
-            <Flex
-              align='center'
-              className='bg-gray-500 text-white uppercase p-2 rounded-md font-medium mr-3 gap-2 text-sm'
-            >
-              {meta.spec.unstable_icons.map((icon, i) => (
-                <FontAwesomeIcon key={i} icon={icon} />
-              ))}
-            </Flex>
-          </Flex>
         </Flex>
       </Flex>
     ),
@@ -178,7 +186,7 @@ export const PromotionDetailsModal = ({
       })
   });
 
-  const logsByStepAlias: Record<string, object> = useMemo(() => {
+  const outputsByStepAlias: Record<string, object> = useMemo(() => {
     if (promotion?.status?.state?.raw) {
       try {
         const raw = decodeRawData({ result: { case: 'raw', value: promotion.status.state.raw } });
@@ -258,7 +266,7 @@ export const PromotionDetailsModal = ({
                 return Step({
                   step,
                   result: getPromotionDirectiveStepStatus(i, promotion.status),
-                  logs: logsByStepAlias?.[step?.as || '']
+                  output: outputsByStepAlias?.[step?.as || '']
                 });
               })}
             />

--- a/ui/src/features/stage/promotions.tsx
+++ b/ui/src/features/stage/promotions.tsx
@@ -21,6 +21,8 @@ import {
 import { KargoService } from '@ui/gen/service/v1alpha1/service_connect';
 import { ListPromotionsResponse } from '@ui/gen/service/v1alpha1/service_pb';
 import { Freight, Promotion } from '@ui/gen/v1alpha1/generated_pb';
+import uiPlugins from '@ui/plugins';
+import { UiPluginHoles } from '@ui/plugins/ui-plugin-hole/ui-plugin-holes';
 
 import { PromotionDetailsModal } from './promotion-details-modal';
 import { hasAbortRequest, promotionCompareFn } from './utils/promotion';
@@ -171,6 +173,26 @@ export const Promotions = () => {
           </Link>
         </Tooltip>
       )
+    },
+    {
+      title: 'Extra',
+      render: (_, promotion) => {
+        const UiPlugins = uiPlugins
+          .filter((plugin) => plugin.DeepLinkPlugin?.Promotion?.shouldRender({ promotion }))
+          .map((plugin) => plugin.DeepLinkPlugin?.Promotion?.render);
+
+        if (UiPlugins?.length > 0) {
+          return (
+            <UiPluginHoles.DeepLinks.Promotion className='w-fit'>
+              {UiPlugins.map(
+                (ApplyPlugin, idx) => ApplyPlugin && <ApplyPlugin key={idx} promotion={promotion} />
+              )}
+            </UiPluginHoles.DeepLinks.Promotion>
+          );
+        }
+
+        return '-';
+      }
     }
   ];
 

--- a/ui/src/plugins/README.md
+++ b/ui/src/plugins/README.md
@@ -1,0 +1,3 @@
+> NOTE: This isn't actual on-the-fly plugin architecture but type of separation that will make future work easier to split when time arrive and UI learns as much as it can till then.
+
+

--- a/ui/src/plugins/index.tsx
+++ b/ui/src/plugins/index.tsx
@@ -1,0 +1,6 @@
+import { PluginsInstallation } from './plugin-interfaces';
+import prPlugin from './pr-plugin';
+
+const plugins: PluginsInstallation[] = [prPlugin];
+
+export default plugins;

--- a/ui/src/plugins/plugin-helper.ts
+++ b/ui/src/plugins/plugin-helper.ts
@@ -1,0 +1,12 @@
+import { PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
+import { decodeRawData } from '@ui/utils/decode-raw-data';
+
+export const getPromotionStepConfig = (step: PromotionStep): Record<string, unknown> =>
+  JSON.parse(
+    decodeRawData({
+      result: {
+        case: 'raw',
+        value: step?.config?.raw || new Uint8Array()
+      }
+    })
+  );

--- a/ui/src/plugins/plugin-helper.ts
+++ b/ui/src/plugins/plugin-helper.ts
@@ -1,4 +1,4 @@
-import { PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
+import { Promotion, PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
 import { decodeRawData } from '@ui/utils/decode-raw-data';
 
 export const getPromotionStepConfig = (step: PromotionStep): Record<string, unknown> =>
@@ -10,3 +10,16 @@ export const getPromotionStepConfig = (step: PromotionStep): Record<string, unkn
       }
     })
   );
+
+export const getPromotionState = (promotion: Promotion): Record<string, Record<string, unknown>> =>
+  JSON.parse(
+    decodeRawData({
+      result: {
+        case: 'raw',
+        value: promotion?.status?.state?.raw || new Uint8Array()
+      }
+    })
+  );
+
+export const getPromotionStepAlias = (promotionStep: PromotionStep, stepIndex: string) =>
+  promotionStep?.as || `step-${stepIndex}`;

--- a/ui/src/plugins/plugin-interfaces.ts
+++ b/ui/src/plugins/plugin-interfaces.ts
@@ -1,0 +1,40 @@
+// 1. Use case: Deep links
+// Scopes:
+// - PromotionStep:
+//      Plugin generates information from given plugin step and renders in the step view in Promotion steps modal
+// - Promotion:
+//      Plugin summarises promotion and provide useful link(s) and renders in the promotion list view
+// - Stage:
+//      Plugin summarises stage and provide useful link(s) and renders at the top in stage details page
+// - Pipeline Stage:
+//      Similar to stage but since this is in Pipeline and directly accessible so needs carefully show
+
+import { ReactNode } from 'react';
+
+import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
+import { PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
+
+export interface DeepLinkPluginsInstallation {
+  // Scopes
+
+  // Plugin generates information from given plugin step and renders in the step view in Promotion steps modal
+  PromotionStep: {
+    // thoughts.. instead of coupling this to name of step, this would open doors for plugin development based on combination of promotion steps
+    shouldRender: (opts: { step: PromotionStep; result: PromotionDirectiveStepStatus }) => boolean;
+    render: (props: {
+      // step metadata
+      step: PromotionStep;
+      // flexible to render based on status
+      result: PromotionDirectiveStepStatus;
+      // output from steps
+      output?: Record<string, unknown>;
+    }) => ReactNode;
+  };
+}
+
+export interface PluginsInstallation {
+  identity?: string;
+  description?: string;
+
+  DeepLinkPlugin: DeepLinkPluginsInstallation;
+}

--- a/ui/src/plugins/plugin-interfaces.ts
+++ b/ui/src/plugins/plugin-interfaces.ts
@@ -12,13 +12,13 @@
 import { ReactNode } from 'react';
 
 import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
-import { PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
+import { Promotion, PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
 
 export interface DeepLinkPluginsInstallation {
   // Scopes
 
   // Plugin generates information from given plugin step and renders in the step view in Promotion steps modal
-  PromotionStep: {
+  PromotionStep?: {
     // thoughts.. instead of coupling this to name of step, this would open doors for plugin development based on combination of promotion steps
     shouldRender: (opts: { step: PromotionStep; result: PromotionDirectiveStepStatus }) => boolean;
     render: (props: {
@@ -30,11 +30,17 @@ export interface DeepLinkPluginsInstallation {
       output?: Record<string, unknown>;
     }) => ReactNode;
   };
+
+  // Plugin summarises promotion and provide useful link(s) and renders in the promotion list view
+  Promotion?: {
+    shouldRender: (opts: { promotion: Promotion }) => boolean;
+    render: (props: { promotion: Promotion }) => ReactNode;
+  };
 }
 
 export interface PluginsInstallation {
   identity?: string;
   description?: string;
 
-  DeepLinkPlugin: DeepLinkPluginsInstallation;
+  DeepLinkPlugin?: DeepLinkPluginsInstallation;
 }

--- a/ui/src/plugins/pr-plugin.tsx
+++ b/ui/src/plugins/pr-plugin.tsx
@@ -1,14 +1,51 @@
 import { faGithub, faGitlab } from '@fortawesome/free-brands-svg-icons';
-import { faCodePullRequest } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faCodePullRequest } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Flex } from 'antd';
+import { Flex, Space } from 'antd';
+import Dropdown from 'antd/es/dropdown/dropdown';
 import { ReactNode, useMemo } from 'react';
 
 import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
+import { PromotionStep } from '@ui/gen/v1alpha1/generated_pb';
 
-import { getPromotionStepConfig } from './plugin-helper';
+import { getPromotionState, getPromotionStepAlias, getPromotionStepConfig } from './plugin-helper';
 import { PluginsInstallation } from './plugin-interfaces';
 
+const getPullRequestLink = (
+  promotionStep: PromotionStep,
+  promotionStepOutput: Record<string, unknown>
+) => {
+  const stepConfig = getPromotionStepConfig(promotionStep);
+
+  // plugins responsibility to keep up to date with actual promotion step config
+  const provider = stepConfig?.provider as 'github' | 'gitlab';
+
+  const repoURL = stepConfig?.repoURL as string;
+
+  const prNumber = promotionStepOutput?.prNumber;
+
+  if (typeof prNumber !== 'number' || !repoURL) {
+    // TODO: Throw plugin identified error to handle it at plugin level
+    throw new Error(
+      `cannot generate pull request link, either promotion step didn't return proper output or promotion step config is corrupted`
+    );
+  }
+
+  // url without slash at the end so it is easy to append path
+  const url = repoURL?.endsWith?.('/') ? repoURL.slice(0, -1) : repoURL;
+
+  if (provider === 'github') {
+    return `${url}/pull/${prNumber}`;
+  }
+
+  if (provider === 'gitlab') {
+    return `${url}/merge_requests/${prNumber}`;
+  }
+
+  throw new Error(`provider ${provider} not supported by this plugin`);
+};
+
+// TODO: refactor as it is getting bigger
 const plugin: PluginsInstallation = {
   DeepLinkPlugin: {
     PromotionStep: {
@@ -22,8 +59,6 @@ const plugin: PluginsInstallation = {
         const provider = stepConfig?.provider as 'github' | 'gitlab';
 
         const repoURL = stepConfig?.repoURL as string;
-
-        const prNumber = props.output?.prNumber;
 
         const nodes: ReactNode[] = [];
 
@@ -41,24 +76,75 @@ const plugin: PluginsInstallation = {
           );
         }
 
-        if (typeof prNumber === 'number') {
-          // url without slash at the end so it is easy to append path
-          let url = repoURL.endsWith('/') ? repoURL.slice(0, -1) : repoURL;
+        const url = getPullRequestLink(props.step, props.output || {});
 
-          if (provider === 'github') {
-            url = `${url}/pull/${prNumber}`;
-          } else if (provider === 'gitlab') {
-            url = `${url}/merge_requests/${prNumber}`;
+        nodes.push(
+          <a href={url} target='_blank'>
+            <FontAwesomeIcon icon={faCodePullRequest} />
+          </a>
+        );
+
+        return <Flex gap={8}>{nodes}</Flex>;
+      }
+    },
+    Promotion: {
+      shouldRender(opts) {
+        return Boolean(opts.promotion?.spec?.steps?.find((step) => step?.uses === 'git-open-pr'));
+      },
+      render(props) {
+        // array of [step-alias, deep-link]
+        const deepLinks: string[][] = [];
+
+        const promotionState = getPromotionState(props.promotion);
+
+        for (const [idx, step] of Object.entries(props.promotion?.spec?.steps || [])) {
+          if (step?.uses === 'git-open-pr') {
+            const alias = getPromotionStepAlias(step, idx);
+
+            try {
+              const deepLink = getPullRequestLink(step, promotionState[alias]);
+
+              deepLinks.push([alias, deepLink]);
+            } catch {
+              // TODO: failed to get deep link.. most probably due to invalid config/output
+            }
           }
+        }
 
-          nodes.push(
-            <a href={url} target='_blank'>
+        if (deepLinks?.length === 0) {
+          return null;
+        }
+
+        if (deepLinks.length === 1) {
+          // no need to have step context just show the deep link
+          return (
+            <a href={deepLinks[0][1]} target='_blank'>
               <FontAwesomeIcon icon={faCodePullRequest} />
             </a>
           );
         }
 
-        return <Flex gap={8}>{nodes}</Flex>;
+        return (
+          <Dropdown
+            menu={{
+              items: deepLinks.map((deepLink, idx) => ({
+                key: idx,
+                label: (
+                  <a key={idx} href={deepLink[1]} target='_blank'>
+                    {deepLink[0]} - <FontAwesomeIcon icon={faCodePullRequest} />
+                  </a>
+                )
+              }))
+            }}
+          >
+            <a onClick={(e) => e.preventDefault()}>
+              <Space>
+                PRs
+                <FontAwesomeIcon icon={faChevronDown} className='text-xs' />
+              </Space>
+            </a>
+          </Dropdown>
+        );
       }
     }
   }

--- a/ui/src/plugins/pr-plugin.tsx
+++ b/ui/src/plugins/pr-plugin.tsx
@@ -1,0 +1,67 @@
+import { faGithub, faGitlab } from '@fortawesome/free-brands-svg-icons';
+import { faCodePullRequest } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Flex } from 'antd';
+import { ReactNode, useMemo } from 'react';
+
+import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
+
+import { getPromotionStepConfig } from './plugin-helper';
+import { PluginsInstallation } from './plugin-interfaces';
+
+const plugin: PluginsInstallation = {
+  DeepLinkPlugin: {
+    PromotionStep: {
+      shouldRender({ step, result }) {
+        return result === PromotionDirectiveStepStatus.SUCCESS && step?.uses === 'git-open-pr';
+      },
+      render(props) {
+        const stepConfig = useMemo(() => getPromotionStepConfig(props.step), [props.step]);
+
+        // plugins responsibility to keep up to date with actual promotion step config
+        const provider = stepConfig?.provider as 'github' | 'gitlab';
+
+        const repoURL = stepConfig?.repoURL as string;
+
+        const prNumber = props.output?.prNumber;
+
+        const nodes: ReactNode[] = [];
+
+        if (provider === 'github') {
+          nodes.push(
+            <a href={repoURL} target='_blank'>
+              <FontAwesomeIcon icon={faGithub} />
+            </a>
+          );
+        } else if (provider === 'gitlab') {
+          nodes.push(
+            <a href={repoURL} target='_blank'>
+              <FontAwesomeIcon icon={faGitlab} />
+            </a>
+          );
+        }
+
+        if (typeof prNumber === 'number') {
+          // url without slash at the end so it is easy to append path
+          let url = repoURL.endsWith('/') ? repoURL.slice(0, -1) : repoURL;
+
+          if (provider === 'github') {
+            url = `${url}/pull/${prNumber}`;
+          } else if (provider === 'gitlab') {
+            url = `${url}/merge_requests/${prNumber}`;
+          }
+
+          nodes.push(
+            <a href={url} target='_blank'>
+              <FontAwesomeIcon icon={faCodePullRequest} />
+            </a>
+          );
+        }
+
+        return <Flex gap={8}>{nodes}</Flex>;
+      }
+    }
+  }
+};
+
+export default plugin;

--- a/ui/src/plugins/ui-plugin-hole/deep-link-promotion-step.tsx
+++ b/ui/src/plugins/ui-plugin-hole/deep-link-promotion-step.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames';
+import { PropsWithChildren } from 'react';
+
+export const DeepLinkPromotionStep = ({
+  children,
+  className
+}: PropsWithChildren<{ className?: string }>) => {
+  return (
+    <div className={classNames(className, 'bg-gray-100 px-2 py-1 rounded-md text-sm')}>
+      {children}
+    </div>
+  );
+};

--- a/ui/src/plugins/ui-plugin-hole/deep-link-promotion-step.tsx
+++ b/ui/src/plugins/ui-plugin-hole/deep-link-promotion-step.tsx
@@ -6,7 +6,13 @@ export const DeepLinkPromotionStep = ({
   className
 }: PropsWithChildren<{ className?: string }>) => {
   return (
-    <div className={classNames(className, 'bg-gray-100 px-2 py-1 rounded-md text-sm')}>
+    <div
+      className={classNames(className, 'bg-gray-100 px-2 py-1 rounded-md text-sm w-fit')}
+      onClick={(e) => {
+        // prevent opening the collapsible menu
+        e.stopPropagation();
+      }}
+    >
       {children}
     </div>
   );

--- a/ui/src/plugins/ui-plugin-hole/deep-link-promotion.tsx
+++ b/ui/src/plugins/ui-plugin-hole/deep-link-promotion.tsx
@@ -1,0 +1,11 @@
+import classNames from 'classnames';
+import { PropsWithChildren } from 'react';
+
+export const DeepLinkPromotion = ({
+  children,
+  className
+}: PropsWithChildren<{ className?: string }>) => (
+  <div className={classNames(className, 'bg-gray-100 px-2 py-1 rounded-md text-sm')}>
+    {children}
+  </div>
+);

--- a/ui/src/plugins/ui-plugin-hole/ui-plugin-holes.tsx
+++ b/ui/src/plugins/ui-plugin-hole/ui-plugin-holes.tsx
@@ -1,9 +1,11 @@
 // the UI space for plugins but with limit in terms of layout
 
+import { DeepLinkPromotion } from './deep-link-promotion';
 import { DeepLinkPromotionStep } from './deep-link-promotion-step';
 
 export const UiPluginHoles = {
   DeepLinks: {
-    PromotionStep: DeepLinkPromotionStep
+    PromotionStep: DeepLinkPromotionStep,
+    Promotion: DeepLinkPromotion
   }
 };

--- a/ui/src/plugins/ui-plugin-hole/ui-plugin-holes.tsx
+++ b/ui/src/plugins/ui-plugin-hole/ui-plugin-holes.tsx
@@ -1,0 +1,9 @@
+// the UI space for plugins but with limit in terms of layout
+
+import { DeepLinkPromotionStep } from './deep-link-promotion-step';
+
+export const UiPluginHoles = {
+  DeepLinks: {
+    PromotionStep: DeepLinkPromotionStep
+  }
+};


### PR DESCRIPTION
fixes https://github.com/akuity/kargo/issues/3024

Other than fix. This PR does some works for

- Lays very soft foundation for future plugin architecture. UI takes opportunity of learn possible ways to split plugins. Note that this is not final and subject to change based on discussions when time comes but at the very least makes it easier to break into pieces
- Removes the icons in promotion steps.. with deep links, it looked more busy with icons.

https://github.com/user-attachments/assets/bd4d2ad7-a106-458d-871b-6c0ea3995e91

Will cleanup some UI a bit but other than that its ready to review