### PR TITLE
docs: move promotion steps index to document

### DIFF
--- a/docs/docs/60-new-docs/50-user-guide/20-how-to-guides/14-working-with-stages.md
+++ b/docs/docs/60-new-docs/50-user-guide/20-how-to-guides/14-working-with-stages.md
@@ -219,7 +219,7 @@ promotionTemplate:
 
 :::info
 For complete documentation of all Kargo's built-in promotion steps, refer
-to the [Promotion Steps Reference](../reference-docs/promotion-steps).
+to the [Promotion Steps Reference](../60-reference-docs/30-promotion-steps/index.md).
 :::
 
 ### Verifications

--- a/docs/docs/60-new-docs/50-user-guide/30-patterns/index.md
+++ b/docs/docs/60-new-docs/50-user-guide/30-patterns/index.md
@@ -640,8 +640,8 @@ such as Argo CD. There are a few viable options by which to approach this:
 
 Being mostly unopinionated, Kargo does not pre-define any specific promotion
 processes. Instead, it provides a number of fine-grained
-[Promotion Steps](../reference-docs/promotion-steps) that can be combined to
-implement a user-defined promotion process.
+[Promotion Steps](../60-reference-docs/30-promotion-steps/index.md) that can
+be combined to implement a user-defined promotion process.
 
 This section documents a "typical" promotion process as well as a few common
 techniques.

--- a/docs/docs/60-new-docs/50-user-guide/60-reference-docs/30-promotion-steps/_category_.json
+++ b/docs/docs/60-new-docs/50-user-guide/60-reference-docs/30-promotion-steps/_category_.json
@@ -1,10 +1,8 @@
 {
   "label": "Promotion Steps",
   "link": {
-    "type": "generated-index",
-    "title": "Promotion Steps Reference",
-    "description": "Reference documentation for the steps available to use in promotions.",
-    "slug": "new-docs/user-guide/reference-docs/promotion-steps"
+    "type": "doc",
+    "id": "index"
   },
   "collapsible": true,
   "collapsed": true

--- a/docs/docs/60-new-docs/50-user-guide/60-reference-docs/30-promotion-steps/index.md
+++ b/docs/docs/60-new-docs/50-user-guide/60-reference-docs/30-promotion-steps/index.md
@@ -1,0 +1,9 @@
+# Promotion Steps Reference
+
+Below is an overview of the available promotion steps that can be used in
+[Promotion Templates](../15-promotion-templates.md) and
+[Promotion Tasks](../20-promotion-tasks.md).
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
Compared to the previous approach, this is less likely to cause issues when we change the documentation structure (for example, to remove the `/new-docs/` element from the path).