### PR TITLE
fix(indexer): enrich context ArgoCD App indexer

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -146,14 +146,36 @@ func RunningPromotionsByArgoCDApplications(
 			return nil
 		}
 
+		// Get the Stage for the Promotion. We need this to build the context
+		// for the Promotion step.
+		stage := &kargoapi.Stage{}
+		if err := cl.Get(ctx, client.ObjectKey{
+			Name:      promo.Spec.Stage,
+			Namespace: promo.Namespace,
+		}, stage); err != nil {
+			logger.Error(
+				err,
+				"failed to get Stage for Promotion",
+				"promo", promo.Name,
+				"namespace", promo.Namespace,
+				"stage", promo.Spec.Stage,
+			)
+			return nil
+		}
+
 		// Build just enough context to extract the relevant config from the
 		// argocd-update promotion step.
 		promoCtx := promotion.Context{
-			Project:   promo.Namespace,
-			Stage:     promo.Spec.Stage,
-			Promotion: promo.Name,
-			State:     promo.Status.GetState(),
-			Vars:      promo.Spec.Vars,
+			Project:         promo.Namespace,
+			Stage:           promo.Spec.Stage,
+			FreightRequests: stage.Spec.RequestedFreight,
+			Promotion:       promo.Name,
+			State:           promo.Status.GetState(),
+			Vars:            promo.Spec.Vars,
+		}
+
+		if promo.Status.FreightCollection != nil {
+			promoCtx.Freight = *promo.Status.FreightCollection.DeepCopy()
 		}
 
 		// Extract the Argo CD Applications from the promotion steps.

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -276,6 +277,13 @@ func TestPromotionsByStage(t *testing.T) {
 func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 	const testShardName = "test-shard"
 
+	fakeStage := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-stage",
+			Namespace: "fake-namespace",
+		},
+	}
+
 	testCases := []struct {
 		name      string
 		obj       client.Object
@@ -328,7 +336,7 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 					Namespace: "fake-namespace",
 				},
 				Spec: kargoapi.PromotionSpec{
-					Stage: "fake-stage",
+					Stage: fakeStage.Name,
 					Vars: []kargoapi.ExpressionVariable{
 						{
 							Name:  "app",
@@ -429,7 +437,7 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 					Namespace: "fake-namespace",
 				},
 				Spec: kargoapi.PromotionSpec{
-					Stage: "fake-stage",
+					Stage: fakeStage.Name,
 					Steps: []kargoapi.PromotionStep{
 						{
 							Uses: "fake-directive",
@@ -449,12 +457,20 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = kargoapi.AddToScheme(scheme)
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(fakeStage.DeepCopy()).
+				Build()
+
 			require.Equal(
 				t,
 				testCase.expected,
 				RunningPromotionsByArgoCDApplications(
 					context.TODO(),
-					fake.NewClientBuilder().Build(),
+					c,
 					testCase.shardName,
 				)(testCase.obj),
 			)


### PR DESCRIPTION
Fixes: #4187

The context used by the indexer to build up a (minimal) evaluated version of the step configuration did not have any information about Freight (references) set. Given variables are allowed to use expr-lang functions, which may make use of this information (e.g., `getImage()`), this could result in unexpected issues.

The quick fix is to enrich the context with this information. But this indexer continues to be a candidate to be revised in full...