### PR TITLE
chore: enforce LF line endings in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
Adding a .gitattributes file to normalize on LF for line endings in text files even if someone has their Git config set up to use CRLF.