### PR TITLE
fix(ui): projects filter ui

### DIFF
--- a/ui/src/features/project/list/project-list-filter.tsx
+++ b/ui/src/features/project/list/project-list-filter.tsx
@@ -26,7 +26,7 @@ export const ProjectListFilter = ({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== 'Enter') return;
 
-    if (filteredProjects?.length !== 1) {
+    if (filteredProjects?.length !== 1 || !filter) {
       onChange(filter);
       return;
     }

--- a/ui/src/features/project/list/project-list-filter.tsx
+++ b/ui/src/features/project/list/project-list-filter.tsx
@@ -24,11 +24,16 @@ export const ProjectListFilter = ({
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && filteredProjects?.length === 1) {
-      const selectedProject = filteredProjects[0].metadata?.name;
-      if (selectedProject) {
-        navigate(paths.project.replace(':name', selectedProject));
-      }
+    if (e.key !== 'Enter') return;
+
+    if (filteredProjects?.length !== 1) {
+      onChange(filter);
+      return;
+    }
+
+    const selectedProject = filteredProjects![0].metadata?.name;
+    if (selectedProject) {
+      navigate(paths.project.replace(':name', selectedProject));
     }
   };
 

--- a/ui/src/features/project/list/projects-list.tsx
+++ b/ui/src/features/project/list/projects-list.tsx
@@ -55,12 +55,22 @@ export const ProjectsList = () => {
 
   if (isLoading) return <LoadingState />;
 
-  if (!data || data.projects.length === 0) return <Empty />;
+  const isEmpty = !data || data.projects.length === 0;
+  const projectListFilter = () => <ProjectListFilter onChange={handleFilterChange} init={filter} />;
+
+  if (isEmpty) {
+    return (
+      <>
+        <div className='flex items-center mb-20'>{projectListFilter()}</div>
+        <Empty />
+      </>
+    );
+  }
 
   return (
     <>
       <div className='flex items-center mb-6'>
-        <ProjectListFilter onChange={handleFilterChange} init={filter} />
+        {projectListFilter()}
         <Pagination
           total={data?.total || 0}
           className='ml-auto flex-shrink-0'


### PR DESCRIPTION
Two issues with project filter input are fixed. (You may also see it as one issue and a feature)

## 1. The hidden search bar

In the case that the filter result was returned empty, the search bar would disappear, blocking the user from resetting the search. The only fix in this situation was to remove the `projects-filter` cookie to get the search bar back.

The image below shows how it would like before, if you would search for a non-existing project name:
<img width="1503" alt="ne" src="https://github.com/user-attachments/assets/c85deaf0-dda3-47c2-a545-f3447c22b4b4" />

## 2. Hitting the enter button wouldn't change the `projects-filter`

This one was more of an annoying thing because previously you had to manually click on the search button to change the search filter. Now just hitting enter will do that.

I've checked the other interactions with the search bar like selecting different items and all still work as expected.

P.S. I've uploaded a screen recording of how it looks with this PR in [this](https://github.com/akuity/kargo/pull/3771#issuecomment-2773570479) comment below.
