### PR TITLE
docs: aws credentials Secret requires awsRegion field

### DIFF
--- a/docs/docs/50-user-guide/50-security/30-managing-credentials.md
+++ b/docs/docs/50-user-guide/50-security/30-managing-credentials.md
@@ -414,6 +414,7 @@ metadata:
   labels:
     kargo.akuity.io/cred-type: image
 stringData:
+  awsRegion: us-west-2
   awsAccessKeyID: <access key id>
   awsSecretAccessKey: <secret access key>
   repoURL: <ecr url>


### PR DESCRIPTION
The `awsRegion` field is necessary when using static, long-lived credentials to auth to ECR