### PR TITLE
chore: deprecate gitRepoURL in API and UI

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -295,6 +295,8 @@ message DiscoveredImageReference {
   // GitRepoURL is the URL of the Git repository that contains the source
   // code for this image. This field is optional, and only populated if the
   // ImageSubscription specifies a GitRepoURL.
+  //
+  // Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
   optional string gitRepoURL = 3;
 
   // CreatedAt is the time the image was created. This field is optional, and
@@ -678,6 +680,8 @@ message Image {
   // GitRepoURL specifies the URL of a Git repository that contains the source
   // code for the image repository referenced by the RepoURL field if Kargo was
   // able to infer it.
+  //
+  // Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
   optional string gitRepoURL = 2;
 
   // Tag identifies a specific version of the image in the repository specified
@@ -728,6 +732,8 @@ message ImageSubscription {
   // the source code for the image repository referenced by the RepoURL field.
   // When this is specified, Kargo MAY be able to infer and link to the exact
   // revision of that source code that was used to build the image.
+  //
+  // Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
   //
   // +kubebuilder:validation:Optional
   // +kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -533,6 +533,8 @@ type Image struct {
 	// GitRepoURL specifies the URL of a Git repository that contains the source
 	// code for the image repository referenced by the RepoURL field if Kargo was
 	// able to infer it.
+	//
+	// Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
 	GitRepoURL string `json:"gitRepoURL,omitempty" protobuf:"bytes,2,opt,name=gitRepoURL"`
 	// Tag identifies a specific version of the image in the repository specified
 	// by RepoURL.

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -220,6 +220,8 @@ type ImageSubscription struct {
 	// When this is specified, Kargo MAY be able to infer and link to the exact
 	// revision of that source code that was used to build the image.
 	//
+	// Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
+	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`
 	GitRepoURL string `json:"gitRepoURL,omitempty" protobuf:"bytes,2,opt,name=gitRepoURL"`
@@ -473,6 +475,8 @@ type DiscoveredImageReference struct {
 	// GitRepoURL is the URL of the Git repository that contains the source
 	// code for this image. This field is optional, and only populated if the
 	// ImageSubscription specifies a GitRepoURL.
+	//
+	// Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
 	GitRepoURL string `json:"gitRepoURL,omitempty" protobuf:"bytes,3,opt,name=gitRepoURL"`
 	// CreatedAt is the time the image was created. This field is optional, and
 	// not populated for every ImageSelectionStrategy.

--- a/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
@@ -131,6 +131,7 @@ spec:
                     GitRepoURL specifies the URL of a Git repository that contains the source
                     code for the image repository referenced by the RepoURL field if Kargo was
                     able to infer it.
+                    Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                   type: string
                 repoURL:
                   description: RepoURL describes the repository in which the image

--- a/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_freights.yaml
@@ -131,6 +131,7 @@ spec:
                     GitRepoURL specifies the URL of a Git repository that contains the source
                     code for the image repository referenced by the RepoURL field if Kargo was
                     able to infer it.
+
                     Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                   type: string
                 repoURL:

--- a/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
@@ -348,6 +348,7 @@ spec:
                             GitRepoURL specifies the URL of a Git repository that contains the source
                             code for the image repository referenced by the RepoURL field if Kargo was
                             able to infer it.
+                            Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                           type: string
                         repoURL:
                           description: RepoURL describes the repository in which the
@@ -489,6 +490,7 @@ spec:
                                   GitRepoURL specifies the URL of a Git repository that contains the source
                                   code for the image repository referenced by the RepoURL field if Kargo was
                                   able to infer it.
+                                  Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                 type: string
                               repoURL:
                                 description: RepoURL describes the repository in which

--- a/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_promotions.yaml
@@ -348,6 +348,7 @@ spec:
                             GitRepoURL specifies the URL of a Git repository that contains the source
                             code for the image repository referenced by the RepoURL field if Kargo was
                             able to infer it.
+
                             Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                           type: string
                         repoURL:
@@ -490,6 +491,7 @@ spec:
                                   GitRepoURL specifies the URL of a Git repository that contains the source
                                   code for the image repository referenced by the RepoURL field if Kargo was
                                   able to infer it.
+
                                   Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                 type: string
                               repoURL:

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -589,6 +589,7 @@ spec:
                                 GitRepoURL specifies the URL of a Git repository that contains the source
                                 code for the image repository referenced by the RepoURL field if Kargo was
                                 able to infer it.
+                                Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                               type: string
                             repoURL:
                               description: RepoURL describes the repository in which
@@ -736,6 +737,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+                                    Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
                                   description: RepoURL describes the repository in
@@ -879,6 +881,7 @@ spec:
                                           GitRepoURL specifies the URL of a Git repository that contains the source
                                           code for the image repository referenced by the RepoURL field if Kargo was
                                           able to infer it.
+                                          Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                         type: string
                                       repoURL:
                                         description: RepoURL describes the repository
@@ -1183,6 +1186,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+                                    Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
                                   description: RepoURL describes the repository in
@@ -1430,6 +1434,7 @@ spec:
                                 GitRepoURL specifies the URL of a Git repository that contains the source
                                 code for the image repository referenced by the RepoURL field if Kargo was
                                 able to infer it.
+                                Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                               type: string
                             repoURL:
                               description: RepoURL describes the repository in which
@@ -1577,6 +1582,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+                                    Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
                                   description: RepoURL describes the repository in
@@ -1720,6 +1726,7 @@ spec:
                                           GitRepoURL specifies the URL of a Git repository that contains the source
                                           code for the image repository referenced by the RepoURL field if Kargo was
                                           able to infer it.
+                                          Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                         type: string
                                       repoURL:
                                         description: RepoURL describes the repository

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -589,6 +589,7 @@ spec:
                                 GitRepoURL specifies the URL of a Git repository that contains the source
                                 code for the image repository referenced by the RepoURL field if Kargo was
                                 able to infer it.
+
                                 Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                               type: string
                             repoURL:
@@ -737,6 +738,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+
                                     Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
@@ -881,6 +883,7 @@ spec:
                                           GitRepoURL specifies the URL of a Git repository that contains the source
                                           code for the image repository referenced by the RepoURL field if Kargo was
                                           able to infer it.
+
                                           Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                         type: string
                                       repoURL:
@@ -1186,6 +1189,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+
                                     Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
@@ -1434,6 +1438,7 @@ spec:
                                 GitRepoURL specifies the URL of a Git repository that contains the source
                                 code for the image repository referenced by the RepoURL field if Kargo was
                                 able to infer it.
+
                                 Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                               type: string
                             repoURL:
@@ -1582,6 +1587,7 @@ spec:
                                     GitRepoURL specifies the URL of a Git repository that contains the source
                                     code for the image repository referenced by the RepoURL field if Kargo was
                                     able to infer it.
+
                                     Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                   type: string
                                 repoURL:
@@ -1726,6 +1732,7 @@ spec:
                                           GitRepoURL specifies the URL of a Git repository that contains the source
                                           code for the image repository referenced by the RepoURL field if Kargo was
                                           able to infer it.
+
                                           Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                         type: string
                                       repoURL:

--- a/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
@@ -292,6 +292,7 @@ spec:
                             the source code for the image repository referenced by the RepoURL field.
                             When this is specified, Kargo MAY be able to infer and link to the exact
                             revision of that source code that was used to build the image.
+                            Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                           pattern: ^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
                           type: string
                         ignoreTags:
@@ -601,6 +602,7 @@ spec:
                                   GitRepoURL is the URL of the Git repository that contains the source
                                   code for this image. This field is optional, and only populated if the
                                   ImageSubscription specifies a GitRepoURL.
+                                  Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                 type: string
                               tag:
                                 description: Tag is the tag of the image.

--- a/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_warehouses.yaml
@@ -292,6 +292,7 @@ spec:
                             the source code for the image repository referenced by the RepoURL field.
                             When this is specified, Kargo MAY be able to infer and link to the exact
                             revision of that source code that was used to build the image.
+
                             Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                           pattern: ^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$
                           type: string
@@ -602,6 +603,7 @@ spec:
                                   GitRepoURL is the URL of the Git repository that contains the source
                                   code for this image. This field is optional, and only populated if the
                                   ImageSubscription specifies a GitRepoURL.
+
                                   Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
                                 type: string
                               tag:

--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -84,8 +84,9 @@ fields:
     encountering rate limits -- decreasing this limit may improve performance.
     :::
 
-- `gitRepoURL`: Optional metadata to inform Kargo of the Git repository that
-  contains the image's Dockerfile or other build context.
+- `gitRepoURL`: (Deprecated as of version 1.5, will be removed in version 1.7) 
+  Optional metadata to inform Kargo of the Git repository that contains the 
+  image's Dockerfile or other build context.
 
 - `insecureSkipTLSVerify`: Set to `true` to disable validation of the
   repository's TLS certificate.

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -380,7 +380,7 @@ The returned `Image` object has the following fields:
 | Field | Description |
 |-------|-------------|
 | `RepoURL` | The URL of the container image repository the image originates from. |
-| `GitRepoURL` | The URL of the Git repository which contains the source code for the image. Only present if Kargo was able to infer it from the URL. |
+| `GitRepoURL` | (Deprecated as of version 1.5, will be removed in version 1.7) The URL of the Git repository which contains the source code for the image. Only present if Kargo was able to infer it from the URL. |
 | `Tag` | The tag of the image. |
 | `Digest` | The digest of the image. |
 | `Annotations` | A map of [annotations](https://specs.opencontainers.org/image-spec/annotations/) discovered for the image. |

--- a/docs/old-docs/35-references/20-expression-language.md
+++ b/docs/old-docs/35-references/20-expression-language.md
@@ -262,7 +262,7 @@ first argument and returns a corresponding `Image` object from the `Promotion`'s
 | Field | Description |
 |-------|-------------|
 | `RepoURL` | The URL of the container image repository the image originates from. |
-| `GitRepoURL` | The URL of the Git repository which contains the source code for the image. Only present if Kargo was able to infer it from the URL. |
+| `GitRepoURL` | (Deprecated as of version 1.5, will be removed in version 1.7) The URL of the Git repository which contains the source code for the image. Only present if Kargo was able to infer it from the URL. |
 | `Tag` | The tag of the image. |
 | `Digest` | The digest of the image. |
 

--- a/internal/controller/warehouses/images.go
+++ b/internal/controller/warehouses/images.go
@@ -79,7 +79,6 @@ func (r *reconciler) discoverImages(
 				Tag:         img.Tag,
 				Digest:      img.Digest,
 				Annotations: img.Annotations,
-				GitRepoURL:  r.getImageSourceURL(sub.GitRepoURL, img.Tag),
 			}
 			if img.CreatedAt != nil {
 				discovery.CreatedAt = &metav1.Time{Time: *img.CreatedAt}

--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -462,7 +462,6 @@ func (r *reconciler) buildFreightFromLatestArtifacts(
 		latestImage := result.References[0]
 		freight.Images = append(freight.Images, kargoapi.Image{
 			RepoURL:     result.RepoURL,
-			GitRepoURL:  latestImage.GitRepoURL,
 			Tag:         latestImage.Tag,
 			Digest:      latestImage.Digest,
 			Annotations: latestImage.Annotations,

--- a/ui/src/features/assemble-freight/assemble-freight.tsx
+++ b/ui/src/features/assemble-freight/assemble-freight.tsx
@@ -60,6 +60,7 @@ const constructFreight = (
         repoURL: artifact.repoURL,
         tag: imageRef.tag,
         digest: imageRef.digest,
+        // Deprecated: Use OCI annotations instead. Will be removed in version 1.7.
         gitRepoURL: imageRef.gitRepoURL
       } as Image);
     } else if ('versions' in artifact) {

--- a/ui/src/features/assemble-freight/image-table.tsx
+++ b/ui/src/features/assemble-freight/image-table.tsx
@@ -37,6 +37,7 @@ export const ImageTable = ({
           title: 'Source Repo',
           render: (record: DiscoveredImageReference) =>
             record?.gitRepoURL ? (
+              // Deprecated: Use OCI annotations instead. Will be removed in version 1.7.
               <a href={record?.gitRepoURL} target='_blank' rel='noreferrer'>
                 {record?.gitRepoURL}
               </a>

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -671,6 +671,8 @@ export type DiscoveredImageReference = Message<"github.com.akuity.kargo.api.v1al
    * code for this image. This field is optional, and only populated if the
    * ImageSubscription specifies a GitRepoURL.
    *
+   * Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
+   *
    * @generated from field: optional string gitRepoURL = 3;
    */
   gitRepoURL: string;
@@ -1451,6 +1453,8 @@ export type Image = Message<"github.com.akuity.kargo.api.v1alpha1.Image"> & {
    * code for the image repository referenced by the RepoURL field if Kargo was
    * able to infer it.
    *
+   * Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
+   *
    * @generated from field: optional string gitRepoURL = 2;
    */
   gitRepoURL: string;
@@ -1554,6 +1558,8 @@ export type ImageSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.Im
    * the source code for the image repository referenced by the RepoURL field.
    * When this is specified, Kargo MAY be able to infer and link to the exact
    * revision of that source code that was used to build the image.
+   *
+   * Deprecated: Use OCI annotations instead. Will be removed in v1.7.0.
    *
    * +kubebuilder:validation:Optional
    * +kubebuilder:validation:Pattern=`^https?://(\w+([\.-]\w+)*@)?\w+([\.-]\w+)*(:[\d]+)?(/.*)?$`

--- a/ui/src/gen/schema/freights.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/freights.kargo.akuity.io_v1alpha1.json
@@ -87,7 +87,7 @@
             "type": "string"
           },
           "gitRepoURL": {
-            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
             "type": "string"
           },
           "repoURL": {

--- a/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/promotions.kargo.akuity.io_v1alpha1.json
@@ -254,7 +254,7 @@
                     "type": "string"
                   },
                   "gitRepoURL": {
-                    "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                    "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                     "type": "string"
                   },
                   "repoURL": {
@@ -386,7 +386,7 @@
                           "type": "string"
                         },
                         "gitRepoURL": {
-                          "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                          "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                           "type": "string"
                         },
                         "repoURL": {

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -476,7 +476,7 @@
                         "type": "string"
                       },
                       "gitRepoURL": {
-                        "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                        "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                         "type": "string"
                       },
                       "repoURL": {
@@ -619,7 +619,7 @@
                             "type": "string"
                           },
                           "gitRepoURL": {
-                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                             "type": "string"
                           },
                           "repoURL": {
@@ -751,7 +751,7 @@
                                   "type": "string"
                                 },
                                 "gitRepoURL": {
-                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                                   "type": "string"
                                 },
                                 "repoURL": {
@@ -1039,7 +1039,7 @@
                             "type": "string"
                           },
                           "gitRepoURL": {
-                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                             "type": "string"
                           },
                           "repoURL": {
@@ -1274,7 +1274,7 @@
                         "type": "string"
                       },
                       "gitRepoURL": {
-                        "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                        "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                         "type": "string"
                       },
                       "repoURL": {
@@ -1417,7 +1417,7 @@
                             "type": "string"
                           },
                           "gitRepoURL": {
-                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                            "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                             "type": "string"
                           },
                           "repoURL": {
@@ -1549,7 +1549,7 @@
                                   "type": "string"
                                 },
                                 "gitRepoURL": {
-                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.",
+                                  "description": "GitRepoURL specifies the URL of a Git repository that contains the source\ncode for the image repository referenced by the RepoURL field if Kargo was\nable to infer it.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                                   "type": "string"
                                 },
                                 "repoURL": {

--- a/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/warehouses.kargo.akuity.io_v1alpha1.json
@@ -167,7 +167,7 @@
                     "type": "integer"
                   },
                   "gitRepoURL": {
-                    "description": "GitRepoURL optionally specifies the URL of a Git repository that contains\nthe source code for the image repository referenced by the RepoURL field.\nWhen this is specified, Kargo MAY be able to infer and link to the exact\nrevision of that source code that was used to build the image.",
+                    "description": "GitRepoURL optionally specifies the URL of a Git repository that contains\nthe source code for the image repository referenced by the RepoURL field.\nWhen this is specified, Kargo MAY be able to infer and link to the exact\nrevision of that source code that was used to build the image.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                     "pattern": "^https?://(\\w+([\\.-]\\w+)*@)?\\w+([\\.-]\\w+)*(:[\\d]+)?(/.*)?$",
                     "type": "string"
                   },
@@ -428,7 +428,7 @@
                           "type": "string"
                         },
                         "gitRepoURL": {
-                          "description": "GitRepoURL is the URL of the Git repository that contains the source\ncode for this image. This field is optional, and only populated if the\nImageSubscription specifies a GitRepoURL.",
+                          "description": "GitRepoURL is the URL of the Git repository that contains the source\ncode for this image. This field is optional, and only populated if the\nImageSubscription specifies a GitRepoURL.\n\nDeprecated: Use OCI annotations instead. Will be removed in v1.7.0.",
                           "type": "string"
                         },
                         "tag": {


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/3850

This PR **only deprecates** `gitRepoURL` field.

I have [created this separate issue](https://github.com/akuity/kargo/issues/3901) for tracking the Removal of the same in `v1.7.0`