### PR TITLE
fix(git): get full commit message body

### DIFF
--- a/internal/controller/git/repo_test.go
+++ b/internal/controller/git/repo_test.go
@@ -103,7 +103,10 @@ func TestRepo(t *testing.T) {
 		require.True(t, hasDiffs)
 	})
 
-	testCommitMessage := fmt.Sprintf("test commit %s", uuid.NewString())
+	testCommitMessage := fmt.Sprintf(`test commit %s
+
+with a body
+`, uuid.NewString())
 	err = rep.AddAllAndCommit(testCommitMessage, nil)
 	require.NoError(t, err)
 

--- a/internal/controller/git/work_tree.go
+++ b/internal/controller/git/work_tree.go
@@ -250,7 +250,7 @@ func (w *workTree) Commit(message string, opts *CommitOptions) error {
 
 func (w *workTree) CommitMessage(id string) (string, error) {
 	msgBytes, err := libExec.Exec(
-		w.buildGitCommand("log", "-n", "1", "--pretty=format:%s", id),
+		w.buildGitCommand("log", "-n", "1", "--pretty=format:%B", id),
 	)
 	if err != nil {
 		return "", fmt.Errorf("error obtaining commit message for commit %q: %w", id, err)

--- a/internal/promotion/runner/builtin/git_commiter_test.go
+++ b/internal/promotion/runner/builtin/git_commiter_test.go
@@ -253,5 +253,5 @@ func Test_gitCommitter_run(t *testing.T) {
 	require.Equal(t, expectedCommit, actualCommit)
 	lastCommitMsg, err := workTree.CommitMessage("HEAD")
 	require.NoError(t, err)
-	require.Equal(t, "Initial commit", lastCommitMsg)
+	require.Equal(t, "Initial commit\n", lastCommitMsg)
 }

--- a/internal/promotion/runner/builtin/git_pr_opener.go
+++ b/internal/promotion/runner/builtin/git_pr_opener.go
@@ -183,13 +183,19 @@ func (g *gitPROpener) run(
 		)
 	}
 
-	var title string
-	if cfg.Title != "" {
-		title = cfg.Title
-	} else {
-		title = strings.Split(commitMsg, "\n")[0]
-	}
+	title := cfg.Title
 	description := commitMsg
+
+	if title == "" {
+		parts := strings.SplitN(commitMsg, "\n", 2)
+		title = parts[0]
+		description = ""
+
+		if len(parts) > 1 {
+			description = parts[1]
+		}
+	}
+
 	if stepCtx.UIBaseURL != "" {
 		description = fmt.Sprintf(
 			"%s\n\n[View in Kargo UI](%s/project/%s/stage/%s)",


### PR DESCRIPTION
This ensures that the full body of the commit message is available (for example, when creating a pull request) instead of just the title.