### PR TITLE
refactor(runner): promotion engine improvements

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -204,7 +204,7 @@ func RunningPromotionsByArgoCDApplications(
 
 			// As step-level variables are allowed to reference to output, we
 			// need to provide the state.
-			vars, err := dirStep.GetVars(ctx, cl, nil, promoCtx, promoCtx.State)
+			vars, err := dirStep.GetVars(ctx, cl, nil, promoCtx)
 			if err != nil {
 				logger.Error(
 					err,

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -3,6 +3,8 @@ package promotion
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -34,11 +36,14 @@ type Context struct {
 	// Promotion is the name of the Promotion.
 	Promotion string
 	// FreightRequests is the list of Freight from various origins that is
-	// requested by the Stage targeted by the Promotion. This information is
-	// sometimes useful to Steps that reference a particular artifact and, in the
-	// absence of any explicit information about the origin of that artifact, may
-	// need to examine FreightRequests to determine whether there exists any
-	// ambiguity as to its origin, which a user may then need to resolve.
+	// requested by the Stage targeted by the Promotion.
+	//
+	// This information is sometimes useful to Steps that reference a particular
+	// artifact. When explicit information about the artifact's origin is absent,
+	// Steps may need to examine FreightRequests.
+	// This examination helps determine whether any ambiguity exists regarding
+	// the artifact's origin. If ambiguity is found, a user may need to resolve
+	// it.
 	FreightRequests []kargoapi.FreightRequest
 	// Freight is the collection of all Freight referenced by the Promotion. This
 	// collection contains both the Freight that is actively being promoted and
@@ -53,13 +58,47 @@ type Context struct {
 	StepExecutionMetadata kargoapi.StepExecutionMetadataList
 	// State is the current state of the promotion process.
 	State promotion.State
-	// Vars is a list of variables definitions that can be used by the
+	// Vars is a list of variable definitions that can be used by the
 	// Steps.
 	Vars []kargoapi.ExpressionVariable
 	// Secrets is a map of secrets that can be used by the Steps.
 	Secrets map[string]map[string]string
 	// Actor is the name of the actor triggering the Promotion.
 	Actor string
+}
+
+// DeepCopy creates a deep copy of the Context. It can be used to ensure that
+// modifications to the Context do not affect the original Context.
+func (c Context) DeepCopy() Context {
+	newC := Context{
+		UIBaseURL:             c.UIBaseURL,
+		WorkDir:               c.WorkDir,
+		Project:               c.Project,
+		Stage:                 c.Stage,
+		Promotion:             c.Promotion,
+		Freight:               *c.Freight.DeepCopy(),
+		StartFromStep:         c.StartFromStep,
+		StepExecutionMetadata: c.StepExecutionMetadata.DeepCopy(),
+		State:                 c.State.DeepCopy(),
+		Vars:                  slices.Clone(c.Vars),
+		Actor:                 c.Actor,
+	}
+
+	if c.FreightRequests != nil {
+		newC.FreightRequests = make([]kargoapi.FreightRequest, len(c.FreightRequests))
+		for i, fr := range c.FreightRequests {
+			newC.FreightRequests[i] = *fr.DeepCopy()
+		}
+	}
+
+	if c.Secrets != nil {
+		newC.Secrets = make(map[string]map[string]string, len(c.Secrets))
+		for k, v := range c.Secrets {
+			newC.Secrets[k] = maps.Clone(v)
+		}
+	}
+
+	return newC
 }
 
 // Step describes a single step in a user-defined promotion process. Steps are
@@ -203,13 +242,12 @@ func (s *Step) BuildEnv(promoCtx Context, opts ...StepEnvOption) map[string]any 
 }
 
 // Skip returns true if the Step should be skipped based on the If condition.
-// The If condition is evaluated against the provided Context and State.
+// The If condition is evaluated against the provided Context.
 func (s *Step) Skip(
 	ctx context.Context,
 	cl client.Client,
 	cache *gocache.Cache,
 	promoCtx Context,
-	state promotion.State,
 ) (bool, error) {
 	// If no "if" condition is provided, then this step is automatically skipped
 	// if any of the previous steps have errored or failed and is not skipped
@@ -218,7 +256,7 @@ func (s *Step) Skip(
 		return promoCtx.StepExecutionMetadata.HasFailures(), nil
 	}
 
-	vars, err := s.GetVars(ctx, cl, cache, promoCtx, state)
+	vars, err := s.GetVars(ctx, cl, cache, promoCtx)
 	if err != nil {
 		return false, err
 	}
@@ -226,8 +264,8 @@ func (s *Step) Skip(
 	env := s.BuildEnv(
 		promoCtx,
 		StepEnvWithStepMetas(promoCtx),
-		StepEnvWithOutputs(state),
-		StepEnvWithTaskOutputs(s.Alias, state),
+		StepEnvWithOutputs(promoCtx.State),
+		StepEnvWithTaskOutputs(s.Alias, promoCtx.State),
 		StepEnvWithVars(vars),
 	)
 
@@ -267,13 +305,12 @@ func (s *Step) GetConfig(
 	cl client.Client,
 	cache *gocache.Cache,
 	promoCtx Context,
-	state promotion.State,
 ) (promotion.Config, error) {
 	if s.Config == nil {
 		return nil, nil
 	}
 
-	vars, err := s.GetVars(ctx, cl, cache, promoCtx, state)
+	vars, err := s.GetVars(ctx, cl, cache, promoCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,8 +318,8 @@ func (s *Step) GetConfig(
 	env := s.BuildEnv(
 		promoCtx,
 		StepEnvWithStepMetas(promoCtx),
-		StepEnvWithOutputs(state),
-		StepEnvWithTaskOutputs(s.Alias, state),
+		StepEnvWithOutputs(promoCtx.State),
+		StepEnvWithTaskOutputs(s.Alias, promoCtx.State),
 		StepEnvWithVars(vars),
 		StepEnvWithSecrets(promoCtx.Secrets),
 	)
@@ -318,7 +355,6 @@ func (s *Step) GetVars(
 	cl client.Client,
 	cache *gocache.Cache,
 	promoCtx Context,
-	state promotion.State,
 ) (map[string]any, error) {
 	vars := make(map[string]any)
 
@@ -347,8 +383,8 @@ func (s *Step) GetVars(
 			s.BuildEnv(
 				promoCtx,
 				StepEnvWithStepMetas(promoCtx),
-				StepEnvWithOutputs(state),
-				StepEnvWithTaskOutputs(s.Alias, state),
+				StepEnvWithOutputs(promoCtx.State),
+				StepEnvWithTaskOutputs(s.Alias, promoCtx.State),
 				StepEnvWithVars(vars),
 			),
 			append(

--- a/internal/promotion/runner/builtin/init.go
+++ b/internal/promotion/runner/builtin/init.go
@@ -41,7 +41,9 @@ func Initialize(kargoClient, argocdClient client.Client, credsDB credentials.Dat
 		newJSONUpdater(),
 		newKustomizeBuilder(),
 		newKustomizeImageSetter(kargoClient),
-		newOutputComposer(),
+		pkgPromotion.NewTaskLevelOutputStepRunner(
+			newOutputComposer(),
+		),
 		newYAMLParser(),
 		newYAMLUpdater(),
 	}

--- a/internal/promotion/runner/builtin/output_composer.go
+++ b/internal/promotion/runner/builtin/output_composer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
-	"github.com/akuity/kargo/internal/promotion"
 	pkgPromotion "github.com/akuity/kargo/pkg/promotion"
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
@@ -48,7 +47,7 @@ func newOutputComposer() pkgPromotion.StepRunner {
 
 // Name implements the promotion.StepRunner interface.
 func (c *outputComposer) Name() string {
-	return promotion.ComposeOutputStepKind
+	return "compose-output"
 }
 
 // Run implements the promotion.StepRunner interface.

--- a/internal/promotion/simple_engine.go
+++ b/internal/promotion/simple_engine.go
@@ -101,36 +101,17 @@ func (e *simpleEngine) executeSteps(
 
 	var (
 		healthChecks []health.Criteria
-		err          error
 	)
 
 	// Execute each step in sequence, starting from the step index specified in
 	// the Context if provided.
-stepLoop:
 	for i := promoCtx.StartFromStep; i < int64(len(steps)); i++ {
 		step := steps[i]
 
-		// If we don't have metadata for this step yet, create it.
-		if int64(len(promoCtx.StepExecutionMetadata)) == i {
-			promoCtx.StepExecutionMetadata = append(
-				promoCtx.StepExecutionMetadata,
-				kargoapi.StepExecutionMetadata{
-					Alias:           step.Alias,
-					ContinueOnError: step.ContinueOnError,
-				},
-			)
-		}
-		stepExecMeta := &promoCtx.StepExecutionMetadata[i]
+		stepExecMeta := e.prepareStepMetadata(&promoCtx, step)
 
-		select {
-		case <-ctx.Done():
-			stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-			stepExecMeta.Message = ctx.Err().Error()
-			if stepExecMeta.StartedAt != nil {
-				stepExecMeta.FinishedAt = ptr.To(metav1.Now())
-			}
-			break stepLoop
-		default:
+		if e.isContextCanceled(ctx, stepExecMeta) {
+			break
 		}
 
 		// Shared cache for expression functions that consult the Kubernetes API.
@@ -142,17 +123,8 @@ stepLoop:
 			exprDataCache = e.cacheFunc()
 		}
 
-		// Check if the step should be skipped.
-		var skip bool
-		if skip, err = step.Skip(ctx, e.kargoClient, exprDataCache, promoCtx); err != nil {
-			stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-			stepExecMeta.Message = fmt.Sprintf("error checking if step %q should be skipped: %s", step.Alias, err)
-			// Continue, because despite this failure, some steps' "if" conditions may
-			// still allow them to run.
+		if e.shouldSkipStep(ctx, exprDataCache, promoCtx, step, stepExecMeta) {
 			continue
-		} else if skip {
-			stepExecMeta.Status = kargoapi.PromotionStepStatusSkipped
-			continue // Move on to the next step
 		}
 
 		// Get the StepRunner for the step.
@@ -162,130 +134,38 @@ stepLoop:
 			stepExecMeta.Message = fmt.Sprintf("no promotion step runner found for kind %q", step.Kind)
 			// Continue, because despite this failure, some steps' "if" conditions may
 			// still allow them to run.
+			//
+			// TODO(hidde): Arguably, we should return a TerminalError here. As
+			// it is an obvious misconfiguration that could have been caught
+			// if our validation webhook was aware of registered steps.
 			continue
 		}
 
-		// Execute the step
+		// Mark the step as started.
 		if stepExecMeta.StartedAt == nil {
 			stepExecMeta.StartedAt = ptr.To(metav1.Now())
 		}
+
+		// Execute the step.
 		result, err := e.executeStep(ctx, exprDataCache, promoCtx, step, runner, workDir)
-		stepExecMeta.Status = result.Status
-		stepExecMeta.Message = result.Message
 
-		// Update the state with the output of the step.
-		promoCtx.State[step.Alias] = result.Output
+		// Propagate the output of the step to the state.
+		e.propagateStepOutput(promoCtx, step, runner, result)
 
-		// If the step instructs that the output should be propagated to the
-		// task namespace, do so.
-		if p, ok := runner.(promotion.TaskLevelOutputStepRunner); ok && p.TaskLevelOutput() {
-			if aliasNamespace := getAliasNamespace(step.Alias); aliasNamespace != "" {
-				if promoCtx.State[aliasNamespace] == nil {
-					promoCtx.State[aliasNamespace] = make(map[string]any)
-				}
-				for k, v := range result.Output {
-					promoCtx.State[aliasNamespace].(map[string]any)[k] = v // nolint: forcetypeassert
-				}
-			}
-		}
-
-		switch result.Status {
-		case kargoapi.PromotionStepStatusErrored, kargoapi.PromotionStepStatusFailed,
-			kargoapi.PromotionStepStatusRunning, kargoapi.PromotionStepStatusSucceeded,
-			kargoapi.PromotionStepStatusSkipped: // Step runners can self-determine they should be skipped
-		default:
-			// Deal with statuses that no step should have returned.
+		// Confirm that the step has a valid status.
+		if !isValidStepStatus(result.Status) {
 			stepExecMeta.FinishedAt = ptr.To(metav1.Now())
 			stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
 			stepExecMeta.Message = fmt.Sprintf("step %q returned an invalid status: %s", step.Alias, result.Status)
-			// Continue, because despite this failure, some steps' "if" conditions may
-			// still allow them to run.
 			continue
 		}
 
-		// Reconcile status and err...
-		if err != nil {
-			if stepExecMeta.Status != kargoapi.PromotionStepStatusFailed {
-				// All states other than Errored and Failed should be mutually exclusive
-				// with a hard error. If we got to here, a step has violated this
-				// assumption. We will prioritize the error over the status and change
-				// the status to Errored.
-				stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-			}
-			// Let the hard error take precedence over the message.
-			stepExecMeta.Message = err.Error()
-		} else if result.Status == kargoapi.PromotionStepStatusErrored {
-			// A nil err should be mutually exclusive with an Errored status. If we
-			// got to here, a step has violated this assumption. We will prioritize
-			// the Errored status over the nil error and create an error.
-			message := stepExecMeta.Message
-			if message == "" {
-				message = "no details provided"
-			}
-			err = fmt.Errorf("step %q errored: %s", step.Alias, message)
-		}
+		// Update the step execution metadata with the result.
+		err = e.reconcileResultWithMetadata(stepExecMeta, step, result, err)
 
-		// At this point, we've sorted out any discrepancies between the status and
-		// err.
-
-		switch {
-		case stepExecMeta.Status == kargoapi.PromotionStepStatusSucceeded ||
-			stepExecMeta.Status == kargoapi.PromotionStepStatusSkipped:
-			// Note: A step that ran briefly and self-determined it should be
-			// "skipped" is treated similarly to success.
-			stepExecMeta.FinishedAt = ptr.To(metav1.Now())
-			if healthCheck := result.HealthCheck; healthCheck != nil {
-				healthChecks = append(healthChecks, *healthCheck)
-			}
-			continue // Move on to the next step
-		case promotion.IsTerminal(err):
-			// This is an unrecoverable error.
-			stepExecMeta.FinishedAt = ptr.To(metav1.Now())
-			stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-			stepExecMeta.Message = fmt.Sprintf("an unrecoverable error occurred: %s", err)
-			// Continue, because despite this failure, some steps' "if" conditions may
-			// still allow them to run.
-			continue
-		case err != nil:
-			// If we get to here, the error is POTENTIALLY recoverable.
-			stepExecMeta.ErrorCount++
-			// Check if the error threshold has been met.
-			errorThreshold := step.GetErrorThreshold(runner)
-			if stepExecMeta.ErrorCount >= errorThreshold {
-				// The error threshold has been met.
-				stepExecMeta.FinishedAt = ptr.To(metav1.Now())
-				stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-				stepExecMeta.Message = fmt.Sprintf(
-					"step %q met error threshold of %d: %s", step.Alias,
-					errorThreshold, stepExecMeta.Message,
-				)
-				// Continue, because despite this failure, some steps' "if" conditions
-				// may still allow them to run.
-				continue
-			}
-		}
-
-		// If we get to here, the step is either Running (waiting for some external
-		// condition to be met) or it Errored/Failed but did not meet the error
-		// threshold. Now we need to check if the timeout has elapsed. A nil timeout
-		// or any non-positive timeout interval are treated as NO timeout, although
-		// a nil timeout really shouldn't happen.
-		timeout := step.GetTimeout(runner)
-		if timeout != nil && *timeout > 0 && metav1.Now().Sub(stepExecMeta.StartedAt.Time) > *timeout {
-			// Timeout has elapsed.
-			stepExecMeta.FinishedAt = ptr.To(metav1.Now())
-			stepExecMeta.Status = kargoapi.PromotionStepStatusErrored
-			stepExecMeta.Message = fmt.Sprintf("step %q timed out after %s", step.Alias, timeout.String())
-			// Continue, because despite this failure, some steps' "if" conditions may
-			// still allow them to run.
-			continue
-		}
-
-		if err != nil {
-			// Treat Errored/Failed as if the step is still running so that the
-			// Promotion will be requeued. The step will be retried on the next
-			// reconciliation.
-			stepExecMeta.Message += "; step will be retried"
+		// Determine what to do based on the result.
+		if !e.determineStepCompletion(step, runner, stepExecMeta, err) {
+			// The step is still running, so we need to wait
 			return Result{
 				Status:                kargoapi.PromotionPhaseRunning,
 				CurrentStep:           i,
@@ -295,15 +175,11 @@ stepLoop:
 			}
 		}
 
-		// If we get to here, the step is still Running (waiting for some external
-		// condition to be met).
-		stepExecMeta.ErrorCount = 0 // Reset the error count
-		return Result{
-			Status:                kargoapi.PromotionPhaseRunning,
-			CurrentStep:           i,
-			StepExecutionMetadata: promoCtx.StepExecutionMetadata,
-			State:                 promoCtx.State,
-			HealthChecks:          healthChecks,
+		// If the step succeeded, we can add any health checks to the list.
+		if stepExecMeta.Status == kargoapi.PromotionStepStatusSucceeded {
+			if result.HealthCheck != nil {
+				healthChecks = append(healthChecks, *result.HealthCheck)
+			}
 		}
 	}
 
@@ -320,6 +196,207 @@ stepLoop:
 	}
 }
 
+func (e *simpleEngine) prepareStepMetadata(promoCtx *Context, step Step) *kargoapi.StepExecutionMetadata {
+	for i := range promoCtx.StepExecutionMetadata {
+		if promoCtx.StepExecutionMetadata[i].Alias == step.Alias {
+			// Found existing metadata for this step, return it.
+			return &promoCtx.StepExecutionMetadata[i]
+		}
+	}
+
+	// If not found, append new metadata
+	promoCtx.StepExecutionMetadata = append(
+		promoCtx.StepExecutionMetadata,
+		kargoapi.StepExecutionMetadata{
+			Alias:           step.Alias,
+			ContinueOnError: step.ContinueOnError,
+		},
+	)
+	return &promoCtx.StepExecutionMetadata[len(promoCtx.StepExecutionMetadata)-1]
+}
+
+func (e *simpleEngine) isContextCanceled(ctx context.Context, meta *kargoapi.StepExecutionMetadata) bool {
+	select {
+	case <-ctx.Done():
+		meta.Status = kargoapi.PromotionStepStatusErrored
+		meta.Message = ctx.Err().Error()
+		if meta.StartedAt != nil {
+			meta.FinishedAt = ptr.To(metav1.Now())
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *simpleEngine) shouldSkipStep(
+	ctx context.Context,
+	cache *gocache.Cache,
+	promoCtx Context,
+	step Step,
+	meta *kargoapi.StepExecutionMetadata,
+) bool {
+	skip, err := step.Skip(ctx, e.kargoClient, cache, promoCtx)
+	if err != nil {
+		meta.Status = kargoapi.PromotionStepStatusErrored
+		meta.Message = fmt.Sprintf("error checking if step %q should be skipped: %s", step.Alias, err)
+		// Skip the step, because despite this failure, some steps' "if"
+		// conditions may still allow them to run.
+		return true
+	}
+
+	if skip {
+		meta.Status = kargoapi.PromotionStepStatusSkipped
+		// Skip the step because it was explicitly skipped.
+		return true
+	}
+
+	return false
+}
+
+func (e *simpleEngine) propagateStepOutput(
+	promoCtx Context,
+	step Step,
+	runner promotion.StepRunner,
+	result promotion.StepResult,
+) {
+	// Update the state with the output of the step.
+	promoCtx.State[step.Alias] = result.Output
+
+	// If the step instructs that the output should be propagated to the
+	// task namespace, do so.
+	if p, ok := runner.(promotion.TaskLevelOutputStepRunner); ok && p.TaskLevelOutput() {
+		if aliasNamespace := getAliasNamespace(step.Alias); aliasNamespace != "" {
+			if promoCtx.State[aliasNamespace] == nil {
+				promoCtx.State[aliasNamespace] = make(map[string]any)
+			}
+			for k, v := range result.Output {
+				promoCtx.State[aliasNamespace].(map[string]any)[k] = v // nolint: forcetypeassert
+			}
+		}
+	}
+}
+
+func (e *simpleEngine) reconcileResultWithMetadata(
+	meta *kargoapi.StepExecutionMetadata,
+	step Step,
+	result promotion.StepResult,
+	err error,
+) error {
+	meta.Status = result.Status
+	meta.Message = result.Message
+
+	if err != nil {
+		if meta.Status != kargoapi.PromotionStepStatusFailed {
+			// All states other than Errored and Failed should be mutually
+			// exclusive with a hard error. If we got to here, a step has
+			// violated this assumption. We will prioritize the error over the
+			// status and change the status to Errored.
+			meta.Status = kargoapi.PromotionStepStatusErrored
+		}
+		meta.Message = err.Error()
+		return err
+	}
+
+	if result.Status == kargoapi.PromotionStepStatusErrored {
+		message := meta.Message
+		if message == "" {
+			message = "no details provided"
+		}
+		// A nil err should be mutually exclusive with an Errored status. If we
+		// got to here, a step has violated this assumption. We will prioritize
+		// the Errored status over the nil error and create an error.
+		err = fmt.Errorf("step %q errored: %s", step.Alias, message)
+		return err
+	}
+
+	return nil
+}
+
+func (e *simpleEngine) determineStepCompletion(
+	step Step,
+	runner promotion.StepRunner,
+	meta *kargoapi.StepExecutionMetadata,
+	err error,
+) bool {
+	switch {
+	case meta.Status == kargoapi.PromotionStepStatusSucceeded ||
+		meta.Status == kargoapi.PromotionStepStatusSkipped:
+		// Note: A step that ran briefly and self-determined it should be
+		// "skipped" is treated similarly to success.
+		meta.FinishedAt = ptr.To(metav1.Now())
+		return true
+	case promotion.IsTerminal(err):
+		// This is an unrecoverable error.
+		meta.FinishedAt = ptr.To(metav1.Now())
+		meta.Status = kargoapi.PromotionStepStatusErrored
+		meta.Message = fmt.Sprintf("an unrecoverable error occurred: %s", err)
+		// Continue, because despite this failure, some steps' "if" conditions may
+		// still allow them to run.
+		return true
+	case err != nil:
+		// If we get to here, the error is POTENTIALLY recoverable.
+		meta.ErrorCount++
+		// Check if the error threshold has been met.
+		errorThreshold := step.GetErrorThreshold(runner)
+		if meta.ErrorCount >= errorThreshold {
+			// The error threshold has been met.
+			meta.FinishedAt = ptr.To(metav1.Now())
+			meta.Status = kargoapi.PromotionStepStatusErrored
+			meta.Message = fmt.Sprintf(
+				"step %q met error threshold of %d: %s", step.Alias,
+				errorThreshold, meta.Message,
+			)
+			// Continue, because despite this failure, some steps' "if" conditions
+			// may still allow them to run.
+			return true
+		}
+	}
+
+	// If we get to here, the step is either Running (waiting for some external
+	// condition to be met) or it Errored/Failed but did not meet the error
+	// threshold. Now we need to check if the timeout has elapsed. A nil timeout
+	// or any non-positive timeout interval are treated as NO timeout, although
+	// a nil timeout really shouldn't happen.
+	timeout := step.GetTimeout(runner)
+	if timeout != nil && *timeout > 0 && metav1.Now().Sub(meta.StartedAt.Time) > *timeout {
+		// Timeout has elapsed.
+		meta.FinishedAt = ptr.To(metav1.Now())
+		meta.Status = kargoapi.PromotionStepStatusErrored
+		meta.Message = fmt.Sprintf("step %q timed out after %s", step.Alias, timeout.String())
+		// Continue, because despite this failure, some steps' "if" conditions may
+		// still allow them to run.
+		return true
+	}
+
+	if err != nil {
+		// Treat Errored/Failed as if the step is still running so that the
+		// Promotion will be requeued. The step will be retried on the next
+		// reconciliation.
+		meta.Message += "; step will be retried"
+		return false
+	}
+
+	// If we get to here, the step is still Running (waiting for some external
+	// condition to be met).
+	meta.ErrorCount = 0 // Reset the error count
+	return false
+}
+
+func isValidStepStatus(status kargoapi.PromotionStepStatus) bool {
+	switch status {
+	case kargoapi.PromotionStepStatusSucceeded,
+		kargoapi.PromotionStepStatusSkipped,
+		kargoapi.PromotionStepStatusAborted,
+		kargoapi.PromotionStepStatusFailed,
+		kargoapi.PromotionStepStatusErrored,
+		kargoapi.PromotionStepStatusRunning:
+		return true
+	default:
+		return false
+	}
+}
+
 // determinePromoPhase determines the final PromotionPhase as a function of the
 // step configuration and step execution metadata.
 func determinePromoPhase(
@@ -330,7 +407,7 @@ func determinePromoPhase(
 	var worstMsg string
 	for i, stepExecMeta := range stepExecMetas {
 		if steps[i].ContinueOnError {
-			// If continueOnError is set, we don't don't permit this step's outcome
+			// If continueOnError is set, we don't permit this step's outcome
 			// to affect the overall PromotionPhase.
 			continue
 		}

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -588,9 +588,9 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 				},
 			},
 			steps: []Step{
-				{Kind: "success-step"},
-				{Kind: "panic-step"},
-				{Kind: "success-step"},
+				{Kind: "success-step", Alias: "step1"},
+				{Kind: "panic-step", Alias: "step2"},
+				{Kind: "success-step", Alias: "step3"},
 			},
 			assertions: func(t *testing.T, result Result) {
 				assert.Equal(t, kargoapi.PromotionPhaseErrored, result.Status)

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -504,18 +504,20 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 			},
 		},
 		{
-			name: "output composition step from task",
+			name: "output propagation to task namespace",
 			stepRunners: []promotion.StepRunner{
-				&promotion.MockStepRunner{
-					StepName: ComposeOutputStepKind,
-					RunResult: promotion.StepResult{
-						Status: kargoapi.PromotionStepStatusSucceeded,
-						Output: map[string]any{"test": "value"},
+				promotion.NewTaskLevelOutputStepRunner(
+					&promotion.MockStepRunner{
+						StepName: "task-level-output-step",
+						RunResult: promotion.StepResult{
+							Status: kargoapi.PromotionStepStatusSucceeded,
+							Output: map[string]any{"test": "value"},
+						},
 					},
-				},
+				),
 			},
 			steps: []Step{{
-				Kind:  ComposeOutputStepKind,
+				Kind:  "task-level-output-step",
 				Alias: "task-1::custom-output",
 			}},
 			assertions: func(t *testing.T, result Result) {
@@ -543,16 +545,18 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 		{
 			name: "stand alone output composition step",
 			stepRunners: []promotion.StepRunner{
-				&promotion.MockStepRunner{
-					StepName: ComposeOutputStepKind,
-					RunResult: promotion.StepResult{
-						Status: kargoapi.PromotionStepStatusSucceeded,
-						Output: map[string]any{"test": "value"},
+				promotion.NewTaskLevelOutputStepRunner(
+					&promotion.MockStepRunner{
+						StepName: "task-level-output-step",
+						RunResult: promotion.StepResult{
+							Status: kargoapi.PromotionStepStatusSucceeded,
+							Output: map[string]any{"test": "value"},
+						},
 					},
-				},
+				),
 			},
 			steps: []Step{{
-				Kind:  ComposeOutputStepKind,
+				Kind:  "task-level-output-step",
 				Alias: "custom-output",
 			}},
 			assertions: func(t *testing.T, result Result) {

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -490,17 +490,12 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 				assert.Contains(t, result.Message, context.Canceled.Error())
 				assert.Equal(t, int64(1), result.CurrentStep)
 
-				assert.Len(t, result.StepExecutionMetadata, 2)
+				assert.Len(t, result.StepExecutionMetadata, 1)
 
 				assert.Equal(t, kargoapi.PromotionStepStatusErrored, result.StepExecutionMetadata[0].Status)
 				assert.Contains(t, result.StepExecutionMetadata[0].Message, context.Canceled.Error())
 				assert.NotNil(t, result.StepExecutionMetadata[0].StartedAt)
 				assert.NotNil(t, result.StepExecutionMetadata[0].FinishedAt)
-
-				assert.Equal(t, kargoapi.PromotionStepStatusErrored, result.StepExecutionMetadata[1].Status)
-				assert.Contains(t, result.StepExecutionMetadata[1].Message, context.Canceled.Error())
-				assert.Nil(t, result.StepExecutionMetadata[1].StartedAt)
-				assert.Nil(t, result.StepExecutionMetadata[1].FinishedAt)
 			},
 		},
 		{

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -860,7 +860,6 @@ func TestSimpleEngine_executeStep(t *testing.T) {
 				tt.step,
 				tt.runner,
 				t.TempDir(),
-				make(promotion.State),
 			)
 			tt.assertions(t, result, err)
 		})
@@ -903,7 +902,6 @@ func TestSimpleEngine_prepareStepContext(t *testing.T) {
 				tt.promoCtx,
 				tt.step,
 				t.TempDir(),
-				make(promotion.State),
 			)
 			tt.assertions(t, stepCtx, err)
 		})

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -77,6 +77,49 @@ func (r *retryableStepRunner) DefaultErrorThreshold() uint32 {
 	return r.defaultErrorThreshold
 }
 
+// TaskLevelOutputStepRunner is an interface that defines a method to instruct
+// the engine to propagate the output of a step to the task namespace in the
+// shared state of the promotion result.
+type TaskLevelOutputStepRunner interface {
+	StepRunner
+	// TaskLevelOutput returns true if the StepRunner produces output that
+	// should be propagated to the task namespace in the state of the promotion
+	// result by the engine after the step is executed.
+	TaskLevelOutput() bool
+}
+
+// NewTaskLevelOutputStepRunner returns a wrapper around a StepRunner that
+// implements TaskLevelOutputStepRunner.
+func NewTaskLevelOutputStepRunner(runner StepRunner) TaskLevelOutputStepRunner {
+	return &taskLevelOutputStepRunner{
+		runner: runner,
+	}
+}
+
+// taskLevelOutputStepRunner is a wrapper around a StepRunner that implements
+// TaskLevelOutputStepRunner.
+type taskLevelOutputStepRunner struct {
+	runner StepRunner
+}
+
+// Name implements StepRunner.
+func (r *taskLevelOutputStepRunner) Name() string {
+	return r.runner.Name()
+}
+
+// Run implements StepRunner.
+func (r *taskLevelOutputStepRunner) Run(
+	ctx context.Context,
+	stepCtx *StepContext,
+) (StepResult, error) {
+	return r.runner.Run(ctx, stepCtx)
+}
+
+// TaskLevelOutput implements TaskLevelOutputStepRunner.
+func (r *taskLevelOutputStepRunner) TaskLevelOutput() bool {
+	return true
+}
+
 // StepContext is a type that represents the context in which a
 // single promotion step is executed by a StepRunner.
 type StepContext struct {
@@ -122,7 +165,7 @@ type StepContext struct {
 	Freight kargoapi.FreightCollection
 }
 
-// StepResult represents the results of single Step of a user-defined promotion
+// StepResult represents the results of a single Step of a user-defined promotion
 // process executed by a StepRunner.
 type StepResult struct {
 	// Status is the high-level outcome of a Step executed by a StepRunner.
@@ -131,7 +174,7 @@ type StepResult struct {
 	// outcome of a Step executed by a StepRunner.
 	Message string
 	// Output is the opaque output of a Step executed by a StepRunner. The Engine
-	// will update shared state with this output, making it available to the
+	// will update the shared state with this output, making it available to the
 	// StepRunners executing subsequent Steps.
 	Output map[string]any
 	// HealthCheck identifies criteria for a health check process. This is


### PR DESCRIPTION
This refines the "simple" Promotion engine to address technical debt and improve maintainability. As the features in the engine have grown, several architectural weaknesses have emerged — particularly around state management, component coupling, and code structure. This doesn't completely redesign the system, but makes small improvements to reduce complexity and support future development.

- The `promotion.Context` now acts as the single source of truth for state, and methods no longer accept separate state parameters. Previously, I had avoided this and imagined the context to be read-only. However, with the introduction of `StepExecutionMetadata` we started making direct modifications to `promotion.Context` anyway, and maintaining separate state parameters created an inconsistent pattern that was both confusing and error-prone. 
- Instead of determining if output should be added under the "namespace" of a task by being aware of specific step name (e.g. `compose-output`), the engine now looks if the step implements a `TaskLevelOutputStepRunner` interface. This provides better (albeit — not great) separation of concerns and removes step specific knowledge from the engine itself.
- The lengthy `executeSteps` method has been broken down into smaller methods to improve readability. While I still believe there is much room for improvement, this is a small incremental step to (hopefully) something better in the future.