### PR TITLE
chore: move ToVersionProto func

### DIFF
--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -1,13 +1,14 @@
-package svcv1alpha1
+package api
 
 import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	"github.com/akuity/kargo/pkg/x/version"
 )
 
-func ToVersionProto(v version.Version) *VersionInfo {
-	return &VersionInfo{
+func ToVersionProto(v version.Version) *svcv1alpha1.VersionInfo {
+	return &svcv1alpha1.VersionInfo{
 		Version:      v.Version,
 		GitCommit:    v.GitCommit,
 		GitTreeDirty: v.GitTreeDirty,

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -15,6 +15,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/cli/client"
 	"github.com/akuity/kargo/internal/cli/config"
 	"github.com/akuity/kargo/internal/cli/io"
@@ -78,7 +79,7 @@ func (o *versionOptions) addFlags(cmd *cobra.Command) {
 func (o *versionOptions) run(ctx context.Context) error {
 	printToStdout := o.PrintFlags.OutputFlagSpecified == nil || !o.PrintFlags.OutputFlagSpecified()
 
-	cliVersion := svcv1alpha1.ToVersionProto(versionpkg.GetVersion())
+	cliVersion := api.ToVersionProto(versionpkg.GetVersion())
 	if printToStdout {
 		_, _ = fmt.Fprintln(o.IOStreams.Out, "Client Version:", cliVersion.GetVersion())
 	}

--- a/internal/server/get_version_info_v1alpha1.go
+++ b/internal/server/get_version_info_v1alpha1.go
@@ -6,6 +6,7 @@ import (
 	"connectrpc.com/connect"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/pkg/x/version"
 )
 
@@ -15,7 +16,7 @@ func (s *server) GetVersionInfo(
 ) (*connect.Response[svcv1alpha1.GetVersionInfoResponse], error) {
 	return connect.NewResponse(
 		&svcv1alpha1.GetVersionInfoResponse{
-			VersionInfo: svcv1alpha1.ToVersionProto(version.GetVersion()),
+			VersionInfo: api.ToVersionProto(version.GetVersion()),
 		},
 	), nil
 }


### PR DESCRIPTION
This move clears the `api` package's final dependency on any other parts of Kargo.