### PR TITLE
fix: Indent typo in 15-concepts.md

### DIFF
--- a/docs/docs/15-concepts.md
+++ b/docs/docs/15-concepts.md
@@ -235,9 +235,9 @@ metadata:
   name: my-warehouse
   namespace: kargo-demo
 spec:
-    subscriptions:
-    - git:
-        repoURL: https://github.com/example/kargo-demo.git
+  subscriptions:
+  - git:
+      repoURL: https://github.com/example/kargo-demo.git
       excludePaths:
       - docs
 ```


### PR DESCRIPTION
This PR fix the yaml indent typo in Warehouse's excludePaths example