### PR TITLE
docs: explain `promote` verb and add RBAC examples

### DIFF
--- a/docs/docs/50-user-guide/50-security/20-access-controls/index.md
+++ b/docs/docs/50-user-guide/50-security/20-access-controls/index.md
@@ -268,6 +268,16 @@ With the exception of the claim-mapping annotations on `ServiceAccount`
 resources, these resources do not need to be labeled or annotated in any special
 way.
 
+##### `promote` Verb
+
+Kargo introduces custom verbs to extend Kubernetes'
+[standard RBAC verbs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#request-verb-resource) 
+(such as get, create, list) to support more granular authorization.
+
+One such verb is `promote`, which applies to the `stages` resource.
+Kargo uses this verb to determine whether a user or `ServiceAccount`
+is authorized to initiate a promotion into a specific Stage.
+
 ##### Example: Custom Promoter Role
 
 The following example demonstrates how to create a custom role named

--- a/docs/docs/50-user-guide/50-security/20-access-controls/index.md
+++ b/docs/docs/50-user-guide/50-security/20-access-controls/index.md
@@ -276,6 +276,7 @@ to `promote` into the `dev` and `staging` `Stages` in the `guestbook`
 `Project`.
 
 ```yaml
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -284,7 +285,6 @@ metadata:
   annotations:
     kargo.akuity.io/description: Permissions to promote into pre-prod Stages
     rbac.kargo.akuity.io/claim.groups: devops
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -310,7 +310,6 @@ rules:
   resourceNames:
   - dev
   - staging
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -325,7 +324,6 @@ subjects:
 - kind: ServiceAccount
   name: promoter
   namespace: guestbook
-
 ---
 # This RoleBinding allows the promoter ServiceAccount to view project
 # resources (without redefining read rules), by binding it to the
@@ -356,6 +354,7 @@ In the example below, users in the `devops` OIDC group are granted
 admin-level permissions within the `guestbook` `Project`:
 
 ```yaml
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -363,7 +362,6 @@ metadata:
   namespace: guestbook
   annotations:
     rbac.kargo.akuity.io/claim.groups: devops
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/docs/docs/50-user-guide/50-security/20-access-controls/index.md
+++ b/docs/docs/50-user-guide/50-security/20-access-controls/index.md
@@ -355,8 +355,8 @@ subjects:
 
 ##### Example: Declarative OIDC Claim Mapping to Built-in Roles
 
-To declaratively assign OIDC group claims to Kargo’s built-in roles,
-such as `kargo-admin` or `kargo-viewer`, you can create a `ServiceAccount`
+To declaratively assign OIDC claims to Kargo’s built-in roles, such
+as `kargo-admin` or `kargo-viewer`, you can create a `ServiceAccount`
 annotated with the appropriate claims, then bind it to the desired 
 role using a `RoleBinding`.
 


### PR DESCRIPTION
* Explains the existence and purpose of the `promote` verb
* Adds two examples for declarative RBAC:
1. How to create custom role that gives only promote privileges to a subset of Stages
2. How to declarative bind OIDC claims to built-in roles (e.g. `kargo-admin`) using a second ServiceAccount/RoleBinding