### PR TITLE
chore: remove deprecated `messageFromSteps` field

### DIFF
--- a/docs/docs/20-quickstart/index.md
+++ b/docs/docs/20-quickstart/index.md
@@ -336,7 +336,7 @@ the previous section.
         config:
           path: ./out
       - uses: kustomize-set-image
-        as: update-image
+        as: update
         config:
           path: ./src/base
           images:
@@ -350,8 +350,7 @@ the previous section.
         as: commit
         config:
           path: ./out
-          messageFromSteps:
-          - update-image
+          message: \${{ outputs.update.commitMessage }}
       - uses: git-push
         config:
           path: ./out
@@ -505,7 +504,7 @@ the previous section.
         config:
           path: ./out
       - uses: kustomize-set-image
-        as: update-image
+        as: update
         config:
           path: ./src/base
           images:
@@ -519,8 +518,7 @@ the previous section.
         as: commit
         config:
           path: ./out
-          messageFromSteps:
-          - update-image
+          message: \${{ outputs.update.commitMessage }}
       - uses: git-push
         config:
           path: ./out

--- a/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
@@ -234,8 +234,7 @@ promotionTemplate:
       as: commit
       config:
         path: ${{ vars.outPath }}
-        messageFromSteps:
-        - update-image
+        message: ${{ outputs['update-image'].commitMessage }}
     - uses: git-push
       config:
         path: ${{ vars.outPath }}

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -106,8 +106,7 @@ steps:
   as: commit
   config:
     path: ./out
-    messageFromSteps:
-    - update-image
+    message: ${{ outputs['update-image'].commitMessage }}
 - uses: git-push
   config:
     path: ./out

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -14,8 +14,7 @@ desired state and is commonly followed by a [`git-push` step](git-push.md).
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing changes to be committed. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
-| `message` | `string` | N | The commit message. Mutually exclusive with `messageFromSteps`. |
-| `messageFromSteps` | `[]string` | N | References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.<br/><br/>__Deprecated: Use `message` with an expression instead. Will be removed in v1.5.0.__ |
+| `message` | `string` | Y | The commit message. |
 | `author` | `[]object` | N | Optionally provider authorship information for the commit. |
 | `author.name` | `string` | N | The committer's name. |
 | `author.email` | `string` | N | The committer's email address. |

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -208,8 +208,7 @@ promotionTemplate:
       as: commit
       config:
         path: ${{ vars.outPath }}
-        messageFromSteps:
-        - update-image
+        message: ${{ outputs['update-image'].commitMessage }}
     - uses: git-push
       config:
         path: ${{ vars.outPath }}

--- a/docs/old-docs/20-quickstart.md
+++ b/docs/old-docs/20-quickstart.md
@@ -347,7 +347,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -361,8 +361,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}
@@ -412,7 +411,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -426,8 +425,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}
@@ -477,7 +475,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -491,8 +489,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}
@@ -618,7 +615,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -632,8 +629,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}
@@ -683,7 +679,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -697,8 +693,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}
@@ -748,7 +743,7 @@ the previous section.
             config:
               path: \${{ vars.outPath }}
           - uses: kustomize-set-image
-            as: update-image
+            as: update
             config:
               path: \${{ vars.srcPath }}/base
               images:
@@ -762,8 +757,7 @@ the previous section.
             as: commit
             config:
               path: \${{ vars.outPath }}
-              messageFromSteps:
-              - update-image
+              message: \${{ outputs.update.commitMessage }}
           - uses: git-push
             config:
               path: \${{ vars.outPath }}

--- a/docs/old-docs/30-how-to-guides/14-working-with-stages.md
+++ b/docs/old-docs/30-how-to-guides/14-working-with-stages.md
@@ -202,8 +202,7 @@ promotionTemplate:
       as: commit
       config:
         path: ${{ vars.outPath }}
-        messageFromSteps:
-        - update-image
+        message: ${{ outputs['update-image'].commitMessage }}
     - uses: git-push
       config:
         path: ${{ vars.outPath }}

