### PR TITLE
fix(controller): allow promo when health is unknown

### DIFF
--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -677,7 +677,7 @@ func (r *RegularStageReconciler) syncPromotions(
 		// or the verification failed, then we can allow the next Promotion to
 		// start immediately as the expectation is that the Promotion can fix the
 		// issue.
-		if stage.Status.Health == nil || stage.Status.Health.Status != kargoapi.HealthStateUnhealthy {
+		if stage.Status.Health == nil || stage.Status.Health.Status == kargoapi.HealthStateHealthy {
 			curVI := curFreight.VerificationHistory.Current()
 			if curVI == nil || !curVI.Phase.IsTerminal() {
 				logger.Debug("current Freight needs to be verified before allowing new promotions to start")


### PR DESCRIPTION
This fixes the issue reported in https://github.com/akuity/kargo/pull/3053#issuecomment-2823434333, which was introduced when we changed the health status from `HealthStateUnhealthy` to `HealthStateUnknown` for failed Promotions (in #3191).

The change created a deadlock in the Stage controller where stages with `Unknown` health (resulting from a failed Promotion) couldn't start a new Promotion due to the condition `stage.Status.Health == nil || stage.Status.Health.Status != kargoapi.HealthStateUnhealthy`.

By changing the latter bit to an explicit `stage.Status.Health.Status == kargoapi.HealthStateHealthy`, we only block a Promotion (and wait for verification to complete) in scenarios where we can still expect progress.

The rest of the controller logic maintains all other safety checks, including non-terminal verification state still blocking a new Promotion to ensure verification completes.