### PR TITLE
fix(chart): give controller cluster-wide configmap reads

### DIFF
--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -10,6 +10,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
This was meant to be included in #3865

cc @gdsoumya for the permissions change.