### PR TITLE
docs: add common chart configuration options

### DIFF
--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -1,0 +1,247 @@
+---
+sidebar_label: Common Configurations
+---
+
+# Common Configurations
+
+This document outlines common advanced installation scenarios and
+configurations for Kargo. 
+
+:::info
+For complete parameter documentation, refer to the
+[chart documentation](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md).
+:::
+
+:::info
+For more information on how to apply these configurations, see the
+advanced installation guides for [Helm](10-advanced-with-helm.md) and
+[Argo CD](20-advanced-with-argocd.md).
+:::
+
+## Standard Kubernetes Configuration
+
+For common Kubernetes configurations, like setting a `nodeSelector`, `labels`,
+`annotations`, `affinity`, `tolerations`, etc. Kargo supports both global and
+resource-specific configurations. For example, to add `labels` to all resources
+created by Kargo, the following configuration can be used:
+
+```yaml
+global:
+  labels:
+    label.example.com/key: value
+```
+
+To add `labels` to a specific component (the `kargo-controller` in this example),
+the following configuration can be used:
+    
+```yaml
+controller:
+  labels:
+    label.example.com/key: value
+```
+
+:::note
+For a full list of supported configurations, refer to the
+[Global Parameters](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md#global-parameters)
+or the component-specific parameters in the chart documentation.
+:::
+
+## Git Configuration
+
+Kargo supports a number of Git-related configurations that can be set at
+installation time.
+
+### Default Commit Author
+
+To set the default commit author Kargo will use when committing changes using
+the [`git-commit` Promotion step](../../50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md),
+the following configuration can be set (shown here with the default values):
+
+```yaml
+controller:
+  gitClient:
+    name: Kargo
+    email: no-reply@kargo.io
+```
+
+### Signing Commits
+
+To sign commits made by Kargo, a reference to a `Secret` (in the same namespace
+as Kargo is installed to) containing a signing key can be configured. The key
+should be a GPG key in ASCII-armored format  without a passphrase, under the
+key `signingKey`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kargo-git-signing-key
+type: Opaque
+data:
+  signingKey: <base64-encoded-ascii-armored-gpg-key>
+```
+
+The `Secret` can then be referenced in the Kargo configuration.
+
+```yaml
+controller:
+  gitClient:
+    signingKeySecret:
+      name: kargo-git-signing-key
+      type: gpg
+```
+
+:::note
+When using a signing key, the `gitClient.name` and `gitClient.email`
+configuration options must match the name and email associated with the GPG
+key.
+:::
+
+## Argo CD Configuration
+
+Kargo supports a number of Argo CD-related configurations that can be set at
+installation time.
+
+### Disabling the Argo CD Integration
+
+By default, Kargo will enable the Argo CD integration, which configures Kargo
+to work with `Application` resources created by Argo CD. This can be disabled
+as follows:
+
+```yaml
+controller:
+  argocd:
+    integrationEnabled: false
+```
+
+When not enabled, the controller will not watch Argo CD `Application` resources
+and disable Argo CD specific features. Explicitly disabling is preferred if this
+integration is not desired, as it will grant fewer permissions to the controller.
+
+### Argo CD Namespace
+
+By default, Kargo expects Argo CD to be installed to the `argocd` namespace,
+which is also the default namespace it will use for `Application` resources
+if a namespace is not specified in the
+[`argocd-update` Promotion step](../../50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md).
+
+If you want to use a different default namespace, this can be configured as
+follows:
+
+```yaml
+controller:
+  argocd:
+    namespace: argocd
+```
+
+## Argo Rollouts Configuration
+
+### Disabling the Argo Rollouts Integration
+
+By default, Kargo will enable the Argo Rollouts integration, which configures
+Kargo to work with `Rollout` resources created by Argo Rollouts as part of the
+[verification feature](../../50-user-guide/20-how-to-guides/14-working-with-stages.md#verifications).
+
+This can be disabled as follows:
+
+```yaml
+controller:
+  argoRollouts:
+    integrationEnabled: false
+```
+
+When not enabled, the controller will not reconcile Argo Rollouts `AnalysisRun`
+resources and attempts to verify Stages via `Analysis` will fail. Explicitly
+disabling is preferred if this integration is not desired, as it will grant
+fewer permissions to the controller.
+
+## Resource Management
+
+### Tuning Concurrent Reconciliation Limits
+
+By default, Kargo will reconcile up to 4 resources of the same kind concurrently
+(e.g. 4 `Stage` resources at a time). It is possible to tune this limit by
+setting a new global value, or by setting a limit per resource kind:
+
+```yaml
+controller:
+  reconcilers:
+    # Global setting
+    maxConcurrentReconciles: 4
+
+  managementController:
+    # Kind specific setting
+    namespaces:
+      maxConcurrentReconciles: 2
+```
+
+:::note
+For a list of resource kinds that can be configured, refer to the
+[chart documentation](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md).
+:::
+
+## Garbage Collection
+
+Kargo includes a garbage collector that automatically removes old `Freight` and
+`Promotion` resources. The garbage collector offers a number of configuration
+options to manage the retention of these resources.
+
+### Disabling the Garbage Collector
+
+By default, the garbage collector is enabled. To disable it, set the following
+configuration:
+
+```yaml
+garbageCollector:
+  enabled: false
+```
+
+:::caution
+Disabling the garbage collector will result in old `Freight` and `Promotion`
+resources accumulating in the cluster. This can lead to increased resource
+usage and potential performance issues. Therefore, this is typically not
+recommended and should only be done with caution.
+:::
+
+### Scheduling the Garbage Collection
+
+By default, the garbage collector runs every 24 hours. This can be configured
+using a cron expression:
+
+```yaml
+garbageCollector:
+  schedule: "0 0 * * *"
+```
+
+### Retention Settings
+
+The garbage collector offers a number of settings to control the retention of
+`Freight` and `Promotion` resources. The following settings are available:
+
+```yaml
+garbageCollector:
+  # The minimum age a Promotion resource must be before it can be deleted.
+  # This is a duration string (e.g. 336h for 14 days).
+  minPromotionDeletionAge: 336h
+  # The number of Promotion resources for each Stage to retain that are older
+  # than the minimum deletion age. I.e., if a Stage has 30 Promotions older
+  # than minPromotionDeletionAge, only the 20 most recent will be retained.
+  maxRetainedPromotions: 20
+  
+  # The minimum age a Freight resource must be before it can be deleted.
+  # This is a duration string (e.g. 336h for 14 days).
+  minFreightDeletionAge: 336h
+  # The number of Freight resources for each Warehouse to retain that are older
+  # than the minimum deletion age. I.e., if a Warehouse has 20 Freight older
+  # than minFreightDeletionAge, only the 20 most recent will be retained.
+  maxRetainedFreight: 10
+```
+
+:::note
+`Promotion` resources are only deleted if they are in a terminal state (i.e.
+`Succeeded` or `Failed`). `Freight` resources are only deleted if they are not
+actively in use by any `Stage`.
+
+In both cases, this holds true even if the resource is older than the minimum
+deletion age.
+:::

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -141,9 +141,11 @@ the API server.
 
 #### Terminating TLS
 
-In certain cases, you may want to disable TLS on the API server because it is
-terminated at the [`Ingress`](#api-ingress) level. To do this, set the following
-configuration:
+In some cases, TLS may be terminated upstream of the API server by various
+components like reverse proxies, load balancers, or `Ingress` controllers using
+wildcard certificates.
+
+For these cases, the API server can be configured to not enforce TLS:
 
 ```yaml
 api:
@@ -153,8 +155,13 @@ api:
 ```
 
 :::info
-When setting `terminatedUpstream` to `true`, the API server will continue to
-generate URLs with the `https` scheme, but will not enforce TLS.
+When setting `terminatedUpstream` to `true`, the API server will generate URLs
+with the `https` scheme but will not enforce TLS. This option serves as an
+escape hatch for scenarios where HTTPS should be used for links, but Kargo
+cannot infer this from its own configuration.
+
+When you are using the [built-in `Ingress` resource](#api-ingress), this
+configuration is typically not required.
 :::
 
 ### API Ingress
@@ -279,9 +286,15 @@ controller:
     integrationEnabled: false
 ```
 
-When not enabled, the controller will not watch Argo CD `Application` resources
-and disable Argo CD specific features. Explicitly disabling is preferred if this
-integration is not desired, as it will grant fewer permissions to the controller.
+When disabled, the controller will not watch Argo CD `Application` resources
+and disable Argo CD specific features.
+
+:::info
+If the integration is enabled without Argo CD installed, the controller will
+disable the Argo CD specific features on boot. Explicitly disabling is preferred
+if this integration is not desired, as it will grant fewer permissions to the
+controller.
+:::
 
 ### Argo CD Namespace
 
@@ -328,18 +341,24 @@ controller:
     integrationEnabled: false
 ```
 
-When not enabled, the controller will not reconcile Argo Rollouts `AnalysisRun`
-resources and attempts to verify Stages via `Analysis` will fail. Explicitly
-disabling is preferred if this integration is not desired, as it will grant
-fewer permissions to the controller.
+When disabled, the controller will not reconcile Argo Rollouts `AnalysisRun`
+resources and attempts to verify Stages via `Analysis` will fail.
+
+:::info
+If the integration is enabled without Argo Rollouts installed, the controller
+will disable the Argo Rollouts specific features on boot. Explicitly disabling
+is preferred if this integration is not desired, as it will grant fewer
+permissions to the controller.
+:::
 
 ## Resource Management
 
 ### Tuning Concurrent Reconciliation Limits
 
-By default, Kargo will reconcile up to 4 resources of the same kind concurrently
-(e.g. 4 `Stage` resources at a time). It is possible to tune this limit by
-setting a new global value, or by setting a limit per resource kind:
+By default, Kargo will reconcile up to four resources of the same kind
+concurrently (e.g. four `Stage` resources at a time). It is possible to tune
+this limit by setting a new global value, or by setting a limit per resource
+kind:
 
 ```yaml
 controller:

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -43,7 +43,7 @@ controller:
 :::note
 For a full list of supported configurations, refer to the
 [Global Parameters](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md#global-parameters)
-or the component-specific parameters in the chart documentation.
+or the component-specific parameter sections in the chart documentation.
 :::
 
 ## API Configuration
@@ -55,13 +55,15 @@ Kargo's API server and its web-based user interface.
 :::info
 The sections below outline common configurations for the API server. For a full
 list of supported configurations, refer to the
-[API Parameters](](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md#api).
+[API Parameters](https://github.com/akuity/kargo/blob/main/charts/kargo/README.md#api).
+section in the chart documentation.
+:::
 
 ### API Host
 
 By default, the API server host (i.e. the domain or IP address that the API is
 accessible at) is set to `localhost`. This host is used for generation of
-Ingress resources, certificates, the OpenID Connect issuer and callback URLs,
+`Ingress` resources, certificates, the OpenID Connect issuer and callback URLs,
 and any URLs that are exposed to users.
 
 To configure the API host, set the following configuration:
@@ -92,11 +94,11 @@ more information on securing the API server.
 
 :::info
 Instead of making use of a `Service` resource, you can also expose the API
-server using an [Ingress resource](#api-ingress).
+server using an [`Ingress` resource](#api-ingress).
 :::
 
 If you want to expose the API server to the internet, but do not want to make
-use of an [Ingress resource](#api-ingress), you can change the service type:
+use of an `Ingress` resource, you can change the service type:
 
 ```yaml
 api:

--- a/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/60-new-docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -141,11 +141,14 @@ the API server.
 
 #### Terminating TLS
 
-In some cases, TLS may be terminated upstream of the API server by various
-components like reverse proxies, load balancers, or `Ingress` controllers using
-wildcard certificates.
+If you have opted out of all the chart's built-in TLS options, but TLS is
+terminated upstream from the API server by a component such as a reverse proxy,
+load balancer, or `Ingress` controller using a wildcard certificate, Kargo will be
+unable to infer from its own configuration that any generated URLs should use
+HTTPS.
 
-For these cases, the API server can be configured to not enforce TLS:
+For such cases, you can explicitly declare that TLS is terminated upstream and
+Kargo will sort out the rest:
 
 ```yaml
 api:
@@ -155,13 +158,8 @@ api:
 ```
 
 :::info
-When setting `terminatedUpstream` to `true`, the API server will generate URLs
-with the `https` scheme but will not enforce TLS. This option serves as an
-escape hatch for scenarios where HTTPS should be used for links, but Kargo
-cannot infer this from its own configuration.
-
-When you are using the [built-in `Ingress` resource](#api-ingress), this
-configuration is typically not required.
+If you exercise any of the chart's built-in TLS configuration options,
+setting `terminatedUpstream` is never required.
 :::
 
 ### API Ingress


### PR DESCRIPTION
@krancour: This had a bit more, but I discovered some overlap between your security documents and what I wrote. So, I am holding that part back until I have a clear view of what would still be required here. Besides this, I am absolutely open to any additional suggestions you have in mind.