### PR TITLE
chore: pipeline view updates

### DIFF
--- a/ui/src/features/project/pipelines/freight/filter-timerange-utils.ts
+++ b/ui/src/features/project/pipelines/freight/filter-timerange-utils.ts
@@ -59,7 +59,6 @@ export const timerangeToLabel = (timerange: timerangeTypes) => {
 };
 
 export const timerangeOrderedOptions: timerangeTypes[] = [
-  '1-minute',
   '15-minutes',
   '30-minutes',
   '1-hour',

--- a/ui/src/features/project/pipelines/freight/freight-card.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-card.tsx
@@ -165,7 +165,8 @@ export const FreightCard = (props: FreightCardProps) => {
       </div>
 
       <div className='flex mx-auto w-full gap-2 items-center justify-center text-nowrap my-1'>
-        {noOfGitCommits + noOfHelmReleases + noOfContainerImages > 0 && (
+        {(noOfGitCommits ? 1 : 0) + (noOfHelmReleases ? 1 : 0) + (noOfContainerImages ? 1 : 0) >
+          2 && (
           <>
             <FreightCard.ArtifactCount icon={faGithub} count={noOfGitCommits} />
 

--- a/ui/src/features/project/pipelines/graph-filters.tsx
+++ b/ui/src/features/project/pipelines/graph-filters.tsx
@@ -45,19 +45,18 @@ export const GraphFilters = (props: GraphFiltersProps) => {
         }
       />
 
-      {stackedNodesParents.length > 0 && (
-        <Button
-          className='ml-3'
-          title='Group stages'
-          icon={<FontAwesomeIcon icon={faObjectGroup} />}
-          onClick={() => {
-            filterContext?.setPreferredFilter({
-              ...filterContext?.preferredFilter,
-              stackedNodesParents
-            });
-          }}
-        />
-      )}
+      <Button
+        className='ml-3'
+        title='Group stages'
+        icon={<FontAwesomeIcon icon={faObjectGroup} />}
+        onClick={() => {
+          filterContext?.setPreferredFilter({
+            ...filterContext?.preferredFilter,
+            stackedNodesParents
+          });
+        }}
+        disabled={stackedNodesParents.length < 1}
+      />
     </Card>
   );
 };

--- a/ui/src/features/project/pipelines/graph-filters.tsx
+++ b/ui/src/features/project/pipelines/graph-filters.tsx
@@ -1,6 +1,7 @@
 import { faObjectGroup } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Card, Select, Typography } from 'antd';
+import { useMemo } from 'react';
 
 import { Stage, Warehouse } from '@ui/gen/api/v1alpha1/generated_pb';
 
@@ -14,6 +15,11 @@ type GraphFiltersProps = {
 
 export const GraphFilters = (props: GraphFiltersProps) => {
   const filterContext = useFreightTimelineControllerContext();
+
+  const stackedNodesParents = useMemo(
+    () => groupNodes(props.stages, props.warehouses).filter(Boolean),
+    [props.stages, props.warehouses]
+  );
 
   return (
     <Card size='small'>
@@ -39,17 +45,19 @@ export const GraphFilters = (props: GraphFiltersProps) => {
         }
       />
 
-      <Button
-        className='ml-3'
-        title='Group stages'
-        icon={<FontAwesomeIcon icon={faObjectGroup} />}
-        onClick={() => {
-          filterContext?.setPreferredFilter({
-            ...filterContext?.preferredFilter,
-            stackedNodesParents: groupNodes(props.stages, props.warehouses)
-          });
-        }}
-      />
+      {stackedNodesParents.length > 0 && (
+        <Button
+          className='ml-3'
+          title='Group stages'
+          icon={<FontAwesomeIcon icon={faObjectGroup} />}
+          onClick={() => {
+            filterContext?.setPreferredFilter({
+              ...filterContext?.preferredFilter,
+              stackedNodesParents
+            });
+          }}
+        />
+      )}
     </Card>
   );
 };

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -1,14 +1,12 @@
 import { useMutation } from '@connectrpc/connect-query';
 import {
-  faBullseye,
-  faEllipsis,
+  faArrowUpRightFromSquare,
   faExternalLink,
-  faInfo,
   faMinus,
   faTruckArrowRight
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Card, Dropdown, Flex, message, Typography } from 'antd';
+import { Button, Card, Dropdown, Flex, message, Space, Typography } from 'antd';
 import { ItemType } from 'antd/es/menu/interface';
 import classNames from 'classnames';
 import { formatDistance } from 'date-fns';
@@ -68,14 +66,6 @@ export const StageNode = (props: { stage: Stage }) => {
     }
   });
 
-  const onStageDetails = () =>
-    navigate(
-      generatePath(paths.stage, {
-        name: props.stage?.metadata?.namespace,
-        stageName: props.stage?.metadata?.name
-      })
-    );
-
   let descriptionItems: ReactNode;
 
   if (!controlFlow) {
@@ -103,7 +93,6 @@ export const StageNode = (props: { stage: Stage }) => {
             name: props.stage?.metadata?.namespace,
             promotionId: props.stage?.status?.currentPromotion?.name || ''
           })}
-          onClick={(e) => e.stopPropagation()}
         >
           {Phase}
         </Link>
@@ -130,7 +119,6 @@ export const StageNode = (props: { stage: Stage }) => {
               name: props.stage?.metadata?.namespace,
               promotionId: props.stage?.status?.lastPromotion?.name
             })}
