### PR TITLE
fix(ui): freight assembly tables keep resetting to page 1

### DIFF
--- a/ui/src/features/assemble-freight/assemble-freight.tsx
+++ b/ui/src/features/assemble-freight/assemble-freight.tsx
@@ -252,14 +252,18 @@ export const AssembleFreight = ({
   );
 };
 
-const DiscoveryTable = ({ selected, chosenItems, select }: {
-  selected?: DiscoveryResult,
+const DiscoveryTable = ({
+  selected,
+  chosenItems,
+  select
+}: {
+  selected?: DiscoveryResult;
   chosenItems: {
     [key: string]: {
       artifact: DiscoveryResult;
       info: FreightInfo;
     };
-  },
+  };
   select: (item?: FreightInfo) => void;
 }) => {
   if (!selected) {

--- a/ui/src/features/assemble-freight/assemble-freight.tsx
+++ b/ui/src/features/assemble-freight/assemble-freight.tsx
@@ -192,40 +192,6 @@ export const AssembleFreight = ({
     }
   }
 
-  const DiscoveryTable = () => {
-    if (!selected) {
-      return null;
-    }
-
-    const selectedItem = chosenItems[selected?.repoURL as string]?.info;
-
-    if ('references' in selected) {
-      return (
-        <ImageTable
-          references={(selected as ImageDiscoveryResult).references}
-          select={select}
-          selected={selectedItem as DiscoveredImageReference}
-        />
-      );
-    } else if ('commits' in selected) {
-      return (
-        <CommitTable
-          commits={(selected as GitDiscoveryResult).commits}
-          select={select}
-          selected={selectedItem as DiscoveredCommit}
-        />
-      );
-    } else if ('versions' in selected) {
-      return (
-        <ChartTable
-          versions={(selected as ChartDiscoveryResult).versions}
-          select={select}
-          selected={selectedItem as string}
-        />
-      );
-    }
-  };
-
   const commonProps = {
     onClick: setSelected,
     selected: selected
@@ -276,7 +242,7 @@ export const AssembleFreight = ({
             <ArtifactMenuGroup icon={faGitAlt} label='Git' items={git} {...commonProps} />
           </div>
           <div className='w-full p-4 overflow-auto'>
-            <DiscoveryTable />
+            <DiscoveryTable selected={selected} chosenItems={chosenItems} select={select} />
           </div>
         </div>
       ) : (
@@ -284,4 +250,47 @@ export const AssembleFreight = ({
       )}
     </div>
   );
+};
+
+const DiscoveryTable = ({ selected, chosenItems, select }: {
+  selected?: DiscoveryResult,
+  chosenItems: {
+    [key: string]: {
+      artifact: DiscoveryResult;
+      info: FreightInfo;
+    };
+  },
+  select: (item?: FreightInfo) => void;
+}) => {
+  if (!selected) {
+    return null;
+  }
+
+  const selectedItem = chosenItems[selected?.repoURL as string]?.info;
+
+  if ('references' in selected) {
+    return (
+      <ImageTable
+        references={(selected as ImageDiscoveryResult).references}
+        select={select}
+        selected={selectedItem as DiscoveredImageReference}
+      />
+    );
+  } else if ('commits' in selected) {
+    return (
+      <CommitTable
+        commits={(selected as GitDiscoveryResult).commits}
+        select={select}
+        selected={selectedItem as DiscoveredCommit}
+      />
+    );
+  } else if ('versions' in selected) {
+    return (
+      <ChartTable
+        versions={(selected as ChartDiscoveryResult).versions}
+        select={select}
+        selected={selectedItem as string}
+      />
+    );
+  }
 };

--- a/ui/src/features/assemble-freight/chart-table.tsx
+++ b/ui/src/features/assemble-freight/chart-table.tsx
@@ -1,6 +1,7 @@
-import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 import { Radio, Table } from 'antd';
 import { useState } from 'react';
+
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 
 export const ChartTable = ({
   versions,
@@ -11,7 +12,9 @@ export const ChartTable = ({
   selected: string | undefined;
   select: (version?: string) => void;
 }) => {
-  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, versions, (version) => version));
+  const [defaultPage] = useState<number>(() =>
+    calculatePageForSelectedRow(selected, versions, (version) => version)
+  );
 
   return (
     <Table

--- a/ui/src/features/assemble-freight/chart-table.tsx
+++ b/ui/src/features/assemble-freight/chart-table.tsx
@@ -1,4 +1,6 @@
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 import { Radio, Table } from 'antd';
+import { useState } from 'react';
 
 export const ChartTable = ({
   versions,
@@ -9,9 +11,12 @@ export const ChartTable = ({
   selected: string | undefined;
   select: (version?: string) => void;
 }) => {
+  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, versions, (version) => version));
+
   return (
     <Table
       dataSource={versions.map((version) => ({ version }))}
+      pagination={{ defaultCurrent: defaultPage }}
       columns={[
         {
           width: '50px',

--- a/ui/src/features/assemble-freight/commit-table.tsx
+++ b/ui/src/features/assemble-freight/commit-table.tsx
@@ -1,11 +1,11 @@
 import { Radio, Table } from 'antd';
+import { useState } from 'react';
 
 import { DiscoveredCommit } from '@ui/gen/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 
 import { TruncatedCopyable } from './truncated-copyable';
-import { calculatePageForSelectedRow } from '@ui/utils/pagination';
-import { useState } from 'react';
 
 export const CommitTable = ({
   commits,
@@ -16,7 +16,9 @@ export const CommitTable = ({
   selected: DiscoveredCommit | undefined;
   select: (commit?: DiscoveredCommit) => void;
 }) => {
-  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, commits, (commit) => commit.id));
+  const [defaultPage] = useState<number>(() =>
+    calculatePageForSelectedRow(selected, commits, (commit) => commit.id)
+  );
 
   return (
     <>

--- a/ui/src/features/assemble-freight/commit-table.tsx
+++ b/ui/src/features/assemble-freight/commit-table.tsx
@@ -4,6 +4,8 @@ import { DiscoveredCommit } from '@ui/gen/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
 
 import { TruncatedCopyable } from './truncated-copyable';
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
+import { useState } from 'react';
 
 export const CommitTable = ({
   commits,
@@ -14,10 +16,13 @@ export const CommitTable = ({
   selected: DiscoveredCommit | undefined;
   select: (commit?: DiscoveredCommit) => void;
 }) => {
+  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, commits, (commit) => commit.id));
+
   return (
     <>
       <Table
         dataSource={commits}
+        pagination={{ defaultCurrent: defaultPage }}
         columns={[
           {
             render: (record: DiscoveredCommit) => (

--- a/ui/src/features/assemble-freight/image-table.tsx
+++ b/ui/src/features/assemble-freight/image-table.tsx
@@ -6,6 +6,8 @@ import { DiscoveredImageReference } from '@ui/gen/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
 
 import { TruncatedCopyable } from './truncated-copyable';
+import { useState } from 'react';
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 
 export const ImageTable = ({
   references,
@@ -15,41 +17,46 @@ export const ImageTable = ({
   references: DiscoveredImageReference[];
   selected: DiscoveredImageReference | undefined;
   select: (reference?: DiscoveredImageReference) => void;
-}) => (
-  <>
-    <Table
-      dataSource={references}
-      columns={[
-        {
-          render: (record: DiscoveredImageReference) => (
-            <Radio
-              checked={selected?.tag === record?.tag}
-              onClick={() => select(selected === record ? undefined : record)}
-            />
-          )
-        },
-        { title: 'Tag', dataIndex: 'tag' },
-        {
-          title: 'Digest',
-          render: (record: DiscoveredImageReference) => <TruncatedCopyable text={record?.digest} />
-        },
-        {
-          title: 'Source Repo',
-          render: (record: DiscoveredImageReference) =>
-            record?.gitRepoURL ? (
-              <a href={record?.gitRepoURL} target='_blank' rel='noreferrer'>
-                {record?.gitRepoURL}
-              </a>
-            ) : (
-              <FontAwesomeIcon icon={faQuestionCircle} className='text-gray-400' />
+}) => {
+  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, references, (ref) => ref.tag));
+
+  return (
+    <>
+      <Table
+        dataSource={references}
+        pagination={{ defaultCurrent: defaultPage }}
+        columns={[
+          {
+            render: (record: DiscoveredImageReference) => (
+              <Radio
+                checked={selected?.tag === record?.tag}
+                onClick={() => select(selected === record ? undefined : record)}
+              />
             )
-        },
-        {
-          title: 'Created At',
-          render: (record: DiscoveredImageReference) =>
-            timestampDate(record.createdAt)?.toLocaleString()
-        }
-      ]}
-    />
-  </>
-);
+          },
+          { title: 'Tag', dataIndex: 'tag' },
+          {
+            title: 'Digest',
+            render: (record: DiscoveredImageReference) => <TruncatedCopyable text={record?.digest} />
+          },
+          {
+            title: 'Source Repo',
+            render: (record: DiscoveredImageReference) =>
+              record?.gitRepoURL ? (
+                <a href={record?.gitRepoURL} target='_blank' rel='noreferrer'>
+                  {record?.gitRepoURL}
+                </a>
+              ) : (
+                <FontAwesomeIcon icon={faQuestionCircle} className='text-gray-400' />
+              )
+          },
+          {
+            title: 'Created At',
+            render: (record: DiscoveredImageReference) =>
+              timestampDate(record.createdAt)?.toLocaleString()
+          }
+        ]}
+      />
+    </>
+  )
+};

--- a/ui/src/features/assemble-freight/image-table.tsx
+++ b/ui/src/features/assemble-freight/image-table.tsx
@@ -1,13 +1,13 @@
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Radio, Table } from 'antd';
+import { useState } from 'react';
 
 import { DiscoveredImageReference } from '@ui/gen/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
+import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 
 import { TruncatedCopyable } from './truncated-copyable';
-import { useState } from 'react';
-import { calculatePageForSelectedRow } from '@ui/utils/pagination';
 
 export const ImageTable = ({
   references,
@@ -18,7 +18,9 @@ export const ImageTable = ({
   selected: DiscoveredImageReference | undefined;
   select: (reference?: DiscoveredImageReference) => void;
 }) => {
-  const [defaultPage] = useState<number>(() => calculatePageForSelectedRow(selected, references, (ref) => ref.tag));
+  const [defaultPage] = useState<number>(() =>
+    calculatePageForSelectedRow(selected, references, (ref) => ref.tag)
+  );
 
   return (
     <>
@@ -37,7 +39,9 @@ export const ImageTable = ({
           { title: 'Tag', dataIndex: 'tag' },
           {
             title: 'Digest',
-            render: (record: DiscoveredImageReference) => <TruncatedCopyable text={record?.digest} />
+            render: (record: DiscoveredImageReference) => (
+              <TruncatedCopyable text={record?.digest} />
+            )
           },
           {
             title: 'Source Repo',
@@ -58,5 +62,5 @@ export const ImageTable = ({
         ]}
       />
     </>
-  )
+  );
 };

--- a/ui/src/utils/pagination.test.ts
+++ b/ui/src/utils/pagination.test.ts
@@ -1,14 +1,18 @@
-import { describe, expect, test } from "vitest";
-import { calculatePageForSelectedRow } from "./pagination";
+import { describe, expect, test } from 'vitest';
 
-describe("calculatePageForSelectedRow", () => {
-    test.each([
-        [undefined, ["a", "b", "c"], (option: string) => option, 1],
-        ["a", ["a", "b", "c"], (option: string) => option, 1],
-        ["j", ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"], (option: string) => option, 1],
-        ["k", ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"], (option: string) => option, 2],
-    ])('selectedOption: %s, options: %s, key: %s, expectedPage: %s', (selectedOption, options, key, expectedPage) => {
-        const page = calculatePageForSelectedRow(selectedOption, options, key);
-        expect(page).toBe(expectedPage);
-    });
+import { calculatePageForSelectedRow } from './pagination';
+
+describe('calculatePageForSelectedRow', () => {
+  test.each([
+    [undefined, ['a', 'b', 'c'], (option: string) => option, 1],
+    ['a', ['a', 'b', 'c'], (option: string) => option, 1],
+    ['j', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'], (option: string) => option, 1],
+    ['k', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'], (option: string) => option, 2]
+  ])(
+    'selectedOption: %s, options: %s, key: %s, expectedPage: %s',
+    (selectedOption, options, key, expectedPage) => {
+      const page = calculatePageForSelectedRow(selectedOption, options, key);
+      expect(page).toBe(expectedPage);
+    }
+  );
 });

--- a/ui/src/utils/pagination.test.ts
+++ b/ui/src/utils/pagination.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { calculatePageForSelectedRow } from "./pagination";
+
+describe("calculatePageForSelectedRow", () => {
+    test.each([
+        [undefined, ["a", "b", "c"], (option: string) => option, 1],
+        ["a", ["a", "b", "c"], (option: string) => option, 1],
+        ["j", ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"], (option: string) => option, 1],
+        ["k", ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"], (option: string) => option, 2],
+    ])('selectedOption: %s, options: %s, key: %s, expectedPage: %s', (selectedOption, options, key, expectedPage) => {
+        const page = calculatePageForSelectedRow(selectedOption, options, key);
+        expect(page).toBe(expectedPage);
+    });
+});

--- a/ui/src/utils/pagination.ts
+++ b/ui/src/utils/pagination.ts
@@ -1,12 +1,16 @@
-export function calculatePageForSelectedRow<T>(selectedOption: T | undefined, options: T[], key: (option: T) => string): number {
-    const pageSize = 10;
+export function calculatePageForSelectedRow<T>(
+  selectedOption: T | undefined,
+  options: T[],
+  key: (option: T) => string
+): number {
+  const pageSize = 10;
 
-    if (selectedOption) {
-        const index = options.findIndex((option) => key(option) === key(selectedOption));
-        if (index >= 0) {
-            const page = Math.floor(index / pageSize) + 1;
-            return page;
-        }
+  if (selectedOption) {
+    const index = options.findIndex((option) => key(option) === key(selectedOption));
+    if (index >= 0) {
+      const page = Math.floor(index / pageSize) + 1;
+      return page;
     }
-    return 1;
+  }
+  return 1;
 }

--- a/ui/src/utils/pagination.ts
+++ b/ui/src/utils/pagination.ts
@@ -1,0 +1,12 @@
+export function calculatePageForSelectedRow<T>(selectedOption: T | undefined, options: T[], key: (option: T) => string): number {
+    const pageSize = 10;
+
+    if (selectedOption) {
+        const index = options.findIndex((option) => key(option) === key(selectedOption));
+        if (index >= 0) {
+            const page = Math.floor(index / pageSize) + 1;
+            return page;
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
fixes: https://github.com/akuity/kargo/issues/2581

**RCA**:
1. The ImageTable/CommitTable/ChartTable component gets re-mounted (unmounted and mounted again) when the _select_ function is called. This leads to the loss of any local state in these components (including the active page).
2. The _select_ function modifies a state in the AssembleFreight component.
3. The DiscoveryTable component (which wraps the ImageTable/CommitTable/ChartTable component) is a nested function inside AssembleFreight. Every time AssembleFreight rerenders due to a change in its state, the DiscoveryTable function is redeclared, changing its memory reference. React thinks the component has been replaced, unmounts the old Table, and mounts a new one.

This problem is also described here: https://stackoverflow.com/a/64211013