### PR TITLE
fix: responsive versioned dropdown

### DIFF
--- a/docs/src/components/VersionDropdown.css
+++ b/docs/src/components/VersionDropdown.css
@@ -9,10 +9,17 @@
     cursor: pointer;
     padding: 5px 10px;
     font-size: 1rem;
-    font-family: 'Monospace', 'Roboto', 'Open Sans', 'Lato', 'Courier New', monospace;
     font-weight: bold;
+    width: 73px;
+    text-align: center;
 }
 
 .version_dropdown option {
     font-weight: normal; /* Keeps options normal weight */
+}
+
+@media (max-width: 996px) {
+    .navbar__items--right .version_dropdown {
+        display: none;
+    }
 }

--- a/docs/src/components/VersionDropdown.css
+++ b/docs/src/components/VersionDropdown.css
@@ -9,6 +9,7 @@
     cursor: pointer;
     padding: 5px 10px;
     font-size: 1rem;
+    width: fit-content;
     font-weight: bold;
     text-align: center;
 }
@@ -21,4 +22,18 @@
     .navbar__items--right .version_dropdown {
         display: none;
     }
+
+    .version_dropdown {
+        display: flex;
+        flex-direction: column;
+        order: -1;
+        width: fit-content;
+        margin: 10px 0px 10px 10px;
+    }
+
+    .menu__list {
+        display: flex;
+        flex-direction: column;
+    }
+
 }

--- a/docs/src/components/VersionDropdown.css
+++ b/docs/src/components/VersionDropdown.css
@@ -10,7 +10,6 @@
     padding: 5px 10px;
     font-size: 1rem;
     font-weight: bold;
-    width: 73px;
     text-align: center;
 }
 

--- a/docs/src/components/VersionDropdown.js
+++ b/docs/src/components/VersionDropdown.js
@@ -109,6 +109,7 @@ function VersionDropdown() {
       className="version_dropdown"
       onChange={handleVersionChange}
       value={currentVersion}
+      title={`${currentVersion}`}
     >
       {versions.map(version => (
         <option key={version.version} value={version.version}>


### PR DESCRIPTION
added version width and title
<img width="659" alt="image" src="https://github.com/user-attachments/assets/6dec3897-e94f-4b41-96e7-e3b598866ef8" />


---
fixed dropdown component
before:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/072bed91-74f0-4425-b555-c1c199d728af" />
after:
<img width="659" alt="image" src="https://github.com/user-attachments/assets/6dd0ee05-3a02-420c-af9f-c62f6234e6b6" />
