### PR TITLE
chore: remove deprecated `ProjectSecretLabelKey`

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -10,13 +10,6 @@ const (
 	CredentialTypeLabelValueImage = "image"
 	CredentialTypeLabelGeneric    = "generic"
 
-	// Project Secrets
-	// Deprecated: Use CredentialTypeLabelGeneric instead. This label should not
-	// be used and won't be documented, but will be supported short-term for
-	// backward compatibility.
-	// TODO(krancour): Remove for v1.4.0.
-	ProjectSecretLabelKey = "kargo.akuity.io/project-secret" // nolint: gosec
-
 	// Kargo core API
 	FreightCollectionLabelKey = "kargo.akuity.io/freight-collection"
 	ProjectLabelKey           = "kargo.akuity.io/project"

--- a/internal/promotion/simple_engine.go
+++ b/internal/promotion/simple_engine.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -414,34 +413,14 @@ func (e *simpleEngine) getProjectSecrets(
 		&secretList,
 		client.InNamespace(project),
 		client.MatchingLabels{
-			// Newer label
 			kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("error listing Secrets for Project %q: %w", project, err)
 	}
-	secrets := secretList.Items
-	if err := e.kargoClient.List(
-		ctx,
-		&secretList,
-		client.InNamespace(project),
-		client.MatchingLabels{
-			// Legacy label
-			kargoapi.ProjectSecretLabelKey: kargoapi.LabelTrueValue,
-		},
-	); err != nil {
-		return nil, fmt.Errorf("error listing Secrets for Project %q: %w", project, err)
-	}
-	secrets = append(secrets, secretList.Items...)
-	// Sort and de-dupe
-	slices.SortFunc(secrets, func(lhs, rhs corev1.Secret) int {
-		return strings.Compare(lhs.Name, rhs.Name)
-	})
-	secrets = slices.CompactFunc(secrets, func(lhs, rhs corev1.Secret) bool {
-		return lhs.Name == rhs.Name
-	})
-	secretsMap := make(map[string]map[string]string, len(secrets))
-	for _, secret := range secrets {
+
+	secretsMap := make(map[string]map[string]string, len(secretList.Items))
+	for _, secret := range secretList.Items {
 		secretsMap[secret.Name] = make(map[string]string, len(secret.Data))
 		for key, value := range secret.Data {
 			secretsMap[secret.Name][key] = string(value)

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -764,7 +764,7 @@ func TestSimpleEngine_getProjectSecrets(t *testing.T) {
 					},
 					Data: testData,
 				},
-				&corev1.Secret{ // Labeled with new label; should be included
+				&corev1.Secret{ // Labeled; should be included
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-secret-b",
 						Namespace: "test-project",
@@ -774,37 +774,12 @@ func TestSimpleEngine_getProjectSecrets(t *testing.T) {
 					},
 					Data: testData,
 				},
-				&corev1.Secret{ // Labeled with legacy label; should be included
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-secret-c",
-						Namespace: "test-project",
-						Labels: map[string]string{
-							kargoapi.ProjectSecretLabelKey: kargoapi.LabelTrueValue,
-						},
-					},
-					Data: testData,
-				},
-				&corev1.Secret{ // Labeled both ways; should be included ONCE
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-secret-d",
-						Namespace: "test-project",
-						Labels: map[string]string{
-							kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
-							kargoapi.ProjectSecretLabelKey:  kargoapi.LabelTrueValue,
-						},
-					},
-					Data: testData,
-				},
 			},
 			assertions: func(t *testing.T, secrets map[string]map[string]string, err error) {
 				assert.NoError(t, err)
-				require.Len(t, secrets, 3)
+				require.Len(t, secrets, 1)
 				assert.Equal(t, "value1", secrets["test-secret-b"]["key1"])
 				assert.Equal(t, "value2", secrets["test-secret-b"]["key2"])
-				assert.Equal(t, "value1", secrets["test-secret-c"]["key1"])
-				assert.Equal(t, "value2", secrets["test-secret-c"]["key2"])
-				assert.Equal(t, "value1", secrets["test-secret-d"]["key1"])
-				assert.Equal(t, "value2", secrets["test-secret-d"]["key2"])
 			},
 		},
 		{

--- a/internal/server/delete_project_secret_v1alpha1.go
+++ b/internal/server/delete_project_secret_v1alpha1.go
@@ -46,10 +46,9 @@ func (s *server) DeleteProjectSecret(
 	); err != nil {
 		return nil, fmt.Errorf("get secret: %w", err)
 	}
-	// Check for either of the two possible labels (newer and legacy) that
-	// indicate the secret is a generic project secret.
-	if secret.Labels[kargoapi.CredentialTypeLabelKey] != kargoapi.CredentialTypeLabelGeneric &&
-		secret.Labels[kargoapi.ProjectSecretLabelKey] != kargoapi.LabelTrueValue { // Legacy
+
+	// Check for the label that indicates this is a generic secret.
+	if secret.Labels[kargoapi.CredentialTypeLabelKey] != kargoapi.CredentialTypeLabelGeneric {
 		return nil, connect.NewError(
 			connect.CodeNotFound,
 			fmt.Errorf(

--- a/internal/server/list_project_secrets_v1alpha1_test.go
+++ b/internal/server/list_project_secrets_v1alpha1_test.go
@@ -53,27 +53,6 @@ func TestListProjectSecrets(t *testing.T) {
 							},
 							Data: testData,
 						},
-						&corev1.Secret{ // Labeled with the legacy project secret label; should be in the list
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "kargo-demo",
-								Name:      "secret-c",
-								Labels: map[string]string{
-									kargoapi.ProjectSecretLabelKey: kargoapi.LabelTrueValue,
-								},
-							},
-							Data: testData,
-						},
-						&corev1.Secret{ // Labeled both ways; should be in the list ONCE
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "kargo-demo",
-								Name:      "secret-d",
-								Labels: map[string]string{
-									kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
-									kargoapi.ProjectSecretLabelKey:  kargoapi.LabelTrueValue,
-								},
-							},
-							Data: testData,
-						},
 					).
 					Build(), nil
 			},
@@ -94,10 +73,8 @@ func TestListProjectSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	secrets := resp.Msg.GetSecrets()
-	require.Len(t, secrets, 3)
+	require.Len(t, secrets, 1)
 	require.Equal(t, "secret-b", secrets[0].Name)
-	require.Equal(t, "secret-c", secrets[1].Name)
-	require.Equal(t, "secret-d", secrets[2].Name)
 	for _, secret := range secrets {
 		require.Equal(t, redacted, secret.StringData["PROJECT_SECRET"])
 	}

--- a/internal/server/update_project_secret_v1alpha1_test.go
+++ b/internal/server/update_project_secret_v1alpha1_test.go
@@ -39,7 +39,7 @@ func TestUpdateProjectSecret(t *testing.T) {
 								Namespace: "kargo-demo",
 								Name:      "secret",
 								Labels: map[string]string{
-									kargoapi.ProjectSecretLabelKey: kargoapi.LabelTrueValue,
+									kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
 								},
 							},
 							StringData: map[string]string{
@@ -67,7 +67,6 @@ func TestUpdateProjectSecret(t *testing.T) {
 			"TOKEN_1": "bar",
 		},
 	}))
-
 	require.NoError(t, err)
 
 	secret := corev1.Secret{}
@@ -90,9 +89,6 @@ func TestApplyProjectSecretUpdateToK8sSecret(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "kargo-demo",
 			Name:      "secret",
-			Labels: map[string]string{
-				kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
-			},
 		},
 		Data: map[string][]byte{
 			"TOKEN_1": []byte("foo"),
@@ -140,18 +136,5 @@ func TestApplyProjectSecretUpdateToK8sSecret(t *testing.T) {
 			},
 		})
 		require.Equal(t, expectedSecret, secret)
-	})
-
-	t.Run("legacy project secret label gets converted", func(t *testing.T) {
-		expectedSecret := baseSecret.DeepCopy()
-		expectedSecret.Labels = map[string]string{
-			kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
-		}
-		secret := baseSecret.DeepCopy()
-		secret.Labels = map[string]string{
-			kargoapi.ProjectSecretLabelKey: kargoapi.LabelTrueValue,
-		}
-		applyProjectSecretUpdateToK8sSecret(secret, projectSecret{data: nil})
-		require.Equal(t, expectedSecret.Labels, secret.Labels)
 	})
 }


### PR DESCRIPTION
This was already scheduled for `v1.4.0`.