### PR TITLE
fix: invalid type conversion for the `git-wait-for-pr` step

### DIFF
--- a/internal/expressions/json_templates.go
+++ b/internal/expressions/json_templates.go
@@ -155,14 +155,19 @@ func EvaluateTemplate(template string, env map[string]any, exprOpts ...expr.Opti
 		}
 		return result, nil
 	}
-	// If the result is parseable as a bool return that.
-	if resBool, err := strconv.ParseBool(result); err == nil {
-		return resBool, nil
-	}
+
+	// NOTE: The result is explicitly parsed as numbers before booleans to prevent values like
+	// "0" and "1" from being misinterpreted as boolean `false` and `true`,
+	// respectively. See: https://github.com/akuity/kargo/pull/3516
+
 	// If the result is parseable as a float64, return that. float64 is used
 	// because it can represent all JSON numbers.
 	if resNum, err := strconv.ParseFloat(result, 64); err == nil {
 		return resNum, nil
+	}
+	// If the result is parseable as a bool return that.
+	if resBool, err := strconv.ParseBool(result); err == nil {
+		return resBool, nil
 	}
 	// If the result is valid JSON, return its unmarshaled value.
 	var resMap any

--- a/internal/expressions/json_templates.go
+++ b/internal/expressions/json_templates.go
@@ -156,12 +156,11 @@ func EvaluateTemplate(template string, env map[string]any, exprOpts ...expr.Opti
 		return result, nil
 	}
 
-	// NOTE: The result is explicitly parsed as numbers before booleans to prevent values like
-	// "0" and "1" from being misinterpreted as boolean `false` and `true`,
-	// respectively. See: https://github.com/akuity/kargo/pull/3516
-
 	// If the result is parseable as a float64, return that. float64 is used
 	// because it can represent all JSON numbers.
+	//
+	// NB: This is attempted prior to attempting to parse the result as a boolean
+	// so that "0" and "1" will be interpreted as numbers.
 	if resNum, err := strconv.ParseFloat(result, 64); err == nil {
 		return resNum, nil
 	}


### PR DESCRIPTION
This PR fixes an issue where Kargo incorrectly interprets a PR number as a boolean if the PR number is "1". This causes the `gh-wait-for-pr` promotion step to fail with the error:

`invalid type, expected number, given boolean`

- If a PR number evaluates to "1", Kargo mistakenly treats it as a boolean (true).
- The PR itself is created successfully and can be merged in GitHub, but Kargo fails to detect it, preventing the promotion from proceeding.

## Before
![Screenshot from 2025-02-18 15-04-27](https://github.com/user-attachments/assets/db287be8-7991-4015-b296-798bc650a073)

## After
![Screenshot from 2025-02-18 15-23-28](https://github.com/user-attachments/assets/f5a1865d-a235-41e5-b2f7-31852b886155)