### PR TITLE
fix(directives): HTTP repo cache `helm-chart-update`

### DIFF
--- a/internal/directives/helm_chart_updater.go
+++ b/internal/directives/helm_chart_updater.go
@@ -2,9 +2,11 @@ package directives
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -211,7 +213,7 @@ func (h *helmChartUpdater) updateDependencies(
 		}
 	}
 
-	if err = h.loadDependencyCredentials(
+	if err = h.setupDependencyRepositories(
 		ctx,
 		stepCtx.CredentialsDB,
 		registryClient,
@@ -248,11 +250,21 @@ func (h *helmChartUpdater) updateDependencies(
 		return nil, fmt.Errorf("failed to check Chart.lock: %w", err)
 	}
 
-	// Run the dependency update
+	// Prepare the environment settings for Helm
 	env := &cli.EnvSettings{
 		RepositoryConfig: repositoryConfig,
 		RepositoryCache:  filepath.Join(helmHome, "cache"),
 	}
+
+	// Download the repository indexes. This is necessary to ensure that the
+	// cache is properly populated, as otherwise the download manager will
+	// attempt to download the repository indexes to the default cache path
+	// instead of using the cache path set in the environment settings.
+	if err = h.downloadRepositoryIndexes(repositoryFile.Repositories, env); err != nil {
+		return nil, err
+	}
+
+	// Run the dependency update
 	manager := downloader.Manager{
 		Out:              io.Discard,
 		ChartPath:        chartPath,
@@ -325,7 +337,7 @@ func (h *helmChartUpdater) validateFileDependency(workDir, chartPath, dependency
 	return checkSymlinks(workDir, dependencyPath, visited, 0, 100)
 }
 
-func (h *helmChartUpdater) loadDependencyCredentials(
+func (h *helmChartUpdater) setupDependencyRepositories(
 	ctx context.Context,
 	credentialsDB credentials.Database,
 	registryClient *registry.Client,
@@ -334,42 +346,70 @@ func (h *helmChartUpdater) loadDependencyCredentials(
 	dependencies []chartDependency,
 ) error {
 	for _, dep := range dependencies {
-		var credType credentials.Type
-		var credURL string
-
 		switch {
-		case strings.HasPrefix(dep.Repository, "https://"):
-			credType = credentials.TypeHelm
-			credURL = dep.Repository
-		case strings.HasPrefix(dep.Repository, "oci://"):
-			credType = credentials.TypeHelm
-			credURL = "oci://" + path.Join(helm.NormalizeChartRepositoryURL(dep.Repository), dep.Name)
-		default:
+		case strings.HasPrefix(dep.Repository, "file://"):
 			continue
-		}
-
-		creds, ok, err := credentialsDB.Get(ctx, project, credType, credURL)
-		if err != nil {
-			return fmt.Errorf("failed to obtain credentials for chart repository %q: %w", dep.Repository, err)
-		}
-		if !ok {
-			continue
-		}
-
-		if strings.HasPrefix(dep.Repository, "https://") {
-			repositoryFile.Add(&repo.Entry{
-				Name:     dep.Name,
-				URL:      dep.Repository,
-				Username: creds.Username,
-				Password: creds.Password,
-			})
-		} else {
-			if err = registryClient.Login(
-				strings.TrimPrefix(dep.Repository, "oci://"),
-				registry.LoginOptBasicAuth(creds.Username, creds.Password),
-			); err != nil {
-				return fmt.Errorf("failed to authenticate with chart repository %q: %w", dep.Repository, err)
+		case strings.HasPrefix(dep.Repository, "http://"):
+			entry := &repo.Entry{
+				Name: nameForRepositoryURL(dep.Repository),
+				URL:  dep.Repository,
 			}
+			repositoryFile.Update(entry)
+		case strings.HasPrefix(dep.Repository, "https://"):
+			entry := &repo.Entry{
+				Name: nameForRepositoryURL(dep.Repository),
+				URL:  dep.Repository,
+			}
+
+			creds, ok, err := credentialsDB.Get(ctx, project, credentials.TypeHelm, dep.Repository)
+			if err != nil {
+				return fmt.Errorf("failed to obtain credentials for chart repository %q: %w", dep.Repository, err)
+			}
+			if ok {
+				entry.Username = creds.Username
+				entry.Password = creds.Password
+			}
+
+			repositoryFile.Update(entry)
+		case strings.HasPrefix(dep.Repository, "oci://"):
+			credURL := "oci://" + path.Join(helm.NormalizeChartRepositoryURL(dep.Repository), dep.Name)
+			creds, ok, err := credentialsDB.Get(ctx, project, credentials.TypeHelm, credURL)
+			if err != nil {
+				return fmt.Errorf("failed to obtain credentials for chart repository %q: %w", dep.Repository, err)
+			}
+			if ok {
+				if err = registryClient.Login(
+					strings.TrimPrefix(dep.Repository, "oci://"),
+					registry.LoginOptBasicAuth(creds.Username, creds.Password),
+				); err != nil {
+					return fmt.Errorf("failed to authenticate with chart repository %q: %w", dep.Repository, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (h *helmChartUpdater) downloadRepositoryIndexes(
+	repositories []*repo.Entry,
+	env *cli.EnvSettings,
+) error {
+	for _, entry := range repositories {
+		cr, err := repo.NewChartRepository(entry, getter.All(env))
+		if err != nil {
+			return fmt.Errorf("failed to create chart repository for %q: %w", entry.URL, err)
+		}
+
+		// NB: Explicitly overwrite the cache path to avoid using the default
+		// cache path from the environment variables. Without this, the download
+		// manager will not find the repository index files in the cache, and
+		// will attempt to download them again (to the default cache path).
+		// I.e. without this, the download manager will not use the isolated
+		// cache.
+		cr.CachePath = env.RepositoryCache
+
+		if _, err = cr.DownloadIndexFile(); err != nil {
+			return fmt.Errorf("failed to download repository index for %q: %w", entry.URL, err)
 		}
 	}
 	return nil
@@ -604,4 +644,28 @@ func backupFile(src, dst string) (err error) {
 		return err
 	}
 	return nil
+}
+
+// nameForRepositoryURL generates an SHA-256 hash of the repository URL to use
+// as the name for the repository in the Helm repository cache.
+//
+// The repository URL is normalized before hashing using the same logic as
+// urlutil.Equal from Helm, which is used to compare repository URLs in the
+// download manager when looking at cached repository indexes to find the
+// correct chart URL.
+func nameForRepositoryURL(repoURL string) string {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		repoURL = filepath.Clean(repoURL)
+	}
+
+	if u != nil {
+		if u.Path == "" {
+			u.Path = "/"
+		}
+		u.Path = filepath.Clean(u.Path)
+		repoURL = u.String()
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(repoURL)))
 }


### PR DESCRIPTION
Fixes: #3299
Fixes: #3298 
Fixes: #3290

---

The reason `/home/nonroot` is being touched, is that Helm has decided to do something odd within their download manager by not taking the configured value into account for the repository cache while trying to resolve a chart dependency for a repository that does not have a cache entry for the `index.yaml`.

Instead, it temporarily caches the index to an `index.yaml` with a random 20-byte name to the [environment variable-based cache path](https://github.com/helm/helm/blob/v3.17.0/pkg/helmpath/lazypath.go#L60), and then removes it as soon as it has resolved the chart URL for the version it is interested in.

Stack trace:

1. https://github.com/helm/helm/blob/v3.17.0/pkg/downloader/manager.go#L315
2. https://github.com/helm/helm/blob/v3.17.0/pkg/downloader/manager.go#L745-L748
3. https://github.com/helm/helm/blob/v3.17.0/pkg/repo/chartrepo.go#L243-L254
4. https://github.com/helm/helm/blob/v3.17.0/pkg/repo/chartrepo.go#L78

---

To solve this issue, we now add all the "classic" repositories (even those that do not require authentication) to our isolated cache and fetch their indexes before running a Helm chart update, which prevents Helm from attempting to download them.