### PR TITLE
fix: typo on verifications and correct cluster promo tasks message

### DIFF
--- a/ui/src/features/settings/cluster-promotion-tasks/cluster-promotion-tasks.tsx
+++ b/ui/src/features/settings/cluster-promotion-tasks/cluster-promotion-tasks.tsx
@@ -80,7 +80,8 @@ export const ClusterPromotionTasks = () => {
         locale={{
           emptyText: (
             <>
-              This project does not have any Promotion Tasks. Read more about ClusterPromotionTasks{' '}
+              This instance does not have any Cluster Promotion Tasks.
+              Read more about ClusterPromotionTasks{' '}
               <a
                 href='https://docs.kargo.io/user-guide/reference-docs/promotion-tasks/#defining-a-global-promotion-task'
                 target='_blank'

--- a/ui/src/features/settings/cluster-promotion-tasks/cluster-promotion-tasks.tsx
+++ b/ui/src/features/settings/cluster-promotion-tasks/cluster-promotion-tasks.tsx
@@ -80,8 +80,8 @@ export const ClusterPromotionTasks = () => {
         locale={{
           emptyText: (
             <>
-              This instance does not have any Cluster Promotion Tasks.
-              Read more about ClusterPromotionTasks{' '}
+              This instance does not have any Cluster Promotion Tasks. Read more about
+              ClusterPromotionTasks{' '}
               <a
                 href='https://docs.kargo.io/user-guide/reference-docs/promotion-tasks/#defining-a-global-promotion-task'
                 target='_blank'

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -9,7 +9,7 @@ import { ClusterPromotionTasks } from '@ui/features/settings/cluster-promotion-t
 
 const settingsViews = {
   verification: {
-    label: 'Verificaion',
+    label: 'Verification',
     icon: faBarChart,
     path: 'analysis-templates',
     component: ClusterAnalysisTemplatesList


### PR DESCRIPTION
Fixes a typo where we say `Verificaion` instead of `Verification`.

Also it mentions a "project" even though it is a system level configuration, not project