### PR TITLE
fix(runner): step panic recovery within engine

### DIFF
--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -569,14 +569,14 @@ func Test_parseCreateActorAnnotation(t *testing.T) {
 func Test_calculateRequeueInterval(t *testing.T) {
 	testStepKindWithoutTimeout := "fake-step-without-timeout"
 	promotion.RegisterStepRunner(
-		&pkgPromotion.MockStepRunner{Nm: testStepKindWithoutTimeout},
+		&pkgPromotion.MockStepRunner{StepName: testStepKindWithoutTimeout},
 	)
 
 	testStepKindWithTimeout := "fake-step-with-timeout"
 	testTimeout := 10 * time.Minute
 	promotion.RegisterStepRunner(
 		pkgPromotion.NewRetryableStepRunner(
-			&pkgPromotion.MockStepRunner{Nm: testStepKindWithTimeout},
+			&pkgPromotion.MockStepRunner{StepName: testStepKindWithTimeout},
 			&testTimeout,
 			0, // Retries don't matter for this test
 		),

--- a/pkg/promotion/mock_step_runner.go
+++ b/pkg/promotion/mock_step_runner.go
@@ -5,8 +5,8 @@ import "context"
 // MockStepRunner is a mock implementation of the StepRunner interface, which
 // can be used for testing.
 type MockStepRunner struct {
-	// Nm is the name of the StepRunner.
-	Nm string
+	// StepName is the name of the StepRunner.
+	StepName string
 	// RunFunc is the function that the StepRunner should call when Run is called.
 	// If set, this function will be called instead of returning RunResult and
 	// RunErr.
@@ -20,7 +20,7 @@ type MockStepRunner struct {
 
 // Name implements the StepRunner interface.
 func (m *MockStepRunner) Name() string {
-	return m.Nm
+	return m.StepName
 }
 
 // Run implements the StepRunner interface.


### PR DESCRIPTION
Branched off from another local branch that was getting out of hand with other engine-related refactoring.

This should address (at least a part of) #4072, and it works because we catch the panic within the engine. By doing this, we can still construct a `Result` to return to the reconciler, which will then propagate this into the actual status of the Promotion.

This detachment (or separation of concerns) is the primary reason why [the `recover()` within the reconciler itself](https://github.com/akuity/kargo/blob/e53abcca8a37c4d623400391c69359d154f8725e/internal/controller/promotions/promotions.go#L308-L318) did not have an effect. Arguably, this also means it is a potential candidate for removal, as I doubt it will be of much use after this has been merged.