### PR TITLE
fix(cmd): improve Argo integration checks

### DIFF
--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -81,17 +81,28 @@ func (o *apiOptions) run(ctx context.Context) error {
 		return fmt.Errorf("error creating Kubernetes client for Kargo API server: %w", err)
 	}
 
-	switch {
-	case !serverCfg.RolloutsIntegrationEnabled:
-		o.Logger.Info("Argo Rollouts integration is disabled")
-	case !argoRolloutsExists(ctx, restCfg):
-		o.Logger.Info(
-			"Argo Rollouts integration was enabled, but no Argo Rollouts " +
-				"CRDs were found. Proceeding without Argo Rollouts integration.",
-		)
-		serverCfg.RolloutsIntegrationEnabled = false
-	default:
-		o.Logger.Info("Argo Rollouts integration is enabled")
+	if serverCfg.RolloutsIntegrationEnabled {
+		var exists bool
+		if exists, err = argoRolloutsExists(ctx, restCfg); !exists {
+			// If we are unable to determine if Argo Rollouts is installed, we
+			// will return an error and fail to start the server. Note this
+			// will only happen if we get an inconclusive response from the API
+			// server (e.g. due to network issues), and not if Argo Rollouts is
+			// not installed.
+			if err != nil {
+				return fmt.Errorf("unable to determine if Argo Rollouts is installed: %w", err)
+			}
+
+			o.Logger.Info(
+				"Argo Rollouts integration was enabled, but no Argo Rollouts " +
+					"CRDs were found. Proceeding without Argo Rollouts integration.",
+			)
+			serverCfg.RolloutsIntegrationEnabled = false
+		} else {
+			o.Logger.Debug("Argo Rollouts integration is enabled")
+		}
+	} else {
+		o.Logger.Debug("Argo Rollouts integration is disabled")
 	}
 
 	if serverCfg.AdminConfig != nil {

--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -83,7 +83,7 @@ func (o *apiOptions) run(ctx context.Context) error {
 
 	if serverCfg.RolloutsIntegrationEnabled {
 		var exists bool
-		if exists, err = argoRolloutsExists(ctx, restCfg); !exists {
+		if exists, err = argoRolloutsExists(ctx, restCfg); !exists || err != nil {
 			// If we are unable to determine if Argo Rollouts is installed, we
 			// will return an error and fail to start the server. Note this
 			// will only happen if we get an inconclusive response from the API

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -255,7 +255,7 @@ func (o *controllerOptions) setupArgoCDManager(ctx context.Context) (manager.Man
 	// Application resources in a single namespace, so we will use that
 	// namespace when attempting to determine if Argo CD CRDs are installed.
 	var exists bool
-	if exists, err = argoCDExists(ctx, restCfg, argocdNamespace); !exists {
+	if exists, err = argoCDExists(ctx, restCfg, argocdNamespace); !exists || err != nil {
 		// If we are unable to determine if Argo CD is installed, we will
 		// return an error and fail to start the controller. Note this
 		// will only happen if we get an inconclusive response from the API

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -158,7 +158,8 @@ func (o *controllerOptions) setupKargoManager(
 		)
 	}
 	if stagesReconcilerCfg.RolloutsIntegrationEnabled {
-		if argoRolloutsExists(ctx, restCfg) {
+		var exists bool
+		if exists, err = argoRolloutsExists(ctx, restCfg); exists {
 			o.Logger.Info("Argo Rollouts integration is enabled")
 			if err = rollouts.AddToScheme(scheme); err != nil {
 				return nil, stagesReconcilerCfg, fmt.Errorf(
@@ -167,6 +168,18 @@ func (o *controllerOptions) setupKargoManager(
 				)
 			}
 		} else {
+			// If we are unable to determine if Argo Rollouts is installed, we
+			// will return an error and fail to start the controller. Note this
+			// will only happen if we get an inconclusive response from the API
+			// server (e.g. due to network issues), and not if Argo Rollouts is
+			// not installed.
+			if err != nil {
+				return nil, stagesReconcilerCfg, fmt.Errorf(
+					"unable to determine if Argo Rollouts is installed: %w",
+					err,
+				)
+			}
+
 			// Disable Argo Rollouts integration if the CRDs are not found.
 			stagesReconcilerCfg.RolloutsIntegrationEnabled = false
 			o.Logger.Info(
@@ -241,7 +254,16 @@ func (o *controllerOptions) setupArgoCDManager(ctx context.Context) (manager.Man
 	// There's a chance there is only permission to interact with Argo CD
 	// Application resources in a single namespace, so we will use that
 	// namespace when attempting to determine if Argo CD CRDs are installed.
-	if !argoCDExists(ctx, restCfg, argocdNamespace) {
+	var exists bool
+	if exists, err = argoCDExists(ctx, restCfg, argocdNamespace); !exists {
+		// If we are unable to determine if Argo CD is installed, we will
+		// return an error and fail to start the controller. Note this
+		// will only happen if we get an inconclusive response from the API
+		// server (e.g. due to network issues), and not if Argo CD is not
+		// installed.
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine if Argo CD is installed: %w", err)
+		}
 		o.Logger.Info(
 			"Argo CD integration was enabled, but no Argo CD CRDs were found. " +
 				"Proceeding without Argo CD integration.",

--- a/cmd/controlplane/utils.go
+++ b/cmd/controlplane/utils.go
@@ -7,38 +7,41 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func argoCDExists(
 	ctx context.Context,
 	restCfg *rest.Config,
 	namespace string,
-) bool {
-	if client, err := dynamic.NewForConfig(restCfg); err == nil {
-		if _, err = client.Resource(
+) (bool, error) {
+	c, err := dynamic.NewForConfig(restCfg)
+	if err == nil {
+		if _, err = c.Resource(
 			schema.GroupVersionResource{
 				Group:    "argoproj.io",
 				Version:  "v1alpha1",
 				Resource: "applications",
 			},
 		).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1}); err == nil {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, client.IgnoreNotFound(err)
 }
 
-func argoRolloutsExists(ctx context.Context, restCfg *rest.Config) bool {
-	if client, err := dynamic.NewForConfig(restCfg); err == nil {
-		if _, err = client.Resource(
+func argoRolloutsExists(ctx context.Context, restCfg *rest.Config) (bool, error) {
+	c, err := dynamic.NewForConfig(restCfg)
+	if err == nil {
+		if _, err = c.Resource(
 			schema.GroupVersionResource{
 				Group:    "argoproj.io",
 				Version:  "v1alpha1",
 				Resource: "analysistemplates",
 			},
 		).List(ctx, metav1.ListOptions{Limit: 1}); err == nil {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, client.IgnoreNotFound(err)
 }


### PR DESCRIPTION
This ensures that if the API server or controller is unable to determine if Argo CD or Argo Rollouts is installed (e.g. because of some transient Kubernetes API error), the respective service will fail to start instead of disabling the integration.

By doing this, the service will restart to get an accurate result once the API server is available again. Providing a more reliable result than the integrations not working for the lifetime of the Pod because of API server flakiness at boot time.