### PR TITLE
docs: update quickstart to use promo tasks

### DIFF
--- a/docs/docs/60-new-docs/20-quickstart/index.md
+++ b/docs/docs/60-new-docs/20-quickstart/index.md
@@ -312,6 +312,58 @@ the previous section.
           discoveryLimit: 5
     ---
     apiVersion: kargo.akuity.io/v1alpha1
+    kind: PromotionTask
+    metadata:
+      name: promo-process
+      namespace: kargo-demo
+    spec:
+      vars:
+      - name: gitopsRepo
+        value: ${GITOPS_REPO_URL}
+      - name: imageRepo
+        value: public.ecr.aws/nginx/nginx
+      steps:
+      - uses: git-clone
+        config:
+          repoURL: \${{ vars.gitopsRepo }}
+          checkout:
+          - branch: main
+            path: ./src
+          - branch: stage/\${{ ctx.stage }}
+            create: true
+            path: ./out
+      - uses: git-clear
+        config:
+          path: ./out
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          path: ./src/base
+          images:
+          - image: \${{ vars.imageRepo }}
+            tag: \${{ imageFrom(vars.imageRepo).Tag }}
+      - uses: kustomize-build
+        config:
+          path: ./src/stages/\${{ ctx.stage }}
+          outPath: ./out
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./out
+          messageFromSteps:
+          - update-image
+      - uses: git-push
+        config:
+          path: ./out
+      - uses: argocd-update
+        config:
+          apps:
+          - name: kargo-demo-\${{ ctx.stage }}
+            sources:
+            - repoURL: \${{ vars.gitopsRepo }}
+              desiredRevision: \${{ task.outputs.commit.commit }}
+    ---
+    apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
     metadata:
       name: test
@@ -325,55 +377,9 @@ the previous section.
           direct: true
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -390,55 +396,9 @@ the previous section.
           - test
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -455,55 +415,9 @@ the previous section.
           - uat
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     EOF
     ```
 
@@ -564,6 +478,58 @@ the previous section.
           discoveryLimit: 5
     ---
     apiVersion: kargo.akuity.io/v1alpha1
+    kind: PromotionTask
+    metadata:
+      name: promo-process
+      namespace: kargo-demo
+    spec:
+      vars:
+      - name: gitopsRepo
+        value: ${GITOPS_REPO_URL}
+      - name: imageRepo
+        value: public.ecr.aws/nginx/nginx
+      steps:
+      - uses: git-clone
+        config:
+          repoURL: \${{ vars.gitopsRepo }}
+          checkout:
+          - branch: main
+            path: ./src
+          - branch: stage/\${{ ctx.stage }}
+            create: true
+            path: ./out
+      - uses: git-clear
+        config:
+          path: ./out
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          path: ./src/base
+          images:
+          - image: \${{ vars.imageRepo }}
+            tag: \${{ imageFrom(vars.imageRepo).Tag }}
+      - uses: kustomize-build
+        config:
+          path: ./src/stages/\${{ ctx.stage }}
+          outPath: ./out
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./out
+          messageFromSteps:
+          - update-image
+      - uses: git-push
+        config:
+          path: ./out
+      - uses: argocd-update
+        config:
+          apps:
+          - name: kargo-demo-\${{ ctx.stage }}
+            sources:
+            - repoURL: \${{ vars.gitopsRepo }}
+              desiredRevision: \${{ task.outputs.commit.commit }}
+    ---
+    apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
     metadata:
       name: test
@@ -577,55 +543,9 @@ the previous section.
           direct: true
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -642,55 +562,9 @@ the previous section.
           - test
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -707,55 +581,9 @@ the previous section.
           - uat
       promotionTemplate:
         spec:
-          vars:
-          - name: gitopsRepo
-            value: ${GITOPS_REPO_URL}
-          - name: imageRepo
-            value: public.ecr.aws/nginx/nginx
-          - name: srcPath
-            value: ./src
-          - name: outPath
-            value: ./out
           steps:
-          - uses: git-clone
-            config:
-              repoURL: \${{ vars.gitopsRepo }}
-              checkout:
-              - branch: main
-                path: \${{ vars.srcPath }}
-              - branch: stage/\${{ ctx.stage }}
-                create: true
-                path: \${{ vars.outPath }}
-          - uses: git-clear
-            config:
-              path: \${{ vars.outPath }}
-          - uses: kustomize-set-image
-            as: update-image
-            config:
-              path: \${{ vars.srcPath }}/base
-              images:
-              - image: \${{ vars.imageRepo }}
-                tag: \${{ imageFrom(vars.imageRepo).Tag }}
-          - uses: kustomize-build
-            config:
-              path: \${{ vars.srcPath }}/stages/\${{ ctx.stage }}
-              outPath: \${{ vars.outPath }}/manifests.yaml
-          - uses: git-commit
-            as: commit
-            config:
-              path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
-          - uses: git-push
-            config:
-              path: \${{ vars.outPath }}
-          - uses: argocd-update
-            config:
-              apps:
-              - name: kargo-demo-\${{ ctx.stage }}
-                sources:
-                - repoURL: \${{ vars.gitopsRepo }}
-                  desiredRevision: \${{ outputs.commit.commit }}
+          - task:
+              name: promo-process
     EOF
     ```
 

--- a/docs/docs/60-new-docs/20-quickstart/index.md
+++ b/docs/docs/60-new-docs/20-quickstart/index.md
@@ -314,7 +314,7 @@ the previous section.
     apiVersion: kargo.akuity.io/v1alpha1
     kind: PromotionTask
     metadata:
-      name: promo-process
+      name: demo-promo-process
       namespace: kargo-demo
     spec:
       vars:
@@ -379,7 +379,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -398,7 +399,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -417,7 +419,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     EOF
     ```
 
@@ -545,7 +548,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -564,7 +568,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     ---
     apiVersion: kargo.akuity.io/v1alpha1
     kind: Stage
@@ -583,7 +588,8 @@ the previous section.
         spec:
           steps:
           - task:
-              name: promo-process
+              name: demo-promo-process
+            as: promo-process
     EOF
     ```
 


### PR DESCRIPTION
We should have done this sooner... the wall of YAML in the quickstart is significantly reduced by leveraging `PromotionTask`s.