### PR TITLE
fix(docs): correctly reference outputs

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
@@ -66,7 +66,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "A new PR has been opened: ${{ outputs['pr-link'].url }}"
+              "text": "A new PR has been opened: ${{ task.outputs['pr-link'].url }}"
             }
           }
         ]


### PR DESCRIPTION
Outputs from previous steps are available from `task` variable, see also [Expression Language](https://docs.kargo.io/user-guide/reference-docs/expressions)