### PR TITLE
docs: Fix example for Helm warehouses

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -487,7 +487,7 @@ Helm chart repository subscriptions can be defined using the following fields:
   ```yaml
   spec:
     subscriptions:
-    - helm:
+    - chart:
         repoURL: https://charts.example.com
         name: my-chart
         semverConstraint: ^1.0.0


### PR DESCRIPTION
While going through the docs and using an example, I noticed that I was getting an error for using
```yaml
spec:
  subscriptions:
  - helm:
      repoURL: https://charts.example.com
      name: my-chart
      semverConstraint: ^1.0.0
```
After noticing that creating a Helm chart warehouse via the UI, it should be
```yaml
spec:
  subscriptions:
  - chart:
      repoURL: https://charts.example.com
      name: my-chart
      semverConstraint: ^1.0.0
```

This simply fixes the example.