### PR TITLE
refactor: fix env var with a poorly chosen name

### DIFF
--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -21,8 +21,8 @@ import (
 type apiOptions struct {
 	KubeConfig string
 
-	Host string
-	Port string
+	BindAddress string
+	Port        string
 
 	Logger *logging.Logger
 }
@@ -52,7 +52,7 @@ func newAPICommand() *cobra.Command {
 func (o *apiOptions) complete() {
 	o.KubeConfig = os.GetEnv("KUBECONFIG", "")
 
-	o.Host = os.GetEnv("HOST", "0.0.0.0")
+	o.BindAddress = os.GetEnv("BIND_ADDRESS", "0.0.0.0")
 	o.Port = os.GetEnv("PORT", "8080")
 }
 
@@ -128,7 +128,7 @@ func (o *apiOptions) run(ctx context.Context) error {
 			"api",
 		),
 	)
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.Host, o.Port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.BindAddress, o.Port))
 	if err != nil {
 		return fmt.Errorf("error creating listener: %w", err)
 	}

--- a/cmd/controlplane/external_webhooks.go
+++ b/cmd/controlplane/external_webhooks.go
@@ -21,8 +21,8 @@ import (
 type externalWebhooksServerOptions struct {
 	KubeConfig string
 
-	Host string
-	Port string
+	BindAddress string
+	Port        string
 
 	Logger *logging.Logger
 }
@@ -51,7 +51,7 @@ func newExternalWebhooksServerCommand() *cobra.Command {
 
 func (o *externalWebhooksServerOptions) complete() {
 	o.KubeConfig = os.GetEnv("KUBECONFIG", "")
-	o.Host = os.GetEnv("HOST", "0.0.0.0")
+	o.BindAddress = os.GetEnv("BIND_ADDRESS", "0.0.0.0")
 	o.Port = os.GetEnv("PORT", "8080")
 }
 
@@ -92,7 +92,7 @@ func (o *externalWebhooksServerOptions) run(ctx context.Context) error {
 	}
 
 	srv := external.NewServer(serverCfg, cluster.GetClient())
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.Host, o.Port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.BindAddress, o.Port))
 	if err != nil {
 		return fmt.Errorf("error creating listener: %w", err)
 	}


### PR DESCRIPTION
`HOST` was a poorly chosen env var name that I regret. I regard this as a non-breaking change because it's not now, and never was, configurable by the chart. (When running in k8s, the bind address, should really _always_ be `0.0.0.0`.) This only would have ever affected anyone attempting to run a server component as a native process and that's not really something we've ever officially supported.

cc @fuskovic 