--- a/docs/old-docs/35-references/10-promotion-steps.md
+++ b/docs/old-docs/35-references/10-promotion-steps.md
@@ -953,8 +953,7 @@ desired state and is commonly followed by a [`git-push`](#git-push) step.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing changes to be committed. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
-| `message` | `string` | N | The commit message. Mutually exclusive with `messageFromSteps`. |
-| `messageFromSteps` | `[]string` | N | References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`. |
+| `message` | `string` | Y | The commit message. |
 | `author` | `[]object` | N | Optionally provider authorship information for the commit. |
 | `author.name` | `string` | N | The committer's name. |
 | `author.email` | `string` | N | The committer's email address. |
@@ -990,8 +989,7 @@ steps:
 - uses: git-commit
   config:
     path: ./out
-    messageFromSteps:
-    - update-image
+    message: ${{ outputs['update-image'].commitMessage }}
 # Push, etc...
 ```
 
@@ -1257,8 +1255,7 @@ steps:
   as: commit
   config:
     path: ./out
-    messageFromSteps:
-    - update-image
+    message: ${{ outputs['update-image'].commitMessage }}
 - uses: git-push
   config:
     path: ./out

--- a/docs/old-docs/35-references/20-expression-language.md
+++ b/docs/old-docs/35-references/20-expression-language.md
@@ -162,8 +162,7 @@ promotionTemplate:
       as: commit
       config:
         path: ${{ vars.outPath }}
-        messageFromSteps:
-        - update-image
+        message: ${{ outputs['update-image'].commitMessage }}
     - uses: git-push
       config:
         path: ${{ vars.outPath }}

--- a/internal/promotion/runner/builtin/schemas/git-commit-config.json
+++ b/internal/promotion/runner/builtin/schemas/git-commit-config.json
@@ -3,7 +3,7 @@
   "title": "GitCommitConfig",
   "type": "object",
   "additionalProperties": false,
-  "required": ["path"],
+  "required": ["path", "message"],
   "properties": {
     "author": {
       "type": "object",
@@ -30,37 +30,13 @@
     },
     "message": {
       "type": "string",
-      "description": "The commit message. Mutually exclusive with 'messageFromSteps'.",
+      "description": "The commit message.",
       "minLength": 1
-    },
-    "messageFromSteps": {
-      "type": "array",
-      "deprecated": true,
-      "description": "References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.\n\nDeprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.",
-      "minItems": 1,
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
     },
     "path": {
       "type": "string",
       "description": "The path to a working directory of a local repository.",
       "minLength": 1
     }
-  },
-  "oneOf": [
-    {
-      "required": ["message"],
-      "properties": {
-        "messageFromSteps": { "enum": [null] }
-      }
-    },
-    {
-      "required": ["messageFromSteps"],
-      "properties": {
-        "message": { "enum": [null] }
-      }
-    }
-  ]
+  }
 }

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -134,14 +134,8 @@ type Checkout struct {
 type GitCommitConfig struct {
 	// The author of the commit.
 	Author *Author `json:"author,omitempty"`
-	// The commit message. Mutually exclusive with 'messageFromSteps'.
-	Message string `json:"message,omitempty"`
-	// References the `commitMessage` output of previous steps. When one or more are specified,
-	// the commit message will be constructed by concatenating the messages from individual
-	// steps. Mutually exclusive with `message`.
-	//
-	// Deprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.
-	MessageFromSteps []string `json:"messageFromSteps,omitempty"`
+	// The commit message.
+	Message string `json:"message"`
 	// The path to a working directory of a local repository.
 	Path string `json:"path"`
 }

--- a/ui/src/gen/directives/git-commit-config.json
+++ b/ui/src/gen/directives/git-commit-config.json
@@ -21,17 +21,8 @@
   },
   "message": {
    "type": "string",
-   "description": "The commit message. Mutually exclusive with 'messageFromSteps'.",
+   "description": "The commit message.",
    "minLength": 1
-  },
-  "messageFromSteps": {
-   "type": "array",
-   "deprecated": true,
-   "description": "References the `commitMessage` output of previous steps. When one or more are specified, the commit message will be constructed by concatenating the messages from individual steps. Mutually exclusive with `message`.\n\nDeprecated: Use 'message' with an expression instead. Will be removed in v1.5.0.",
-   "items": {
-    "type": "string",
-    "minLength": 1
-   }
   },
   "path": {
    "type": "string",


### PR DESCRIPTION
Scheduled for removal in `v1.5.0`: https://docs.kargo.io/release-notes/deprecations#deprecations