### PR TITLE
docs: Fixed sourceBranch reference for git-open-pr promotion step

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -63,7 +63,7 @@ steps:
   config:
     repoURL: https://github.com/example/repo.git
     createTargetBranch: true
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ task.outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
 # Wait for the PR to be merged or closed...
 ```
@@ -92,7 +92,7 @@ steps:
 - uses: git-open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ task.outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
     title: Deploy to ${{ ctx.stage }}
     labels: ["infra", "needs-review"]


### PR DESCRIPTION
Fixes: https://github.com/akuity/kargo/issues/4250

This PR fixes an issue in the docs, where the `git-open-pr` promotion step suggests an incorrect way to reference the output branch of the following `git-push` step.