### PR TITLE
fix(controller): make yaml-update quote numeric-looking strings as necessary

### DIFF
--- a/internal/promotion/runner/builtin/helm_chart_updater.go
+++ b/internal/promotion/runner/builtin/helm_chart_updater.go
@@ -102,7 +102,7 @@ func (h *helmChartUpdater) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
 	}
 
-	if err = intyaml.SetStringsInFile(chartFilePath, changes); err != nil {
+	if err = intyaml.SetValuesInFile(chartFilePath, changes); err != nil {
 		return promotion.StepResult{
 			Status: kargoapi.PromotionStepStatusErrored,
 		}, fmt.Errorf("failed to update chart dependencies in %q: %w", chartFilePath, err)

--- a/internal/promotion/runner/builtin/schemas/yaml-update-config.json
+++ b/internal/promotion/runner/builtin/schemas/yaml-update-config.json
@@ -14,7 +14,6 @@
           "minLength": 1
         },
         "value": {
-          "type": "string",
           "description": "The new value for the specified key."
         }
       },

--- a/internal/promotion/runner/builtin/yaml_updater.go
+++ b/internal/promotion/runner/builtin/yaml_updater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/yaml"
 	intyaml "github.com/akuity/kargo/internal/yaml"
 	"github.com/akuity/kargo/pkg/promotion"
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
@@ -106,7 +107,13 @@ func (y *yamlUpdater) generateCommitMessage(path string, updates []builtin.YAMLU
 	var commitMsg strings.Builder
 	_, _ = commitMsg.WriteString(fmt.Sprintf("Updated %s\n", path))
 	for _, update := range updates {
-		_, _ = commitMsg.WriteString(fmt.Sprintf("\n- %s: %q", update.Key, update.Value))
+		_, _ = commitMsg.WriteString(
+			fmt.Sprintf(
+				"\n- %s: %v",
+				update.Key,
+				yaml.QuoteIfNecessary(update.Value),
+			),
+		)
 	}
 
 	return commitMsg.String()

--- a/internal/promotion/runner/builtin/yaml_updater.go
+++ b/internal/promotion/runner/builtin/yaml_updater.go
@@ -92,7 +92,7 @@ func (y *yamlUpdater) updateFile(workDir string, path string, updates []intyaml.
 	if err != nil {
 		return fmt.Errorf("error joining path %q: %w", path, err)
 	}
-	if err := intyaml.SetStringsInFile(absValuesFile, updates); err != nil {
+	if err := intyaml.SetValuesInFile(absValuesFile, updates); err != nil {
 		return fmt.Errorf("error updating image references in values file %q: %w", path, err)
 	}
 	return nil

--- a/internal/yaml/quote.go
+++ b/internal/yaml/quote.go
@@ -29,8 +29,7 @@ func QuoteIfNecessary(val any) any {
 	}
 	// If valStr is valid JSON, return its unmarshaled value. This could be an
 	// object, array, or null.
-	var parsedOther any
-	if err := json.Unmarshal([]byte(valStr), &parsedOther); err == nil {
+	if json.Valid([]byte(valStr)) {
 		return fmt.Sprintf("%q", valStr)
 	}
 	// If we get to here, just return the string.

--- a/internal/yaml/quote.go
+++ b/internal/yaml/quote.go
@@ -1,0 +1,38 @@
+package yaml
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// QuoteIfNecessary takes a value and returns it as-is if it is not a string. If
+// it is a string, it ascertains whether a YAML parser would interpret it as
+// another type. If so, it returns the string with additional quotes around it.
+// If not, it returns the string as-is.
+func QuoteIfNecessary(val any) any {
+	valStr, ok := val.(string)
+	if !ok {
+		return val
+	}
+	// If valStr is parseable as a float64, return that. float64 is used because
+	// it can represent all JSON numbers.
+	//
+	// NB: This is attempted prior to attempting to parse valStr as a boolean so
+	// that "0" and "1" will be interpreted as numbers.
+	if _, err := strconv.ParseFloat(valStr, 64); err == nil {
+		return fmt.Sprintf("%q", valStr)
+	}
+	// If valStr is parseable as a bool return that.
+	if _, err := strconv.ParseBool(valStr); err == nil {
+		return fmt.Sprintf("%q", valStr)
+	}
+	// If valStr is valid JSON, return its unmarshaled value. This could be an
+	// object, array, or null.
+	var parsedOther any
+	if err := json.Unmarshal([]byte(valStr), &parsedOther); err == nil {
+		return fmt.Sprintf("%q", valStr)
+	}
+	// If we get to here, just return the string.
+	return val
+}

--- a/internal/yaml/quote_test.go
+++ b/internal/yaml/quote_test.go
@@ -1,0 +1,33 @@
+package yaml
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuoteIfNecessary(t *testing.T) {
+	tests := []struct {
+		input    any
+		expected any
+	}{
+		{123, 123},
+		{123.0, 123.0},
+		{true, true},
+		{false, false},
+		{nil, nil},
+		{"123", `"123"`},
+		{"true", `"true"`},
+		{"false", `"false"`},
+		{"null", `"null"`},
+		{"[1, 2, 3]", `"[1, 2, 3]"`},
+		{`{"key": "value"}`, `"{\"key\": \"value\"}"`},
+		{"string", "string"},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.Equal(t, test.expected, QuoteIfNecessary(test.input))
+		})
+	}
+}

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -432,7 +432,7 @@ type YAMLUpdate struct {
 	// The key whose value needs to be updated. For nested values, use a YAML dot notation path.
 	Key string `json:"key"`
 	// The new value for the specified key.
-	Value string `json:"value"`
+	Value interface{} `json:"value"`
 }
 
 // The name of the Git provider to use. Currently 'azure', 'bitbucket', 'gitea', 'github',

--- a/ui/src/gen/directives/yaml-update-config.json
+++ b/ui/src/gen/directives/yaml-update-config.json
@@ -12,7 +12,6 @@
      "minLength": 1
     },
     "value": {
-     "type": "string",
      "description": "The new value for the specified key."
     }
    }
@@ -39,7 +38,6 @@
       "minLength": 1
      },
      "value": {
-      "type": "string",
       "description": "The new value for the specified key."
      }
     }


### PR DESCRIPTION
Fixes #4099

#4099 was probably introduced when a different bug was closed by #3794.

This fix does the following:

- Adds a utility function for quoting strings intended for use as values in YAML files as necessary.

  i.e. If you have a string that looks like a number, you get back the original string enclosed in quotes. Anything else, including non-string values are returned as-is.

- Make the `internal/yaml` package able to set non-string values.

  It only did strings before. If it was a string that looked like a number, you got it without any extra quotes that would hint to a YAML parser that the value should be treated as a string. Because it _only_ worked with strings there wasn't any way to _know_ whether the value should be treated as a string or other type. It _used_ to rely on extra quotes around the numeric looking string value, but #3794 closed the door on that.

  By supporting other types we can know what the actual intent is. We can use the new utility (previous bullet) to quote numeric-looking strings only and all other values are used as-is.

- Update the JSON schema for the yaml-update promotion step's config to not require values to be a string and run codegen.

- At this point, the bug was fixed, however I realized the commit message fragments composed by the yaml-update step that are added to the step's output unconditionally quoted all values in its summary of changes. This created a slight impedance between the summary and what the step actually did. This was also fixed by using the new utility (first bullet).