### PR TITLE
fix: make stage health unknown when last promotion failed

### DIFF
--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -733,12 +733,12 @@ func (r *RegularStageReconciler) assessHealth(ctx context.Context, stage *kargoa
 			Type:               kargoapi.ConditionTypeHealthy,
 			Status:             metav1.ConditionUnknown,
 			Reason:             fmt.Sprintf("LastPromotion%s", lastPromo.Status.Phase),
-			Message:            "Last Promotion did not succeed",
+			Message:            "Cannot assess health because last Promotion did not succeed",
 			ObservedGeneration: stage.Generation,
 		})
 		newStatus.Health = &kargoapi.Health{
 			Status: kargoapi.HealthStateUnknown,
-			Issues: []string{"Last Promotion did not succeed"},
+			Issues: []string{"Cannot assess health because last Promotion did not succeed"},
 		}
 		return newStatus
 	}

--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -721,22 +721,23 @@ func (r *RegularStageReconciler) assessHealth(ctx context.Context, stage *kargoa
 
 	// If the last Promotion did not succeed, then we cannot perform any health
 	// checks because they are only available after a successful Promotion.
+	// Since we lack enough information to determine health, we mark it as Unknown.
 	//
 	// TODO(hidde): Long term, this should probably be changed to allow to
 	//  continue to run health checks from the last successful Promotion,
 	//  even if the current Promotion did not succeed (e.g. because it was
 	//  aborted).
 	if lastPromo.Status.Phase != kargoapi.PromotionPhaseSucceeded {
-		logger.Debug("Last promotion did not succeed: defaulting Stage health to Unhealthy")
+		logger.Debug("Last promotion did not succeed: defaulting Stage health to Unknown")
 		conditions.Set(&newStatus, &metav1.Condition{
 			Type:               kargoapi.ConditionTypeHealthy,
-			Status:             metav1.ConditionFalse,
+			Status:             metav1.ConditionUnknown,
 			Reason:             fmt.Sprintf("LastPromotion%s", lastPromo.Status.Phase),
 			Message:            "Last Promotion did not succeed",
 			ObservedGeneration: stage.Generation,
 		})
 		newStatus.Health = &kargoapi.Health{
-			Status: kargoapi.HealthStateUnhealthy,
+			Status: kargoapi.HealthStateUnknown,
 			Issues: []string{"Last Promotion did not succeed"},
 		}
 		return newStatus

--- a/internal/controller/stages/regular_stages_test.go
+++ b/internal/controller/stages/regular_stages_test.go
@@ -1442,7 +1442,7 @@ func TestRegularStageReconciler_assessHealth(t *testing.T) {
 				require.NotNil(t, healthyCond)
 				assert.Equal(t, metav1.ConditionUnknown, healthyCond.Status)
 				assert.Equal(t, "LastPromotionAborted", healthyCond.Reason)
-				assert.Equal(t, "Last Promotion did not succeed", healthyCond.Message)
+				assert.Equal(t, "Cannot assess health because last Promotion did not succeed", healthyCond.Message)
 			},
 		},
 		{

--- a/internal/controller/stages/regular_stages_test.go
+++ b/internal/controller/stages/regular_stages_test.go
@@ -1436,12 +1436,11 @@ func TestRegularStageReconciler_assessHealth(t *testing.T) {
 			},
 			assertions: func(t *testing.T, status kargoapi.StageStatus) {
 				assert.NotNil(t, status.Health)
-				assert.Equal(t, kargoapi.HealthStateUnhealthy, status.Health.Status)
-				assert.Equal(t, []string{"Last Promotion did not succeed"}, status.Health.Issues)
+				assert.Equal(t, kargoapi.HealthStateUnknown, status.Health.Status)
 
 				healthyCond := conditions.Get(&status, kargoapi.ConditionTypeHealthy)
 				require.NotNil(t, healthyCond)
-				assert.Equal(t, metav1.ConditionFalse, healthyCond.Status)
+				assert.Equal(t, metav1.ConditionUnknown, healthyCond.Status)
 				assert.Equal(t, "LastPromotionAborted", healthyCond.Reason)
 				assert.Equal(t, "Last Promotion did not succeed", healthyCond.Message)
 			},


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/3191
