### PR TITLE
refactor: limit expressions secret() func to secrets labeled as creds

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -285,7 +285,10 @@ config:
 
 The `secret()` function returns the `Data` field of a Kubernetes `Secret` with
 the specified name from the `Project`'s namespace decoded into a
-`map[string]string`. If no such `Secret` exists, an empty map is returned.
+`map[string]string`. The secret _must_ be labeled with the key
+`kargo.akuity.io/cred-type` with a value of `git`, `helm`, `image`, or
+`generic`. If no such `Secret` exists, or is not labeled correctly, an empty map
+is returned.
 
 Examples:
 

--- a/internal/expressions/function/functions_test.go
+++ b/internal/expressions/function/functions_test.go
@@ -774,12 +774,60 @@ func Test_getSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "missing required label",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      testSecret,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				},
+			},
+			args: []any{testSecret},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.IsType(t, map[string]string{}, result)
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "required label has invalid value",
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      testSecret,
+						Labels: map[string]string{
+							kargoapi.CredentialTypeLabelKey: "invalid",
+						},
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				},
+			},
+			args: []any{testSecret},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.IsType(t, map[string]string{}, result)
+				assert.Empty(t, result)
+			},
+		},
+		{
 			name: "success",
 			objects: []client.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testProject,
 						Name:      testSecret,
+						Labels: map[string]string{
+							kargoapi.CredentialTypeLabelKey: kargoapi.CredentialTypeLabelGeneric,
+						},
 					},
 					Data: map[string][]byte{
 						"foo": []byte("bar"),


### PR DESCRIPTION
See conversation [here](https://github.com/akuity/kargo/pull/4062#discussion_r2087679481).