### PR TITLE
fix: fix faulty logic for handling possible double-encoding of github app private key

### DIFF
--- a/internal/credentials/kubernetes/github/app_test.go
+++ b/internal/credentials/kubernetes/github/app_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"testing"
@@ -184,6 +185,70 @@ func TestAppCredentialHelper(t *testing.T) {
 				testCase.secret,
 			)
 			testCase.assertions(t, creds, testCase.helper.tokenCache, err)
+		})
+	}
+}
+
+func TestGetAccessToken(t *testing.T) {
+	const key = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCg7I2MQea22DNj
+aGKrTx2Bl3rEkKf+mqLZp8N45qtkjzw6EiCRPpvDav4+e2uXwWZkvD0CXYsQGsa4
+ntperwJJY9OsqRQ+TbFzowps7u4Fhb3FnqRbE4uiZrInNYwuArnOCJwSbaxTFkxm
+EjypUUs/lRbhJwpfv71BvcVjNztwc9TXOu4bgeOntfmLWUjvaatVx1XGPWqiQEdp
+O0+2y7N9lCkW+euLT3awd7q+N/R/r7fNEfn4N+NZe/dwUVE2QnHYhKUk0Cr6+KtD
+zbCtQysE7sDj67pNsIXbRn7fUfdzVmxZ0Mfbko+ABkUVajBhOsN4ubzL1K/JQU0w
+Bmgonsk7AgMBAAECggEAO9Qmvg4kRjd0R5GgGXu1ByC32ovDgZOhVxWZxYHRF/Zu
+2FIz/HwP8iP9uWIuesHDHVGkxxPbJ1YlKq+YlVowmfN817UW2yEMh+cGccCVCsWR
+6/6SsW+/WtYehxhP8S0/QjwONoXC6zMfnVVLa1HXjaCS3IukvjttlBsHX19CAIjh
+D9RqZ28R1Nwy5pFJB++dAfchW2TtlXVkXlOna6Mlc1lwtZby1lMj9xT5yPMKdPB3
+JoKjiOZuOwI6h8b40MZhxPwJ4ePJv+A3ZQC8idQ9C8iJtWKvfUN2DXpstDziSlTs
+MUOXU+P9yPZLvjKL4OZ+edGYDWk53FYoxVm/FWyBjQKBgQDQVoHmZoAzYKnMnoVY
+ThfDMGMlj0xhUkNnHkEXCcompC7Kh7p/q70Bq8ZrT9o+R2EXyyQa1rLpUp1HsWKM
+/7hiA9X9RIrUzk3Bbk8fg3muETEdFtcME+s+FbCski4iYE2/bBVjqODvaO/rzxu9
+sSIqf5wM8BROGwHbEFqAl3vMZwKBgQDFvTW4fmH8DWL+mTQUghD99QG6H/CBipVs
+lKu/84P6m2hnue9EUBlBJl35DSkISv0hElO5AdI7Ev63NJtz8ziXvbd6PbsldWks
++B4i8UN6GsWqwd8M9vmdr3a1mG4FAOL7jEpOqNkvs3D4xWL+M3uymc8wE4yniJTM
+/uarQx5YDQKBgEk8f8F8esiUzFvPxdQ674N/+Pp1G0aC4orXSc5NdLCMup4bhGXo
++zIhLkj+8xs9gFYa5QBCRPZcQkm3g4tJQYnDC3BSrfMM6qx6mHndf+K+zGMLamEm
+h2V1vnuLj4gqDmqiFgrIjPncC6r7TScro3UJEtRBeQHT4J0fbJETr0M1AoGAaX8y
+KxVah5RIzZbFP2/JSwStgDTMJwDeCckj/MwaDNlfEYAU1Hh7kNO8bUSFMMR5Wmyh
+uGHtXNEcjngFvA32kpaITjKjJzAGBhT2VyQrIPkpnpnCu/MEaAmWJvqFMCwx7Y0C
+lAbnoNh2nHMLBp5HD5mZ/Ydgkn1/DgOs45Bynv0CgYEAiiPCMoyzqUoVYM7VPrE3
+ib8XhxGI267P8OKWwRu2w8+wU3yQPThkXOhIknLyg5EMN/8zOxVmFUJ8FLzGGz30
+N64Yi5HQL++EXu+7g8QfA3JYZvF0yTWW4HIQbT1MO8Gw+oPkueZ41z8DAqzHcUuk
+gV5Uyur1krfumoTPJpjqTo0=
+-----END PRIVATE KEY-----`
+	testCases := []struct {
+		name        string
+		key         string
+		expectedKey string
+		expectsErr  bool
+	}{
+		{
+			name:        "key is PEM encoded",
+			key:         key,
+			expectedKey: key,
+		},
+		{
+			name:        "key is base64 encoding of PEM encoded key",
+			key:         base64.StdEncoding.EncodeToString([]byte(key)),
+			expectedKey: key,
+		},
+		{
+			name:       "key is garbage",
+			key:        "garbage",
+			expectsErr: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			key, err := decodeKey(testCase.key)
+			if testCase.expectsErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, []byte(testCase.expectedKey), key)
 		})
 	}
 }

--- a/internal/credentials/kubernetes/github/app_test.go
+++ b/internal/credentials/kubernetes/github/app_test.go
@@ -190,34 +190,7 @@ func TestAppCredentialHelper(t *testing.T) {
 }
 
 func TestGetAccessToken(t *testing.T) {
-	const key = `-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCg7I2MQea22DNj
-aGKrTx2Bl3rEkKf+mqLZp8N45qtkjzw6EiCRPpvDav4+e2uXwWZkvD0CXYsQGsa4
-ntperwJJY9OsqRQ+TbFzowps7u4Fhb3FnqRbE4uiZrInNYwuArnOCJwSbaxTFkxm
-EjypUUs/lRbhJwpfv71BvcVjNztwc9TXOu4bgeOntfmLWUjvaatVx1XGPWqiQEdp
-O0+2y7N9lCkW+euLT3awd7q+N/R/r7fNEfn4N+NZe/dwUVE2QnHYhKUk0Cr6+KtD
-zbCtQysE7sDj67pNsIXbRn7fUfdzVmxZ0Mfbko+ABkUVajBhOsN4ubzL1K/JQU0w
-Bmgonsk7AgMBAAECggEAO9Qmvg4kRjd0R5GgGXu1ByC32ovDgZOhVxWZxYHRF/Zu
-2FIz/HwP8iP9uWIuesHDHVGkxxPbJ1YlKq+YlVowmfN817UW2yEMh+cGccCVCsWR
-6/6SsW+/WtYehxhP8S0/QjwONoXC6zMfnVVLa1HXjaCS3IukvjttlBsHX19CAIjh
-D9RqZ28R1Nwy5pFJB++dAfchW2TtlXVkXlOna6Mlc1lwtZby1lMj9xT5yPMKdPB3
-JoKjiOZuOwI6h8b40MZhxPwJ4ePJv+A3ZQC8idQ9C8iJtWKvfUN2DXpstDziSlTs
-MUOXU+P9yPZLvjKL4OZ+edGYDWk53FYoxVm/FWyBjQKBgQDQVoHmZoAzYKnMnoVY
-ThfDMGMlj0xhUkNnHkEXCcompC7Kh7p/q70Bq8ZrT9o+R2EXyyQa1rLpUp1HsWKM
-/7hiA9X9RIrUzk3Bbk8fg3muETEdFtcME+s+FbCski4iYE2/bBVjqODvaO/rzxu9
-sSIqf5wM8BROGwHbEFqAl3vMZwKBgQDFvTW4fmH8DWL+mTQUghD99QG6H/CBipVs
-lKu/84P6m2hnue9EUBlBJl35DSkISv0hElO5AdI7Ev63NJtz8ziXvbd6PbsldWks
-+B4i8UN6GsWqwd8M9vmdr3a1mG4FAOL7jEpOqNkvs3D4xWL+M3uymc8wE4yniJTM
-/uarQx5YDQKBgEk8f8F8esiUzFvPxdQ674N/+Pp1G0aC4orXSc5NdLCMup4bhGXo
-+zIhLkj+8xs9gFYa5QBCRPZcQkm3g4tJQYnDC3BSrfMM6qx6mHndf+K+zGMLamEm
-h2V1vnuLj4gqDmqiFgrIjPncC6r7TScro3UJEtRBeQHT4J0fbJETr0M1AoGAaX8y
-KxVah5RIzZbFP2/JSwStgDTMJwDeCckj/MwaDNlfEYAU1Hh7kNO8bUSFMMR5Wmyh
-uGHtXNEcjngFvA32kpaITjKjJzAGBhT2VyQrIPkpnpnCu/MEaAmWJvqFMCwx7Y0C
-lAbnoNh2nHMLBp5HD5mZ/Ydgkn1/DgOs45Bynv0CgYEAiiPCMoyzqUoVYM7VPrE3
-ib8XhxGI267P8OKWwRu2w8+wU3yQPThkXOhIknLyg5EMN/8zOxVmFUJ8FLzGGz30
-N64Yi5HQL++EXu+7g8QfA3JYZvF0yTWW4HIQbT1MO8Gw+oPkueZ41z8DAqzHcUuk
-gV5Uyur1krfumoTPJpjqTo0=
------END PRIVATE KEY-----`
+	const key = "-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----"
 	testCases := []struct {
 		name        string
 		key         string
@@ -225,18 +198,18 @@ gV5Uyur1krfumoTPJpjqTo0=
 		expectsErr  bool
 	}{
 		{
-			name:        "key is PEM encoded",
+			name:        "key is not base64 encoded",
 			key:         key,
 			expectedKey: key,
 		},
 		{
-			name:        "key is base64 encoding of PEM encoded key",
+			name:        "key is base64 encoded",
 			key:         base64.StdEncoding.EncodeToString([]byte(key)),
 			expectedKey: key,
 		},
 		{
-			name:       "key is garbage",
-			key:        "garbage",
+			name:       "key is a corrupted base64 encoding",
+			key:        "corrupted", // These are all base64 digits. :)
 			expectsErr: true,
 		},
 	}


### PR DESCRIPTION
Follows up on #3055 and #3059

cc @hiddeco

The issue was here:

```
if corruptInputErr := new(base64.CorruptInputError); !errors.As(err, &corruptInputErr) {
```

`&corruptInputErr` is a `**base64.CorruptInputError`, which `err` never is.

Rather than just delete the offending `&`, I've refactored this and added a test to be sure this is fixed, but I've also switched over to a different strategy for identifying whether we're dealing with a "raw" PEM-encoded PKCS1 or PKCS8 key (i.e. one not unnecessarily double-encoded). It seems this might actually be more reliable than guessing we have a PEM-encoded key whenever the input happens not to be a valid base64 encoding.

But please lmk if you see any problems with the new approach or if you have any ideas for making it more robust.

