### PR TITLE
chore(docs): fix typo in "Logging In"

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/10-logging-in/index.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/10-logging-in/index.md
@@ -5,7 +5,7 @@ description: Learn how to log in to Kargo
 # Logging In
 
 Whether you wish to interact with Kargo through its web-based UI or through
-it's [CLI](../../05-installing-the-cli/index.md), you will need to log in first.
+its [CLI](../../05-installing-the-cli/index.md), you will need to log in first.
 
 1. Obtain the address of your Kargo API server.
 


### PR DESCRIPTION
## Background
This pull request includes a small change to the `docs/docs/50-user-guide/20-how-to-guides/10-logging-in/index.md` file. The change corrects a grammatical error in the documentation.