### PR TITLE
fix(controller): fix two bugs in evaluation of status() func in expressions

### DIFF
--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -243,7 +243,7 @@ func (s *Step) Skip(
 				),
 				exprfn.DataOperations(ctx, cl, promoCtx.Project)...,
 			),
-			exprfn.StatusOperations(promoCtx.StepExecutionMetadata)...,
+			exprfn.StatusOperations(s.Alias, promoCtx.StepExecutionMetadata)...,
 		)...,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #4154

PromotionStepStatus needs to be cast as a string to be successfully compared to a string.

This PR also updates the status() func to be usable within the context of a task.