### PR TITLE
fix(chart): set `divisor` for `resourceFieldRef`s

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -64,11 +64,13 @@ spec:
             valueFrom:
               resourceFieldRef:
                 containerName: api
+                divisor: "1"
                 resource: limits.memory
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
                 containerName: api
+                divisor: "1"
                 resource: limits.cpu
           {{- with (concat .Values.global.env .Values.api.env) }}
           {{- toYaml . | nindent 10 }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -64,11 +64,13 @@ spec:
           valueFrom:
             resourceFieldRef:
               containerName: controller
+              divisor: "1"
               resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:
               containerName: controller
+              divisor: "1"
               resource: limits.cpu
         {{- with (concat .Values.global.env .Values.controller.env) }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -47,11 +47,13 @@ spec:
           valueFrom:
             resourceFieldRef:
               containerName: dex-server
+              divisor: "1"
               resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:
               containerName: dex-server
+              divisor: "1"
               resource: limits.cpu
         {{- with (concat .Values.global.env .Values.api.oidc.dex.env) }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -63,11 +63,13 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   containerName: garbage-collector
+                  divisor: "1"
                   resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: garbage-collector
+                  divisor: "1"
                   resource: limits.cpu
             {{- with (concat .Values.global.env .Values.garbageCollector.env) }}
             {{- toYaml . | nindent 12 }}

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -64,11 +64,13 @@ spec:
           valueFrom:
             resourceFieldRef:
               containerName: management-controller
+              divisor: "1"
               resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:
               containerName: management-controller
+              divisor: "1"
               resource: limits.cpu
         {{- with (concat .Values.global.env .Values.managementController.env) }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -64,11 +64,13 @@ spec:
           valueFrom:
             resourceFieldRef:
               containerName: webhooks-server
+              divisor: "1"
               resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:
               containerName: webhooks-server
+              divisor: "1"
               resource: limits.cpu
         {{- with (concat .Values.global.env .Values.webhooksServer.env) }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes: #3444

They are all set to one, based on the Kubernetes documentation[1] that states:

> The `divisor` field is optional and has the default value of `1`.
> A divisor of `1` means cores for cpu resources, or bytes for memory
> resources.

[1]: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#store-container-fields