### PR TITLE
fix: require tag or digest for kustomize-set-image

### DIFF
--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -61,6 +61,32 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 			},
 		},
 		{
+			name: "digest and tag are both not specified",
+			config: Config{
+				"images": []Config{{
+					"image": "fake-image",
+				}},
+			},
+			expectedProblems: []string{
+				"images.0: Must validate one and only one schema (oneOf)",
+				"images.0: tag is required",
+			},
+		},
+		{
+			name: "digest and tag are both empty",
+			config: Config{
+				"images": []Config{{
+					"image":  "fake-image",
+					"digest": "",
+					"tag":    "",
+				}},
+			},
+			expectedProblems: []string{
+				"images.0: Must validate one and only one schema (oneOf)",
+				"images.0.tag: String length must be greater than or equal to 1",
+			},
+		},
+		{
 			name: "digest and tag are both specified",
 			// These should be mutually exclusive.
 			config: Config{
@@ -79,14 +105,6 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 				"path": "fake-path",
 				"images": []Config{
 					{
-						"image": "fake-image-0",
-					},
-					{
-						"image":  "fake-image-1",
-						"digest": "",
-						"tag":    "",
-					},
-					{
 						"image":  "fake-image-2",
 						"digest": "fake-digest",
 					},
@@ -103,17 +121,6 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 						"image":  "fake-image-5",
 						"digest": "",
 						"tag":    "fake-tag",
-					},
-					{
-						"image": "fake-image-6",
-					},
-					{
-						"image":  "fake-image-7",
-						"digest": "",
-						"tag":    "",
-					},
-					{
-						"image": "fake-image-8",
 					},
 				},
 			},

--- a/internal/directives/kustomize_image_setter_test.go
+++ b/internal/directives/kustomize_image_setter_test.go
@@ -69,7 +69,6 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 			},
 			expectedProblems: []string{
 				"images.0: Must validate one and only one schema (oneOf)",
-				"images.0: tag is required",
 			},
 		},
 		{
@@ -83,7 +82,6 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 			},
 			expectedProblems: []string{
 				"images.0: Must validate one and only one schema (oneOf)",
-				"images.0.tag: String length must be greater than or equal to 1",
 			},
 		},
 		{

--- a/internal/directives/schemas/kustomize-set-image-config.json
+++ b/internal/directives/schemas/kustomize-set-image-config.json
@@ -42,9 +42,10 @@
         },
         "oneOf": [
           {
+            "required": ["tag"],
             "properties": {
               "digest": { "enum": ["", null] },
-              "tag": { "enum": ["", null] }
+              "tag": { "minLength": 1 }
             }
           },
           {
@@ -52,13 +53,6 @@
             "properties": {
               "digest": { "minLength": 1 },
               "tag": { "enum": ["", null] }
-            }
-          },
-          {
-            "required": ["tag"],
-            "properties": {
-              "digest": { "enum": ["", null] },
-              "tag": { "minLength": 1 }
             }
           }
         ]


### PR DESCRIPTION
After `fromOrigin` fields were removed, not having either defined could result in the tag of the `image` unexpectedly being set to `latest`. To avoid this, explicitly require either `tag` or `digest` to be set.