-            onClick={(e) => e.stopPropagation()}
           >
             <Flex gap={4} align='center'>
               <span>Last Promotion: </span>
@@ -150,12 +138,7 @@ export const StageNode = (props: { stage: Stage }) => {
   if (!controlFlow) {
     dropdownItems.push({
       key: 'promote',
-      label: (
-        <Flex align='center' gap={12}>
-          <FontAwesomeIcon icon={faBullseye} />
-          Promote
-        </Flex>
-      ),
+      label: 'Promote',
       onClick: () => actionContext?.actPromote(IAction.PROMOTE, props.stage)
     });
   }
@@ -163,26 +146,10 @@ export const StageNode = (props: { stage: Stage }) => {
   if (controlFlow || totalSubscribersToThisStage > 1) {
     dropdownItems.push({
       key: 'promote-downstream',
-      label: (
-        <Flex align='center' gap={12}>
-          <FontAwesomeIcon icon={faTruckArrowRight} />
-          Promote to downstream
-        </Flex>
-      ),
+      label: 'Promote to downstream',
       onClick: () => actionContext?.actPromote(IAction.PROMOTE_DOWNSTREAM, props.stage)
     });
   }
-
-  dropdownItems.push({
-    key: 'stage-details',
-    label: (
-      <Flex align='center' gap={12}>
-        <FontAwesomeIcon icon={faInfo} />
-        Details
-      </Flex>
-    ),
-    onClick: onStageDetails
-  });
 
   return (
     <Card
@@ -198,28 +165,36 @@ export const StageNode = (props: { stage: Stage }) => {
           {autoPromotionMode && (
             <span className='text-[9px] lowercase font-normal mr-1'>Auto Promotion</span>
           )}
-          <Dropdown
-            trigger={['click']}
-            overlayClassName='w-[250px]'
-            menu={{
-              items: dropdownItems
-            }}
-          >
+          <Space>
+            <Dropdown
+              trigger={['click']}
+              overlayClassName='w-[220px]'
+              menu={{
+                items: dropdownItems
+              }}
+            >
+              <Button size='small' icon={<FontAwesomeIcon icon={faTruckArrowRight} size='sm' />} />
+            </Dropdown>
             <Button
+              icon={<FontAwesomeIcon icon={faArrowUpRightFromSquare} />}
               size='small'
-              className='text-xs'
-              icon={<FontAwesomeIcon icon={faEllipsis} />}
-              onClick={(e) => e.stopPropagation()}
+              onClick={() =>
+                navigate(
+                  generatePath(paths.stage, {
+                    name: props.stage?.metadata?.namespace,
+                    stageName: props.stage?.metadata?.name
+                  })
+                )
+              }
             />
-          </Dropdown>
+          </Space>
         </Flex>
       }
-      className={classNames('stage-node cursor-pointer', style['stage-node-size'], {
+      className={classNames('stage-node', style['stage-node-size'], {
         'opacity-40': hideStage
       })}
       size='small'
       variant='borderless'
-      onClick={onStageDetails}
     >
       {controlFlow && (
         <Typography.Text type='secondary'>

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -68,6 +68,14 @@ export const StageNode = (props: { stage: Stage }) => {
     }
   });
 
+  const onStageDetails = () =>
+    navigate(
+      generatePath(paths.stage, {
+        name: props.stage?.metadata?.namespace,
+        stageName: props.stage?.metadata?.name
+      })
+    );
+
   let descriptionItems: ReactNode;
 
   if (!controlFlow) {
@@ -95,6 +103,7 @@ export const StageNode = (props: { stage: Stage }) => {
             name: props.stage?.metadata?.namespace,
             promotionId: props.stage?.status?.currentPromotion?.name || ''
           })}
+          onClick={(e) => e.stopPropagation()}
         >
           {Phase}
         </Link>
@@ -121,6 +130,7 @@ export const StageNode = (props: { stage: Stage }) => {
               name: props.stage?.metadata?.namespace,
               promotionId: props.stage?.status?.lastPromotion?.name
             })}
+            onClick={(e) => e.stopPropagation()}
           >
             <Flex gap={4} align='center'>
               <span>Last Promotion: </span>
@@ -171,13 +181,7 @@ export const StageNode = (props: { stage: Stage }) => {
         Details
       </Flex>
     ),
-    onClick: () =>
-      navigate(
-        generatePath(paths.stage, {
-          name: props.stage?.metadata?.namespace,
-          stageName: props.stage?.metadata?.name
-        })
-      )
+    onClick: onStageDetails
   });
 
   return (
@@ -201,15 +205,21 @@ export const StageNode = (props: { stage: Stage }) => {
               items: dropdownItems
             }}
           >
-            <Button size='small' className='text-xs' icon={<FontAwesomeIcon icon={faEllipsis} />} />
+            <Button
+              size='small'
+              className='text-xs'
+              icon={<FontAwesomeIcon icon={faEllipsis} />}
+              onClick={(e) => e.stopPropagation()}
+            />
           </Dropdown>
         </Flex>
       }
