### PR TITLE
chore: skip ci for prs opened against the newdocs branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    branches-ignore:
+    - newdocs
   merge_group:
   push:
     branches:


### PR DESCRIPTION
This is so we don't waste time running the full battery of CI tests on a series of PRs we know will exclusively contain doc changes.

We can still gate PRs on Netlify successfully building a preview of the changes, as that is all configured independently of the Actions workflows.