### PR TITLE
feat(cli): improve UX (re-)login

### DIFF
--- a/internal/cli/cmd/login/login.go
+++ b/internal/cli/cmd/login/login.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -120,7 +121,7 @@ func (o *loginOptions) complete(args []string) {
 	// Use the API address in config as a default address
 	o.ServerAddress = o.Config.APIAddress
 	if len(args) == 1 {
-		o.ServerAddress = strings.TrimSpace(args[0])
+		o.ServerAddress = normalizeURL(args[0])
 	}
 }
 
@@ -498,6 +499,26 @@ func randStringFromCharset(n int, charset string) (string, error) {
 		b[i] = charset[randIdxInt]
 	}
 	return string(b), nil
+}
+
+// normalizeURL ensures a given address has a scheme, defaulting to "https".
+func normalizeURL(address string) string {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return address
+	}
+
+	// If no scheme is present, prepend "https://"
+	if !strings.Contains(address, "://") {
+		address = "https://" + address
+	}
+
+	// Parse to normalize
+	parsedURL, err := url.Parse(address)
+	if err != nil {
+		return address // Return the best attempt if parsing fails
+	}
+	return parsedURL.String()
 }
 
 var splashHTML = []byte(`<!DOCTYPE html>

--- a/internal/cli/cmd/login/login_test.go
+++ b/internal/cli/cmd/login/login_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,5 +94,54 @@ func TestRandStringFromCharset(t *testing.T) {
 			require.False(t, ok)
 			set[str] = struct{}{}
 		}
+	}
+}
+
+func Test_normalizeURL(t *testing.T) {
+	tests := []struct {
+		address string
+		want    string
+	}{
+		{
+			address: "example.com",
+			want:    "https://example.com",
+		},
+		{
+			address: "example.com:8080",
+			want:    "https://example.com:8080",
+		},
+		{
+			address: "http://example.com",
+			want:    "http://example.com",
+		},
+		{
+			address: "https://example.com",
+			want:    "https://example.com",
+		},
+		{
+			address: " ftp://example.com",
+			want:    "ftp://example.com",
+		},
+		{
+			address: "  example.com/path  ",
+			want:    "https://example.com/path",
+		},
+		{
+			address: "localhost",
+			want:    "https://localhost",
+		},
+		{
+			address: "localhost:3000",
+			want:    "https://localhost:3000",
+		},
+		{
+			address: "",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeURL(tt.address))
+		})
 	}
 }

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -40,6 +40,8 @@ func init() {
 
 // CLIConfig represents CLI configuration.
 type CLIConfig struct {
+	// AuthMethod is the method used to authenticate with the Kargo API server.
+	AuthMethod string `json:"authMethod,omitempty"`
 	// APIAddress is the address of the Kargo API server.
 	APIAddress string `json:"apiAddress,omitempty"`
 	// BearerToken is used to authenticate with the Kargo API server. This could


### PR DESCRIPTION
This brings two improvements:

- When providing the server address, the scheme is now optional when connecting to a HTTPS endpoint. (I.e. `kargo login localhost:8080` works as long as it serves an HTTPS endpoint).
- It remembers the last authentication method, and you can run `kargo login` to connect to the last used server with the last used method.