### PR TITLE
fix(cli): fix get + delete projectconfig commands

### DIFF
--- a/internal/cli/cmd/delete/project_config.go
+++ b/internal/cli/cmd/delete/project_config.go
@@ -42,17 +42,17 @@ func newProjectConfigCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "projectconfiguration [PROJECT]",
-		Aliases: []string{"projectconfigurations", "projectconfig", "projectconfigs"},
+		Use:     "projectconfig [PROJECT]",
+		Aliases: []string{"projectconfigs"},
 		Short:   "Delete project configuration",
 		Args:    option.MaximumNArgs(1),
 		Example: templates.Example(`
 # Delete project configuration for my-project
-kargo delete projectconfiguration my-project
+kargo delete projectconfig my-project
 
 # Delete project configuration for the default project
 kargo config set-project my-project
-kargo delete projectconfiguration
+kargo delete projectconfig
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)

--- a/internal/cli/cmd/get/project_config.go
+++ b/internal/cli/cmd/get/project_config.go
@@ -46,17 +46,17 @@ func newGetProjectConfigCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:     "projectconfiguration [PROJECT] [--no-headers]",
-		Aliases: []string{"projectconfigurations", "projectconfig", "projectconfigs"},
+		Use:     "projectconfig [PROJECT] [--no-headers]",
+		Aliases: []string{"projectconfigs"},
 		Short:   "Display project configuration",
 		Args:    cobra.MaximumNArgs(1),
 		Example: templates.Example(`
 # Get project configuration for my-project
-kargo get projectconfiguration my-project
+kargo get projectconfig my-project
 
 # Get project configuration for the default project
 kargo config set-project my-project
-kargo get projectconfiguration
+kargo get projectconfig
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)


### PR DESCRIPTION
Fixes a mistake in #4067.

The new sub-commands mistakenly called `projectconfiguration`, although `projectconfig` is actually the official name for the new type.