### PR TITLE
feat:  improve step timeout accuracy

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -668,6 +668,7 @@ func calculateRequeueInterval(p *kargoapi.Promotion) time.Duration {
 	step := p.Spec.Steps[p.Status.CurrentStep]
 	runner := promotion.GetStepRunner(step.Uses)
 	timeout := ptr.To(time.Duration(0))
+	
 	if retryCfg, isRetryable := runner.(pkgPromotion.RetryableStepRunner); isRetryable {
 		timeout = retryCfg.DefaultTimeout()
 	}

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -666,8 +666,8 @@ func parseCreateActorAnnotation(promo *kargoapi.Promotion) string {
 func calculateRequeueInterval(p *kargoapi.Promotion) time.Duration {
 	var (
 		defaultRequeueInterval = 5 * time.Minute
-		apiStep                = p.Spec.Steps[p.Status.CurrentStep]
-		runner                 = promotion.GetStepRunner(apiStep.As)
+		step                   = p.Spec.Steps[p.Status.CurrentStep]
+		runner                 = promotion.GetStepRunner(step.As)
 		timeout                = ptr.To(time.Duration(0))
 	)
 

--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -668,8 +668,9 @@ func calculateRequeueInterval(p *kargoapi.Promotion) time.Duration {
 	step := p.Spec.Steps[p.Status.CurrentStep]
 	runner := promotion.GetStepRunner(step.Uses)
 	timeout := ptr.To(time.Duration(0))
-	
-	if retryCfg, isRetryable := runner.(pkgPromotion.RetryableStepRunner); isRetryable {
+
+	retryCfg, isRetryable := runner.(pkgPromotion.RetryableStepRunner)
+	if isRetryable {
 		timeout = retryCfg.DefaultTimeout()
 	}
 

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -551,7 +551,7 @@ func Test_calculateRequeueInterval(t *testing.T) {
 					Stage: "fake-stage",
 					Steps: []kargoapi.PromotionStep{
 						{
-							As: "slow-step",
+							Uses: "slow-step",
 							Retry: &kargoapi.PromotionStepRetry{
 								Timeout: &metav1.Duration{
 									// exceeds default threshold
@@ -599,7 +599,7 @@ func Test_calculateRequeueInterval(t *testing.T) {
 					Stage: "fake-stage",
 					Steps: []kargoapi.PromotionStep{
 						{
-							As: "fast-step",
+							Uses: "fast-step",
 							Retry: &kargoapi.PromotionStepRetry{
 								Timeout: &metav1.Duration{
 									// faster than default threshold

--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -531,6 +531,118 @@ func Test_parseCreateActorAnnotation(t *testing.T) {
 	}
 }
 
+func Test_calculateRequeueInterval(t *testing.T) {
+	defaultTimeout := 5 * time.Minute
+	for _, test := range []struct {
+		name       string
+		promo      *kargoapi.Promotion
+		setup      func(*testing.T)
+		assertions func(*testing.T, time.Duration)
+	}{
+		{
+			name: "should return default requeue interval",
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: now,
+					Name:              "fake-name",
+					Namespace:         "fake-namespace",
+				},
+				Spec: kargoapi.PromotionSpec{
+					Stage: "fake-stage",
+					Steps: []kargoapi.PromotionStep{
+						{
+							As: "slow-step",
+							Retry: &kargoapi.PromotionStepRetry{
+								Timeout: &metav1.Duration{
+									// exceeds default threshold
+									Duration: 10 * time.Minute,
+								},
+							},
+						},
+					},
+				},
+				Status: kargoapi.PromotionStatus{
+					Phase:       kargoapi.PromotionPhasePending,
+					CurrentStep: 0,
+					StepExecutionMetadata: []kargoapi.StepExecutionMetadata{
+						{StartedAt: &now},
+					},
+				},
+			},
+			setup: func(tt *testing.T) {
+				tt.Helper()
+				var (
+					// exceeds than the 5 minute default
+					stepRunnerTimeout = 10 * time.Minute
+					numRetries        = uint32(1)
+					runner            = promotion.NewMockRetryableStepRunner(
+						"slow-step",
+						&stepRunnerTimeout,
+						numRetries,
+					)
+				)
+				promotion.RegisterStepRunner(runner)
+			},
+			assertions: func(tt *testing.T, d time.Duration) {
+				require.Equal(tt, d, defaultTimeout)
+			},
+		},
+		{
+			name: "requeue interval should return requeue interval less than the default",
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: now,
+					Name:              "fake-name",
+					Namespace:         "fake-namespace",
+				},
+				Spec: kargoapi.PromotionSpec{
+					Stage: "fake-stage",
+					Steps: []kargoapi.PromotionStep{
+						{
+							As: "fast-step",
+							Retry: &kargoapi.PromotionStepRetry{
+								Timeout: &metav1.Duration{
+									// faster than default threshold
+									Duration: 3 * time.Minute,
+								},
+							},
+						},
+					},
+				},
+				Status: kargoapi.PromotionStatus{
+					Phase:       kargoapi.PromotionPhasePending,
+					CurrentStep: 0,
+					StepExecutionMetadata: []kargoapi.StepExecutionMetadata{
+						{StartedAt: &now},
+					},
+				},
+			},
+			setup: func(tt *testing.T) {
+				tt.Helper()
+				var (
+					// lower than the 5 minute default
+					stepRunnerTimeout = 3 * time.Minute
+					numRetries        = uint32(1)
+					runner            = promotion.NewMockRetryableStepRunner(
+						"fast-step",
+						&stepRunnerTimeout,
+						numRetries,
+					)
+				)
+				promotion.RegisterStepRunner(runner)
+			},
+			assertions: func(tt *testing.T, d time.Duration) {
+				require.Less(tt, d, defaultTimeout)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.setup(t)
+			test.assertions(t, calculateRequeueInterval(test.promo))
+		})
+	}
+}
+
 // nolint: unparam
 func newPromo(namespace, name, stage string,
 	phase kargoapi.PromotionPhase,

--- a/internal/promotion/mock_step_runner.go
+++ b/internal/promotion/mock_step_runner.go
@@ -2,6 +2,7 @@ package promotion
 
 import (
 	"context"
+	"time"
 
 	"github.com/akuity/kargo/pkg/promotion"
 )
@@ -36,4 +37,30 @@ func (m *mockStepRunner) Run(
 		return m.runFunc(ctx, stepCtx)
 	}
 	return m.runResult, m.runErr
+}
+
+type MockRetryableStepRunner struct {
+	*mockStepRunner
+	defaultTimeout        *time.Duration
+	defaultErrorThreshold uint32
+}
+
+func NewMockRetryableStepRunner(
+	name string,
+	defaultTimeout *time.Duration,
+	defaultErrThreshold uint32,
+) MockRetryableStepRunner {
+	return MockRetryableStepRunner{
+		mockStepRunner:        &mockStepRunner{name: name},
+		defaultTimeout:        defaultTimeout,
+		defaultErrorThreshold: defaultErrThreshold,
+	}
+}
+
+func (m MockRetryableStepRunner) DefaultTimeout() *time.Duration {
+	return m.defaultTimeout
+}
+
+func (m MockRetryableStepRunner) DefaultErrorThreshold() uint32 {
+	return m.defaultErrorThreshold
 }

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -17,20 +17,6 @@ import (
 	"github.com/akuity/kargo/pkg/promotion"
 )
 
-type mockRetryableStepRunner struct {
-	*mockStepRunner
-	defaultTimeout        *time.Duration
-	defaultErrorThreshold uint32
-}
-
-func (m mockRetryableStepRunner) DefaultTimeout() *time.Duration {
-	return m.defaultTimeout
-}
-
-func (m mockRetryableStepRunner) DefaultErrorThreshold() uint32 {
-	return m.defaultErrorThreshold
-}
-
 func TestStep_GetTimeout(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -70,7 +56,7 @@ func TestStep_GetTimeout(t *testing.T) {
 					},
 				},
 			},
-			runner: mockRetryableStepRunner{defaultTimeout: ptr.To(time.Duration(3))},
+			runner: MockRetryableStepRunner{defaultTimeout: ptr.To(time.Duration(3))},
 			assertions: func(t *testing.T, result *time.Duration) {
 				assert.Equal(t, ptr.To(time.Duration(5)), result)
 			},
@@ -80,7 +66,7 @@ func TestStep_GetTimeout(t *testing.T) {
 			step: &Step{
 				Retry: &kargoapi.PromotionStepRetry{},
 			},
-			runner: mockRetryableStepRunner{defaultTimeout: ptr.To(time.Duration(3))},
+			runner: MockRetryableStepRunner{defaultTimeout: ptr.To(time.Duration(3))},
 			assertions: func(t *testing.T, result *time.Duration) {
 				assert.Equal(t, ptr.To(time.Duration(3)), result)
 			},

--- a/internal/promotion/registry.go
+++ b/internal/promotion/registry.go
@@ -27,6 +27,6 @@ func RegisterStepRunner(runner promotion.StepRunner) {
 	stepRunnerReg.register(runner)
 }
 
-func GetStepRunner(step *Step) promotion.StepRunner {
-	return stepRunnerReg.getStepRunner(step.Alias)
+func GetStepRunner(name string) promotion.StepRunner {
+	return stepRunnerReg.getStepRunner(name)
 }

--- a/internal/promotion/registry.go
+++ b/internal/promotion/registry.go
@@ -27,6 +27,8 @@ func RegisterStepRunner(runner promotion.StepRunner) {
 	stepRunnerReg.register(runner)
 }
 
+// GetStepRunner returns a StepRunner from the package's internal registry. If
+// no StepRunner is registered with the given name, nil is returned instead.
 func GetStepRunner(name string) promotion.StepRunner {
 	return stepRunnerReg.getStepRunner(name)
 }

--- a/internal/promotion/registry.go
+++ b/internal/promotion/registry.go
@@ -1,6 +1,8 @@
 package promotion
 
-import "github.com/akuity/kargo/pkg/promotion"
+import (
+	"github.com/akuity/kargo/pkg/promotion"
+)
 
 // stepRunnerRegistry is a registry of StepRunners.
 type stepRunnerRegistry map[string]promotion.StepRunner
@@ -23,4 +25,8 @@ var stepRunnerReg = stepRunnerRegistry{}
 // RegisterStepRunner adds a StepRunner to the package's internal registry.
 func RegisterStepRunner(runner promotion.StepRunner) {
 	stepRunnerReg.register(runner)
+}
+
+func GetStepRunner(step *Step) promotion.StepRunner {
+	return stepRunnerReg.getStepRunner(step.Alias)
 }


### PR DESCRIPTION
Closes https://github.com/akuity/kargo/issues/3663

Previously we were hard-coding the requeue interval to 5 minutes.

This sets a lower requeue interval if the target timeout is before 5 minutes from now.
