### PR TITLE
fix(ui): link to image repo correctly in Warehouse UI

### DIFF
--- a/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
+++ b/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
@@ -1,8 +1,7 @@
 import { Descriptions, Typography } from 'antd';
 
-import { urlForImage } from '@ui/utils/url';
-
 import { RepoSubscription } from '@ui/gen/v1alpha1/generated_pb';
+import { urlForImage } from '@ui/utils/url';
 
 type Props = {
   subscriptions?: RepoSubscription[];

--- a/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
+++ b/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
@@ -1,5 +1,7 @@
 import { Descriptions, Typography } from 'antd';
 
+import { urlForImage } from '@ui/utils/url';
+
 import { RepoSubscription } from '@ui/gen/v1alpha1/generated_pb';
 
 type Props = {
@@ -38,7 +40,7 @@ export const RepoSubscriptions = ({ subscriptions }: Props) => {
             {subscription.image && (
               <Descriptions.Item label='Image'>
                 <Typography.Link
-                  href={subscription.image?.repoURL}
+                  href={urlForImage(subscription.image?.repoURL)}
                   target='_blank'
                   rel='noreferrer'
                 >


### PR DESCRIPTION
Link was pointing relative to the current URL rather than to a repository. Reusing `urlForImage` function that was used for linking in the repo node already.

Before (See bottom of screenshot):
![image](https://github.com/user-attachments/assets/8f265db9-8a86-48d7-b864-12e386dbbf3b)


Now (See bottom of screenshot):
![image](https://github.com/user-attachments/assets/4fa8235c-ca1b-461e-a665-bd0e1247b62b)
