### PR TITLE
fix(api server): take greater care decoding log steams

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -1,0 +1,80 @@
+package encoding
+
+import (
+	"net/http"
+	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
+)
+
+// Determine attempts to determine the encoding of the provided bytes by first
+// parsing the provided content type and then, if that fails, by sniffing the
+// provided bytes. If the encoding can be determined, it is returned. If it
+// cannot be determined, nil is returned.
+func Determine(contentType string, bytes []byte) encoding.Encoding {
+	parts := strings.Split(
+		strings.TrimSpace(
+			strings.ToLower(contentType),
+		),
+		";",
+	)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, charsetPrefix) {
+			if enc := CharsetTo(strings.TrimPrefix(part, charsetPrefix)); enc != nil {
+				return enc
+			}
+		}
+	}
+	// If we get to here, we could not determine the encoding. Try to determine it
+	// by sniffing the provided bytes.
+	//
+	// Note: This actually has little chance of succeeding because it relies
+	// heavily on BOMs, which are not commonly included in an HTTP response body.
+	// The likely outcome is the function's default return value of
+	// application/octet-stream.
+	detectedContentType := http.DetectContentType(bytes)
+	parts = strings.Split(
+		strings.TrimSpace(
+			strings.ToLower(detectedContentType),
+		),
+		";",
+	)
+	for _, part := range parts[1:] {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, charsetPrefix) {
+			// Return no matter whether we determined the encoding or not.
+			return CharsetTo(strings.TrimPrefix(part, charsetPrefix))
+		}
+	}
+	// If we get to here, we could not determine the encoding.
+	return nil
+}
+
+const charsetPrefix = "charset="
+
+// CharsetTo maps common character set names to their corresponding encoding.
+func CharsetTo(cs string) encoding.Encoding {
+	switch strings.TrimPrefix(cs, charsetPrefix) {
+	case "iso-8859-1":
+		return charmap.ISO8859_1
+	case "utf-8":
+		return unicode.UTF8
+	case "utf-16", "utf-16be":
+		return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)
+	case "utf-16le":
+		return unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	// TODO: Add other charsets as needed
+	default:
+		return nil
+	}
+}
+
+// HasUTF16BOM returns a boolean indicating whether the provided bytes begin
+// with either of a UTF-16 Big Endian or Little Endian byte order mark.
+func HasUTF16BOM(bytes []byte) bool {
+	return len(bytes) >= 2 &&
+		(bytes[0] == 0xfe && bytes[1] == 0xff || bytes[0] == 0xff && bytes[1] == 0xfe)
+}

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -1,0 +1,115 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
+)
+
+func TestDetermine(t *testing.T) {
+	testUTF16NoBOM := []byte{0x00, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f}
+	testUTF16WithBEBOM := []byte{0xfe, 0xff, 0x00, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f}
+	testCases := []struct {
+		name        string
+		contentType string
+		bytes       []byte
+		expected    encoding.Encoding
+	}{
+		{
+			name:        "charset specified in content type",
+			contentType: "text/plain; charset=iso-8859-1",
+			expected:    charmap.ISO8859_1,
+		},
+		{
+			name:        "charset not specified in content type; cannot be inferred from bytes",
+			contentType: "",
+			// With no BOM, we cannot determine the encoding.
+			bytes:    testUTF16NoBOM,
+			expected: nil,
+		},
+		{
+			name:        "charset not specified in content type; can be inferred from bytes",
+			contentType: "",
+			bytes:       testUTF16WithBEBOM,
+			expected:    unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, Determine(testCase.contentType, testCase.bytes))
+		})
+	}
+}
+
+func TestCharsetTo(t *testing.T) {
+	testCases := []struct {
+		charset  string
+		expected encoding.Encoding
+	}{
+		{
+			charset:  "iso-8859-1",
+			expected: charmap.ISO8859_1,
+		},
+		{
+			charset:  "utf-8",
+			expected: unicode.UTF8,
+		},
+		{
+			charset:  "utf-16",
+			expected: unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
+		},
+		{
+			charset:  "utf-16be",
+			expected: unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
+		},
+		{
+			charset:  "utf-16le",
+			expected: unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
+		},
+		{
+			charset:  "other",
+			expected: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.charset, func(t *testing.T) {
+			require.Equal(t, testCase.expected, CharsetTo(testCase.charset))
+		})
+	}
+}
+
+func TestHasUTF16BOM(t *testing.T) {
+	testCases := []struct {
+		name     string
+		bytes    []byte
+		expected bool
+	}{
+		{
+			name:     "empty",
+			expected: false,
+		},
+		{
+			name:     "UTF-16BE BOM",
+			bytes:    []byte{0xfe, 0xff},
+			expected: true,
+		},
+		{
+			name:     "UTF-16LE BOM",
+			bytes:    []byte{0xff, 0xfe},
+			expected: true,
+		},
+		{
+			name:     "UTF-8 BOM",
+			bytes:    []byte{0xef, 0xbb, 0xbf},
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, HasUTF16BOM(testCase.bytes))
+		})
+	}
+}

