### PR TITLE
fix: improve construction of HTTP transports

### DIFF
--- a/internal/api/dex/proxy.go
+++ b/internal/api/dex/proxy.go
@@ -5,11 +5,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -49,13 +49,14 @@ func NewProxy(cfg ProxyConfig) (*httputil.ReverseProxy, error) {
 		}
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			RootCAs:    caCertPool,
-		},
+	transport := cleanhttp.DefaultPooledTransport()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    caCertPool,
 	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = transport
 
 	return proxy, nil
 }

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"connectrpc.com/connect"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/spf13/pflag"
 
 	"github.com/akuity/kargo/internal/cli/config"
@@ -57,13 +57,16 @@ func GetClient(
 	credential string,
 	insecureTLS bool,
 ) svcv1alpha1connect.KargoServiceClient {
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: insecureTLS, // nolint: gosec
-			},
-		},
+	httpClient := cleanhttp.DefaultClient()
+
+	if insecureTLS {
+		transport := cleanhttp.DefaultTransport()
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, // nolint: gosec
+		}
+		httpClient.Transport = transport
 	}
+
 	if credential == "" {
 		return svcv1alpha1connect.NewKargoServiceClient(httpClient, serverAddress)
 	}


### PR DESCRIPTION
Fixes: #3569

This PR refactors our HTTP client and transport initialization across the codebase to leverage Hashicorp's `go-cleanhttp` library. Previously, we manually constructed HTTP transports with inconsistent configurations, which could lead to connection leaks and suboptimal performance.

We now apply `cleanhttp.DefaultPooledTransport()` for our reverse proxy use case where connection reuse is beneficial, while using `cleanhttp.DefaultTransport()` and `cleanhttp.DefaultClient()` for API clients and Git providers to maintain proper tenant isolation.

Additionally, expected default configurations like HTTP/S proxy configurations, etc. are now properly accounted for.