### PR TITLE
fix(api): update Git branch validation

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -527,7 +527,8 @@ message GitSubscription {
   // subscription is implicitly to the repository's default branch.
   //
   // +kubebuilder:validation:MinLength=1
-  // +kubebuilder:validation:Pattern=`^\w+([-/\.]\w+)*$`
+  // +kubebuilder:validation:MaxLength=255
+  // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
   optional string branch = 3;
 
   // StrictSemvers specifies whether only "strict" semver tags should be

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -124,7 +124,8 @@ type GitSubscription struct {
 	// subscription is implicitly to the repository's default branch.
 	//
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^\w+([-/\.]\w+)*$`
+	// +kubebuilder:validation:MaxLength=255
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
 	Branch string `json:"branch,omitempty" protobuf:"bytes,3,opt,name=branch"`
 	// StrictSemvers specifies whether only "strict" semver tags should be
 	// considered. A "strict" semver tag is one containing ALL of major, minor,

--- a/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
@@ -152,8 +152,9 @@ spec:
                             NewestFromBranch). This field is optional. When left unspecified, (and the
                             CommitSelectionStrategy is NewestFromBranch or unspecified), the
                             subscription is implicitly to the repository's default branch.
+                          maxLength: 255
                           minLength: 1
-                          pattern: ^\w+([-/\.]\w+)*$
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$
                           type: string
                         commitSelectionStrategy:
                           default: NewestFromBranch

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -1179,7 +1179,8 @@ export type GitSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.GitS
    * subscription is implicitly to the repository's default branch.
    *
    * +kubebuilder:validation:MinLength=1
-   * +kubebuilder:validation:Pattern=`^\w+([-/\.]\w+)*$`
+   * +kubebuilder:validation:MaxLength=255
+   * +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
    *
    * @generated from field: optional string branch = 3;
    */

--- a/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
@@ -80,8 +80,9 @@
                   },
                   "branch": {
                     "description": "Branch references a particular branch of the repository. The value in this\nfield only has any effect when the CommitSelectionStrategy is\nNewestFromBranch or left unspecified (which is implicitly the same as\nNewestFromBranch). This field is optional. When left unspecified, (and the\nCommitSelectionStrategy is NewestFromBranch or unspecified), the\nsubscription is implicitly to the repository's default branch.",
+                    "maxLength": 255,
                     "minLength": 1,
-                    "pattern": "^\\w+([-/\\.]\\w+)*$",
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._\\/-]*[a-zA-Z0-9_-]$",
                     "type": "string"
                   },
                   "commitSelectionStrategy": {


### PR DESCRIPTION
This updates the branch validation to simply ensure it:

1. Starts with an alphanumeric character
2. Contains only alphanumeric characters, dots, underscores, hyphens, and slashes
3. Doesn't end with a slash or dot (but hyphens and underscores _are_ allowed)
4. Doesn't exceed the maximum length of most Git providers (GitHub, etc.)

As the previous pattern continued to give problems. For example, when a name includes a double dash (`--`).