### PR TITLE
feat: json-parse promotion step

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/json-parse.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/json-parse.md
@@ -43,7 +43,7 @@ After cloning the repository and clearing the output directory, the `json-parse`
 to extract the image tag from the `Freight` being promoted.
 Using dot notation (image.tag), it extracts the nested value from the JSON file.
 
-```json
+```yaml
 vars:
 - name: gitRepo
   value: https://github.com/example/repo.git

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/json-parse.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/json-parse.md
@@ -1,0 +1,90 @@
+---
+sidebar_label: json-parse
+description: Parses a JSON string and extracts values based on specified expressions.
+---
+
+# `json-parse`
+
+`json-parse` is a utility step that parses a JSON string and extracts values using [expr-lang][] expressions.
+
+## Configuration
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Y | Path to a JSON file. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `outputs` | `[]object` | Y | A list of rules for extracting values from the parsed JSON. |
+| `outputs[].name` | `string` | Y | The name of the output variable. |
+| `outputs[].fromExpression` | `string` | Y | An [expr-lang](https://expr-lang.org/) expression that can extract the value from the JSON file. Note that this expression should not be offset by `${{` and `}}`. See examples for more details. |
+
+## Expressions
+
+The `fromExpression` field supports [expr-lang](https://expr-lang.org/) expressions.
+
+:::note
+Expressions should _not_ be offset by `${{` and `}}` to prevent pre-processing evaluation by Kargo. The `json-parse` step itself will evaluate these expressions.
+:::
+
+A `outputs` object (a `map[string]any`) is available to these expressions. It is structured as follows:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outputs` | `map[string]any` | The parsed JSON object. |
+
+## Outputs
+
+The `json-parse` step produces the outputs described by the `outputs` field in its configuration.
+
+## Examples
+
+### Common Usage
+
+In this example, a values file is parsed to find the container image tag.
+After cloning the repository and clearing the output directory, the `json-parse` step parses `values.json`
+to extract the image tag from the `Freight` being promoted.
+Using dot notation (image.tag), it extracts the nested value from the JSON file.
+
+```json
+vars:
+- name: gitRepo
+  value: https://github.com/example/repo.git
+steps:
+- uses: git-clone
+  config:
+    repoURL: ${{ vars.gitRepo }}
+    checkout:
+    - commit: ${{ commitFrom(vars.gitRepo).ID }}
+      path: ./src
+    - branch: stage/${{ ctx.stage }}
+      create: true
+      path: ./out
+- uses: git-clear
+  config:
+    path: ./out
+- uses: json-parse
+  as: parse-user
+  config:
+    path: './src/charts/my-chart/values.json'
+    outputs:
+    - name: imageTag
+      fromExpression: image.tag
+# Render manifests to ./out, commit, push, etc...
+```
+
+Given the sample input JSON:
+
+```json
+{
+  "image": {
+    "tag": "latest"
+  },
+  "rbac": {
+    "installClusterRoles": true
+  }
+}
+```
+
+The step would produce the following output:
+
+| Name | Type | Value |
+|------|------|-------|
+| `imageTag` | `string` | `latest` |

--- a/internal/directives/json_parser.go
+++ b/internal/directives/json_parser.go
@@ -1,0 +1,132 @@
+package directives
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/expr-lang/expr"
+	"github.com/xeipuuv/gojsonschema"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func init() {
+	builtins.RegisterPromotionStepRunner(newJSONParser(), nil)
+}
+
+// jsonParser is an implementation of the PromotionStepRunner interface that
+// parses a JSON file and extracts specified outputs.
+type jsonParser struct {
+	schemaLoader gojsonschema.JSONLoader
+}
+
+// newJSONParser returns a new instance of jsonParser.
+func newJSONParser() PromotionStepRunner {
+	r := &jsonParser{}
+	r.schemaLoader = getConfigSchemaLoader(r.Name())
+	return r
+}
+
+// Name implements the PromotionStepRunner interface.
+func (jp *jsonParser) Name() string {
+	return "json-parse"
+}
+
+func (jp *jsonParser) RunPromotionStep(
+	ctx context.Context,
+	stepCtx *PromotionStepContext,
+) (PromotionStepResult, error) {
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
+
+	if err := jp.validate(stepCtx.Config); err != nil {
+		return failure, err
+	}
+
+	cfg, err := ConfigToStruct[JSONParseConfig](stepCtx.Config)
+	if err != nil {
+		return failure, fmt.Errorf("could not convert config into %s config: %w", jp.Name(), err)
+	}
+
+	return jp.runPromotionStep(ctx, stepCtx, cfg)
+}
+
+// validate validates jsonParser configuration against a JSON schema.
+func (jp *jsonParser) validate(cfg Config) error {
+	return validate(jp.schemaLoader, gojsonschema.NewGoLoader(cfg), jp.Name())
+}
+
+func (jp *jsonParser) runPromotionStep(
+	_ context.Context,
+	stepCtx *PromotionStepContext,
+	cfg JSONParseConfig,
+) (PromotionStepResult, error) {
+	failure := PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}
+
+	if cfg.Path == "" {
+		return failure, fmt.Errorf("JSON file path cannot be empty")
+	}
+
+	if len(cfg.Outputs) == 0 {
+		return failure, fmt.Errorf("invalid json-parse config: outputs is required")
+	}
+
+	data, err := jp.readAndParseJSON(stepCtx.WorkDir, cfg.Path)
+	if err != nil {
+		return failure, err
+	}
+
+	extractedValues, err := jp.extractValues(data, cfg.Outputs)
+	if err != nil {
+		return failure, fmt.Errorf("failed to extract outputs: %w", err)
+	}
+
+	return PromotionStepResult{
+		Status: kargoapi.PromotionPhaseSucceeded,
+		Output: extractedValues,
+	}, nil
+}
+
+// readAndParseJSON reads a JSON file and unmarshals it into a map.
+func (jp *jsonParser) readAndParseJSON(workDir string, path string) (map[string]any, error) {
+
+	absFilePath, err := securejoin.SecureJoin(workDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("error joining path %q: %w", path, err)
+	}
+
+	jsonData, err := os.ReadFile(absFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading JSON file %q: %w", absFilePath, err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return nil, fmt.Errorf("could not parse JSON file: %w", err)
+	}
+
+	return data, nil
+}
+
+// extractValues evaluates JSONPath expressions using expr and returns extracted values.
+func (jp *jsonParser) extractValues(data map[string]any, outputs []JSONParse) (map[string]any, error) {
+	results := make(map[string]any)
+
+	for _, output := range outputs {
+		program, err := expr.Compile(output.FromExpression, expr.Env(data))
+		if err != nil {
+			return nil, fmt.Errorf("error compiling expression %s: %w", output.FromExpression, err)
+		}
+
+		value, err := expr.Run(program, data)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating expression %s: %w", output.FromExpression, err)
+		}
+
+		results[output.Name] = value
+	}
+
+	return results, nil
+}

--- a/internal/directives/json_parser_test.go
+++ b/internal/directives/json_parser_test.go
@@ -1,0 +1,425 @@
+package directives
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func Test_jsonParser_validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        map[string]any
+		expectedError string
+	}{
+		{
+			name: "path not specified (missing path field)",
+			config: map[string]any{
+				"outputs": []map[string]any{
+					{"name": "output1", "fromExpression": "$.data"},
+				},
+			},
+			expectedError: "(root): path is required",
+		},
+		{
+			name: "path is empty string",
+			config: map[string]any{
+				"path": "",
+				"outputs": []map[string]any{
+					{"name": "output1", "fromExpression": "$.data"},
+				},
+			},
+			expectedError: "path: String length must be greater than or equal to 1",
+		},
+		{
+			name: "outputs field is missing",
+			config: map[string]any{
+				"path": "valid.json",
+			},
+			expectedError: "(root): outputs is required",
+		},
+		{
+			name: "outputs field is an empty array",
+			config: map[string]any{
+				"path":    "valid.json",
+				"outputs": []map[string]any{},
+			},
+			expectedError: "outputs: Array must have at least 1 items",
+		},
+		{
+			name: "name is not specified",
+			config: map[string]any{
+				"path": "valid.json",
+				"outputs": []map[string]any{
+					{"fromExpression": "$.data"},
+				},
+			},
+			expectedError: "outputs.0: name is required",
+		},
+		{
+			name: "name is empty",
+			config: map[string]any{
+				"path": "valid.json",
+				"outputs": []map[string]any{
+					{"name": "", "fromExpression": "$.data"},
+				},
+			},
+			expectedError: "name: String length must be greater than or equal to 1",
+		},
+		{
+			name: "FromExpression is not specified",
+			config: map[string]any{
+				"path": "valid.json",
+				"outputs": []map[string]any{
+					{"name": "output1"},
+				},
+			},
+			expectedError: "outputs.0: fromExpression is required",
+		},
+		{
+			name: "FromExpression is empty",
+			config: map[string]any{
+				"path": "valid.json",
+				"outputs": []map[string]any{
+					{"name": "output1", "fromExpression": ""},
+				},
+			},
+			expectedError: "fromExpression: String length must be greater than or equal to 1",
+		},
+		{
+			name: "valid configuration (path + outputs present)",
+			config: map[string]any{
+				"path": "valid.json",
+				"outputs": []map[string]any{
+					{"name": "output1", "fromExpression": "$.data"},
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	r := newJSONParser()
+	runner, ok := r.(*jsonParser)
+	require.True(t, ok)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runner.validate(tc.config)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			}
+		})
+	}
+}
+
+func Test_jsonParser_runPromotionStep(t *testing.T) {
+	tests := []struct {
+		name       string
+		stepCtx    *PromotionStepContext
+		cfg        JSONParseConfig
+		files      map[string]string
+		assertions func(*testing.T, string, PromotionStepResult, error)
+	}{
+		{
+			name: "successful run with outputs",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: JSONParseConfig{
+				Path: "config.json",
+				Outputs: []JSONParse{
+					{Name: "appVersion", FromExpression: "app.version"},
+					{Name: "featureStatus", FromExpression: "features.newFeature"},
+				},
+			},
+			files: map[string]string{
+				"config.json": `{
+					"app": {
+						"version": "1.0.0"
+					},
+					"features": {
+						"newFeature": false
+					}
+				}`,
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{
+					Status: kargoapi.PromotionPhaseSucceeded,
+					Output: map[string]any{
+						"appVersion":    "1.0.0",
+						"featureStatus": false,
+					},
+				}, result)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "failed to extract outputs",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: JSONParseConfig{
+				Path: "config.json",
+				Outputs: []JSONParse{
+					{Name: "invalidField", FromExpression: "nonexistent.path"},
+				},
+			},
+			files: map[string]string{"config.json": `{ "app": { "version": "1.0.0" }}`},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+				assert.Contains(t, err.Error(), "failed to extract outputs")
+			},
+		},
+		{
+			name: "no outputs provided",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: JSONParseConfig{
+				Path:    "config.json",
+				Outputs: []JSONParse{},
+			},
+			files: map[string]string{
+				"config.json": `{
+					"app": {
+						"version": "1.0.0"
+					}
+				}`,
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{
+					Status: kargoapi.PromotionPhaseErrored,
+				}, result)
+				assert.Contains(t, err.Error(), "outputs is required")
+			},
+		},
+		{
+			name: "handle empty JSON file",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: JSONParseConfig{
+				Path: "config.json",
+				Outputs: []JSONParse{
+					{Name: "key", FromExpression: "app.key"},
+				},
+			},
+			files: map[string]string{
+				"config.json": ``,
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+				assert.Contains(t, err.Error(), "could not parse JSON file")
+			},
+		},
+		{
+			name:    "path is empty",
+			stepCtx: &PromotionStepContext{Project: "test-project"},
+			cfg:     JSONParseConfig{Path: "", Outputs: []JSONParse{{Name: "key", FromExpression: "app.key"}}},
+			files:   map[string]string{},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+				assert.Contains(t, err.Error(), "JSON file path cannot be empty")
+			},
+		},
+		{
+			name:    "path is a directory instead of a file",
+			stepCtx: &PromotionStepContext{Project: "test-project"},
+			cfg:     JSONParseConfig{Path: "config", Outputs: []JSONParse{{Name: "key", FromExpression: "app.key"}}},
+			files:   map[string]string{},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+				assert.Contains(t, err.Error(), "no such file or directory")
+			},
+		},
+		{
+			name: "valid JSON, valid expressions, valid path",
+			stepCtx: &PromotionStepContext{
+				Project: "test-project",
+			},
+			cfg: JSONParseConfig{
+				Path: "config.json",
+				Outputs: []JSONParse{
+					{Name: "appVersion", FromExpression: "app.version"},
+					{Name: "isEnabled", FromExpression: "features.enabled"},
+					{Name: "threshold", FromExpression: "config.threshold"},
+				},
+			},
+			files: map[string]string{
+				"config.json": `{
+					"app": {
+						"version": "2.0.1"
+					},
+					"features": {
+						"enabled": true
+					},
+					"config": {
+						"threshold": 10.0
+					}
+				}`,
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{
+					Status: kargoapi.PromotionPhaseSucceeded,
+					Output: map[string]any{
+						"appVersion": "2.0.1",
+						"isEnabled":  true,
+						"threshold":  10.0,
+					},
+				}, result)
+			},
+		},
+	}
+	runner := &jsonParser{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepCtx := tt.stepCtx
+
+			stepCtx.WorkDir = t.TempDir()
+			for p, c := range tt.files {
+				require.NoError(t, os.MkdirAll(path.Join(stepCtx.WorkDir, path.Dir(p)), 0o700))
+				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
+			}
+
+			result, err := runner.runPromotionStep(context.Background(), stepCtx, tt.cfg)
+			tt.assertions(t, stepCtx.WorkDir, result, err)
+		})
+	}
+}
+
+func Test_jsonParser_readAndParseJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	validJSON := `{"key": "value", "num": 42, "flag": true}`
+	invalidJSON := `{key: "value"}`
+	tests := []struct {
+		name    string
+		content string
+		expects error
+	}{
+		{"Valid JSON", validJSON, nil},
+		{"Invalid JSON syntax", invalidJSON, errors.New("could not parse JSON file")},
+		{"Empty JSON file", "", errors.New("could not parse JSON file")},
+	}
+
+	r := newJSONParser()
+	runner, ok := r.(*jsonParser)
+	require.True(t, ok)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tempDir, "test.json")
+			err := os.WriteFile(filePath, []byte(tt.content), 0600)
+			if err != nil {
+				t.Fatalf("failed to write file: %v", err)
+			}
+			_, err = runner.readAndParseJSON(tempDir, "test.json")
+			if tt.expects != nil {
+				assert.ErrorContains(t, err, tt.expects.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_jsonParser_extractValues(t *testing.T) {
+	jp := &jsonParser{}
+
+	tests := []struct {
+		name           string
+		data           map[string]any
+		outputs        []JSONParse
+		expected       map[string]any
+		expectedErrMsg string
+	}{
+		{
+			name: "valid json, valid expression",
+			data: map[string]any{"key": "value"},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "key"},
+			},
+			expected: map[string]any{"result": "value"},
+		},
+		{
+			name: "valid json, expression points to missing key",
+			data: map[string]any{"key": "value"},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "missingKey"},
+			},
+			expectedErrMsg: "error compiling expression",
+		},
+		{
+			name: "expression evaluates to a nested object",
+			data: map[string]any{"nested": map[string]any{"key": "value"}},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "nested"},
+			},
+			expected: map[string]any{"result": map[string]any{"key": "value"}},
+		},
+		{
+			name: "expression evaluates to an array",
+			data: map[string]any{"array": []any{1, 2, 3}},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "array"},
+			},
+			expected: map[string]any{"result": []any{1, 2, 3}},
+		},
+		{
+			name: "expression evaluates to a string",
+			data: map[string]any{"key": "value"},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "key"},
+			},
+			expected: map[string]any{"result": "value"},
+		},
+		{
+			name: "expression evaluates to an integer",
+			data: map[string]any{"number": 42},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "number"},
+			},
+			expected: map[string]any{"result": 42},
+		},
+		{
+			name: "expression compilation error",
+			data: map[string]any{"key": "value"},
+			outputs: []JSONParse{
+				{Name: "result", FromExpression: "(1 + 2"},
+			},
+			expectedErrMsg: "error compiling expression",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := jp.extractValues(tt.data, tt.outputs)
+
+			if tt.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/directives/schemas/json-parse-config.json
+++ b/internal/directives/schemas/json-parse-config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JSONParseConfig",
+
+  "definitions": {
+    "jsonParse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "fromExpression"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The name of the output variable to store the result."
+        },
+        "fromExpression": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The expression used to extract data from the JSON file."
+        }
+      }
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["path", "outputs"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "The path to the JSON file to be parsed.",
+      "minLength": 1
+    },
+    "outputs": {
+      "type": "array",
+      "description": "An array of outputs to extract from the JSON file.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/jsonParse"
+      }
+    }
+  }
+}

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -296,6 +296,20 @@ type HTTPQueryParam struct {
 	Value string `json:"value"`
 }
 
+type JSONParseConfig struct {
+	// An array of outputs to extract from the JSON file.
+	Outputs []JSONParse `json:"outputs"`
+	// The path to the JSON file to be parsed.
+	Path string `json:"path"`
+}
+
+type JSONParse struct {
+	// The expression used to extract data from the JSON file.
+	FromExpression string `json:"fromExpression"`
+	// The name of the output variable to store the result.
+	Name string `json:"name"`
+}
+
 type JSONUpdateConfig struct {
 	// The path to a JSON file.
 	Path string `json:"path"`

--- a/ui/src/gen/directives/json-parse-config.json
+++ b/ui/src/gen/directives/json-parse-config.json
@@ -1,0 +1,51 @@
+{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "JSONParseConfig",
+ "definitions": {
+  "jsonParse": {
+   "type": "object",
+   "additionalProperties": false,
+   "properties": {
+    "name": {
+     "type": "string",
+     "minLength": 1,
+     "description": "The name of the output variable to store the result."
+    },
+    "fromExpression": {
+     "type": "string",
+     "minLength": 1,
+     "description": "The expression used to extract data from the JSON file."
+    }
+   }
+  }
+ },
+ "type": "object",
+ "additionalProperties": false,
+ "properties": {
+  "path": {
+   "type": "string",
+   "description": "The path to the JSON file to be parsed.",
+   "minLength": 1
+  },
+  "outputs": {
+   "type": "array",
+   "description": "An array of outputs to extract from the JSON file.",
+   "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+     "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the output variable to store the result."
+     },
+     "fromExpression": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The expression used to extract data from the JSON file."
+     }
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/3240

`parse-file` step allows users to specify file paths and extract specific values using expressions. The `fromExpression` field accepts direct expressions without `${{}}` wrappers, as evaluation happens within the step logic itself.

eg.
```
steps:
  - uses: json-parse
    config:
      path: "path/to/file1.json"
      outputs:
        - fromExpression: "object.version"
          name: "version1"
        - fromExpression: "object.name"
          name: "name1"
```