### PR TITLE
chore: add api.oidc.forceHttpsInBaseUrl in values.yaml to support external TLS termi…

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -92,7 +92,7 @@ app.kubernetes.io/component: webhooks-server
 {{- end -}}
 
 {{- define "kargo.api.baseURL" -}}
-{{- if or .Values.api.tls.enabled (and .Values.api.ingress.enabled (or .Values.api.ingress.tls.enabled .Values.api.ingress.tls.usesControllerCert)) -}}
+{{- if or .Values.api.oidc.forceHttpsInBaseUrl (or .Values.api.tls.enabled (and .Values.api.ingress.enabled (or .Values.api.ingress.tls.enabled .Values.api.ingress.tls.usesControllerCert))) -}}
 {{- printf "https://%s" .Values.api.host -}}
 {{- else -}}
 {{- printf "http://%s" .Values.api.host -}}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -212,6 +212,9 @@ api:
     additionalScopes:
     - groups
 
+    # This option is useful when you turn off TLS on ingress and api, while terminating TLS on AWS, Azure, GCP Load Balancers etc.
+    forceHttpsInBaseUrl: true
+
     admins:
       ## @param api.oidc.admins.claims Subjects having any of these claims will automatically be Kargo admins.
       claims: {}


### PR DESCRIPTION
This pull request introduces a new configuration option, forceHttps, to the Kargo Helm chart. This enhancement allows users to enforce the use of https in the kargo.api.baseURL, even when TLS options are disabled for the API and ingress. This is particularly useful for scenarios where the API is exposed behind an AWS Load Balancer that terminates SSL certificates.

Changes Made
_helpers.tpl: Updated the kargo.api.baseURL helper function to include a condition that checks the new forceHttps value. If forceHttps is set to true, the base URL will use https regardless of other TLS settings.

values.yaml: Added the forceHttps configuration option under the api section with a default value of true.

Use Case
This change is designed to support environments where the API is secured by external mechanisms, such as an AWS Load Balancer, and internal TLS settings are not required. By setting forceHttps to true, users can ensure that the API base URL is always constructed with https.

Testing
Deployed the updated Helm chart in a test environment with forceHttps set to true and verified that the API base URL uses https.
Tested with forceHttps set to false to ensure the base URL respects the existing TLS settings.

Documentation
Updated the values.yaml file with comments explaining the new forceHttps option.