### PR TITLE
docs: Added Advanced installation with Argo CD doc

### DIFF
--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -4,20 +4,35 @@ sidebar_label: With Argo CD
 
 # Installation with Argo CD
 
-This section outlines a few generalized approaches to installing and managing Kargo with non-default configuration options using Argo CD.
-
+This document outlines a few generalized approaches to installing and managing
+Kargo using Argo CD.
 :::note
-This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../operator-guide/basic-installation#prerequisites) for more details.
+This section assumes that you have already installed any dependencies or
+prerequisites required for running Kargo on a Kubernetes cluster. Please refer
+to [Basic Installation](../../operator-guide/basic-installation#prerequisites)
+for more details.
 :::
 
 All methods described here will involve deploying Kargo using an Argo CD
-`Application` resource that is configured to obtain Kargo's Helm chart directly
-from its official repo. We will demonstrate a variety of ways to specify
-your own configuration values using `api.adminAccount.passwordHash` and `api.adminAccount.tokenSigningKey` as examples since you are _required_ to
+`Application` resource that is configured to obtain Kargo's Helm chart
+_directly_ from its official repository. We will demonstrate a variety of ways
+to specify your own configuration values using `api.adminAccount.passwordHash`
+and `api.adminAccount.tokenSigningKey` as examples since you are _required_ to
 provide values for these anyway (unless
-[the admin account is disabled instead](../40-security/10-secure-configuration.md#disabling-the-admin-account)).
+[the admin account is disabled instead](../40-security/10-secure-configuration.md#disabling-the-admin-account)),
+but the techniques shown here can be applied to any configurable elements of
+the Kargo Helm chart.
 
-Recommended commands for generating a complex password and signing key, and for hashing the password as required are:
+:::info
+Detailed information about available options can be found in the
+[Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
+
+For important security-related configuration, refer to the
+[Secure Configuration Guide](../40-security/10-secure-configuration.md).
+:::
+
+Recommended commands for generating a complex password and signing key, and for
+hashing the password as required are:
 
 ```console
 pass=$(openssl rand -base64 48 | tr -d "=+/" | head -c 32)
@@ -27,7 +42,8 @@ echo "Signing Key: $(openssl rand -base64 48 | tr -d "=+/" | head -c 32)"
 ```
 
 :::note
-Methods of securing the admin account are explored in greater detail [here](../40-security/10-secure-configuration.md#securing-the-admin-account).
+Methods of securing the admin account are explored in greater detail
+[here](../40-security/10-secure-configuration.md#securing-the-admin-account).
 :::
 
 ## `spec.source.helm.parameters`
@@ -35,12 +51,7 @@ Methods of securing the admin account are explored in greater detail [here](../4
 The most straightforward way to specify chart configuration options is by using the
 `Application`'s `spec.source.helm.parameters` field:
 
-:::info
-The parameters used are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
-:::
-
 ```yaml
----
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -70,7 +81,6 @@ spec:
     syncOptions:
     - CreateNamespace=true
 ```
-
 
 ## `spec.source.helm.values`
 
@@ -110,15 +120,27 @@ spec:
 
 ## Multi-Source Argo CD Application
 
-__Our recommended method__ is to use an `Application` with
-[multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/) to reference _both_ the Kargo Helm chart repository a `values.yaml`
-of your own from your own Git repository.
+The most advanced method covered here __is nevertheless our recommendation
+because it aligns best with with GitOps principles.__ Use an `Application`
+with
+[multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources)
+to reference _both_ the Kargo Helm chart repository and a `values.yaml` file of
+your own from your own Git repository.
 
-__This is our recommendation because it aligns best with with GitOps principles.__
+:::info
+An added benefit to this approach is that if you have other resources to
+include in the Kargo installation, such as
+[`SealedSecret`s](https://github.com/bitnami-labs/sealed-secrets) or
+[`ExternalSecret`s](https://external-secrets.io/latest/), they also can
+be obtained from your own Git repository using the second source.
+:::
 
-
-In the configuration below, the second source (the one with `repoURL` pointed at your own Git repository) is assigned a `ref` of `values`. This permits content from that
-repository (in particular, a `values.yaml` file) to be referenced by the _other_ source:
+In the configuration below, the second source (the one with `repoURL` pointed at
+your own Git repository) is assigned a `ref` of `values`. This permits content
+from that repository (in particular, a `values.yaml` file) to be referenced by
+the _other_ source. We _also_ use the `path` parameter as usual to direct the
+second source to the location of additional manifests to include in the `kargo`
+namespace along with the chart:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -141,6 +163,7 @@ spec:
     - repoURL: https://github.com/<username>/kargo-helm-values
       targetRevision: main
       ref: values
+      path: kargo/additional-manifests
   syncPolicy:
     automated:
       prune: true

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -4,6 +4,160 @@ sidebar_label: With Argo CD
 
 # Advanced Installation with Argo CD
 
+This section outlines the various advanced installation options available for deploying Kargo on a Kubernetes cluster using Argo CD.
+
 :::warning
-Placeholder
+This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please see the [installation guide](../../40-operator-guide/10-basic-installation.md#prerequisites) for more information.
 :::
+
+## Argo CD Helm Application
+
+The most common way to deploy Kargo using Argo CD is to create a Helm `Application`, and use the `.spec.source.helm.parameters` section to specify any parameters you may need. This is the most straightforward way to deploy Kargo using Argo CD.
+
+:::info
+If using the `api.adminAccount.passwordHash` parameter, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.
+:::
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: kargo
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: ghcr.io/akuity/kargo-charts
+    chart: kargo
+    targetRevision: 1.2.0
+    helm:
+      parameters:
+        - name: api.adminAccount.passwordHash
+          value: "$$2a$$10$$Zrhhie4vLz5ygtVSaif6o.qN36jgs6vjtMBdM6yrU1FOeiAAMMxOm"
+        - name: controller.logLevel
+          value: "DEBUG"
+        - name: api.adminAccount.tokenTTL
+          value: "24h"
+        - name: api.adminAccount.tokenSigningKey
+          value: "iwishtowashmyirishwristwatch"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+```
+
+Conversely, insetad of using the `parameters` field under the `.spec.source.helm` section; you can use the `values` block or `valuesObject` object to specify the values for the Kargo Helm chart.
+
+Another method is to use `.spec.sources` and store your values files in a separate repository. This is useful if you are using GitOps to track your values configuration changes, which still use the public Helm chart repository.
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: kargo
+    server: https://kubernetes.default.svc
+  sources:
+    - repoURL: ghcr.io/akuity/kargo-charts
+      chart: kargo
+      targetRevision: 1.2.0
+      helm:
+        valueFiles:
+          - $values/kargo/values.yaml
+    - repoURL: https://github.com/<username>/kargo-helm-values
+      targetRevision: main
+      ref: values
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+```
+
+Here, the `parametes` seciton isn't used and instead, the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
+
+## Argo CD Kustomize Application
+
+Another method to deploy Kargo using Argo CD is to use a Kustomize. This method is useful if you want to customize the Kargo deployment using Kustomize overlays or patching. To do this, you will need to add the Kargo Helm chart to your `kustomization.yaml` file using the `helmCharts` field.
+
+:::info
+The `valueFile` field references a `values.yaml` file in the same directory as the `kustomization.yaml` file.
+:::
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+- name: kargo
+  version: 1.2.0
+  repo: oci://ghcr.io/akuity/kargo-charts
+  releaseName: kargo
+  valuesFile: values.yaml
+```
+
+In the overlay, you can then reference the Kargo Helm chart and apply any patches or customizations you need. For example, you can change the log level of the controller to `DEBUG`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patches:
+- target:
+    kind: ConfigMap
+    name: kargo-controller
+    version: v1
+  patch: |
+    - op: replace
+      path: /data/LOG_LEVEL
+      value: "DEBUG"
+```
+
+The corresponding Argo CD `Application` would look like this (referencing the Kustomize `dev` overlay, in this example):
+
+:::warning
+Using Helm with Kustomize requires you to make an Argo CD configuration change. Please see [the offical Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/kustomize/#kustomizing-helm-charts) for more details.
+:::
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: kargo
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/<username>/kargo-helm-values
+    path: kustomize/overlays/dev
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+```
+
+## What's Next?
+
+Now that you have deployed Kargo using Argo CD, you can explore the various features and capabilities of Kargo. Please see the [Operator Guide](../../40-operator-guide/) or the [User Guide](../../50-user-guide/) for futher information.

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -54,6 +54,10 @@ spec:
 
 Conversely, insetad of using the `parameters` field under the `.spec.source.helm` section; you can use the `values` block or `valuesObject` object to specify the values for the Kargo Helm chart.
 
+:::info
+The parameters used in the above `Application` are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
+:::
+
 Another method is to use `.spec.sources` and store your values files in a separate repository. This is useful if you are using GitOps to track your values configuration changes, which still use the public Helm chart repository.
 
 ```yaml
@@ -86,11 +90,15 @@ spec:
     - CreateNamespace=true
 ```
 
+:::info
+We recommend using the above approach as it more closely aligns with GitOps principles and best practices.
+:::
+
 Here, the `parametes` section isn't used and instead, the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
 
-## Argo CD Kustomize Application
+## Using Kustomize Overlays
 
-Another method to deploy Kargo using Argo CD is to use a Kustomize. This method is useful if you want to customize the Kargo deployment using Kustomize overlays or patching. To do this, you will need to add the Kargo Helm chart to your `kustomization.yaml` file using the `helmCharts` field.
+Another method to deploy Kargo using Argo CD is to use a Kustomize. This method is useful if you want to customize the Kargo deployment using Kustomize overlays or patching. Since Kargo's installation manifests are packaged as a Helm chart, you will need to add the Kargo Helm chart to your `kustomization.yaml` file using the `helmCharts` field.
 
 :::info
 The `valueFile` field references a `values.yaml` file in the same directory as the `kustomization.yaml` file.

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -160,4 +160,4 @@ spec:
 
 ## What's Next?
 
-Now that you have deployed Kargo using Argo CD, you can explore the various features and capabilities of Kargo. Please see the [Operator Guide](../../40-operator-guide/) or the [User Guide](../../50-user-guide/) for futher information.
+Now that you have deployed Kargo using Argo CD, you can explore the various features and capabilities of Kargo. Please see the [Operator Guide](../../operator-guide/) or the [User Guide](../../user-guide/) for futher information.

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -10,9 +10,9 @@ This section outlines a few generalized approaches to installing and managing Ka
 This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../40-operator-guide/10-basic-installation.md#prerequisites) for more details.
 :::
 
-## Argo CD Helm Application
+## Direct Chart Installation
 
-The most common way to deploy Kargo using Argo CD is to create a Helm `Application`, and use the `.spec.source.helm.parameters` section to specify any parameters you may need. This is the most straightforward way to deploy Kargo using Argo CD.
+The most common way to deploy Kargo using Argo CD is to create an `Application` and use the Helm chart directly. Using this method, you can use the `.spec.source.helm.parameters` section to specify any parameters you may need. This is the most straightforward way to deploy Kargo using Argo CD.
 
 :::info
 If using the `api.adminAccount.passwordHash` parameter, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -10,12 +10,12 @@ This section outlines a few generalized approaches to installing and managing Ka
 This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../operator-guide/basic-installation#prerequisites) for more details.
 :::
 
-## Direct Chart Installation
+## Direct Argo CD Application 
 
 The most common way to deploy Kargo using Argo CD is to create an `Application` and use the Helm chart directly. Using this method, you can use the `.spec.source.helm.parameters` section to specify any parameters you may need. This is the most straightforward way to deploy Kargo using Argo CD.
 
 :::info
-If using the `api.adminAccount.passwordHash` parameter in this method, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.
+The parameters used are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
 :::
 
 ```yaml
@@ -52,6 +52,10 @@ spec:
     - CreateNamespace=true
 ```
 
+:::info
+If using the `api.adminAccount.passwordHash` parameter in this method, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.
+:::
+
 Conversely, insetad of using the `parameters` field under the `.spec.source.helm` section; you can use the `values` block or `valuesObject` object to specify the values for the Kargo Helm chart. Below is an example of how to use `valuesObject` to specify the values.
 
 ```yaml
@@ -87,11 +91,13 @@ spec:
     - CreateNamespace=true
 ```
 
-:::info
-The parameters used are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
-:::
+## Multi-Source Argo CD Application
 
 Another method is to use a Multi-Source Argo CD Application. Here, you'd use the `.spec.sources` field and store your values files in a separate repository. This is useful if you are using GitOps to track your values configuration changes, but will still use the public Helm chart repository.
+
+:::info
+We recommend using this method as it more closely aligns with GitOps principles and best practices.
+:::
 
 ```yaml
 ---
@@ -123,81 +129,7 @@ spec:
     - CreateNamespace=true
 ```
 
-:::info
-We recommend using the above approach as it more closely aligns with GitOps principles and best practices.
-:::
-
 The `parametes` section isn't used in this method, instead the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
-
-## Using Kustomize Overlays
-
-Another method to deploy Kargo using Argo CD is to use a Kustomize. This method is useful if you want to customize the Kargo deployment using Kustomize overlays or patching. Since Kargo's installation manifests are packaged as a Helm chart, you will need to add the Kargo Helm chart to your `kustomization.yaml` file using the `helmCharts` field.
-
-:::info
-The `valueFile` field references a `values.yaml` file in the same directory as the `kustomization.yaml` file.
-:::
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-helmCharts:
-- name: kargo
-  version: 1.2.0
-  repo: oci://ghcr.io/akuity/kargo-charts
-  releaseName: kargo
-  valuesFile: values.yaml
-```
-
-In the overlay, you can then reference the Kargo Helm chart and apply any patches or customizations you need. For example, you can change the log level of the controller to `DEBUG`
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- ../../base
-
-patches:
-- target:
-    kind: ConfigMap
-    name: kargo-controller
-    version: v1
-  patch: |
-    - op: replace
-      path: /data/LOG_LEVEL
-      value: "DEBUG"
-```
-
-The corresponding Argo CD `Application` would look like this (referencing the Kustomize `dev` overlay, in this example):
-
-:::warning
-Using Helm with Kustomize requires you to make an Argo CD configuration change. Please see [the offical Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/kustomize/#kustomizing-helm-charts) for more details.
-:::
-
-```yaml
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: kargo
-  namespace: argocd
-spec:
-  project: default
-  destination:
-    namespace: kargo
-    server: https://kubernetes.default.svc
-  source:
-    repoURL: https://github.com/<username>/kargo-helm-values
-    path: kustomize/overlays/dev
-    targetRevision: main
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-    - CreateNamespace=true
-```
 
 ## What's Next?
 

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -7,7 +7,7 @@ sidebar_label: With Argo CD
 This section outlines a few generalized approaches to installing and managing Kargo with non-default configuration options using Argo CD.
 
 :::note
-This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../40-operator-guide/10-basic-installation.md#prerequisites) for more details.
+This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../operator-guide/basic-installation#prerequisites) for more details.
 :::
 
 ## Direct Chart Installation
@@ -15,7 +15,7 @@ This section assumes that you have already installed any dependencies or prerequ
 The most common way to deploy Kargo using Argo CD is to create an `Application` and use the Helm chart directly. Using this method, you can use the `.spec.source.helm.parameters` section to specify any parameters you may need. This is the most straightforward way to deploy Kargo using Argo CD.
 
 :::info
-If using the `api.adminAccount.passwordHash` parameter, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.
+If using the `api.adminAccount.passwordHash` parameter in this method, you must escape the `$` character with `$$` to prevent Helm from interpreting it as a variable. Please see [this discussion](https://discord.com/channels/1138942074998235187/1138946346217394407/1267966083168469102) for more information.
 :::
 
 ```yaml
@@ -52,13 +52,46 @@ spec:
     - CreateNamespace=true
 ```
 
-Conversely, insetad of using the `parameters` field under the `.spec.source.helm` section; you can use the `values` block or `valuesObject` object to specify the values for the Kargo Helm chart.
+Conversely, insetad of using the `parameters` field under the `.spec.source.helm` section; you can use the `values` block or `valuesObject` object to specify the values for the Kargo Helm chart. Below is an example of how to use `valuesObject` to specify the values.
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: kargo
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: ghcr.io/akuity/kargo-charts
+    chart: kargo
+    targetRevision: 1.2.0
+    helm:
+      valuesObject:
+        api:
+          adminAccount:
+            passwordHash: $2a$10$Zrhhie4vLz5ygtVSaif6o.qN36jgs6vjtMBdM6yrU1FOeiAAMMxOm
+            tokenSigningKey: iwishtowashmyirishwristwatch
+            tokenTTL: 24h
+        controller:
+          logLevel: DEBUG
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+```
 
 :::info
-The parameters used in the above `Application` are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
+The parameters used are just examples, and you should use the values that are appropriate for your environment. Detailed information about available options can also be found in the [Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
 :::
 
-Another method is to use `.spec.sources` and store your values files in a separate repository. This is useful if you are using GitOps to track your values configuration changes, which still use the public Helm chart repository.
+Another method is to use a Multi-Source Argo CD Application. Here, you'd use the `.spec.sources` field and store your values files in a separate repository. This is useful if you are using GitOps to track your values configuration changes, but will still use the public Helm chart repository.
 
 ```yaml
 ---
@@ -94,7 +127,7 @@ spec:
 We recommend using the above approach as it more closely aligns with GitOps principles and best practices.
 :::
 
-Here, the `parametes` section isn't used and instead, the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
+The `parametes` section isn't used in this method, instead the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
 
 ## Using Kustomize Overlays
 

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -86,7 +86,7 @@ spec:
     - CreateNamespace=true
 ```
 
-Here, the `parametes` seciton isn't used and instead, the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
+Here, the `parametes` section isn't used and instead, the `values.yaml` file is hosted in a separate repository and is referenced using the `ref` field.
 
 ## Argo CD Kustomize Application
 

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -84,7 +84,9 @@ spec:
 
 ## `spec.source.helm.values`
 
-Alternatively, instead of using `spec.source.helm`'s `parameters` field, you can use the either of the `values` or `valuesObject` fields to specify configuration options for the chart:
+Alternatively, instead of using `spec.source.helm`'s `parameters` field, you can
+use either of its `values` or `valuesObject` fields to specify configuration
+options for the chart:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -4,7 +4,7 @@ sidebar_label: With Argo CD
 
 # Installation with Argo CD
 
-This section outlines the various advanced installation options available for deploying Kargo on a Kubernetes cluster using Argo CD.
+This section outlines a few generalized approaches to installing and managing Kargo with non-default configuration options using Argo CD.
 
 :::warning
 This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please see the [installation guide](../../40-operator-guide/10-basic-installation.md#prerequisites) for more information.

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -2,7 +2,7 @@
 sidebar_label: With Argo CD
 ---
 
-# Advanced Installation with Argo CD
+# Installation with Argo CD
 
 This section outlines the various advanced installation options available for deploying Kargo on a Kubernetes cluster using Argo CD.
 

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -6,7 +6,7 @@ sidebar_label: With Argo CD
 
 This section outlines a few generalized approaches to installing and managing Kargo with non-default configuration options using Argo CD.
 
-:::warning
+:::note
 This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please see the [installation guide](../../40-operator-guide/10-basic-installation.md#prerequisites) for more information.
 :::
 

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -7,7 +7,7 @@ sidebar_label: With Argo CD
 This section outlines a few generalized approaches to installing and managing Kargo with non-default configuration options using Argo CD.
 
 :::note
-This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please see the [installation guide](../../40-operator-guide/10-basic-installation.md#prerequisites) for more information.
+This section assumes that you have already installed any dependencies or prerequisites required for running Kargo on a Kubernetes cluster. Please refer to [Basic Installation](../../40-operator-guide/10-basic-installation.md#prerequisites) for more details.
 :::
 
 ## Argo CD Helm Application

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/20-advanced-with-argocd.md
@@ -160,7 +160,7 @@ spec:
       helm:
         valueFiles:
           - $values/kargo/values.yaml
-    - repoURL: https://github.com/<username>/kargo-helm-values
+    - repoURL: https://github.com/example/repo.git
       targetRevision: main
       ref: values
       path: kargo/additional-manifests


### PR DESCRIPTION
Added different ways to deploy Kargo using Argo CD. I stuck with the 3 main ways folks would do this using Argo CD. I stayed away from Umbrella Charts as I feel folks would manage `cert-manager` and `argo-rollouts` with their own Argo CD `Application`. (also I think having a "Kargo + Cert Manager + Argo Rollouts" Umbrella chart would be bad practice)