### PR TITLE
fix compose-out example

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/compose-output.md
@@ -67,7 +67,7 @@ steps:
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "A new PR has been opened: " + task.outputs['pr-link'].url
+              "text": "A new PR has been opened: " + outputs['pr-link'].url
             }
           }
         ]


### PR DESCRIPTION
The current example of referencing the output of `compose-output` in a `http` step's for Slack message will fail with a "cannot fetch output" error. However, dropping the `task` works. (ie. `outputs['pr-link'].url`) 