### PR TITLE
fix(api): verify RepoURL validation

### DIFF
--- a/api/testing/regexp.go
+++ b/api/testing/regexp.go
@@ -1,4 +1,4 @@
-package testhelper
+package testing
 
 import (
 	"regexp"

--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -158,6 +158,7 @@ message ChartSubscription {
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`^(((https?)|(oci))://)([\w\d\.\-]+)(:[\d]+)?(/.*)*$`
+  // +akuity:test-kubebuilder-pattern=HelmRepoURL
   optional string repoURL = 1;
 
   // Name specifies the name of a Helm chart to subscribe to within a classic
@@ -280,12 +281,14 @@ message DiscoveredImageReference {
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=128
   // +kubebuilder:validation:Pattern=`^[\w.\-\_]+$`
+  // +akuity:test-kubebuilder-pattern=Tag
   optional string tag = 1;
 
   // Digest is the digest of the image.
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`^[a-z0-9]+:[a-f0-9]+$`
+  // +akuity:test-kubebuilder-pattern=Digest
   optional string digest = 2;
 
   // Annotations is a map of key-value pairs that provide additional
@@ -456,7 +459,8 @@ message FreightSources {
   // requirement.
   //
   // +kubebuilder:validation:Type=string
-  // +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+  // +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
+  // +akuity:test-kubebuilder-pattern=Duration
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration requiredSoakTime = 3;
 
   // AvailabilityStrategy specifies the semantics for how requested Freight is
@@ -525,6 +529,7 @@ message GitDiscoveryResult {
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+  // +akuity:test-kubebuilder-pattern=GitRepoURL
   optional string repoURL = 1;
 
   // Commits is a list of commits discovered by the Warehouse for the
@@ -541,6 +546,7 @@ message GitSubscription {
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+  // +akuity:test-kubebuilder-pattern=GitRepoURL
   optional string repoURL = 1;
 
   // CommitSelectionStrategy specifies the rules for how to identify the newest
@@ -580,6 +586,7 @@ message GitSubscription {
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=255
   // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
+  // +akuity:test-kubebuilder-pattern=Branch
   optional string branch = 3;
 
   // StrictSemvers specifies whether only "strict" semver tags should be
@@ -760,6 +767,7 @@ message ImageSubscription {
   //
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`^(\w+([\.-]\w+)*(:[\d]+)?/)?(\w+([\.-]\w+)*)(/\w+([\.-]\w+)*)*$`
+  // +akuity:test-kubebuilder-pattern=ImageRepoURL
   optional string repoURL = 1;
 
   // GitRepoURL optionally specifies the URL of a Git repository that contains
@@ -1057,7 +1065,8 @@ message PromotionSpec {
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=253
-  // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+  // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+  // +akuity:test-kubebuilder-pattern=KubernetesName
   optional string stage = 1;
 
   // Freight specifies the piece of Freight to be promoted into the Stage
@@ -1066,7 +1075,8 @@ message PromotionSpec {
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=253
-  // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+  // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+  // +akuity:test-kubebuilder-pattern=KubernetesName
   optional string freight = 2;
 
   // Vars is a list of variables that can be referenced by expressions in
@@ -1236,7 +1246,8 @@ message PromotionTaskReference {
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:MaxLength=253
-  // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+  // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+  // +akuity:test-kubebuilder-pattern=KubernetesName
   optional string name = 1;
 
   // Kind is the type of the PromotionTask. Can be either PromotionTask or
@@ -1544,8 +1555,9 @@ message WarehouseSpec {
   // field is implicitly treated as if its value were "5m0s".
   //
   // +kubebuilder:validation:Type=string
-  // +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+  // +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
   // +kubebuilder:default="5m0s"
+  // +akuity:test-kubebuilder-pattern=Duration
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration interval = 4;
 
   // FreightCreationPolicy describes how Freight is created by this Warehouse.

--- a/api/v1alpha1/promotion_types.go
+++ b/api/v1alpha1/promotion_types.go
@@ -147,7 +147,8 @@ type PromotionSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +akuity:test-kubebuilder-pattern=KubernetesName
 	Stage string `json:"stage" protobuf:"bytes,1,opt,name=stage"`
 	// Freight specifies the piece of Freight to be promoted into the Stage
 	// referenced by the Stage field.
@@ -155,7 +156,8 @@ type PromotionSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +akuity:test-kubebuilder-pattern=KubernetesName
 	Freight string `json:"freight" protobuf:"bytes,2,opt,name=freight"`
 	// Vars is a list of variables that can be referenced by expressions in
 	// promotion steps.
@@ -177,7 +179,8 @@ type PromotionTaskReference struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +akuity:test-kubebuilder-pattern=KubernetesName
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Kind is the type of the PromotionTask. Can be either PromotionTask or

--- a/api/v1alpha1/regexp_test.go
+++ b/api/v1alpha1/regexp_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/kargo/api/v1alpha1/testhelper"
+	testingPkg "github.com/akuity/kargo/api/testing"
 )
 
 // ValidateResourceExpression checks the regular expression identified by marker
@@ -20,7 +20,7 @@ import (
 func ValidateResourceExpression(t *testing.T, marker string, testCases map[string]bool) {
 	expression, err := findExpression(marker)
 	require.NoError(t, err)
-	testhelper.ValidateRegularExpression(t, expression, testCases)
+	testingPkg.ValidateRegularExpression(t, expression, testCases)
 }
 
 func TestBranchPattern(t *testing.T) {

--- a/api/v1alpha1/regexp_test.go
+++ b/api/v1alpha1/regexp_test.go
@@ -1,0 +1,294 @@
+package v1alpha1_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/akuity/kargo/api/v1alpha1/testhelper"
+)
+
+// ValidateResourceExpression checks the regular expression identified by marker
+// against the provided test cases.
+func ValidateResourceExpression(t *testing.T, marker string, testCases map[string]bool) {
+	expression, err := findExpression(marker)
+	require.NoError(t, err)
+	testhelper.ValidateRegularExpression(t, expression, testCases)
+}
+
+func Test_Pattern_Branch(t *testing.T) {
+	testCases := map[string]bool{
+		"":             false,
+		"foo/bar":      true,
+		"foo.bar":      true,
+		"release-0.58": true,
+		"/foo":         false,
+		"foo/":         false,
+		"foo//bar":     true,
+		".foo":         false,
+		"foo.":         false,
+		"foo..bar":     true,
+	}
+
+	ValidateResourceExpression(t, "Branch", testCases)
+}
+
+func Test_Pattern_Digest(t *testing.T) {
+	testCases := map[string]bool{
+		"":                        false,
+		"sha256:":                 false,
+		"sha256:1234567890abcdef": true,
+		":1234567890abcdef":       false,
+		"sha256:xyz":              false,
+		"xyz:1234567890abcdef":    true,
+		"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef": true,
+	}
+
+	ValidateResourceExpression(t, "Digest", testCases)
+}
+
+func Test_Pattern_Duration(t *testing.T) {
+	testCases := map[string]bool{
+		"":  false,
+		"s": false,
+		".": false,
+		// simple cases
+		"10s": true,
+		"20h": true,
+		// Decimal cases
+		"1.5s": true,
+		".5s":  false,
+		"0.5s": true,
+		"1.5":  false,
+		"1.5h": true,
+		"1.5m": true,
+		"1,4s": false,
+		// edge cases
+		"1":    false,
+		"0":    false,
+		"-1":   false,
+		"-1s":  false,
+		"+33s": false,
+	}
+
+	ValidateResourceExpression(t, "Duration", testCases)
+}
+
+func Test_Pattern_HelmRepoURL(t *testing.T) {
+	testCases := map[string]bool{}
+
+	ValidateResourceExpression(t, "HelmRepoURL", testCases)
+}
+
+func Test_Pattern_GitRepoURL(t *testing.T) {
+	testCases := map[string]bool{
+		"":             false,
+		":":            false,
+		"/etc/passwd":  false,
+		"//etc/passwd": false,
+		"https:":       false,
+
+		"https://not a url":                      false,
+		"http://github.com/example/repo?foo=bar": true,
+		"ssh://not a url":                        false,
+		"ssh://github.com/example/repo?foo=bar":  true,
+		"not even remotely a url":                false,
+		// URLs of the form http[s]://[proxy-user:proxy-pass@]host.xz[:port][/path/to/repo[.git][/]]
+		"https://github.com":          false,
+		"https://github.com/":         true, //?
+		"https://foo:bar@github.com":  false,
+		"https://foo:bar@github.com/": true, //?
+		// Variable features of the following URLs:
+		//   1000. Outbound proxy or not
+		//   0100. Port number or not
+		//   0010. .git suffix or not
+		//   0001. Trailing slash or not
+		"https://github.com/example/repo":                  true,
+		"https://github.com/example/repo/":                 true,
+		"https://github.com/example/repo.git":              true,
+		"https://github.com/example/repo.git/":             true,
+		"https://localhost:8443/example/repo":              true,
+		"https://localhost:8443/example/repo/":             true,
+		"https://localhost:8443/example/repo.git":          true,
+		"https://localhost:8443/example/repo.git/":         true,
+		"https://foo:bar@github.com/example/repo":          true,
+		"https://foo:bar@github.com/example/repo/":         true,
+		"https://foo:bar@github.com/example/repo.git":      true,
+		"https://foo:bar@github.com/example/repo.git/":     true,
+		"https://foo:bar@localhost:8443/example/repo":      true,
+		"https://foo:bar@localhost:8443/example/repo/":     true,
+		"https://foo:bar@localhost:8443/example/repo.git":  true,
+		"https://foo:bar@localhost:8443/example/repo.git/": true,
+		// URLS of the form ssh://[user@]host.xz[:port][/path/to/repo[.git][/]]
+		"ssh://git.example.com":      false,
+		"ssh://git.example.com/":     true, //?
+		"ssh://git@git.example.com":  false,
+		"ssh://git@git.example.com/": true, //?
+		// Variable features of the following URLs:
+		//   1000. Username or not
+		//   0100. Port number or not
+		//   0010. .git suffix or not
+		//   0001. Trailing slash or not
+		"ssh://github.com/example/repo":              true,
+		"ssh://github.com/example/repo/":             true,
+		"ssh://github.com/example/repo.git":          true,
+		"ssh://github.com/example/repo.git/":         true,
+		"ssh://localhost:2222/example/repo":          true,
+		"ssh://localhost:2222/example/repo/":         true,
+		"ssh://localhost:2222/example/repo.git":      true,
+		"ssh://localhost:2222/example/repo.git/":     true,
+		"ssh://git@github.com/example/repo":          true,
+		"ssh://git@github.com/example/repo/":         true,
+		"ssh://git@github.com/example/repo.git":      true,
+		"ssh://git@github.com/example/repo.git/":     true,
+		"ssh://git@localhost:2222/example/repo":      true,
+		"ssh://git@localhost:2222/example/repo/":     true,
+		"ssh://git@localhost:2222/example/repo.git":  true,
+		"ssh://git@localhost:2222/example/repo.git/": true,
+		// SCP-style URLs of the form [user@]host.xz[:path/to/repo[.git][/]]
+		"git.example.com":     false,
+		"git@git.example.com": false,
+		// Variable features of the following URLs:
+		//   100. Username or not
+		//   010. .git suffix or not
+		//   001. Trailing slash or not
+		"github.com:example/repo":          false, //?
+		"github.com:example/repo/":         false, //?
+		"github.com:example/repo.git":      false, //?
+		"github.com:example/repo.git/":     false, //?
+		"git@github.com:example/repo":      true,
+		"git@github.com:example/repo/":     true,
+		"git@github.com:example/repo.git":  true,
+		"git@github.com:example/repo.git/": true,
+	}
+
+	ValidateResourceExpression(t, "GitRepoURL", testCases)
+}
+
+func Test_Pattern_ImageRepoURL(t *testing.T) {
+	testCases := map[string]bool{
+		"":  false,
+		".": false,
+	}
+
+	ValidateResourceExpression(t, "ImageRepoURL", testCases)
+}
+
+func Test_Pattern_KubernetesName(t *testing.T) {
+	testCases := map[string]bool{
+		"": false,
+		// simple cases
+		"abc":             true,
+		"abc.123":         true,
+		"abc-123-abc-123": true,
+		// edge cases
+		"abc-123-abc-123-": false,
+		"-abc-123-abc-123": false,
+		// invalid characters
+		"abc+123": false,
+		"abc 123": false,
+		"abc/123": false,
+		"abc_123": false,
+		"abc:123": false,
+	}
+
+	ValidateResourceExpression(t, "KubernetesName", testCases)
+}
+
+func Test_Pattern_Tag(t *testing.T) {
+	testCases := map[string]bool{
+		"":  false,
+		".": true, // ?
+		// simple cases
+		"v1.0.0":       true,
+		"v1.0.0-alpha": true,
+		"latest":       true,
+		// invalid characters
+		"plus+one":  false,
+		"not a tag": false,
+	}
+
+	expression, err := findExpression("Tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for tt, expected := range testCases {
+		t.Run(tt, func(t *testing.T) {
+			require.Equal(t, expected, expression.MatchString(tt))
+		})
+	}
+}
+
+var patternRE = regexp.MustCompile("// ?\\+kubebuilder:validation:Pattern=`(.*)`")
+
+// findExpression returns the regular expression that is used by the types in
+// the current directory, that have the provided marker. A marker is part of the
+// directive "// +akuity:test-kubebuilder-pattern=FOO", where FOO is the marker.
+// The marker directive must be paired with the kubebuilder regular expression
+// pattern validation ("// +kubebuilder:validation:Pattern=`BAR`"). When this
+// function is provided "FOO", it will return the regular expression "BAR". It
+// is an error if there are no marker directives that match. It is an error if
+// several marker directives match unless all of the expressions are identical.
+func findExpression(marker string) (*regexp.Regexp, error) {
+	fset := token.NewFileSet()
+
+	// Find all types file in the current directory
+	pkgs, err := parser.ParseDir(fset, "./", func(fi fs.FileInfo) bool {
+		return strings.HasSuffix(fi.Name(), "_types.go")
+	}, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	previouslyFoundExpression := ""
+	markerRE := regexp.MustCompile("// ?\\+akuity:test-kubebuilder-pattern=" + marker) //nolint:gosimple
+
+	firstLocation := ""
+
+	for _, pkg := range pkgs {
+		for _, f := range pkg.Files {
+			cmap := ast.NewCommentMap(fset, f, f.Comments)
+			for _, list := range cmap.Comments() {
+				foundDirective := false
+				commentLocation := ""
+				foundExpression := ""
+
+				for _, comment := range list.List {
+					if markerRE.MatchString(comment.Text) {
+						foundDirective = true
+						commentLocation = fset.Position(comment.Pos()).String()
+					}
+					if patterns := patternRE.FindStringSubmatch(comment.Text); len(patterns) > 1 {
+						foundExpression = patterns[1]
+					}
+				}
+
+				if foundDirective {
+					if previouslyFoundExpression == "" {
+						previouslyFoundExpression = foundExpression
+						firstLocation = commentLocation
+					} else if foundExpression == "" {
+						return nil, fmt.Errorf("marker at %s had no regular expression", commentLocation)
+					} else if previouslyFoundExpression != foundExpression {
+						return nil, fmt.Errorf("regexps marked %s are not in sync: %s and %s, %q and %q",
+							marker, firstLocation, commentLocation, previouslyFoundExpression, foundExpression)
+					}
+				}
+			}
+		}
+	}
+
+	if previouslyFoundExpression == "" {
+		return nil, fmt.Errorf("no regexp found marked %s", marker)
+	}
+
+	return regexp.Compile(previouslyFoundExpression)
+}

--- a/api/v1alpha1/regexp_test.go
+++ b/api/v1alpha1/regexp_test.go
@@ -23,7 +23,7 @@ func ValidateResourceExpression(t *testing.T, marker string, testCases map[strin
 	testhelper.ValidateRegularExpression(t, expression, testCases)
 }
 
-func Test_Pattern_Branch(t *testing.T) {
+func TestBranchPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":             false,
 		"foo/bar":      true,
@@ -40,7 +40,7 @@ func Test_Pattern_Branch(t *testing.T) {
 	ValidateResourceExpression(t, "Branch", testCases)
 }
 
-func Test_Pattern_Digest(t *testing.T) {
+func TestDigestPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":                        false,
 		"sha256:":                 false,
@@ -54,7 +54,7 @@ func Test_Pattern_Digest(t *testing.T) {
 	ValidateResourceExpression(t, "Digest", testCases)
 }
 
-func Test_Pattern_Duration(t *testing.T) {
+func TestDurationPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":  false,
 		"s": false,
@@ -81,13 +81,13 @@ func Test_Pattern_Duration(t *testing.T) {
 	ValidateResourceExpression(t, "Duration", testCases)
 }
 
-func Test_Pattern_HelmRepoURL(t *testing.T) {
+func TestHelmRepoURLPattern(t *testing.T) {
 	testCases := map[string]bool{}
 
 	ValidateResourceExpression(t, "HelmRepoURL", testCases)
 }
 
-func Test_Pattern_GitRepoURL(t *testing.T) {
+func TestGitRepoURLPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":             false,
 		":":            false,
@@ -172,7 +172,7 @@ func Test_Pattern_GitRepoURL(t *testing.T) {
 	ValidateResourceExpression(t, "GitRepoURL", testCases)
 }
 
-func Test_Pattern_ImageRepoURL(t *testing.T) {
+func TestImageRepoURLPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":  false,
 		".": false,
@@ -181,7 +181,7 @@ func Test_Pattern_ImageRepoURL(t *testing.T) {
 	ValidateResourceExpression(t, "ImageRepoURL", testCases)
 }
 
-func Test_Pattern_KubernetesName(t *testing.T) {
+func TestKubernetesNamePattern(t *testing.T) {
 	testCases := map[string]bool{
 		"": false,
 		// simple cases
@@ -202,7 +202,7 @@ func Test_Pattern_KubernetesName(t *testing.T) {
 	ValidateResourceExpression(t, "KubernetesName", testCases)
 }
 
-func Test_Pattern_Tag(t *testing.T) {
+func TestTagPattern(t *testing.T) {
 	testCases := map[string]bool{
 		"":  false,
 		".": true, // ?

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -295,7 +295,8 @@ type FreightSources struct {
 	// requirement.
 	//
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
+	// +akuity:test-kubebuilder-pattern=Duration
 	RequiredSoakTime *metav1.Duration `json:"requiredSoakTime,omitempty" protobuf:"bytes,3,opt,name=requiredSoakTime"`
 	// AvailabilityStrategy specifies the semantics for how requested Freight is
 	// made available to the Stage. This field is optional. When left unspecified,

--- a/api/v1alpha1/testhelper/regexp.go
+++ b/api/v1alpha1/testhelper/regexp.go
@@ -1,0 +1,20 @@
+package testhelper
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ValidateRegularExpression ensures that the provided regular expression
+// matches the expected results for the given test cases. Each key in the
+// testCases is tested against the expression, and the result must match the
+// value in the map of testcases.
+func ValidateRegularExpression(t *testing.T, expression *regexp.Regexp, testCases map[string]bool) {
+	for tt, expected := range testCases {
+		t.Run(tt, func(t *testing.T) {
+			require.Equal(t, expected, expression.MatchString(tt))
+		})
+	}
+}

--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -61,8 +61,9 @@ type WarehouseSpec struct {
 	// field is implicitly treated as if its value were "5m0s".
 	//
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
 	// +kubebuilder:default="5m0s"
+	// +akuity:test-kubebuilder-pattern=Duration
 	Interval metav1.Duration `json:"interval" protobuf:"bytes,4,opt,name=interval"`
 	// FreightCreationPolicy describes how Freight is created by this Warehouse.
 	// This field is optional. When left unspecified, the field is implicitly
@@ -112,6 +113,7 @@ type GitSubscription struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+	// +akuity:test-kubebuilder-pattern=GitRepoURL
 	RepoURL string `json:"repoURL" protobuf:"bytes,1,opt,name=repoURL"`
 	// CommitSelectionStrategy specifies the rules for how to identify the newest
 	// commit of interest in the repository specified by the RepoURL field. This
@@ -149,6 +151,7 @@ type GitSubscription struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
+	// +akuity:test-kubebuilder-pattern=Branch
 	Branch string `json:"branch,omitempty" protobuf:"bytes,3,opt,name=branch"`
 	// StrictSemvers specifies whether only "strict" semver tags should be
 	// considered. A "strict" semver tag is one containing ALL of major, minor,
@@ -238,6 +241,7 @@ type ImageSubscription struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^(\w+([\.-]\w+)*(:[\d]+)?/)?(\w+([\.-]\w+)*)(/\w+([\.-]\w+)*)*$`
+	// +akuity:test-kubebuilder-pattern=ImageRepoURL
 	RepoURL string `json:"repoURL" protobuf:"bytes,1,opt,name=repoURL"`
 	// GitRepoURL optionally specifies the URL of a Git repository that contains
 	// the source code for the image repository referenced by the RepoURL field.
@@ -352,6 +356,7 @@ type ChartSubscription struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^(((https?)|(oci))://)([\w\d\.\-]+)(:[\d]+)?(/.*)*$`
+	// +akuity:test-kubebuilder-pattern=HelmRepoURL
 	RepoURL string `json:"repoURL" protobuf:"bytes,1,opt,name=repoURL"`
 	// Name specifies the name of a Helm chart to subscribe to within a classic
 	// chart repository specified by the RepoURL field. This field is required
@@ -444,6 +449,7 @@ type GitDiscoveryResult struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+	// +akuity:test-kubebuilder-pattern=GitRepoURL
 	RepoURL string `json:"repoURL" protobuf:"bytes,1,opt,name=repoURL"`
 	// Commits is a list of commits discovered by the Warehouse for the
 	// GitSubscription. An empty list indicates that the discovery operation was
@@ -508,11 +514,13 @@ type DiscoveredImageReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
 	// +kubebuilder:validation:Pattern=`^[\w.\-\_]+$`
+	// +akuity:test-kubebuilder-pattern=Tag
 	Tag string `json:"tag" protobuf:"bytes,1,opt,name=tag"`
 	// Digest is the digest of the image.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]+:[a-f0-9]+$`
+	// +akuity:test-kubebuilder-pattern=Digest
 	Digest string `json:"digest" protobuf:"bytes,2,opt,name=digest"`
 	// Annotations is a map of key-value pairs that provide additional
 	// information about the image.

--- a/internal/controller/git/work_tree_test.go
+++ b/internal/controller/git/work_tree_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sosedoff/gitkit"
 	"github.com/stretchr/testify/require"
 
-	"github.com/akuity/kargo/api/v1alpha1/testhelper"
+	testingPkg "github.com/akuity/kargo/api/testing"
 	"github.com/akuity/kargo/internal/types"
 )
 
@@ -25,7 +25,7 @@ func TestNonFastForwardRegex(t *testing.T) {
 		" ! [rejected]        HEAD -> experiment (fetch first)": true,
 	}
 
-	testhelper.ValidateRegularExpression(t, nonFastForwardRegex, testCases)
+	testingPkg.ValidateRegularExpression(t, nonFastForwardRegex, testCases)
 }
 
 func TestWorkTree(t *testing.T) {

--- a/internal/controller/git/work_tree_test.go
+++ b/internal/controller/git/work_tree_test.go
@@ -11,8 +11,22 @@ import (
 	"github.com/sosedoff/gitkit"
 	"github.com/stretchr/testify/require"
 
+	"github.com/akuity/kargo/api/v1alpha1/testhelper"
 	"github.com/akuity/kargo/internal/types"
 )
+
+func TestNonFastForwardRegex(t *testing.T) {
+	testCases := map[string]bool{
+		// source: https://regex101.com/r/aNYjHP/1
+		" ! [rejected]        krancour/foo -> krancour/foo (non-fast-forward)": true,
+		" ! [rejected]        main -> main (fetch first)":                      true,
+		" ! [remote rejected] HEAD -> experiment (cannot lock ref 'refs/heads/experiment': is at " +
+			"7dc98ee9c0b75be429e300bb59b3cf6d091ca9ed but expected 1bdf96c8c868981a0e24c43c98aef09a8970a1b8)": true,
+		" ! [rejected]        HEAD -> experiment (fetch first)": true,
+	}
+
+	testhelper.ValidateRegularExpression(t, nonFastForwardRegex, testCases)
+}
 
 func TestWorkTree(t *testing.T) {
 	testRepoCreds := RepoCredentials{

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -379,6 +379,7 @@ export type ChartSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.Ch
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:Pattern=`^(((https?)|(oci))://)([\w\d\.\-]+)(:[\d]+)?(/.*)*$`
+   * +akuity:test-kubebuilder-pattern=HelmRepoURL
    *
    * @generated from field: optional string repoURL = 1;
    */
@@ -643,6 +644,7 @@ export type DiscoveredImageReference = Message<"github.com.akuity.kargo.api.v1al
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=128
    * +kubebuilder:validation:Pattern=`^[\w.\-\_]+$`
+   * +akuity:test-kubebuilder-pattern=Tag
    *
    * @generated from field: optional string tag = 1;
    */
@@ -653,6 +655,7 @@ export type DiscoveredImageReference = Message<"github.com.akuity.kargo.api.v1al
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:Pattern=`^[a-z0-9]+:[a-f0-9]+$`
+   * +akuity:test-kubebuilder-pattern=Digest
    *
    * @generated from field: optional string digest = 2;
    */
@@ -1023,7 +1026,8 @@ export type FreightSources = Message<"github.com.akuity.kargo.api.v1alpha1.Freig
    * requirement.
    *
    * +kubebuilder:validation:Type=string
-   * +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+   * +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
+   * +akuity:test-kubebuilder-pattern=Duration
    *
    * @generated from field: optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration requiredSoakTime = 3;
    */
@@ -1173,6 +1177,7 @@ export type GitDiscoveryResult = Message<"github.com.akuity.kargo.api.v1alpha1.G
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+   * +akuity:test-kubebuilder-pattern=GitRepoURL
    *
    * @generated from field: optional string repoURL = 1;
    */
@@ -1208,6 +1213,7 @@ export type GitSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.GitS
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:Pattern=`(?:^(ssh|https?)://(?:([\w-]+)(:(.+))?@)?([\w-]+(?:\.[\w-]+)*)(?::(\d{1,5}))?(/.*)$)|(?:^([\w-]+)@([\w+]+(?:\.[\w-]+)*):(/?.*))`
+   * +akuity:test-kubebuilder-pattern=GitRepoURL
    *
    * @generated from field: optional string repoURL = 1;
    */
@@ -1255,6 +1261,7 @@ export type GitSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.GitS
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=255
    * +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._\/-]*[a-zA-Z0-9_-])?$`
+   * +akuity:test-kubebuilder-pattern=Branch
    *
    * @generated from field: optional string branch = 3;
    */
@@ -1597,6 +1604,7 @@ export type ImageSubscription = Message<"github.com.akuity.kargo.api.v1alpha1.Im
    *
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:Pattern=`^(\w+([\.-]\w+)*(:[\d]+)?/)?(\w+([\.-]\w+)*)(/\w+([\.-]\w+)*)*$`
+   * +akuity:test-kubebuilder-pattern=ImageRepoURL
    *
    * @generated from field: optional string repoURL = 1;
    */
@@ -2180,7 +2188,8 @@ export type PromotionSpec = Message<"github.com.akuity.kargo.api.v1alpha1.Promot
    * +kubebuilder:validation:Required
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=253
-   * +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+   * +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+   * +akuity:test-kubebuilder-pattern=KubernetesName
    *
    * @generated from field: optional string stage = 1;
    */
@@ -2193,7 +2202,8 @@ export type PromotionSpec = Message<"github.com.akuity.kargo.api.v1alpha1.Promot
    * +kubebuilder:validation:Required
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=253
-   * +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+   * +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+   * +akuity:test-kubebuilder-pattern=KubernetesName
    *
    * @generated from field: optional string freight = 2;
    */
@@ -2533,7 +2543,8 @@ export type PromotionTaskReference = Message<"github.com.akuity.kargo.api.v1alph
    * +kubebuilder:validation:Required
    * +kubebuilder:validation:MinLength=1
    * +kubebuilder:validation:MaxLength=253
-   * +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+   * +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+   * +akuity:test-kubebuilder-pattern=KubernetesName
    *
    * @generated from field: optional string name = 1;
    */
@@ -3229,8 +3240,9 @@ export type WarehouseSpec = Message<"github.com.akuity.kargo.api.v1alpha1.Wareho
    * field is implicitly treated as if its value were "5m0s".
    *
    * +kubebuilder:validation:Type=string
-   * +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))+$"
+   * +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
    * +kubebuilder:default="5m0s"
+   * +akuity:test-kubebuilder-pattern=Duration
    *
    * @generated from field: optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration interval = 4;
    */


### PR DESCRIPTION
From [this comment](https://github.com/akuity/kargo/pull/4048#discussion_r2082458194):

> Anything you are willing to contribute to move the needle on making regexes more reliable and more thoroughly tested is welcome.

I had a go at this:

* It uses go's AST to pull in the source code of the types file
* The field in question gets a "// +akuity:IsGitRepoURL" comment
* The test reads the source code, looks for the comment
* Extracts the regexp
* Runs the regexp against a table test

I think it pointed out some interesting edge cases (see the table tests)

It also verifies that the two RepoURLs that point to git are identical.