### PR TITLE
fix: set region on default config for AWS creds

### DIFF
--- a/internal/credentials/kubernetes/ecr/managed_identity.go
+++ b/internal/credentials/kubernetes/ecr/managed_identity.go
@@ -179,6 +179,7 @@ func (p *managedIdentityCredentialHelper) getAuthToken(
 				"or project-specific role is not authorized to obtain an ECR auth token. " +
 				"Falling back to using controller's IAM role directly.",
 		)
+		cfg.Region = region
 		ecrSvc = ecr.NewFromConfig(cfg)
 		output, err = ecrSvc.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
 		if err != nil {


### PR DESCRIPTION
Fixes #3482

when falling through the non-project-specific role, the AWS config has a different region set than when using the project-specific-role.

for the case where the region where kargo is running is different than the region for the ECR, this causes auth token errors.

fix this by setting the region for the non-project-specific role codepath.

Signed-off-by: Joel Diaz <jo.diaz@celonis.com>