### PR TITLE
fix(gitprovider): use provided scheme for API calls

### DIFF
--- a/internal/gitprovider/gitea/gitea_test.go
+++ b/internal/gitprovider/gitea/gitea_test.go
@@ -18,11 +18,12 @@ const testRepoName = "kargo"
 
 func TestParseGiteaURL(t *testing.T) {
 	testCases := []struct {
-		url           string
-		expectedHost  string
-		expectedOwner string
-		expectedRepo  string
-		errExpected   bool
+		url            string
+		expectedScheme string
+		expectedHost   string
+		expectedOwner  string
+		expectedRepo   string
+		errExpected    bool
 	}{
 		{
 			url:         "not-a-url",
@@ -33,25 +34,42 @@ func TestParseGiteaURL(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			url:           "https://git.domain.com/akuity/kargo",
-			expectedHost:  "git.domain.com",
-			expectedOwner: "akuity",
-			expectedRepo:  "kargo",
+			url:            "https://git.domain.com/akuity/kargo",
+			expectedScheme: "https",
+			expectedHost:   "git.domain.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
 		},
 		{
-			url:           "https://git.domain.com/akuity/kargo.git",
-			expectedHost:  "git.domain.com",
-			expectedOwner: "akuity",
-			expectedRepo:  "kargo",
+			url:            "https://git.domain.com/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "git.domain.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
+		},
+		{
+			url:            "git@git.domain.com:akuity/kargo",
+			expectedScheme: "https",
+			expectedHost:   "git.domain.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
+		},
+		{
+			url:            "http://git.example.com:8080/akuity/kargo",
+			expectedScheme: "http",
+			expectedHost:   "git.example.com:8080",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {
-			host, owner, repo, err := parseRepoURL(testCase.url)
+			scheme, host, owner, repo, err := parseRepoURL(testCase.url)
 			if testCase.errExpected {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, testCase.expectedScheme, scheme)
 				require.Equal(t, testCase.expectedHost, host)
 				require.Equal(t, testCase.expectedOwner, owner)
 				require.Equal(t, testCase.expectedRepo, repo)

--- a/internal/gitprovider/github/github_test.go
+++ b/internal/gitprovider/github/github_test.go
@@ -16,11 +16,12 @@ const testRepoName = "kargo"
 
 func TestParseGitHubURL(t *testing.T) {
 	testCases := []struct {
-		url           string
-		expectedHost  string
-		expectedOwner string
-		expectedRepo  string
-		errExpected   bool
+		url            string
+		expectedScheme string
+		expectedHost   string
+		expectedOwner  string
+		expectedRepo   string
+		errExpected    bool
 	}{
 		{
 			url:         "not-a-url",
@@ -31,33 +32,52 @@ func TestParseGitHubURL(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			url:           "https://github.com/akuity/kargo",
-			expectedHost:  "github.com",
-			expectedOwner: "akuity",
-			expectedRepo:  "kargo",
+			url:            "https://github.com/akuity/kargo",
+			expectedScheme: "https",
+			expectedHost:   "github.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
 		},
 		{
-			url:           "https://github.com/akuity/kargo.git",
-			expectedHost:  "github.com",
-			expectedOwner: "akuity",
-			expectedRepo:  "kargo",
+			url:            "https://github.com/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "github.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
 		},
 		{
 			// This isn't a real URL. It's just to validate that the function can
 			// handle GitHub Enterprise URLs.
-			url:           "https://github.akuity.io/akuity/kargo.git",
-			expectedHost:  "github.akuity.io",
-			expectedOwner: "akuity",
-			expectedRepo:  "kargo",
+			url:            "https://github.akuity.io/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "github.akuity.io",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
+		},
+		{
+			url:            "http://git@example.com:8080/akuity/kargo",
+			errExpected:    false,
+			expectedScheme: "http",
+			expectedHost:   "example.com:8080",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
+		},
+		{
+			url:            "git@github.com:akuity/kargo",
+			expectedScheme: "https",
+			expectedHost:   "github.com",
+			expectedOwner:  "akuity",
+			expectedRepo:   "kargo",
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {
-			host, owner, repo, err := parseRepoURL(testCase.url)
+			scheme, host, owner, repo, err := parseRepoURL(testCase.url)
 			if testCase.errExpected {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, testCase.expectedScheme, scheme)
 				require.Equal(t, testCase.expectedHost, host)
 				require.Equal(t, testCase.expectedOwner, owner)
 				require.Equal(t, testCase.expectedRepo, repo)

--- a/internal/gitprovider/gitlab/gitlab_test.go
+++ b/internal/gitprovider/gitlab/gitlab_test.go
@@ -143,28 +143,43 @@ func TestListPullRequests(t *testing.T) {
 func TestParseGitLabURL(t *testing.T) {
 	const expectedProjectName = "akuity/kargo"
 	testCases := []struct {
-		url          string
-		expectedHost string
+		url            string
+		expectedScheme string
+		expectedHost   string
 	}{
 		{
-			url:          "https://gitlab.com/akuity/kargo",
-			expectedHost: "gitlab.com",
+			url:            "https://gitlab.com/akuity/kargo",
+			expectedScheme: "https",
+			expectedHost:   "gitlab.com",
 		},
 		{
-			url:          "https://gitlab.com/akuity/kargo.git",
-			expectedHost: "gitlab.com",
+			url:            "https://gitlab.com/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "gitlab.com",
 		},
 		{
 			// This isn't a real URL. It's just to validate that the function can
 			// handle GitHub Enterprise URLs.
-			url:          "https://gitlab.akuity.io/akuity/kargo.git",
-			expectedHost: "gitlab.akuity.io",
+			url:            "https://gitlab.akuity.io/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "gitlab.akuity.io",
+		},
+		{
+			url:            "ssh://gitlab.com/akuity/kargo.git",
+			expectedScheme: "https",
+			expectedHost:   "gitlab.com",
+		},
+		{
+			url:            "http://git.example.com/akuity/kargo",
+			expectedScheme: "http",
+			expectedHost:   "git.example.com",
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.url, func(t *testing.T) {
-			host, projectName, err := parseRepoURL(testCase.url)
+			scheme, host, projectName, err := parseRepoURL(testCase.url)
 			require.NoError(t, err)
+			require.Equal(t, testCase.expectedScheme, scheme)
 			require.Equal(t, testCase.expectedHost, host)
 			require.Equal(t, expectedProjectName, projectName)
 		})


### PR DESCRIPTION
Follow up on https://github.com/akuity/kargo/pull/3320#pullrequestreview-2587924812

This ensures that if explicitly defined, a connection over HTTP can still be made instead of silently enforcing HTTPS. This is particularly useful when e.g. running a self-hosted Gitea or GitLab instance in a homelab environment without a proper TLS configuration.