### PR TITLE
docs(oidc-setup): fix wrong example (viewer→viewerS)

### DIFF
--- a/docs/docs/40-operator-guide/40-security/20-openid-connect.md
+++ b/docs/docs/40-operator-guide/40-security/20-openid-connect.md
@@ -151,7 +151,7 @@ When installing Kargo with Helm, all options related to OIDC are grouped under
           claims:
             groups:
             - devops
-        viewer:
+        viewers:
           claims:
             groups:
             - developers


### PR DESCRIPTION
The doc mentions `api.oidc.viewers` everywhere, but the example snippet uses `api.oidc.viewers` (note the missing S).

The expected key being `viewers` is confirmed by the Helm Chart parameters doc: https://github.com/akuity/kargo/blob/f001566652b001b9c2fec628d2df130e145a5ddb/charts/kargo/README.md?plain=1#L116