### PR TITLE
fix(api-server): add projectconfig to types understood by rbac policy normalization logic

### DIFF
--- a/internal/server/rbac/policy_rules.go
+++ b/internal/server/rbac/policy_rules.go
@@ -180,11 +180,13 @@ func buildRule(
 // nolint: goconst
 func validateResourceTypeName(resource string) error {
 	switch resource {
-	case "analysisruns", "analysistemplates", "events", "freights", "freights/status", "roles",
-		"rolebindings", "promotions", "secrets", "serviceaccounts", "stages", "warehouses":
+	case "analysisruns", "analysistemplates", "events", "freights",
+		"freights/status", "projectconfigs", "promotions", "rolebindings", "roles",
+		"secrets", "serviceaccounts", "stages", "warehouses":
 		return nil
-	case "analysisrun", "analysistemplate", "event", "freight", "role",
-		"rolebinding", "promotion", "secret", "serviceaccount", "stage", "warehouse":
+	case "analysisrun", "analysistemplate", "event", "freight", "projectconfig",
+		"promotion", "role", "rolebinding", "secret", "serviceaccount", "stage",
+		"warehouse":
 		return kubeerr.NewBadRequest(
 			fmt.Sprintf(`unrecognized resource type %q; did you mean "%ss"?`, resource, resource),
 		)


### PR DESCRIPTION
This fix is so that viewing and editing "roles" (Kargo managed SA/Role/RoleBinding trios) in the project settings page does not error out on previously unknown/invalid type ProjectConfig.