### PR TITLE
fix(docs): Make compose-output example work

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
@@ -38,13 +38,7 @@ vars:
 - name: repoURL
   value: https://github.com/example/repo
 steps:
-steps:
-# Clone, prepare the contents of ./out, commit, etc...
-- uses: git-push
-  as: push
-  config:
-    path: ./out
-    generateTargetBranch: true
+# Clone, prepare the contents of ./out, commit, push as part of a `push` step etc...
 - uses: git-open-pr
   as: open-pr
   config:

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
@@ -38,17 +38,24 @@ vars:
 - name: repoURL
   value: https://github.com/example/repo
 steps:
+steps:
+# Clone, prepare the contents of ./out, commit, etc...
+- uses: git-push
+  as: push
+  config:
+    path: ./out
+    generateTargetBranch: true
 - uses: git-open-pr
   as: open-pr
   config:
     repoURL: ${{ vars.repoURL }}
     createTargetBranch: true
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ task.outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
 - uses: compose-output
   as: pr-link
   config:
-    url: ${{ vars.repoURL }}/pull/${{ outputs['open-pr'].prNumber }}
+    url: ${{ vars.repoURL }}/pull/${{ task.outputs['open-pr'].prNumber }}
 - uses: http
   config:
     method: POST
@@ -66,7 +73,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "A new PR has been opened: ${{ task.outputs['pr-link'].url }}"
+              "text": "A new PR has been opened: " + task.outputs['pr-link'].url
             }
           }
         ]


### PR DESCRIPTION
The example provided for `compose-output` contains multiple syntax errors

- As with #3862, outputs are wrongly referenced throughout.
- Nesting evaluation in a `quote()` is not supported, thus using string concatenation instead.