### PR TITLE
fix(ui): When moving a cursor, buttons in nodes don't work

### DIFF
--- a/ui/src/features/project/pipelines/graph/custom-node.tsx
+++ b/ui/src/features/project/pipelines/graph/custom-node.tsx
@@ -59,7 +59,9 @@ CustomNode.Container = (
 ) => {
   let id = '';
 
-  const Children = <div className='max-w-[356px] min-w-[250px]'>{props.children}</div>;
+  const Children = (
+    <div className='max-w-[356px] min-w-[250px] nodrag cursor-default'>{props.children}</div>
+  );
 
   if (props.stage) {
     id = stageIndexer.index(props.stage);

--- a/ui/src/features/project/pipelines/nodes/stacked-nodes.tsx
+++ b/ui/src/features/project/pipelines/nodes/stacked-nodes.tsx
@@ -19,7 +19,7 @@ export const StackedNodes = (props: {
   return (
     <>
       <Handle id={props.data.id} position={Position.Left} type='target' />
-      <div className={classNames(styles['stacked-node-size'], 'relative')}>
+      <div className={classNames(styles['stacked-node-size'], 'relative nodrag cursor-default')}>
         <div className='absolute w-full h-full -top-1 -right-1 bg-white shadow-md rounded-md z-10' />
         <div className='absolute w-full h-full -top-2 -right-2 bg-white shadow-md rounded-md' />
         <Card className={classNames(styles['stacked-node-size'], 'relative z-20')}>

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -167,7 +167,7 @@ export const StageNode = (props: { stage: Stage }) => {
           )}
           <Space>
             <Dropdown
-              trigger={['click']}
+              trigger={['hover']}
               overlayClassName='w-[220px]'
               menu={{
                 items: dropdownItems


### PR DESCRIPTION
This is related to React Flow default behaviour. All nodes are in a draggable state. It caused button-click problems.