### PR TITLE
fix: make quote() func in expressions not double-quote strings

### DIFF
--- a/internal/expressions/json_templates.go
+++ b/internal/expressions/json_templates.go
@@ -113,6 +113,9 @@ func EvaluateTemplate(template string, env map[string]any, exprOpts ...expr.Opti
 	exprOpts = append(exprOpts, expr.Function(
 		"quote",
 		func(a ...any) (any, error) {
+			if str, ok := a[0].(string); ok {
+				return fmt.Sprintf("%q", str), nil
+			}
 			jsonBytes, err := json.Marshal(a[0])
 			if err != nil {
 				return nil, fmt.Errorf("error applying quote() function: %w", err)

--- a/internal/expressions/json_templates_test.go
+++ b/internal/expressions/json_templates_test.go
@@ -221,6 +221,16 @@ func TestEvaluateJSONTemplate(t *testing.T) {
 			},
 		},
 		{
+			name:         "quote function doesn't double quote string input",
+			jsonTemplate: `{ "AString": "${{ quote('foo') }}" }`,
+			assertions: func(t *testing.T, jsonOutput []byte, err error) {
+				require.NoError(t, err)
+				parsed := testStruct{}
+				require.NoError(t, json.Unmarshal(jsonOutput, &parsed))
+				require.Equal(t, "foo", parsed.AString)
+			},
+		},
+		{
 			name: "a variety of tricky cases dealing with YAML and quotes",
 			yamlTemplate: `
 value1: {"foo": "bar"} # This is a JSON object


### PR DESCRIPTION
Fixes #3743 

Without the `quote()` function we make available in expressions, many values that should be strings will be misinterpreted as other types.

Example:

```
config:
  meaningOfLife: ${{ 42 }}
```

This becomes the following JSON: `{"meaningOfLife": "${{ 42 }}"}`

After evaluation of expressions, you're left with: `{"meaningOfLife": 42}`

(Strings that _can_ be interpreted as something else -- bool, number, object, etc. -- _are_, which is behavior familiar to anyone who works with YAML.)

If you really want that to be a string, you use `quote()`:

```
config:
  meaningOfLife: ${{ quote(42) }}
```

This becomes the following JSON: `{"meaningOfLife": "${{ quote(42) }}"}`

After evaluation of expressions, you're left with: `{"meaningOfLife": "42"}`

Perfect.

A problem arises when the value passed to `quote()` is _already_ a string.

Example:

```
config:
  meaningOfLife: ${{ quote('42') }}
```

This becomes the following JSON: `{"meaningOfLife": "${{ quote('42') }}"}`

After evaluation of expressions, you're left with: `{"meaningOfLife": "\"42\""}`.

This is clearly not what was wanted.

The issue arises from how we add the surrounding quotes. We _unconditionally, regardless of type_, marshal whatever value is handed to the `quote()` function and _then_ put quotes around it.

If you marshal the _number_ `42`, the resulting JSON is `42` and the final result is `"42"`, which is what we wanted.

But if you marshal the _string_ `42`, the resulting JSON is `"42"`, and after application of the surrounding quotes, the final result is `"\"42\""`. No good.

This small fix checks first if what was provided was already a string, and if so, it adds the surrounding quotes _without marshaling the string as JSON first_, to avoid the second, undesired set of quotes.