### PR TITLE
feat: surface likely oidc misconfiguration through ui

### DIFF
--- a/internal/api/option/auth.go
+++ b/internal/api/option/auth.go
@@ -435,16 +435,17 @@ func (a *authInterceptor) verifyIDPIssuedToken(
 	c := claims{}
 	if a.oidcTokenVerifyFn == nil {
 		verifierMu.Lock()
-		defer verifierMu.Unlock()
 		if a.oidcTokenVerifyFn == nil {
 			a.oidcTokenVerifyFn = newMultiClientVerifier(ctx, a.cfg)
-			if a.oidcTokenVerifyFn == nil {
-				return c, errors.New(
-					"could not validate token, possibly due to a transient network " +
-						"error; if the problem persists, check your OpenID Connect " +
-						"configuration",
-				)
-			}
+		}
+		verifier := a.oidcTokenVerifyFn
+		verifierMu.Unlock()
+		if verifier == nil {
+			return c, errors.New(
+				"could not validate token, possibly due to a transient network " +
+					"error; if the problem persists, check your OpenID Connect " +
+					"configuration",
+			)
 		}
 	}
 	token, err := a.oidcTokenVerifyFn(ctx, rawToken)

--- a/internal/api/option/option.go
+++ b/internal/api/option/option.go
@@ -22,11 +22,7 @@ func NewHandlerOption(
 		newErrorInterceptor(),
 	}
 	if !cfg.LocalMode {
-		authInterceptor, err := newAuthInterceptor(ctx, cfg, kubeclient)
-		if err != nil {
-			return nil, fmt.Errorf("initialize authentication interceptor: %w", err)
-		}
-		interceptors = append(interceptors, authInterceptor)
+		interceptors = append(interceptors, newAuthInterceptor(ctx, cfg, kubeclient))
 	}
 	return connect.WithHandlerOptions(
 		connect.WithInterceptors(interceptors...),


### PR DESCRIPTION
Fixes #3455

#3455 reports the API server crashing during startup if OIDC is misconfigured. tbh, this was the desired behavior. It's hard to tell the difference between misconfiguration (e.g. incorrect issuer URL) and transient errors (common if using Dex and the API server starts faster than Dex), so the k8s way is to let it die and try to start again with hopes of success, however...

1. OIDC misconfiguration is common.

1. If the API server is down, the UI is also inaccessible. If a user doesn't have access to the logs and cannot reach the UI, there is no insight at all into this common problem.

This change allows the only interaction between the API server and the IDP (retrieval of the keyset for token validation) to fail gracefully and be retried just-in-time on future attempts to validate a token, until it succeeds. (And it might never if things are misconfigured.)

This effectively results in the following:

* Invalid issuer URL:

  Keyset retrieval will fail, but the server will not crash.

  * If any request requiring authn is attempted with an _existing_ token, that token would have been issued by an IDP not matching the invalid issuer URL. As such, the token cannot be validated and the user will be asked to log in.
  * If the user attempts to login, they will be doing so with an invalid issuer URL and the _client_ will fail to communicate with the IDP. They will see this, which hints well-enough at ODIC being misconfigured:

    ![Screenshot 2025-02-06 at 9 54 23 AM](https://github.com/user-attachments/assets/992aebd2-79cd-4a4e-a923-78602c72be6f)

* Transient issue:

  Keyset retrieval will fail, but the server will not crash.

  * If any request requiring authn is attempted with an _existing_ token, keyset retrieval will be retried prior to the attempt to validate.
  * If the user attempts to login, they will be doing so with a valid issuer URL and the authorization code flow w/ PKCE will succeed. This doesn't involve the API server. For validation of the newly-issued token, see previous bullet.

cc @gdsoumya @hiddeco 