### PR TITLE
docs: fix broken docs links

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -1004,7 +1004,7 @@ message PromotionStep {
   // Config is opaque configuration for the PromotionStep that is understood
   // only by each PromotionStep's implementation. It is legal to utilize
   // expressions in defining values at any level of this block.
-  // See https://docs.kargo.io/references/expression-language for details.
+  // See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
   optional .k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.JSON config = 3;
 }
 
@@ -1133,7 +1133,7 @@ message PromotionVariable {
 
   // Value is the value of the variable. It is allowed to utilize expressions
   // in the value.
-  // See https://docs.kargo.io/references/expression-language for details.
+  // See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
   optional string value = 2;
 }
 

--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -117,7 +117,7 @@ type PromotionVariable struct {
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Value is the value of the variable. It is allowed to utilize expressions
 	// in the value.
-	// See https://docs.kargo.io/references/expression-language for details.
+	// See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 }
 
@@ -221,7 +221,7 @@ type PromotionStep struct {
 	// Config is opaque configuration for the PromotionStep that is understood
 	// only by each PromotionStep's implementation. It is legal to utilize
 	// expressions in defining values at any level of this block.
-	// See https://docs.kargo.io/references/expression-language for details.
+	// See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
 	Config *apiextensionsv1.JSON `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 }
 

--- a/charts/kargo/resources/crds/kargo.akuity.io_clusterpromotiontasks.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_clusterpromotiontasks.yaml
@@ -64,7 +64,7 @@ spec:
                         Config is opaque configuration for the PromotionStep that is understood
                         only by each PromotionStep's implementation. It is legal to utilize
                         expressions in defining values at any level of this block.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       x-kubernetes-preserve-unknown-fields: true
                     if:
                       description: |-
@@ -163,7 +163,7 @@ spec:
                             description: |-
                               Value is the value of the variable. It is allowed to utilize expressions
                               in the value.
-                              See https://docs.kargo.io/references/expression-language for details.
+                              See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                             type: string
                         required:
                         - name
@@ -195,7 +195,7 @@ spec:
                       description: |-
                         Value is the value of the variable. It is allowed to utilize expressions
                         in the value.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       type: string
                   required:
                   - name

--- a/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
@@ -96,7 +96,7 @@ spec:
                         Config is opaque configuration for the PromotionStep that is understood
                         only by each PromotionStep's implementation. It is legal to utilize
                         expressions in defining values at any level of this block.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       x-kubernetes-preserve-unknown-fields: true
                     if:
                       description: |-
@@ -195,7 +195,7 @@ spec:
                             description: |-
                               Value is the value of the variable. It is allowed to utilize expressions
                               in the value.
-                              See https://docs.kargo.io/references/expression-language for details.
+                              See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                             type: string
                         required:
                         - name
@@ -226,7 +226,7 @@ spec:
                       description: |-
                         Value is the value of the variable. It is allowed to utilize expressions
                         in the value.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       type: string
                   required:
                   - name

--- a/charts/kargo/resources/crds/kargo.akuity.io_promotiontasks.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_promotiontasks.yaml
@@ -64,7 +64,7 @@ spec:
                         Config is opaque configuration for the PromotionStep that is understood
                         only by each PromotionStep's implementation. It is legal to utilize
                         expressions in defining values at any level of this block.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       x-kubernetes-preserve-unknown-fields: true
                     if:
                       description: |-
@@ -163,7 +163,7 @@ spec:
                             description: |-
                               Value is the value of the variable. It is allowed to utilize expressions
                               in the value.
-                              See https://docs.kargo.io/references/expression-language for details.
+                              See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                             type: string
                         required:
                         - name
@@ -195,7 +195,7 @@ spec:
                       description: |-
                         Value is the value of the variable. It is allowed to utilize expressions
                         in the value.
-                        See https://docs.kargo.io/references/expression-language for details.
+                        See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                       type: string
                   required:
                   - name

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -86,7 +86,7 @@ spec:
                                 Config is opaque configuration for the PromotionStep that is understood
                                 only by each PromotionStep's implementation. It is legal to utilize
                                 expressions in defining values at any level of this block.
-                                See https://docs.kargo.io/references/expression-language for details.
+                                See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                               x-kubernetes-preserve-unknown-fields: true
                             if:
                               description: |-
@@ -185,7 +185,7 @@ spec:
                                     description: |-
                                       Value is the value of the variable. It is allowed to utilize expressions
                                       in the value.
-                                      See https://docs.kargo.io/references/expression-language for details.
+                                      See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                                     type: string
                                 required:
                                 - name
@@ -216,7 +216,7 @@ spec:
                               description: |-
                                 Value is the value of the variable. It is allowed to utilize expressions
                                 in the value.
-                                See https://docs.kargo.io/references/expression-language for details.
+                                See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
                               type: string
                           required:
                           - name

--- a/docs/docs/80-release-notes/97-v1.2.0.md
+++ b/docs/docs/80-release-notes/97-v1.2.0.md
@@ -72,7 +72,7 @@ spec:
 
 To use a common sequence of steps across multiple projects, use a cluster-scoped `ClusterPromotionTask` resource instead.
 
-To learn more about this exciting feature, refer to our [PromotionTasks reference doc](https://docs.kargo.io/references/promotion-steps).
+To learn more about this exciting feature, refer to our [PromotionTasks reference doc](https://docs.kargo.io/user-guide/reference-docs/promotion-steps).
 
 ### 🌊 Soak Time {#soak-time}
 
@@ -108,7 +108,7 @@ Note that `requiredSoakTime`, if specified, is _in addition to_ the usual criter
 
 * @muenchdo generously contributed two new options for the `git-open-pr` promotion step to specify a user-defined title and user-defined labels for the PRs it opens.
 
-Refer to the [Promotion Steps reference doc](https://docs.kargo.io/references/promotion-steps) for more details.
+Refer to the [Promotion Steps reference doc](https://docs.kargo.io/user-guide/reference-docs/promotion-steps) for more details.
 
 ### 🖥️ UI Improvements {#ui-improvements}
 

--- a/docs/docs/80-release-notes/98-v1.1.0.md
+++ b/docs/docs/80-release-notes/98-v1.1.0.md
@@ -6,7 +6,7 @@
 
 The community reception to Kargo's transition away from its rigid, legacy promotion mechanisms, toward more flexible promotion steps has been overwhelmingly positive. When promotion steps first appeared in v0.9.0, we knew immediately that support for an expression language would be a powerful complement to that new feature, and this release delivers on that.
 
-For more details, consult our [expression reference documentation](https://docs.kargo.io/references/expression-language). Examples in our [promotion steps reference documentation](https://docs.kargo.io/references/promotion-steps) have also been extensively updated to reflect realistic usage of the expression language.
+For more details, consult our [expression reference documentation](https://docs.kargo.io/user-guide/reference-docs/expressions). Examples in our [promotion steps reference documentation](https://docs.kargo.io/user-guide/reference-docs/expressions) have also been extensively updated to reflect realistic usage of the expression language.
 
 With the advent of expression language support in promotion steps, we're noticing our own promotions processes becoming more and more similar from Stage to Stage -- often varying only in the definition of a few key variables. With this observation, it's clear that the time is right to _promote_ (pun fully intended) promotion processes to a first-class construct. So, to tease the upcoming v1.2.0 release, expect to see a new `PromotionTemplate` CRD that will enable users to DRY up their pipelines!
 
@@ -34,7 +34,7 @@ To correct for this, the `argo-cd-update` step now makes no attempt to automatic
 
 Last, but not least, all steps can now be configured with an optional timeout and error threshold. An error threshold greater than the default of one specifies the number of consecutive failed attempts to execute the step must occur before the entire Promotion is failed.
 
-__Please refer to the [promotion steps reference documentation](https://docs.kargo.io/references/promotion-steps) for detailed information about new and updated promotion steps as well as deprecated steps and fields.__
+__Please refer to the [promotion steps reference documentation](https://docs.kargo.io/user-guide/reference-docs/expressions) for detailed information about new and updated promotion steps as well as deprecated steps and fields.__
 
 ### ⚙️ Resource and Concurrency Settings {#resource-and-concurrency-settings}
 

--- a/ui/src/features/stage/create-stage.tsx
+++ b/ui/src/features/stage/create-stage.tsx
@@ -157,7 +157,7 @@ export const CreateStage = ({
           Create Stage
         </Typography.Title>
         <Typography.Link
-          href='https://docs.kargo.io/concepts/#stage-resources'
+          href='https://docs.kargo.io/user-guide/how-to-guides/working-with-stages'
           target='_blank'
           className='ml-3'
         >

--- a/ui/src/features/stage/create-warehouse/create-warehouse.tsx
+++ b/ui/src/features/stage/create-warehouse/create-warehouse.tsx
@@ -122,7 +122,7 @@ const CreateWarehouse = (props: ModalComponentProps) => {
             Create Warehouse
           </Typography.Title>
           <Typography.Link
-            href='https://docs.kargo.io/concepts/#warehouse-resources'
+            href='https://docs.kargo.io/user-guide/how-to-guides/working-with-warehouses'
             target='_blank'
             className='ml-3'
           >

--- a/ui/src/gen/schema/clusterpromotiontasks.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/clusterpromotiontasks.kargo.akuity.io_v1alpha1.json
@@ -25,7 +25,7 @@
                 "type": "string"
               },
               "config": {
-                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "if": {
@@ -90,7 +90,7 @@
                       "type": "string"
                     },
                     "value": {
-                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                       "type": "string"
                     }
                   },
@@ -125,7 +125,7 @@
                 "type": "string"
               },
               "value": {
-                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "type": "string"
               }
             },

--- a/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
@@ -40,7 +40,7 @@
                 "type": "string"
               },
               "config": {
-                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "if": {
@@ -105,7 +105,7 @@
                       "type": "string"
                     },
                     "value": {
-                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                       "type": "string"
                     }
                   },
@@ -140,7 +140,7 @@
                 "type": "string"
               },
               "value": {
-                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "type": "string"
               }
             },

--- a/ui/src/gen/schema/promotiontasks.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/promotiontasks.kargo.akuity.io_v1alpha1.json
@@ -25,7 +25,7 @@
                 "type": "string"
               },
               "config": {
-                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "if": {
@@ -90,7 +90,7 @@
                       "type": "string"
                     },
                     "value": {
-                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                      "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                       "type": "string"
                     }
                   },
@@ -125,7 +125,7 @@
                 "type": "string"
               },
               "value": {
-                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                 "type": "string"
               }
             },

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -32,7 +32,7 @@
                         "type": "string"
                       },
                       "config": {
-                        "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/references/expression-language for details.",
+                        "description": "Config is opaque configuration for the PromotionStep that is understood\nonly by each PromotionStep's implementation. It is legal to utilize\nexpressions in defining values at any level of this block.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
                       "if": {
@@ -97,7 +97,7 @@
                               "type": "string"
                             },
                             "value": {
-                              "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                              "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                               "type": "string"
                             }
                           },
@@ -132,7 +132,7 @@
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/references/expression-language for details.",
+                        "description": "Value is the value of the variable. It is allowed to utilize expressions\nin the value.\nSee https://docs.kargo.io/user-guide/reference-docs/expressions for details.",
                         "type": "string"
                       }
                     },

--- a/ui/src/gen/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/v1alpha1/generated_pb.ts
@@ -2114,7 +2114,7 @@ export type PromotionStep = Message<"github.com.akuity.kargo.api.v1alpha1.Promot
    * Config is opaque configuration for the PromotionStep that is understood
    * only by each PromotionStep's implementation. It is legal to utilize
    * expressions in defining values at any level of this block.
-   * See https://docs.kargo.io/references/expression-language for details.
+   * See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
    *
    * @generated from field: optional k8s.io.apiextensions_apiserver.pkg.apis.apiextensions.v1.JSON config = 3;
    */
@@ -2385,7 +2385,7 @@ export type PromotionVariable = Message<"github.com.akuity.kargo.api.v1alpha1.Pr
   /**
    * Value is the value of the variable. It is allowed to utilize expressions
    * in the value.
-   * See https://docs.kargo.io/references/expression-language for details.
+   * See https://docs.kargo.io/user-guide/reference-docs/expressions for details.
    *
    * @generated from field: optional string value = 2;
    */


### PR DESCRIPTION
Fix broken links to the documentation. The most noticeable one are in the UI:
![image](https://github.com/user-attachments/assets/b07e9418-9ffb-42c0-8b24-788733ed6a08).

This textbook icon leads to [page not found](https://docs.kargo.io/concepts/#stage-resources).
