### PR TITLE
fix: soak time bug

### DIFF
--- a/internal/api/stage.go
+++ b/internal/api/stage.go
@@ -83,7 +83,7 @@ func ListFreightAvailableToStage(
 				AvailabilityStrategy: req.Sources.AvailabilityStrategy,
 			}
 			if requiredSoak := req.Sources.RequiredSoakTime; requiredSoak != nil {
-				listOpts.VerifiedBefore = &metav1.Time{Time: time.Now().Add(-requiredSoak.Duration)}
+				listOpts.RequiredSoakTime = &requiredSoak.Duration
 			}
 		}
 		freightFromWarehouse, err := ListFreightFromWarehouse(

--- a/internal/api/stage_test.go
+++ b/internal/api/stage_test.go
@@ -208,8 +208,7 @@ func TestListFreightAvailableToStage(t *testing.T) {
 					Status: kargoapi.FreightStatus{
 						VerifiedIn: map[string]kargoapi.VerifiedStage{
 							testStage: {
-								VerifiedAt: &metav1.Time{Time: time.Now()},
-							},
+								LongestCompletedSoak: &metav1.Duration{Duration: 30 * time.Minute}},
 						},
 					},
 				},
@@ -222,7 +221,7 @@ func TestListFreightAvailableToStage(t *testing.T) {
 					Status: kargoapi.FreightStatus{
 						VerifiedIn: map[string]kargoapi.VerifiedStage{
 							testStage: {
-								VerifiedAt: &metav1.Time{Time: time.Now().Add(-time.Hour * 2)},
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
 							},
 						},
 					},

--- a/internal/api/warehouse.go
+++ b/internal/api/warehouse.go
@@ -84,11 +84,10 @@ type ListWarehouseFreightOptions struct {
 	//
 	// IMPORTANT: This is OR'ed with the ApprovedFor field.
 	VerifiedIn []string
-	// VerifiedBefore optionally specifies a time before which a Freight verified
-	// in any of the Stages named in the VerifiedIn field must have been verified.
-	// This is useful for filtering out Freight whose soak time has not yet
-	// elapsed.
-	VerifiedBefore *metav1.Time
+	// RequiredSoakTime optionally specifies a minimum duration that a piece of
+	// Freight must have continuously remained in a Stage at any time after being
+	// verified.
+	RequiredSoakTime *time.Duration
 	// AvailabilityStrategy specifies the semantics for how Freight is determined
 	// to be available. If not set, the default is to consider Freight available
 	// if it has been verified in any of the provided VerifiedIn stages.
@@ -196,7 +195,7 @@ func ListFreightFromWarehouse(
 		return lhs.Name == rhs.Name
 	})
 
-	if len(opts.VerifiedIn) == 0 || opts.VerifiedBefore == nil {
+	if len(opts.VerifiedIn) == 0 || opts.RequiredSoakTime == nil {
 		// Nothing left to do
 		return freight, nil
 	}
@@ -214,11 +213,9 @@ func ListFreightFromWarehouse(
 		// Track set of Stages that have passed the verification soak time
 		// for the Freight.
 		verifiedStages := sets.New[string]()
-		for stage, ver := range f.Status.VerifiedIn {
-			if verifiedAt := ver.VerifiedAt; verifiedAt != nil {
-				if verifiedAt.Time.Before(opts.VerifiedBefore.Time) {
-					verifiedStages.Insert(stage)
-				}
+		for stage := range f.Status.VerifiedIn {
+			if f.GetLongestSoak(stage) >= *opts.RequiredSoakTime {
+				verifiedStages.Insert(stage)
 			}
 		}
 

--- a/internal/controller/stages/regular_stages_test.go
+++ b/internal/controller/stages/regular_stages_test.go
@@ -4794,7 +4794,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 			},
 		},
 		{
-			name: "handles verified freight from upstream stages with verification duration requirement",
+			name: "handles verified freight from upstream stages with soak time requirement",
 			stage: &kargoapi.Stage{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fake-project",
@@ -4874,9 +4874,8 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 					Status: kargoapi.FreightStatus{
 						VerifiedIn: map[string]kargoapi.VerifiedStage{
 							"upstream-stage": {
-								// Should be selected because it was verified
-								// after the required duration.
-								VerifiedAt: &metav1.Time{Time: now.Add(-2 * time.Hour)},
+								// Should be selected because the soak time has elapsed
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
 							},
 						},
 					},


### PR DESCRIPTION
I stumbled upon this bug today and it seemed serious enough to fix immediately.

It's been around since #3100, when soak time was first introduced.

The original strategy for assessing whether soak time had elapsed involved ensuring verification time was in the sufficiently distant past, but that offered no guarantee of how long the Freight had actually _spent_ in the Stage in question, which was exposed during review. The PR was subsequently amended to track how long a piece of Freight actually spent in any given Stage...

Except, as it turns out, I only actually fixed it for `stage.IsFreightAvailable(...)`, which answers whether a single piece of Freight is available to a given Stage.

I _missed_ the `ListFreightFromWarehouse()` which lists all Freight from a given Warehouse, with optional constraints pertaining to verification, approval, soak time, etc.

This PR fixes it.

The flawed logic (listing) was used in finding Freight _available_ for promotion to a given Stage, but the correct logic was used to validate Promotion requests received by the API server and also to validate Promotion resources themselves in a validating webhook.

The net effect of this is that some Promotions that should not have been allowed may have been created, but validation wouldn't have permitted them to proceed. More than anything else, it may have resulted in some head scratching.