### PR TITLE
chore(backport release-1.5): fix(runner): step panic recovery within engine

### DIFF
--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -569,14 +569,14 @@ func Test_parseCreateActorAnnotation(t *testing.T) {
 func Test_calculateRequeueInterval(t *testing.T) {
 	testStepKindWithoutTimeout := "fake-step-without-timeout"
 	promotion.RegisterStepRunner(
-		&pkgPromotion.MockStepRunner{Nm: testStepKindWithoutTimeout},
+		&pkgPromotion.MockStepRunner{StepName: testStepKindWithoutTimeout},
 	)
 
 	testStepKindWithTimeout := "fake-step-with-timeout"
 	testTimeout := 10 * time.Minute
 	promotion.RegisterStepRunner(
 		pkgPromotion.NewRetryableStepRunner(
-			&pkgPromotion.MockStepRunner{Nm: testStepKindWithTimeout},
+			&pkgPromotion.MockStepRunner{StepName: testStepKindWithTimeout},
 			&testTimeout,
 			0, // Retries don't matter for this test
 		),

--- a/internal/promotion/simple_engine.go
+++ b/internal/promotion/simple_engine.go
@@ -348,7 +348,18 @@ func (e *simpleEngine) executeStep(
 	runner promotion.StepRunner,
 	workDir string,
 	state promotion.State,
-) (promotion.StepResult, error) {
+) (result promotion.StepResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = promotion.StepResult{
+				Status: kargoapi.PromotionStepStatusErrored,
+			}
+			err = &promotion.TerminalError{
+				Err: fmt.Errorf("step %q panicked: %v", step.Alias, r),
+			}
+		}
+	}()
+
 	stepCtx, err := e.prepareStepContext(ctx, promoCtx, step, workDir, state)
 	if err != nil {
 		return promotion.StepResult{
@@ -356,8 +367,7 @@ func (e *simpleEngine) executeStep(
 		}, &promotion.TerminalError{Err: err}
 	}
 
-	result, err := runner.Run(ctx, stepCtx)
-	if err != nil {
+	if result, err = runner.Run(ctx, stepCtx); err != nil {
 		err = fmt.Errorf("error running step %q: %w", step.Alias, err)
 	}
 	return result, err

--- a/pkg/promotion/mock_step_runner.go
+++ b/pkg/promotion/mock_step_runner.go
@@ -5,8 +5,8 @@ import "context"
 // MockStepRunner is a mock implementation of the StepRunner interface, which
 // can be used for testing.
 type MockStepRunner struct {
-	// Nm is the name of the StepRunner.
-	Nm string
+	// StepName is the name of the StepRunner.
+	StepName string
 	// RunFunc is the function that the StepRunner should call when Run is called.
 	// If set, this function will be called instead of returning RunResult and
 	// RunErr.
@@ -20,7 +20,7 @@ type MockStepRunner struct {
 
 // Name implements the StepRunner interface.
 func (m *MockStepRunner) Name() string {
-	return m.Nm
+	return m.StepName
 }
 
 // Run implements the StepRunner interface.


### PR DESCRIPTION
Manual backport of #4169 due to merge conflicts.