### PR TITLE
chore: minor project governance updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,7 +21,3 @@ assignees: ''
 # Motivation
 
 <!-- Please give examples of your use case. i.e. When would someone use this? -->
-
-# Suggested Implementation
-
-<!-- Do you have thoughts about how this should be implemented? -->

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -9,9 +9,9 @@ issue:
         - chore
         - discussion
         - enhancement
+        - proposal
         - question
         - refactor
-        - feature-request
       multiple: true
       needs: true
 
@@ -39,13 +39,15 @@ issue:
         - ci-process
         - release-process
         # kargo component areas
-        - api
+        - api-server
         - charts
         - cli
         - controller
         - crds
+        - external-webhooks
         - garbage-collector
+        - kubernetes-webhooks
+        - management-controller
         - ui
-        - webhooks
       multiple: true
       needs: true


### PR DESCRIPTION
Fixes #3916

Also adjusts some labels to align better with all of the Kargo's different areas of concern.

* `api` always _meant_ "api server," but was too easily confused with `crds` -- which are their own sort of API.

* `controller` has never adequately distinguished between the regular/distributed controller and the management controller that runs in the control plane only.

* After #3985, we deal with more than one kind of webhook, making it worthwhile to distinguish between "kubernetes webhooks" and "external webhooks."