### PR TITLE
fix(api): fix list ops in authorizing client

### DIFF
--- a/internal/api/kubernetes/client.go
+++ b/internal/api/kubernetes/client.go
@@ -338,6 +338,10 @@ func (c *client) List(
 			key.Namespace = string(n)
 			break
 		}
+		if clOpt, ok := opt.(*libClient.ListOptions); ok {
+			key.Namespace = clOpt.Namespace
+			break
+		}
 	}
 	client, err := c.getAuthorizedClientFn(
 		ctx,
@@ -462,6 +466,10 @@ func (c *client) DeleteAllOf(
 	for _, opt := range opts { // Need to find namespace, if any, from opts
 		if n, ok := opt.(libClient.InNamespace); ok {
 			key.Namespace = string(n)
+			break
+		}
+		if clOpt, ok := opt.(*libClient.DeleteAllOfOptions); ok {
+			key.Namespace = clOpt.Namespace
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #3296

Only the API server was affected by this.

When listing any sort of resource using out authorizing client wrapper, the following worked fine:

```
cl.List(ctx, &obj, client.InNamespace(ns))
```

But the following did not:

```
cli.List(ctx, &obj, &client.ListOptions{Namespace: project))
```

In the former case, the authorizing client wrapper would fail to glean namespace info from the options, resulting in the query _not_ being constrained by namespace, and thus requiring the user to have cluster-scoped read on the affected types.
