### PR TITLE
feat: Allow users with OIDC JWTs to fall through to bearerToken auth

### DIFF
--- a/internal/server/kubernetes/client.go
+++ b/internal/server/kubernetes/client.go
@@ -813,7 +813,6 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 					}
 				}
 			}
-			return nil, newForbiddenError(ra)
 		}
 
 		// If we get to here, we're dealing with a user who "authenticated" by just


### PR DESCRIPTION
Kubernetes supports the use of OIDC tokens for user authentication by sending the OIDC ID Tokens as the bearer token in requests. So returning access forbidden errors because someone has a OIDC token that doesn't map to Kargo's internal role system doesn't mean they're not authorised to interact with the underlying Kargo CRDs.

By allowing people who have authenticated with an OIDC token to fall through to k8s bearerToken auth, it makes it possible for people to use the same OIDC issuer for both their k8s authentication, and Kargo authentication, then rely solely on k8s RBAC to manage authorisation for both the k8s cluster and Kargo, regardless of the interface the user chooses (Kargo UI/CLI, Kubectl).