### PR TITLE
feat: Added content for examples page

### DIFF
--- a/docs/docs/60-new-docs/50-user-guide/40-examples.md
+++ b/docs/docs/60-new-docs/50-user-guide/40-examples.md
@@ -4,8 +4,30 @@ sidebar_label: Examples
 
 # Examples
 
-:::warning
-This section is expected to be quite extensive.
+Here you'll find practical demonstrations and reference implementations showcasing how to effectively use Kargo in your GitOps workflows.
 
-Alexis to start with a few high-value examples.
-:::
+Whether you're new to Kargo or looking to optimize your existing deployment pipelines, these examples will help you understand key concepts and implement powerful CD workflows. Each example includes detailed explanations, configuration files, and step-by-step guides to get you started.
+
+## Basic
+### Argo CD-Driven Examples
+* [Argo CD Driven | Commit Only](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/01-commit-only)
+* [Argo CD Driven | Helm Driven | Chart Only](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/02-helm-driven/01-chart-only)
+* [Argo CD Driven | Helm Driven | Image only + Chart Repo](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/02-helm-driven/02-image-only/01-with-chart-repo)
+* [Argo CD Driven | Helm Driven | Image only + Git Repo](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/02-helm-driven/02-image-only/02-with-git-repo)
+* [Argo CD Driven | Helm Driven | Chart and Image](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/02-helm-driven/03-chart-n-image)
+* [Argo CD Driven | Helm Driven | Commit + Image](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/02-helm-driven/04-commit-n-image) 
+* [Argo CD Driven | Kustomize Driven | Image only](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/03-kustomize-driven/01-image-only)
+* [Argo CD Driven | Kustomize Driven | Commit + Image](https://github.com/akuity/kargo-examples/tree/main/01-argocd-driven/03-kustomize-driven/02-commit-n-image)
+
+### Git Driven
+* [Git Driven | Commit Only](https://github.com/akuity/kargo-examples/tree/main/02-git-driven/01-commit-only)
+* [Git Driven | Helm Driven | Image Only](https://github.com/akuity/kargo-examples/tree/main/02-git-driven/02-helm-driven/01-image-only)
+* [Git Driven | Helm Driven | Commit + Image](https://github.com/akuity/kargo-examples/tree/main/02-git-driven/02-helm-driven/02-commit-n-image)
+* [Git Driven | Kustomize Driven | Image Only](https://github.com/akuity/kargo-examples/tree/main/02-git-driven/03-kustomize-driven/01-image-only)
+* [Git Driven | Kustomize Driven | Commit + Image](https://github.com/akuity/kargo-examples/tree/main/02-git-driven/03-kustomize-driven/02-commit-n-image) 
+
+## Advanced
+* [kargo-simple](https://github.com/akuity/kargo-simple)
+* [kargo-advanced](https://github.com/akuity/kargo-advanced)
+* [kargo-microservices](https://github.com/akuity/kargo-microservices)
+


### PR DESCRIPTION
As you can see, the page will be a collection of links to repos containing different examples. This is after discussing the final layout with @jessesuen in the google docs [draft](https://docs.google.com/document/d/1PcnpfZkYy17k9-2LCYbcLQLd72jB1pdUkGVy5Jwsuug/edit?disco=AAABcqzaZ2U).

Signed-off-by: Alexis Roberson <alexis.roberson@akuity.io> 