### PR TITLE
feat!: make `delete` directive non-strict by default 

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/delete.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/delete.md
@@ -16,7 +16,8 @@ the [`git-clear` step](git-clear.md) instead.
 
 | Name      | Type | Required | Description                              |
 |-----------|------|----------|------------------------------------------|
-| `path`    | `string` | Y | Path to the file or directory to delete. |
+| `path` | `string` | Y | Path to the file or directory to delete. |
+| `strict` | `bool` | N | Strict will cause the directive to fail if the path does not exist. Defaults to `false`. |
 
 ## Examples
 

--- a/internal/directives/file_deleter_test.go
+++ b/internal/directives/file_deleter_test.go
@@ -60,16 +60,31 @@ func Test_fileDeleter_runPromotionStep(t *testing.T) {
 			},
 		},
 		{
-			name: "fails for non-existent path",
+			name: "fails for non-existent path when strict is true",
 			setupFiles: func(t *testing.T) string {
 				return t.TempDir()
 			},
 			cfg: DeleteConfig{
-				Path: "nonExistentFile.txt",
+				Path:   "nonExistentFile.txt",
+				Strict: true,
 			},
 			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
 				assert.Error(t, err)
 				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseErrored}, result)
+			},
+		},
+		{
+			name: "succeeds for non-existent path when strict is false",
+			setupFiles: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			cfg: DeleteConfig{
+				Path:   "nonExistentFile.txt",
+				Strict: false,
+			},
+			assertions: func(t *testing.T, _ string, result PromotionStepResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, PromotionStepResult{Status: kargoapi.PromotionPhaseSucceeded}, result)
 			},
 		},
 		{

--- a/internal/directives/schemas/delete-config.json
+++ b/internal/directives/schemas/delete-config.json
@@ -9,6 +9,11 @@
       "type": "string",
       "description": "Path is the path to the file or directory to delete.",
       "minLength": 1
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Strict will cause the directive to fail if the path does not exist.",
+      "default": false
     }
   }
 }

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -94,6 +94,8 @@ type CopyConfig struct {
 type DeleteConfig struct {
 	// Path is the path to the file or directory to delete.
 	Path string `json:"path"`
+	// Strict will cause the directive to fail if the path does not exist.
+	Strict bool `json:"strict,omitempty"`
 }
 
 type GitClearConfig struct {

--- a/ui/src/gen/directives/delete-config.json
+++ b/ui/src/gen/directives/delete-config.json
@@ -8,6 +8,11 @@
    "type": "string",
    "description": "Path is the path to the file or directory to delete.",
    "minLength": 1
+  },
+  "strict": {
+   "type": "boolean",
+   "description": "Strict will cause the directive to fail if the path does not exist.",
+   "default": false
   }
  }
 }


### PR DESCRIPTION
Fixes: #3497

This makes a `delete` step succeed when a file or directory that is
attempted to be removed already does not exist, instead of failing.

In case this behavior is undesired, and the promotion has to fail
when the path does not exist, the `strict` configuration option can
be set to `true`.
