### PR TITLE
feat: allow gpg key override at commit-time

### DIFF
--- a/internal/controller/git/bare_repo.go
+++ b/internal/controller/git/bare_repo.go
@@ -104,7 +104,7 @@ func CloneBare(
 			url:     repoURL,
 		},
 	}
-	if err = b.setupClient(clientOpts); err != nil {
+	if err = b.setupClient(homeDir, clientOpts); err != nil {
 		return nil, err
 	}
 	if err = b.clone(); err != nil {
@@ -146,7 +146,7 @@ func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
-	if err := b.setupAuth(); err != nil {
+	if err := b.setupAuth(b.homeDir); err != nil {
 		return nil, fmt.Errorf("error configuring the credentials: %w", err)
 	}
 	return b, nil

--- a/internal/controller/git/bare_repo_test.go
+++ b/internal/controller/git/bare_repo_test.go
@@ -58,7 +58,7 @@ func TestBareRepo(t *testing.T) {
 	defer setupRep.Close()
 	err = os.WriteFile(fmt.Sprintf("%s/%s", setupRep.Dir(), "test.txt"), []byte("foo"), 0600)
 	require.NoError(t, err)
-	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()))
+	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()), nil)
 	require.NoError(t, err)
 	err = setupRep.Push(nil)
 	require.NoError(t, err)

--- a/internal/controller/git/repo.go
+++ b/internal/controller/git/repo.go
@@ -97,7 +97,7 @@ func Clone(
 			baseRepo: baseRepo,
 		},
 	}
-	if err = r.setupClient(clientOpts); err != nil {
+	if err = r.setupClient(homeDir, clientOpts); err != nil {
 		return nil, err
 	}
 	if err = r.clone(cloneOpts); err != nil {
@@ -157,7 +157,7 @@ func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
-	if err := r.setupAuth(); err != nil {
+	if err := r.setupAuth(r.homeDir); err != nil {
 		return nil, fmt.Errorf("error configuring the credentials: %w", err)
 	}
 	return r, nil

--- a/internal/controller/git/repo_test.go
+++ b/internal/controller/git/repo_test.go
@@ -104,7 +104,7 @@ func TestRepo(t *testing.T) {
 	})
 
 	testCommitMessage := fmt.Sprintf("test commit %s", uuid.NewString())
-	err = rep.AddAllAndCommit(testCommitMessage)
+	err = rep.AddAllAndCommit(testCommitMessage, nil)
 	require.NoError(t, err)
 
 	t.Run("can commit", func(t *testing.T) {

--- a/internal/controller/git/work_tree_test.go
+++ b/internal/controller/git/work_tree_test.go
@@ -56,7 +56,7 @@ func TestWorkTree(t *testing.T) {
 	defer setupRep.Close()
 	err = os.WriteFile(fmt.Sprintf("%s/%s", setupRep.Dir(), "test.txt"), []byte("foo"), 0600)
 	require.NoError(t, err)
-	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()))
+	err = setupRep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()), nil)
 	require.NoError(t, err)
 	err = setupRep.Push(nil)
 	require.NoError(t, err)

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -215,7 +215,7 @@ func Test_gitCloner_run(t *testing.T) {
 	defer repo.Close()
 	err = os.WriteFile(filepath.Join(repo.Dir(), "test.txt"), []byte("foo"), 0600)
 	require.NoError(t, err)
-	err = repo.AddAllAndCommit("Initial commit")
+	err = repo.AddAllAndCommit("Initial commit", nil)
 	require.NoError(t, err)
 	err = repo.Push(nil)
 	require.NoError(t, err)

--- a/internal/promotion/runner/builtin/git_commiter_test.go
+++ b/internal/promotion/runner/builtin/git_commiter_test.go
@@ -24,7 +24,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 		expectedProblems []string
 	}{
 		{
-			name:   "path not specified",
+			name: "path not specified",
 			config: promotion.Config{
 				"message": "fake commit message",
 			},
@@ -42,7 +42,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 			},
 		},
 		{
-			name:   "message is not specified",
+			name: "message is not specified",
 			config: promotion.Config{
 				"path": "/tmp/foo",
 			},

--- a/internal/promotion/runner/builtin/git_pusher_test.go
+++ b/internal/promotion/runner/builtin/git_pusher_test.go
@@ -197,7 +197,7 @@ func Test_gitPusher_run(t *testing.T) {
 
 	// Commit the changes similarly to how gitCommitter would
 	// have. It will be gitPushStepRunner's job to push this commit.
-	err = workTree.AddAllAndCommit("Initial commit")
+	err = workTree.AddAllAndCommit("Initial commit", nil)
 	require.NoError(t, err)
 
 	// Now we can proceed to test gitPusher...


### PR DESCRIPTION
Related to #3813 / #3922

This updates our internal `git` package such that any signing key included in optional author information passed to a repo's `Commit()` method will actually be used / override any signing key specified at clone-time, or if applicable, override the system-level signing key.

Prior to this PR, we already allowed for override of author name and email at commit-time. This PR just extends the behavior to signing keys. It's essentially an oversight that it didn't already do this.

The way this works now is pretty simple.

Prior to this PR, a helper method called `setupAuthor()` was run just prior to cloning a repo and that helper "globally" configured git with name, email, and signing key -- "global" in quotes because all commands are run with the `HOME` env var set to a repo-specific virtual home dir.

This PR updates that helper method so that a path to a _different_ virtual home dir can specified when it's called. If optional author information is included in commit options, a new, temporary, virtual home dir is created and the `setupAuthor()` helper method is re-run, referencing the temporary home dir. The same dir is used as the value of the `HOME` env var when executing the `git commit` command.

Note that unit tests are _not_ exercising this feature because `gpg --import` is likely to encounter issues in Mac OS or Windows that it does not encounter inside the Kargo controller's container, however, with slight modifications to the tests to utilize this feature, I have validated its effects when executed within a container.