### PR TITLE
api ingress path match any

### DIFF
--- a/charts/kargo/templates/api/ingress.yaml
+++ b/charts/kargo/templates/api/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     http:
       paths:
       - pathType: {{ .Values.api.ingress.pathType | default "ImplementationSpecific" }}
-        path: /
+        path: /*
         backend:
           service:
             name: kargo-api


### PR DESCRIPTION
The `/` path seems too restrictive. Can't load dependencies, `/login` etc.

![image](https://github.com/user-attachments/assets/9b9c075e-934d-4305-bab5-1d6e4e0139df)
![image](https://github.com/user-attachments/assets/47221d4e-9b6b-411f-b8f1-ac66d055c563)
