### PR TITLE
fix: always honor availability strategy

### DIFF
--- a/api/v1alpha1/freight_types.go
+++ b/api/v1alpha1/freight_types.go
@@ -157,6 +157,19 @@ func (f *Freight) GetLongestSoak(stage string) time.Duration {
 	return time.Duration(max(longestCompleted.Nanoseconds(), current.Nanoseconds()))
 }
 
+// HasSoakedIn returns whether the Freight has soaked in the specified Stage for
+// at least the specified duration. If the specified duration is nil, this
+// method will return true.
+func (f *Freight) HasSoakedIn(stage string, dur *metav1.Duration) bool {
+	if f == nil {
+		return false
+	}
+	if dur == nil {
+		return true
+	}
+	return f.GetLongestSoak(stage) >= dur.Duration
+}
+
 // AddCurrentStage updates the Freight status to reflect that the Freight is
 // currently in the specified Stage.
 func (f *FreightStatus) AddCurrentStage(stage string, since time.Time) {

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -181,15 +181,26 @@ func (s *Stage) IsFreightAvailable(freight *Freight) bool {
 		return true
 	}
 	for _, req := range s.Spec.RequestedFreight {
-		if freight.Origin.Equals(&req.Origin) {
-			if req.Sources.Direct {
-				return true
-			}
-			for _, source := range req.Sources.Stages {
-				if freight.IsVerifiedIn(source) {
-					return req.Sources.RequiredSoakTime == nil ||
-						freight.GetLongestSoak(source) >= req.Sources.RequiredSoakTime.Duration
+		if !freight.Origin.Equals(&req.Origin) {
+			continue
+		}
+
+		if req.Sources.Direct {
+			return true
+		}
+		if req.Sources.AvailabilityStrategy == FreightAvailabilityStrategyAll {
+			// Make sure Freight is verified and soaked in all upstream Stages
+			for _, upstream := range req.Sources.Stages {
+				if !freight.IsVerifiedIn(upstream) || !freight.HasSoakedIn(upstream, req.Sources.RequiredSoakTime) {
+					return false
 				}
+			}
+			return true
+		}
+		// Make sure Freight is verified and soaked in at least one upstream Stage
+		for _, upstream := range req.Sources.Stages {
+			if freight.IsVerifiedIn(upstream) && freight.HasSoakedIn(upstream, req.Sources.RequiredSoakTime) {
+				return true
 			}
 		}
 	}

--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -186,6 +186,65 @@ func TestStage_IsFreightAvailable(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "availability strategy all + freight is verified and soaked in one upstream stage, but not all",
+			stage: &Stage{
+				ObjectMeta: testStageMeta,
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: testOrigin,
+						Sources: FreightSources{
+							AvailabilityStrategy: FreightAvailabilityStrategyAll,
+							Stages:               []string{"upstream-stage-1", "upstream-stage-2"},
+							RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
+						},
+					}},
+				},
+			},
+			freight: &Freight{
+				ObjectMeta: testFreightMeta,
+				Origin:     testOrigin,
+				Status: FreightStatus{
+					VerifiedIn: map[string]VerifiedStage{
+						"upstream-stage-1": {
+							LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "availability strategy all + freight is verified and soaked in all upstream stages",
+			stage: &Stage{
+				ObjectMeta: testStageMeta,
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: testOrigin,
+						Sources: FreightSources{
+							AvailabilityStrategy: FreightAvailabilityStrategyAll,
+							Stages:               []string{"upstream-stage-1", "upstream-stage-2"},
+							RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
+						},
+					}},
+				},
+			},
+			freight: &Freight{
+				ObjectMeta: testFreightMeta,
+				Origin:     testOrigin,
+				Status: FreightStatus{
+					VerifiedIn: map[string]VerifiedStage{
+						"upstream-stage-1": {
+							LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+						},
+						"upstream-stage-2": {
+							LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "freight from origin not requested",
 			stage: &Stage{
 				ObjectMeta: testStageMeta,

--- a/internal/api/stage.go
+++ b/internal/api/stage.go
@@ -81,9 +81,7 @@ func ListFreightAvailableToStage(
 				ApprovedFor:          s.Name,
 				VerifiedIn:           req.Sources.Stages,
 				AvailabilityStrategy: req.Sources.AvailabilityStrategy,
-			}
-			if requiredSoak := req.Sources.RequiredSoakTime; requiredSoak != nil {
-				listOpts.RequiredSoakTime = &requiredSoak.Duration
+				RequiredSoakTime:     req.Sources.RequiredSoakTime,
 			}
 		}
 		freightFromWarehouse, err := ListFreightFromWarehouse(

--- a/internal/api/warehouse.go
+++ b/internal/api/warehouse.go
@@ -87,7 +87,7 @@ type ListWarehouseFreightOptions struct {
 	// RequiredSoakTime optionally specifies a minimum duration that a piece of
 	// Freight must have continuously remained in a Stage at any time after being
 	// verified.
-	RequiredSoakTime *time.Duration
+	RequiredSoakTime *metav1.Duration
 	// AvailabilityStrategy specifies the semantics for how Freight is determined
 	// to be available. If not set, the default is to consider Freight available
 	// if it has been verified in any of the provided VerifiedIn stages.
@@ -214,7 +214,7 @@ func ListFreightFromWarehouse(
 		// for the Freight.
 		verifiedStages := sets.New[string]()
 		for stage := range f.Status.VerifiedIn {
-			if f.GetLongestSoak(stage) >= *opts.RequiredSoakTime {
+			if f.HasSoakedIn(stage, opts.RequiredSoakTime) {
 				verifiedStages.Insert(stage)
 			}
 		}

--- a/internal/api/warehouse_test.go
+++ b/internal/api/warehouse_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -178,7 +177,8 @@ func TestListFreightFromWarehouse(t *testing.T) {
 			opts: &ListWarehouseFreightOptions{
 				ApprovedFor:      testStage,
 				VerifiedIn:       []string{testUpstreamStage},
-				RequiredSoakTime: ptr.To(time.Hour)},
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			},
 			objects: []client.Object{
 				&kargoapi.Freight{ // This should not be returned
 					ObjectMeta: metav1.ObjectMeta{
@@ -279,7 +279,7 @@ func TestListFreightFromWarehouse(t *testing.T) {
 				AvailabilityStrategy: kargoapi.FreightAvailabilityStrategyAll,
 				ApprovedFor:          testStage,
 				VerifiedIn:           []string{testUpstreamStage, testUpstreamStage2},
-				RequiredSoakTime:     ptr.To(time.Hour),
+				RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
 			},
 			objects: []client.Object{
 				&kargoapi.Freight{ // This should be returned as its approved for the Stage
@@ -379,7 +379,7 @@ func TestListFreightFromWarehouse(t *testing.T) {
 				AvailabilityStrategy: "Invalid",
 				ApprovedFor:          testStage,
 				VerifiedIn:           []string{testUpstreamStage, testUpstreamStage2},
-				RequiredSoakTime:     ptr.To(time.Hour),
+				RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
 			},
 			assertions: func(t *testing.T, _ []kargoapi.Freight, err error) {
 				require.ErrorContains(t, err, "unsupported AvailabilityStrategy")


### PR DESCRIPTION
#3257 introduced availability strategies (verified + soaked in any upstream vs all upstreams).

The change was properly implemented as new criterion when _listing_ available Freight, but was overlooked in the function that answers whether a single piece of Freight is available to a given Stage.

The effect is that Freight that was not verified and adequately soaked in _all_ upstream stages may sometimes have been deemed available to a Stage if it met availability criteria in _any_ upstream stage.

This PR fixes that.