### PR TITLE
fix(chart): GOMAXPROCS set request if limit absent

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               resourceFieldRef:
                 containerName: api
                 divisor: "1"
-                resource: limits.cpu
+                resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.api.resources) }}
           {{- with (concat .Values.global.env .Values.api.env) }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             resourceFieldRef:
               containerName: controller
               divisor: "1"
-              resource: limits.cpu
+              resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.controller.resources) }}
         {{- with (concat .Values.global.env .Values.controller.env) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             resourceFieldRef:
               containerName: dex-server
               divisor: "1"
-              resource: limits.cpu
+              resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.api.oidc.dex.resources) }}
         {{- with (concat .Values.global.env .Values.api.oidc.dex.env) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -70,7 +70,7 @@ spec:
                 resourceFieldRef:
                   containerName: garbage-collector
                   divisor: "1"
-                  resource: limits.cpu
+                  resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.garbageCollector.resources) }}
             {{- with (concat .Values.global.env .Values.garbageCollector.env) }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             resourceFieldRef:
               containerName: management-controller
               divisor: "1"
-              resource: limits.cpu
+              resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.managementController.resources) }}
         {{- with (concat .Values.global.env .Values.managementController.env) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kargo/templates/webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/webhooks-server/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             resourceFieldRef:
               containerName: webhooks-server
               divisor: "1"
-              resource: limits.cpu
+              resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.webhooksServer.resources) }}
         {{- with (concat .Values.global.env .Values.webhooksServer.env) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This changes the chart to set `GOMAXPROCS` to `requests.cpu` when `limits.cpu` is not present, to prevent it from defaulting to all cores present on the node.

For in depth information about this change, see: https://kanishk.io/posts/cpu-throttling-in-containerized-go-apps/

> If you do not set CPU limits, I’d still recommend setting your GOMAXPROCS somewhere around 1x or 2x your CPU request to get predictable performance.