### PR TITLE
fix: short term fix for deep copy failing on http status code

### DIFF
--- a/internal/directives/http_requester.go
+++ b/internal/directives/http_requester.go
@@ -196,7 +196,10 @@ func (h *httpRequester) buildExprEnv(resp *http.Response) (map[string]any, error
 	}
 	env := map[string]any{
 		"response": map[string]any{
-			"status":  resp.StatusCode,
+			// TODO(krancour): Casting as an int64 is a short-term fix here because
+			// deep copy of the output map will panic if any value is an int. This is
+			// a near-term fix and a better solution will be PR'ed soon.
+			"status":  int64(resp.StatusCode),
 			"header":  resp.Header.Get,
 			"headers": resp.Header,
 			"body":    map[string]any{},

--- a/internal/directives/http_requester_test.go
+++ b/internal/directives/http_requester_test.go
@@ -251,7 +251,7 @@ func Test_httpRequester_runPromotionStep(t *testing.T) {
 				require.Equal(
 					t,
 					map[string]any{
-						"status":           http.StatusOK,
+						"status":           int64(http.StatusOK),
 						"theMeaningOfLife": nil,
 					},
 					res.Output,
@@ -284,7 +284,7 @@ func Test_httpRequester_runPromotionStep(t *testing.T) {
 				require.Equal(
 					t,
 					map[string]any{
-						"status":           http.StatusOK,
+						"status":           int64(http.StatusOK),
 						"theMeaningOfLife": nil,
 					},
 					res.Output,
@@ -317,7 +317,7 @@ func Test_httpRequester_runPromotionStep(t *testing.T) {
 				require.Equal(
 					t,
 					map[string]any{
-						"status":           http.StatusOK,
+						"status":           int64(http.StatusOK),
 						"theMeaningOfLife": float64(42),
 					},
 					res.Output,
@@ -465,9 +465,9 @@ func Test_httpRequester_buildExprEnv(t *testing.T) {
 				require.NoError(t, err)
 				statusAny, ok := env["response"].(map[string]any)["status"]
 				require.True(t, ok)
-				status, ok := statusAny.(int)
+				status, ok := statusAny.(int64)
 				require.True(t, ok)
-				require.Equal(t, http.StatusOK, status)
+				require.Equal(t, int64(http.StatusOK), status)
 				headerFnAny, ok := env["response"].(map[string]any)["header"]
 				require.True(t, ok)
 				headerFn, ok := headerFnAny.(func(string) string)


### PR DESCRIPTION
If any step adds an int to an output map, it will panic when we attempt a deep copy.

HTTP status codes are ints.

This is a short-term fix until we fix the deep copy routine so that it reliably works for ints.