### PR TITLE
feat: improve step alias error messages

### DIFF
--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -288,9 +288,9 @@ func (s *PromotionStep) GetAlias(i int) string {
 	case s.As != "":
 		return s.As
 	case s.Task != nil:
-		return fmt.Sprintf("task-%d", i)
+		return fmt.Sprintf("task-%d", i+1)
 	default:
-		return fmt.Sprintf("step-%d", i)
+		return fmt.Sprintf("step-%d", i+1)
 	}
 }
 

--- a/internal/kargo/promotion_builder.go
+++ b/internal/kargo/promotion_builder.go
@@ -113,6 +113,7 @@ func (b *PromotionBuilder) InflateSteps(ctx context.Context, promo *kargoapi.Pro
 			}
 			steps = append(steps, taskSteps...)
 		default:
+			step.As = step.GetAlias(i)
 			steps = append(steps, step)
 		}
 	}

--- a/internal/kargo/promotion_builder_test.go
+++ b/internal/kargo/promotion_builder_test.go
@@ -560,8 +560,8 @@ func TestPromotionBuilder_inflateTaskSteps(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, steps, 2)
 
-				assert.Equal(t, "custom-alias::step-0", steps[0].As)
-				assert.Equal(t, "custom-alias::step-1", steps[1].As)
+				assert.Equal(t, "custom-alias::step-1", steps[0].As)
+				assert.Equal(t, "custom-alias::step-2", steps[1].As)
 			},
 		},
 		{

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -844,55 +844,6 @@ func TestSimpleEngine_prepareStepContext(t *testing.T) {
 	}
 }
 
-func TestSimpleEngine_stepAlias(t *testing.T) {
-	tests := []struct {
-		name       string
-		alias      string
-		index      int64
-		assertions func(*testing.T, string, error)
-	}{
-		{
-			name:  "use provided alias",
-			alias: "custom-step",
-			assertions: func(t *testing.T, alias string, err error) {
-				assert.NoError(t, err)
-				assert.Equal(t, "custom-step", alias)
-			},
-		},
-		{
-			name:  "generate default alias",
-			index: 42,
-			assertions: func(t *testing.T, alias string, err error) {
-				assert.NoError(t, err)
-				assert.Equal(t, "step-42", alias)
-			},
-		},
-		{
-			name:  "reject reserved alias",
-			alias: "step-1",
-			assertions: func(t *testing.T, _ string, err error) {
-				assert.ErrorContains(t, err, "forbidden")
-			},
-		},
-		{
-			name:  "trim whitespace",
-			alias: "  step  ",
-			assertions: func(t *testing.T, alias string, err error) {
-				assert.NoError(t, err)
-				assert.Equal(t, "step", alias)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			engine := &simpleEngine{}
-			alias, err := engine.stepAlias(tt.alias, tt.index)
-			tt.assertions(t, alias, err)
-		})
-	}
-}
-
 func TestSimpleEngine_setupWorkDir(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -147,24 +147,6 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 		assertions  func(*testing.T, Result)
 	}{
 		{
-			name: "fail on invalid step alias",
-			steps: []Step{
-				{Kind: "success-step", Alias: "step-1"},
-			},
-			assertions: func(t *testing.T, result Result) {
-				assert.Equal(t, kargoapi.PromotionPhaseErrored, result.Status)
-				assert.Contains(t, result.Message, "is forbidden")
-				assert.Equal(t, int64(0), result.CurrentStep)
-
-				assert.Len(t, result.StepExecutionMetadata, 1)
-
-				assert.Equal(t, kargoapi.PromotionStepStatusErrored, result.StepExecutionMetadata[0].Status)
-				assert.Contains(t, result.StepExecutionMetadata[0].Message, "is forbidden")
-				assert.Nil(t, result.StepExecutionMetadata[0].StartedAt)
-				assert.Nil(t, result.StepExecutionMetadata[0].FinishedAt)
-			},
-		},
-		{
 			name:  "runner not found",
 			steps: []Step{{Kind: "unknown-step"}},
 			assertions: func(t *testing.T, result Result) {
@@ -767,7 +749,10 @@ func TestSimpleEngine_executeStep(t *testing.T) {
 		},
 		{
 			name: "step execution failure",
-			step: Step{Kind: "error-step"},
+			step: Step{
+				Kind:  "error-step",
+				Alias: "my-step",
+			},
 			runner: &mockStepRunner{
 				name: "error-step",
 				runResult: promotion.StepResult{
@@ -776,7 +761,7 @@ func TestSimpleEngine_executeStep(t *testing.T) {
 				runErr: errors.New("something went wrong"),
 			},
 			assertions: func(t *testing.T, result promotion.StepResult, err error) {
-				assert.ErrorContains(t, err, "error running step \"error-step\"")
+				assert.ErrorContains(t, err, "error running step \"my-step\"")
 				assert.ErrorContains(t, err, "something went wrong")
 				assert.Equal(t, kargoapi.PromotionStepStatusErrored, result.Status)
 			},


### PR DESCRIPTION
Fixes #3402

This PR assigns generated step aliases as a `promotionTemplate` and tasks it references are expanded instead of doing so just-in-time.

This allows for slightly easier and easier-to-follow bookkeeping in terms of step execution metadata.

More significantly, it allows any error messages we build that involve steps to use aliases instead of indices. Indices, according to #3402, were confusing because the UI didn't display them and the question of being 0-based vs 1-based was possibly also the source of some confusion. This change alleviates all of that.

![Screenshot 2025-05-01 at 5 10 24 PM](https://github.com/user-attachments/assets/297f17bc-1090-446d-80a0-3ae158033b3d)
