### PR TITLE
docs: releaseName is now required by `helm-template`

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-template.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-template.md
@@ -17,7 +17,7 @@ commonly preceded by a [`git-clear` step](git-clear.md) and followed by
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Helm chart (i.e. to a directory containing a `Chart.yaml` file). This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `outPath` | `string` | Y | Path to the file or directory where rendered manifests are to be written. If the path ends with `.yaml` or `.yml` it is presumed to indicate a file and is otherwise presumed to indicate a directory. |
-| `releaseName` | `string` | N | Optional release name to use when rendering the manifests. This is commonly omitted. |
+| `releaseName` | `string` | Y | Release name to use when rendering the manifests. |
 | `useReleaseName` | `boolean` | N | Whether to use the release name in the output path (instead of the chart name). This is `false` by default, and only has an effect when `outPath` is set to a directory. |
 | `namespace` | `string` | N | Optional namespace to use when rendering the manifests. This is commonly omitted. GitOps agents such as Argo CD will generally ensure the installation of manifests into the namespace specified by their own configuration. |
 | `valuesFiles` | `[]string` | N | Helm values files (apart from the chart's default `values.yaml`) to be used when rendering the manifests.  |

--- a/docs/old-docs/35-references/10-promotion-steps.md
+++ b/docs/old-docs/35-references/10-promotion-steps.md
@@ -869,7 +869,7 @@ commonly preceded by a [`git-clear`](#git-clear) step and followed by
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Helm chart (i.e. to a directory containing a `Chart.yaml` file). This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `outPath` | `string` | Y | Path to the file or directory where rendered manifests are to be written. If the path ends with `.yaml` or `.yml` it is presumed to indicate a file and is otherwise presumed to indicate a directory. |
-| `releaseName` | `string` | N | Optional release name to use when rendering the manifests. This is commonly omitted. |
+| `releaseName` | `string` | Y | Release name to use when rendering the manifests. |
 | `namespace` | `string` | N | Optional namespace to use when rendering the manifests. This is commonly omitted. GitOps agents such as Argo CD will generally ensure the installation of manifests into the namespace specified by their own configuration. |
 | `valuesFiles` | `[]string` | N | Helm values files (apart from the chart's default `values.yaml`) to be used when rendering the manifests.  |
 | `includeCRDs` | `boolean` | N | Whether to include CRDs in the rendered manifests. This is `false` by default. |


### PR DESCRIPTION
https://github.com/akuity/kargo/pull/2628 made `releaseName` mandatory, but docs still say it is optional.