-      className={classNames('stage-node', style['stage-node-size'], {
+      className={classNames('stage-node cursor-pointer', style['stage-node-size'], {
         'opacity-40': hideStage
       })}
       size='small'
       variant='borderless'
+      onClick={onStageDetails}
     >
       {controlFlow && (
         <Typography.Text type='secondary'>

--- a/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
@@ -1,5 +1,11 @@
 import { useMutation } from '@connectrpc/connect-query';
-import { faMinus, faPlus, faRefresh, faWarehouse } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowUpRightFromSquare,
+  faMinus,
+  faPlus,
+  faRefresh,
+  faWarehouse
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Badge, Button, Card, Flex, message } from 'antd';
 import classNames from 'classnames';
@@ -35,26 +41,32 @@ export const WarehouseNode = (props: { warehouse: Warehouse }) => {
     <Card
       size='small'
       title={
-        <Flex
-          align='center'
-          gap={16}
-          className={classNames(warehouseState.hasError && 'text-red-500')}
-        >
-          <FontAwesomeIcon icon={faWarehouse} />
-          <span className='text-xs'>{props.warehouse?.metadata?.name}</span>
+        <Flex justify='space-between'>
+          <Flex
+            align='center'
+            gap={16}
+            className={classNames(warehouseState.hasError && 'text-red-500')}
+          >
+            <FontAwesomeIcon icon={faWarehouse} />
+            <span className='text-xs'>{props.warehouse?.metadata?.name}</span>
 
-          {warehouseState.hasError && <Badge status='error' />}
+            {warehouseState.hasError && <Badge status='error' />}
+          </Flex>
+          <Button
+            icon={<FontAwesomeIcon icon={faArrowUpRightFromSquare} />}
+            size='small'
+            onClick={() =>
+              navigate(
+                generatePath(paths.warehouse, {
+                  name: props.warehouse?.metadata?.namespace,
+                  warehouseName: props.warehouse?.metadata?.name
+                })
+              )
+            }
+          />
         </Flex>
       }
-      className={(styles['warehouse-node-size'], 'cursor-pointer relative')}
-      onClick={() =>
-        navigate(
-          generatePath(paths.warehouse, {
-            name: props.warehouse?.metadata?.namespace,
-            warehouseName: props.warehouse?.metadata?.name
-          })
-        )
-      }
+      className={(styles['warehouse-node-size'], 'relative')}
     >
       <Button
         size='small'


### PR DESCRIPTION
- Numbers in freight boxes should only be visible for > 2
- Stage details can be opened by click on node as well
- Stage stacking filter is only visible when it can be used (ie. not in small pipelines)
- Remove "1 Minute" timerange option