### PR TITLE
fix: incorrectly worded error message in argocd-update is corrected

### DIFF
--- a/internal/directives/argocd_updater.go
+++ b/internal/directives/argocd_updater.go
@@ -388,8 +388,8 @@ func (a *argocdUpdater) mustPerformUpdate(
 			// NB: We return the current phase here because we want the caller
 			//     to know that an operation is still running.
 			return status.Phase, false, fmt.Errorf(
-				"current operation was not initiated by %q and not by %q: waiting for operation to complete",
-				applicationOperationInitiator, status.Operation.InitiatedBy.Username,
+				"current operation was initiated by %q and not by %q: waiting for operation to complete",
+				status.Operation.InitiatedBy.Username, applicationOperationInitiator,
 			)
 		}
 		// Initiate our own operation.

--- a/internal/directives/argocd_updater_test.go
+++ b/internal/directives/argocd_updater_test.go
@@ -978,7 +978,8 @@ func Test_argoCDUpdater_mustPerformUpdate(t *testing.T) {
 				}
 			},
 			assertions: func(t *testing.T, phase argocd.OperationPhase, mustUpdate bool, err error) {
-				require.ErrorContains(t, err, "current operation was not initiated by")
+				require.ErrorContains(t, err, "current operation was initiated by")
+				require.ErrorContains(t, err, "and not by")
 				require.ErrorContains(t, err, "waiting for operation to complete")
 				require.Equal(t, argocd.OperationRunning, phase)
 				require.False(t, mustUpdate)


### PR DESCRIPTION
fixes : #3163
1. Error Message Adjustment:

Changed the phrasing from "was not initiated by %q and not by %q" to "was initiated by %q and not by %q".
This directly states who initiated the operation (status.Operation.InitiatedBy.Username) and clarifies it wasn't initiated by the expected user (applicationOperationInitiator).