### PR TITLE
feat(runner): support custom PR description 

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -24,6 +24,7 @@ GitLab pull/merge requests.
 | `targetBranch` | `string` | N | The branch to which the changes should be merged. |
 | `createTargetBranch` | `boolean` | N | Indicates whether a new, empty orphaned branch should be created and pushed to the remote if the target branch does not already exist there. Default is `false`. |
 | `title` | `string` | N | The title for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified. |
+| `description` | `string` | N | The description for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified. |
 | `labels` | `[]string` | N | Labels to add to the pull request. |
 
 ## Output

--- a/internal/promotion/runner/builtin/git_pr_opener.go
+++ b/internal/promotion/runner/builtin/git_pr_opener.go
@@ -10,11 +10,12 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/promotion"
+	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
+
 	"github.com/akuity/kargo/internal/controller/git"
 	"github.com/akuity/kargo/internal/credentials"
 	"github.com/akuity/kargo/internal/gitprovider"
-	"github.com/akuity/kargo/pkg/promotion"
-	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 
 	_ "github.com/akuity/kargo/internal/gitprovider/azure"     // Azure provider registration
 	_ "github.com/akuity/kargo/internal/gitprovider/bitbucket" // Bitbucket provider registration
@@ -186,13 +187,21 @@ func (g *gitPROpener) run(
 	title := cfg.Title
 	description := commitMsg
 
+	if cfg.Description != "" {
+		description = cfg.Description
+	}
+
 	if title == "" {
 		parts := strings.SplitN(commitMsg, "\n", 2)
 		title = parts[0]
-		description = ""
 
-		if len(parts) > 1 {
-			description = parts[1]
+		// Only override the description if it has not been set in the config.
+		if cfg.Description == "" {
+			if len(parts) > 1 {
+				description = parts[1]
+			} else {
+				description = "" // The commit message is just a title.
+			}
 		}
 	}
 

--- a/internal/promotion/runner/builtin/git_pr_opener_test.go
+++ b/internal/promotion/runner/builtin/git_pr_opener_test.go
@@ -102,6 +102,42 @@ func Test_gitPROpener_validate(t *testing.T) {
 				"title":        "custom title",
 			},
 		},
+		{
+			name: "invalid with empty title",
+			config: promotion.Config{
+				"provider":     "github",
+				"repoURL":      "https://github.com/example/repo.git",
+				"sourceBranch": "fake-branch",
+				"targetBranch": "another-fake-branch",
+				"title":        "",
+			},
+			expectedProblems: []string{
+				"title: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "valid with custom description",
+			config: promotion.Config{
+				"provider":     "github",
+				"repoURL":      "https://github.com/example/repo.git",
+				"sourceBranch": "fake-branch",
+				"targetBranch": "another-fake-branch",
+				"description":  "custom description",
+			},
+		},
+		{
+			name: "invalid with empty description",
+			config: promotion.Config{
+				"provider":     "github",
+				"repoURL":      "https://github.com/example/repo.git",
+				"sourceBranch": "fake-branch",
+				"targetBranch": "another-fake-branch",
+				"description":  "",
+			},
+			expectedProblems: []string{
+				"description: String length must be greater than or equal to 1",
+			},
+		},
 	}
 
 	r := newGitPROpener(nil)
@@ -207,6 +243,7 @@ func Test_gitPROpener_run(t *testing.T) {
 			CreateTargetBranch: true,
 			Provider:           ptr.To(builtin.Provider(fakeGitProviderName)),
 			Title:              "kargo",
+			Description:        "kargo description",
 		},
 	)
 	require.NoError(t, err)

--- a/internal/promotion/runner/builtin/schemas/git-open-pr-config.json
+++ b/internal/promotion/runner/builtin/schemas/git-open-pr-config.json
@@ -39,6 +39,11 @@
       "description": "The title for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified.",
       "minLength": 1
     },
+    "description": {
+      "type": "string",
+      "description": "The description of the pull request. Kargo generates a description based on the commit messages if it is not explicitly specified.",
+      "minLength": 1
+    },
     "labels": {
       "type": "array",
       "description": "Labels to add to the pull request.",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -174,6 +174,9 @@ type GitOpenPRConfig struct {
 	// Indicates whether a new, empty orphan branch should be created and pushed to the remote
 	// if the target branch does not already exist there. Default is false.
 	CreateTargetBranch bool `json:"createTargetBranch,omitempty"`
+	// The description of the pull request. Kargo generates a description based on the commit
+	// messages if it is not explicitly specified.
+	Description string `json:"description,omitempty"`
 	// Indicates whether to skip TLS verification when cloning the repository. Default is false.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// Labels to add to the pull request.

--- a/ui/src/gen/directives/git-open-pr-config.json
+++ b/ui/src/gen/directives/git-open-pr-config.json
@@ -44,6 +44,11 @@
    "description": "The title for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified.",
    "minLength": 1
   },
+  "description": {
+   "type": "string",
+   "description": "The description of the pull request. Kargo generates a description based on the commit messages if it is not explicitly specified.",
+   "minLength": 1
+  },
   "labels": {
    "type": "array",
    "description": "Labels to add to the pull request.",


### PR DESCRIPTION
This adds support for a custom `description` when opening a pull request using `git-open-pr`:

```yaml
steps:
- uses: git-open-pr
  config:
    # ...omitted for brevity
    title: Deploy to ${{ ctx.stage }}
    description: |
      My custom message
```