### PR TITLE
fix(ui): tolerate entra id RFC8414 deviation

### DIFF
--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -65,7 +65,10 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
       })
         .then((response) => processDiscoveryResponse(issuerUrl, response))
         .then((response) => {
-          if (response.code_challenge_methods_supported?.includes('S256') !== true) {
+          if (
+            response.code_challenge_methods_supported?.includes('S256') !== true &&
+            !issuerUrl.toString().startsWith('https://login.microsoftonline.com')
+          ) {
             throw new Error('OIDC config fetch error');
           }
 

--- a/ui/src/features/auth/token-renew.tsx
+++ b/ui/src/features/auth/token-renew.tsx
@@ -56,7 +56,10 @@ export const TokenRenew = () => {
       })
         .then((response) => processDiscoveryResponse(issuerUrl, response))
         .then((response) => {
-          if (response.code_challenge_methods_supported?.includes('S256') !== true) {
+          if (
+            response.code_challenge_methods_supported?.includes('S256') !== true &&
+            !issuerUrl.toString().startsWith('https://login.microsoftonline.com')
+          ) {
             throw new Error('OIDC config fetch error');
           }
 


### PR DESCRIPTION
MS Entra ID (formerly Azure AD) implements OIDC and PKCE, but deviates from [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414#section-2) (OAuth 2.0 Authorization Server Metadata) by failing to include the `code_challenge_method` in its metadata. This can create the impression that it does _not_ support PKCE.

Up to now, this has been the cause of a (previously unknown) incompatibility with our UI.

This PR adds an explicit exception to the expectation that `code_challenge_method` exists and includes the value `"S256"` for Entra ID only.

This is safe, as support for S256 is documented here: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow

