### PR TITLE
feat: make yaml-update syntax the same as json-update syntax

### DIFF
--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -551,7 +551,7 @@ followed by a [`helm-template`](#helm-template) step.
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a YAML file. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `updates` | `[]object` | Y | The details of changes to be applied to the file. At least one must be specified. |
-| `updates[].key` | `string` | Y | The key to update within the file. For nested values, use a YAML dot notation path. |
+| `updates[].key` | `string` | Y | The key to update within the file. For nested values, use dots to delimit key parts. e.g. `image.tag`. The syntax is identical to that supported by the `json-update` step and is documented in more detail [here](https://github.com/tidwall/sjson?tab=readme-ov-file#path-syntax). |
 | `updates[].value` | `string` | Y | The new value for the key. Typically specified using an expression. |
 
 #### `yaml-update` Example

--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -138,9 +138,9 @@ func (h *helmChartUpdater) processChartUpdates(
 	stepCtx *PromotionStepContext,
 	cfg HelmUpdateChartConfig,
 	chartDependencies []chartDependency,
-) (map[string]string, error) {
-	changes := make(map[string]string)
-	for _, update := range cfg.Charts {
+) ([]intyaml.Update, error) {
+	updates := make([]intyaml.Update, len(cfg.Charts))
+	for i, update := range cfg.Charts {
 		version := update.Version
 		if update.Version == "" {
 			// TODO(krancour): Remove this for v1.3.0
@@ -169,9 +169,12 @@ func (h *helmChartUpdater) processChartUpdates(
 		}
 
 		var updateUsed bool
-		for i, dep := range chartDependencies {
+		for j, dep := range chartDependencies {
 			if dep.Repository == update.Repository && dep.Name == update.Name {
-				changes[fmt.Sprintf("dependencies.%d.version", i)] = version
+				updates[i] = intyaml.Update{
+					Key:   fmt.Sprintf("dependencies.%d.version", j),
+					Value: version,
+				}
 				updateUsed = true
 				break
 			}
@@ -183,7 +186,7 @@ func (h *helmChartUpdater) processChartUpdates(
 			)
 		}
 	}
-	return changes, nil
+	return updates, nil
 }
 
 func (h *helmChartUpdater) updateDependencies(

--- a/internal/yaml/decode.go
+++ b/internal/yaml/decode.go
@@ -2,12 +2,9 @@ package yaml
 
 import (
 	"fmt"
-	"strings"
 
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
-
-const pathSeparator = "."
 
 // FieldNotFoundErr is an error type that is returned when a field is not found
 // in the YAML document.
@@ -24,7 +21,10 @@ func (e FieldNotFoundErr) Error() string {
 // and decodes it into the provided value. The path is specified using a
 // dot-separated string, similar to the UpdateField function.
 func DecodeField(node *yaml.Node, path string, out any) error {
-	parts := strings.Split(path, pathSeparator)
+	parts, err := splitKey(path)
+	if err != nil {
+		return err
+	}
 	targetNode, err := findNode(node, parts)
 	if err != nil {
 		return err

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -11,14 +11,21 @@ import (
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
+// Update represents a discrete update to be made to a YAML document.
+type Update struct {
+	// Key is the dot-separated path to the field to update.
+	Key string
+	// Value is the new value to set for the field.
+	Value string
+}
+
 // SetStringsInFile overwrites the specified file with the changes specified by
-// the changes map applied. The changes map maps keys to new values. Keys are of
-// the form <key 0>.<key 1>...<key n>. Integers may be used as keys in cases
-// where a specific node needs to be selected from a sequence. An error is
-// returned for any attempted update to a key that does not exist or does not
-// address a scalar node. Importantly, all comments and style choices in the
-// input bytes are preserved in the output.
-func SetStringsInFile(file string, changes map[string]string) error {
+// the the list of Updates. Keys are of the form <key 0>.<key 1>...<key n>.
+// Integers may be used as keys in cases where a specific node needs to be
+// selected from a sequence. An error is returned for any attempted update to a
+// key that does not exist or does not address a scalar node. Importantly, all
+// comments and style choices in the input bytes are preserved in the output.
+func SetStringsInFile(file string, updates []Update) error {
 	inBytes, err := os.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf(
@@ -27,7 +34,7 @@ func SetStringsInFile(file string, changes map[string]string) error {
 			err,
 		)
 	}
-	outBytes, err := SetStringsInBytes(inBytes, changes)
+	outBytes, err := SetStringsInBytes(inBytes, updates)
 	if err != nil {
 		return fmt.Errorf("error mutating bytes: %w", err)
 	}
@@ -47,16 +54,12 @@ func SetStringsInFile(file string, changes map[string]string) error {
 }
 
 // SetStringsInBytes returns a copy of the provided bytes with the changes
-// specified by the changes map applied. The changes map maps keys to new
-// values. Keys are of the form <key 0>.<key 1>...<key n>. Integers may be used
-// as keys in cases where a specific node needs to be selected from a sequence.
-// An error is returned for any attempted update to a key that does not exist or
-// does not address a scalar node. Importantly, all comments and style choices
-// in the input bytes are preserved in the output.
-func SetStringsInBytes(
-	inBytes []byte,
-	changes map[string]string,
-) ([]byte, error) {
+// specified by Updates applied. Keys are of the form <key 0>.<key 1>...<key n>.
+// Integers may be used as keys in cases where a specific node needs to be
+// selected from a sequence. An error is returned for any attempted update to a
+// key that does not exist or does not address a scalar node. Importantly, all
+// comments and style choices in the input bytes are preserved in the output.
+func SetStringsInBytes(inBytes []byte, updates []Update) ([]byte, error) {
 	doc := &yaml.Node{}
 	if err := yaml.Unmarshal(inBytes, doc); err != nil {
 		return nil, fmt.Errorf("error unmarshaling input: %w", err)
@@ -67,15 +70,15 @@ func SetStringsInBytes(
 		value string
 	}
 	changesByLine := map[int]change{}
-	for k, v := range changes {
-		keyPath := strings.Split(k, ".")
+	for _, update := range updates {
+		keyPath := strings.Split(update.Key, ".")
 		line, col, err := findScalarNode(doc, keyPath)
 		if err != nil {
-			return nil, fmt.Errorf("error finding key %s: %w", k, err)
+			return nil, fmt.Errorf("error finding key %s: %w", update.Key, err)
 		}
 		changesByLine[line] = change{
 			col:   col,
-			value: v,
+			value: update.Value,
 		}
 	}
 

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -12,7 +12,7 @@ func TestSetStringsInBytes(t *testing.T) {
 	testCases := []struct {
 		name       string
 		inBytes    []byte
-		changes    map[string]string
+		updates    []Update
 		assertions func(*testing.T, []byte, error)
 	}{
 		{
@@ -35,8 +35,11 @@ characters:
 - name: Anakin
   affiliation: Light side
 `),
-			changes: map[string]string{
-				"characters.0.affiliation": "Dark side",
+			updates: []Update{
+				{
+					Key:   "characters.0.affiliation",
+					Value: "Dark side",
+				},
 			},
 			assertions: func(t *testing.T, bytes []byte, err error) {
 				require.NoError(t, err)
@@ -54,7 +57,7 @@ characters:
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			b, err := SetStringsInBytes(testCase.inBytes, testCase.changes)
+			b, err := SetStringsInBytes(testCase.inBytes, testCase.updates)
 			testCase.assertions(t, b, err)
 		})
 	}


### PR DESCRIPTION
This complements #3151.

#3151 uses tidwall/sjson for modifying JSON documents whilst preserving their existing formatting.

The keys/paths supported by that library use simple dot-separated notation. Dots can be escaped. Colons are used as a hint that a numeric-looking key part should be treated as a key in an object and not as an index in a sequence. Colons also can be escaped.

Examples:

* foo.bar --> [foo bar]
* foo\.bar --> [foo.bar]
* foo.2 --> [foo 2] (2 is an index in the sequence foo)
* foo.:2 --> [foo 2] (2 is a key in the object foo)
* foo\:bar --> [foo:bar]

-1 can be used as an index to indicate a desire to append to a sequence.

__This is slightly inconsistent with the syntax supported by our yaml-update step.__

* Indices are handled the way Helm does. e.g. foo.[2]
* Negative indices not allowed at all -- appending to a sequence was not possible. (Technically it was, but only if you knew the length of the sequence, which effectively made it useless.)
* No provision for escaped dots

__These slightly different syntaxes were inevitably going to lead to confusion.__

This PR updates the internal `yaml` library we use for editing YAML whilst preserving comments and formatting choices, and by extension the yaml-update step, to use the same syntax as tidwall/sjson and the new json-update step.

__There are no breaking changes in this PR. The legacy syntax still works.__

Since these changes open the possibility of using our internal `yaml` package, and by extension the yaml-update step, to append to a sequence (which it couldn't do before), the notion of using a _map_ of key/value pairs as input to update operations is invalidated. If we can append to a sequence, order matters now...

So to enable all of the above, this PR also contains a small bit of refactoring to transition away from using maps as input to YAML update operations and toward using arrays of yaml.Update structs.

cc @fykaa 