### PR TITLE
docs: update docs re: argocd sync windows

### DIFF
--- a/docs/docs/35-references/10-promotion-steps.md
+++ b/docs/docs/35-references/10-promotion-steps.md
@@ -1130,6 +1130,18 @@ spec:
 ```
 :::
 
+:::info
+Enforcement of Argo CD
+[sync windows](https://argo-cd.readthedocs.io/en/stable/user-guide/sync_windows/)
+was improved substantially in Argo CD v2.11.0. If you wish for the `argocd-update`
+step to honor sync windows, you must use Argo CD v2.11.0 or later.
+
+_Additionally, it is recommended that if a promotion process is expected to
+sometimes encounter an active deny window, the `argocd-update` step should be
+configured with a timeout that is at least as long as the longest expected deny
+window. (The step's default timeout is five minutes.)_
+:::
+
 #### `argocd-update` Configuration
 
 | Name | Type | Required | Description |


### PR DESCRIPTION
Fixes #2078 

Supersedes #3152 

This is the new, docs-only resolution of #2078.

Argo CD implemented enforcement of sync windows by the _App controller_ starting in v2.11.

All we need to do is advise users to use Argo CD v2.11+ if they care about sync windows and to set the timeout on the argocd-update step accordingly.

cc @jessesuen @blakepettersson 