### PR TITLE
fix(api): further improve branch regex

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -528,7 +528,7 @@ message GitSubscription {
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=255
-  // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
+  // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
   optional string branch = 3;
 
   // StrictSemvers specifies whether only "strict" semver tags should be

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -125,7 +125,7 @@ type GitSubscription struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
-	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
 	Branch string `json:"branch,omitempty" protobuf:"bytes,3,opt,name=branch"`
 	// StrictSemvers specifies whether only "strict" semver tags should be
 	// considered. A "strict" semver tag is one containing ALL of major, minor,

--- a/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
@@ -154,7 +154,7 @@ spec:
                             subscription is implicitly to the repository's default branch.
                           maxLength: 255
                           minLength: 1
-                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$
+                          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$
                           type: string
                         commitSelectionStrategy:
                           default: NewestFromBranch

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -1180,7 +1180,7 @@ export type GitSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.GitS
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=255
-   * +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._\/-]*[a-zA-Z0-9_-]$`
+   * +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
    *
    * @generated from field: optional string branch = 3;
    */

--- a/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
@@ -82,7 +82,7 @@
                     "description": "Branch references a particular branch of the repository. The value in this\nfield only has any effect when the CommitSelectionStrategy is\nNewestFromBranch or left unspecified (which is implicitly the same as\nNewestFromBranch). This field is optional. When left unspecified, (and the\nCommitSelectionStrategy is NewestFromBranch or unspecified), the\nsubscription is implicitly to the repository's default branch.",
                     "maxLength": 255,
                     "minLength": 1,
-                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._\\/-]*[a-zA-Z0-9_-]$",
+                    "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9._\\/-]*[a-zA-Z0-9_-])?$",
                     "type": "string"
                   },
                   "commitSelectionStrategy": {


### PR DESCRIPTION
Follow up to #3689, which did not properly capture the edge-case of a branch with a single character (i.e. `a`, `0`, etc).