### PR TITLE
fix(directives): compose-output available to task

### DIFF
--- a/internal/directives/simple_engine_promote.go
+++ b/internal/directives/simple_engine_promote.go
@@ -139,6 +139,9 @@ func (e *SimpleEngine) executeSteps(
 		stepExecMeta.Status = result.Status
 		stepExecMeta.Message = result.Message
 
+		// Update the state with the output of the step.
+		state[step.Alias] = result.Output
+
 		// TODO(hidde): until we have a better way to handle the output of steps
 		// inflated from tasks, we need to apply a special treatment to the output
 		// to allow it to become available under the alias of the "task".
@@ -150,8 +153,6 @@ func (e *SimpleEngine) executeSteps(
 			for k, v := range result.Output {
 				state[aliasNamespace].(map[string]any)[k] = v // nolint: forcetypeassert
 			}
-		} else {
-			state[step.Alias] = result.Output
 		}
 
 		switch result.Status {


### PR DESCRIPTION
Fixes: #3636 

Before this change, it was assumed that `compose-output` used within a PromotionTask would not be used within this task itself. Because of this, the output of a `compose-output` step was only made available under the task namespace but not under the step's own alias.

This caused an issue when trying to reference the output of a `compose-output` step from another step in the same task using expressions like `${{ task.outputs.boo.path }}`, resulting in a "cannot fetch path from <nil>" error.

This PR changes the behavior to always store the step output under the step's alias, and then additionally store it under the task namespace if it's part of a task. This ensures that the output is consistently available regardless of how it's referenced.