### PR TITLE
chore(backport release-1.2): chore(deps): bump Go and Node versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in
@@ -75,7 +75,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -100,7 +100,7 @@ jobs:
   lint-charts:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -124,7 +124,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -147,7 +147,7 @@ jobs:
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -223,7 +223,7 @@ jobs:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
-        node-version: "22.13.0"
+        node-version: "22.14.0"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Run typecheck
@@ -160,7 +160,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
-        node-version: "22.13.0"
+        node-version: "22.14.0"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Install nodejs dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,7 +177,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -245,7 +245,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.4-bookworm
+      image: golang:1.23.6-bookworm
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,7 +205,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
-        node-version: "22.13.0"
+        node-version: "22.14.0"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Build UI
@@ -266,7 +266,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
-        node-version: "22.13.0"
+        node-version: "22.14.0"
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Build UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=kargo-base
 ####################################################################################################
 # ui-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:22.13.0 AS ui-builder
+FROM --platform=$BUILDPLATFORM docker.io/library/node:22.14.0 AS ui-builder
 
 ARG PNPM_VERSION=9.0.3
 RUN npm install --global pnpm@${PNPM_VERSION}
@@ -97,7 +97,7 @@ CMD ["/usr/local/bin/kargo"]
 # - supports development
 # - not used for official image builds
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:22.13.0 AS ui-dev
+FROM --platform=$BUILDPLATFORM docker.io/library/node:22.14.0 AS ui-dev
 
 ARG PNPM_VERSION=9.0.3
 RUN npm install --global pnpm@${PNPM_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.23.4-bookworm AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.23.6-bookworm AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-bookworm
+FROM golang:1.23.6-bookworm
 
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/akuity/kargo
 
-go 1.23.4
+go 1.23.6
 
 require (
 	connectrpc.com/connect v1.18.1


### PR DESCRIPTION
Manual backport of dependency updates to `main` to ensure the patch release is cleared from CVEs.

```
ghcr.io/hiddeco/kargo:1.2.3-rc.721e0c1f (wolfi 20230201)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```