### PR TITLE
fix(credentials): comparable constructor return types

### DIFF
--- a/internal/credentials/kubernetes/ecr/access_key.go
+++ b/internal/credentials/kubernetes/ecr/access_key.go
@@ -27,7 +27,7 @@ type AccessKeyProvider struct {
 	getAuthTokenFn func(ctx context.Context, region, accessKeyID, secretAccessKey string) (string, error)
 }
 
-func NewAccessKeyProvider() *AccessKeyProvider {
+func NewAccessKeyProvider() credentials.Provider {
 	p := &AccessKeyProvider{
 		tokenCache: cache.New(
 			// Tokens live for 12 hours. We'll hang on to them for 10.

--- a/internal/credentials/kubernetes/ecr/access_key_test.go
+++ b/internal/credentials/kubernetes/ecr/access_key_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewAccessKeyProvider(t *testing.T) {
-	provider := NewAccessKeyProvider()
+	provider := NewAccessKeyProvider().(*AccessKeyProvider) // nolint:forcetypeassert
 
 	assert.NotNil(t, provider)
 	assert.NotNil(t, provider.tokenCache)
@@ -262,7 +262,7 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewAccessKeyProvider()
+			provider := NewAccessKeyProvider().(*AccessKeyProvider) // nolint:forcetypeassert
 			provider.getAuthTokenFn = tt.getAuthTokenFn
 
 			if tt.setupCache != nil {

--- a/internal/credentials/kubernetes/ecr/managed_identity.go
+++ b/internal/credentials/kubernetes/ecr/managed_identity.go
@@ -32,7 +32,7 @@ type ManagedIdentityProvider struct {
 	getAuthTokenFn func(ctx context.Context, region, project string) (string, error)
 }
 
-func NewManagedIdentityProvider(ctx context.Context) *ManagedIdentityProvider {
+func NewManagedIdentityProvider(ctx context.Context) credentials.Provider {
 	logger := logging.LoggerFromContext(ctx)
 
 	switch {

--- a/internal/credentials/kubernetes/gar/service_account_key.go
+++ b/internal/credentials/kubernetes/gar/service_account_key.go
@@ -24,7 +24,7 @@ type ServiceAccountKeyProvider struct {
 	getAccessTokenFn func(ctx context.Context, encodedServiceAccountKey string) (string, error)
 }
 
-func NewServiceAccountKeyProvider() *ServiceAccountKeyProvider {
+func NewServiceAccountKeyProvider() credentials.Provider {
 	p := &ServiceAccountKeyProvider{
 		tokenCache: cache.New(
 			// Access tokens live for one hour. We'll hang on to them for 40 minutes.

--- a/internal/credentials/kubernetes/gar/service_account_key_test.go
+++ b/internal/credentials/kubernetes/gar/service_account_key_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestNewServiceAccountKeyProvider(t *testing.T) {
-	provider := NewServiceAccountKeyProvider()
-
+	provider := NewServiceAccountKeyProvider().(*ServiceAccountKeyProvider) // nolint:forcetypeassert
 	assert.NotNil(t, provider)
+
 	assert.NotNil(t, provider.tokenCache)
 	assert.NotNil(t, provider.getAccessTokenFn)
 }
@@ -196,7 +196,7 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewServiceAccountKeyProvider()
+			provider := NewServiceAccountKeyProvider().(*ServiceAccountKeyProvider) // nolint:forcetypeassert
 			provider.getAccessTokenFn = tt.getAccessTokenFn
 
 			if tt.setupCache != nil {

--- a/internal/credentials/kubernetes/gar/workload_identity_federation.go
+++ b/internal/credentials/kubernetes/gar/workload_identity_federation.go
@@ -25,7 +25,7 @@ type WorkloadIdentityFederationProvider struct {
 	getAccessTokenFn func(ctx context.Context, project string) (string, error)
 }
 
-func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentityFederationProvider {
+func NewWorkloadIdentityFederationProvider(ctx context.Context) credentials.Provider {
 	logger := logging.LoggerFromContext(ctx)
 
 	if !metadata.OnGCE() {

--- a/internal/credentials/kubernetes/github/app.go
+++ b/internal/credentials/kubernetes/github/app.go
@@ -38,7 +38,7 @@ type AppCredentialProvider struct {
 }
 
 // NewAppCredentialProvider returns an implementation of credentials.Provider.
-func NewAppCredentialProvider() *AppCredentialProvider {
+func NewAppCredentialProvider() credentials.Provider {
 	p := &AppCredentialProvider{
 		tokenCache: cache.New(
 			// Access tokens live for one hour. We'll hang on to them for 40 minutes.

--- a/internal/credentials/kubernetes/github/app_test.go
+++ b/internal/credentials/kubernetes/github/app_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestNewAppCredentialProvider(t *testing.T) {
-	provider := NewAppCredentialProvider()
-
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
 	assert.NotNil(t, provider)
+
 	assert.NotNil(t, provider.tokenCache)
 	assert.NotNil(t, provider.getAccessTokenFn)
 }
@@ -211,7 +211,8 @@ func TestAppCredentialProvider_GetCredentials(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewAppCredentialProvider()
+			provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+
 			if tt.getAccessTokenFn != nil {
 				provider.getAccessTokenFn = tt.getAccessTokenFn
 			}
@@ -303,7 +304,7 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewAppCredentialProvider()
+			provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
 
 			if tt.setupCache != nil {
 				tt.setupCache(provider.tokenCache)


### PR DESCRIPTION
Follow up to #3617 