### PR TITLE
fix(api): make `availabilityStrategy` optional 

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -438,7 +438,7 @@ message FreightSources {
   // made available to the Stage. This field is optional. When left unspecified,
   // the field is implicitly treated as if its value were "OneOf".
   //
-  // +kubebuilder:default=OneOf
+  // +kubebuilder:validation:Optional
   optional string availabilityStrategy = 4;
 }
 

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -128,7 +128,7 @@ type FreightOriginKind string
 
 const FreightOriginKindWarehouse FreightOriginKind = "Warehouse"
 
-// +kubebuilder:validation:Enum={All,OneOf}
+// +kubebuilder:validation:Enum={All,OneOf,""}
 type FreightAvailabilityStrategy string
 
 const (
@@ -276,8 +276,8 @@ type FreightSources struct {
 	// made available to the Stage. This field is optional. When left unspecified,
 	// the field is implicitly treated as if its value were "OneOf".
 	//
-	// +kubebuilder:default=OneOf
-	AvailabilityStrategy FreightAvailabilityStrategy `json:"availabilityStrategy" protobuf:"bytes,4,opt,name=availabilityStrategy"`
+	// +kubebuilder:validation:Optional
+	AvailabilityStrategy FreightAvailabilityStrategy `json:"availabilityStrategy,omitempty" protobuf:"bytes,4,opt,name=availabilityStrategy"`
 }
 
 // PromotionTemplate defines a template for a Promotion that can be used to

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -268,7 +268,6 @@ spec:
                         a required field.
                       properties:
                         availabilityStrategy:
-                          default: OneOf
                           description: |-
                             AvailabilityStrategy specifies the semantics for how requested Freight is
                             made available to the Stage. This field is optional. When left unspecified,
@@ -276,6 +275,7 @@ spec:
                           enum:
                           - All
                           - OneOf
+                          - ""
                           type: string
                         direct:
                           description: |-
@@ -305,8 +305,6 @@ spec:
                           items:
                             type: string
                           type: array
-                      required:
-                      - availabilityStrategy
                       type: object
                   required:
                   - origin

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -182,11 +182,11 @@
                 "description": "Sources describes where the requested Freight may be obtained from. This is\na required field.",
                 "properties": {
                   "availabilityStrategy": {
-                    "default": "OneOf",
                     "description": "AvailabilityStrategy specifies the semantics for how requested Freight is\nmade available to the Stage. This field is optional. When left unspecified,\nthe field is implicitly treated as if its value were \"OneOf\".",
                     "enum": [
                       "All",
-                      "OneOf"
+                      "OneOf",
+                      ""
                     ],
                     "type": "string"
                   },
@@ -207,9 +207,6 @@
                     "type": "array"
                   }
                 },
-                "required": [
-                  "availabilityStrategy"
-                ],
                 "type": "object"
               }
             },

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -986,7 +986,7 @@ export type FreightSources = Message<"github.com.akuity.kargo.api.v1alpha1.Freig
    * made available to the Stage. This field is optional. When left unspecified,
    * the field is implicitly treated as if its value were "OneOf".
    *
-   * +kubebuilder:default=OneOf
+   * +kubebuilder:validation:Optional
    *
    * @generated from field: optional string availabilityStrategy = 4;
    */


### PR DESCRIPTION
Fixes: #3548 

This ensures that the newly introduced `availabilityStrategy` is not forcefully marked as `required` but instead allows it to be left unspecified, and then (code)automagically defaults to `OneOf`.

The issue also mentions a historical problem with the `semverConstraint` field being required (and arguably, being confusing as it defaults to `true` even if the field has no further impact on the configured selection strategy, i.e. it does not target SemVers) — I do not see an immediate path forward here to resolve this, as protobuf isn't familiar with e.g. nullable booleans.