### PR TITLE
fix: runtime scheme error

### DIFF
--- a/cmd/controlplane/external_webhooks.go
+++ b/cmd/controlplane/external_webhooks.go
@@ -77,6 +77,10 @@ func (o *externalWebhooksServerOptions) run(ctx context.Context) error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
+	if err = kargoapi.AddToScheme(cluster.GetClient().Scheme()); err != nil {
+		return fmt.Errorf("failed to add custom kargo type to runtime scheme: %w", err)
+	}
+
 	err = cluster.GetFieldIndexer().IndexField(
 		ctx,
 		&kargoapi.Warehouse{},


### PR DESCRIPTION
Fixes

```
time="2025-05-07T20:30:46Z" level=info msg="Starting Kargo External Webhooks Server" GOMAXPROCS=16 GOMEMLIMIT=32805588992 commit= version=devel+unknown.dirty
time="2025-05-07T20:30:46Z" level=error error="error registering warehouse by repo url indexer: no kind is registered for the type v1alpha1.Warehouse in scheme \"pkg/runtime/scheme.go:100\""
```

This is due to not adding custom types to the runtime scheme before registering indices