### PR TITLE
chore(directives): deprecate `messageFromSteps`

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -15,7 +15,7 @@ desired state and is commonly followed by a [`git-push` step](git-push.md).
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing changes to be committed. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `message` | `string` | N | The commit message. Mutually exclusive with `messageFromSteps`. |
-| `messageFromSteps` | `[]string` | N | References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`. |
+| `messageFromSteps` | `[]string` | N | References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.<br/><br/>__Deprecated: Use `message` with an expression instead. Will be removed in v1.5.0.__ |
 | `author` | `[]object` | N | Optionally provider authorship information for the commit. |
 | `author.name` | `string` | N | The committer's name. |
 | `author.email` | `string` | N | The committer's email address. |

--- a/internal/directives/schemas/git-commit-config.json
+++ b/internal/directives/schemas/git-commit-config.json
@@ -35,7 +35,8 @@
     },
     "messageFromSteps": {
       "type": "array",
-      "description": "TODO",
+      "deprecated": true,
+      "description": "References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.\n\nDeprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.",
       "minItems": 1,
       "items": {
         "type": "string",

--- a/internal/directives/zz_config_types.go
+++ b/internal/directives/zz_config_types.go
@@ -136,7 +136,11 @@ type GitCommitConfig struct {
 	Author *Author `json:"author,omitempty"`
 	// The commit message. Mutually exclusive with 'messageFromSteps'.
 	Message string `json:"message,omitempty"`
-	// TODO
+	// References the `commitMessage` output of previous steps. When one or more are specified,
+	// the commit message will be constructed by concatenating the messages from individual
+	// steps. Mutually exclusive with `message`.
+	//
+	// Deprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.
 	MessageFromSteps []string `json:"messageFromSteps,omitempty"`
 	// The path to a working directory of a local repository.
 	Path string `json:"path"`

--- a/ui/src/gen/directives/git-commit-config.json
+++ b/ui/src/gen/directives/git-commit-config.json
@@ -26,7 +26,8 @@
   },
   "messageFromSteps": {
    "type": "array",
-   "description": "TODO",
+   "deprecated": true,
+   "description": "References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.\n\nDeprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.",
    "items": {
     "type": "string",
     "minLength": 1


### PR DESCRIPTION
:warning: **This marks `messageFromSteps` of the `git-commit` step as deprecated and schedules it for removal in `v1.5.0`.**

The field was overlooked when we deprecated the other `<thing>FromStep` fields. Likewise functionally can be achieved using expressions and a multiline message, refer to the [tip in this section](https://docs.kargo.io/user-guide/reference-docs/promotion-steps/git-commit#composed-commit-message) for more information.