### PR TITLE
Adding entrypoint

### DIFF
--- a/kargo-base.apko.yaml
+++ b/kargo-base.apko.yaml
@@ -4,7 +4,6 @@ contents:
   repositories:
   - https://packages.wolfi.dev/os
   packages:
-  - busybox # TODO: Remove this if we can figure out how to get by without a shell
   - ca-certificates
   - git~2
   - gpg~2
@@ -22,6 +21,10 @@ accounts:
     uid: 65532
     gid: 65532
   run-as: "65532"
+
+entrypoint:
+  command: /usr/bin/helm
+cmd: help
   
 archs:
 - arm64


### PR DESCRIPTION
Removing busybox  and adding entrypoint. This makes helm as your entrypoint so the image can run with an input of a helm chart.

```
➜  kargo git:(main) ✗ docker run kargo:latest-amd64    
The Kubernetes package manager

Common actions for Helm:

- helm search:    search for charts
- helm pull:      download a chart to your local directory to view
- helm install:   upload the chart to Kubernetes
- helm list:      list releases of charts
``` 