--- a/internal/server/get_analysisrun_logs_v1alpha1_test.go
+++ b/internal/server/get_analysisrun_logs_v1alpha1_test.go
@@ -1,12 +1,17 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/unicode"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
@@ -538,6 +543,73 @@ func TestServer_buildRequest(t *testing.T) {
 				"", "", "", "",
 			)
 			testCase.assertions(t, req, err)
+		})
+	}
+}
+
+func TestStreamLogs(t *testing.T) {
+	// Strings in Go are UTF-8 encoded byte slices.
+	// testBytes is also a UTF-8 encoded byte slice.
+	testBytes := []byte("😊😊😊") // Emojis use four bytes in both UTF-8 and UTF-16
+	testCases := []struct {
+		name    string
+		encoder *encoding.Encoder
+		decoder *encoding.Decoder
+	}{
+		{
+			name:    "no transformation",
+			encoder: unicode.UTF8.NewEncoder(),
+			decoder: unicode.UTF8.NewDecoder(),
+		},
+		{
+			name:    "transform utf-16 bytes without BOM to utf-8 string",
+			encoder: unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder(), // Don't include BOM
+			decoder: unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder(), // Don't expect BOM
+		},
+		{
+			name:    "transform utf-16 bytes with BOM to utf-8 string",
+			encoder: unicode.UTF16(unicode.BigEndian, unicode.UseBOM).NewEncoder(),    // Include BOM
+			decoder: unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder(), // Ignore BOM if present
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Time out in case something doesn't work as expected
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			// Encode input bytes
+			input := make([]byte, len(testBytes)*2) // UTF-16 could use up to 2x the bytes of UTF-8
+			nInput, nTestBytes, err := testCase.encoder.Transform(input, testBytes, true)
+			require.NoError(t, err)
+			require.Equal(t, len(testBytes), nTestBytes)
+
+			// Create a buffered reader with the encoded input
+			bufReader := bufio.NewReader(bytes.NewReader(input[:nInput]))
+
+			// Stream logs using the smallest buffer possible to make sure we test
+			// that multi-byte encoding sequences spanning buffer boundaries are
+			// handled correctly.
+			chunkCh, errCh, err := StreamLogs(ctx, bufReader, testCase.decoder, 256)
+			require.NoError(t, err)
+			var reassembled string
+		loop:
+			for {
+				select {
+				case chunk, ok := <-chunkCh:
+					if !ok {
+						break loop
+					}
+					reassembled += chunk
+				case err := <-errCh:
+					require.NoError(t, err, "received unexpected error while streaming logs")
+				case <-ctx.Done():
+					require.Fail(t, "timed out")
+				}
+			}
+
+			// Did we get the original text back?
+			require.Equal(t, string(testBytes), reassembled)
 		})
 	}
 }


### PR DESCRIPTION
These fixes make the log streaming endpoint more tolerant of different encoding schemes used when retrieving logs from some other source via HTTP.

It's also more careful about the possibility of multi-byte character sequences in any supported encoding spanning the end of one chunk and the start of the next when streaming.

cc @gdsoumya 