### PR TITLE
chore(cli): fix update command example

### DIFF
--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/akuity/kargo/internal/cli/config"
 	"github.com/akuity/kargo/internal/cli/option"
-	"github.com/akuity/kargo/internal/cli/templates"
 )
 
 func NewCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra.Command {

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -14,10 +14,6 @@ func NewCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra
 		Use:   "update SUBCOMMAND",
 		Short: "Update a resource",
 		Args:  option.NoArgs,
-		Example: templates.Example(`
-# Update the alias of a freight for a specified project
-kargo update freight --project=my-project --name=abc123 --new-alias=my-new-alias
-`),
 	}
 
 	// Register subcommands.

--- a/internal/cli/cmd/update/update.go
+++ b/internal/cli/cmd/update/update.go
@@ -16,7 +16,7 @@ func NewCommand(cfg config.CLIConfig, streams genericiooptions.IOStreams) *cobra
 		Args:  option.NoArgs,
 		Example: templates.Example(`
 # Update the alias of a freight for a specified project
-kargo update freight --project=my-project abc123 --alias=my-new-alias
+kargo update freight --project=my-project --name=abc123 --new-alias=my-new-alias
 `),
 	}
 


### PR DESCRIPTION
Fixes outdated cli examples in the update command

- Need to use the `--name` flag when passing freight name
- Replaced `--alias` with `--new-alias` flag