### PR TITLE
 feature(helm): Add forceHttps Option to Helm Chart for Kargo API Base URL

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -92,7 +92,7 @@ app.kubernetes.io/component: webhooks-server
 {{- end -}}
 
 {{- define "kargo.api.baseURL" -}}
-{{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled (or .Values.api.ingress.tls.enabled .Values.api.ingress.tls.usesControllerCert)) -}}
+{{- if or .Values.api.forceHttps (or .Values.api.tls.enabled (and .Values.api.ingress.enabled (or .Values.api.ingress.tls.enabled .Values.api.ingress.tls.usesControllerCert))) -}}
 {{- printf "https://%s" .Values.api.host -}}
 {{- else -}}
 {{- printf "http://%s" .Values.api.host -}}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -172,6 +172,9 @@ api:
     ## @param api.ingress.pathType You may want to use `Prefix` for some controllers (like AWS LoadBalancer Ingress controller), which don't support `/` as wildcard path when pathType is set to `ImplementationSpecific`
     pathType: ImplementationSpecific
 
+  # Force using https in baseUTL. This is useful when terminating TLS on AWS LB and setting api and ingress tls to false.
+  forceHttps: true
+
   service:
     ## @param api.service.type If you're not going to use an ingress controller, you may want to change this value to `LoadBalancer` for production deployments. If running locally, you may want to change it to `NodePort` OR leave it as `ClusterIP` and use `kubectl port-forward` to map a port on the local network interface to the service.
     type: ClusterIP


### PR DESCRIPTION
This pull request introduces a new configuration option, forceHttps, to the Kargo Helm chart. This enhancement allows users to enforce the use of https in the kargo.api.baseURL, even when TLS options are disabled for the API and ingress. This is particularly useful for scenarios where the API is exposed behind an AWS Load Balancer that terminates SSL certificates.

# Changes Made

- _helpers.tpl: Updated the kargo.api.baseURL helper function to include a condition that checks the new forceHttps value. If forceHttps is set to true, the base URL will use https regardless of other TLS settings.

- values.yaml: Added the forceHttps configuration option under the api section with a default value of true.

# Use Case
This change is designed to support environments where the API is secured by external mechanisms, such as an AWS Load Balancer, and internal TLS settings are not required. By setting forceHttps to true, users can ensure that the API base URL is always constructed with https.

# Testing
Deployed the updated Helm chart in a test environment with forceHttps set to true and verified that the API base URL uses https.
Tested with forceHttps set to false to ensure the base URL respects the existing TLS settings.

# Documentation
Updated the values.yaml file with comments explaining the new forceHttps option.