### PR TITLE
chore: update the status for `git commit` step to skip if no diffs are found

### DIFF
--- a/internal/promotion/runner/builtin/git_commiter.go
+++ b/internal/promotion/runner/builtin/git_commiter.go
@@ -82,6 +82,8 @@ func (g *gitCommitter) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error checking for diffs in working tree: %w", err)
 	}
+
+	// only commit if diffs have been found
 	if hasDiffs {
 		commitOpts := &git.CommitOptions{}
 		if cfg.Author != nil {
@@ -96,13 +98,21 @@ func (g *gitCommitter) run(
 				fmt.Errorf("error committing to working tree: %w", err)
 		}
 	}
+
 	commitID, err := workTree.LastCommitID()
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)
 	}
+
+	status := kargoapi.PromotionStepStatusSucceeded
+	// if there are no diffs found, the 'git-status' step is skipped
+	// since there's nothing to commit. Hence, marks the status as skipped.
+	if !hasDiffs {
+		status = kargoapi.PromotionStepStatusSkipped
+	}
 	return promotion.StepResult{
-		Status: kargoapi.PromotionStepStatusSucceeded,
+		Status: status,
 		Output: map[string]any{stateKeyCommit: commitID},
 	}, nil
 }

--- a/internal/promotion/runner/builtin/git_commiter_test.go
+++ b/internal/promotion/runner/builtin/git_commiter_test.go
@@ -69,7 +69,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 		{
 			name: "author email is not specified",
 			config: promotion.Config{ // If author is specified, email must be specified
-				"author":  promotion.Config{
+				"author": promotion.Config{
 					"name": "Tony Stark",
 				},
 				"path":    "/tmp/foo",
@@ -96,7 +96,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 		{
 			name: "author name is not specified",
 			config: promotion.Config{ // If author is specified, name must be specified
-				"author":  promotion.Config{
+				"author": promotion.Config{
 					"email": "example@example.com",
 				},
 				"path":    "/tmp/foo",
@@ -110,7 +110,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 			name: "author name is empty string",
 			config: promotion.Config{
 				"author": promotion.Config{
-					"name": "",
+					"name":  "",
 					"email": "example@example.com",
 				},
 				"path":    "/tmp/foo",
@@ -150,8 +150,8 @@ func Test_gitCommitter_validate(t *testing.T) {
 			name: "valid kitchen sink",
 			config: promotion.Config{
 				"author": promotion.Config{
-					"email": "tony@starkindustries.com",
-					"name":  "Tony Stark",
+					"email":      "tony@starkindustries.com",
+					"name":       "Tony Stark",
 					"signingKey": "valid-signing-key",
 				},
 				"path":    "/tmp/foo",
@@ -254,4 +254,23 @@ func Test_gitCommitter_run(t *testing.T) {
 	lastCommitMsg, err := workTree.CommitMessage("HEAD")
 	require.NoError(t, err)
 	require.Equal(t, "Initial commit\n", lastCommitMsg)
+
+	res, err = runner.run(
+		context.Background(),
+		stepCtx,
+		builtin.GitCommitConfig{
+			Path:    "master",
+			Message: "No-Op commit",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, kargoapi.PromotionStepStatusSkipped, res.Status)
+
+	// it should still return the same commit ID
+	actualCommit, ok = res.Output[stateKeyCommit]
+	require.True(t, ok)
+	require.Equal(t, expectedCommit, actualCommit)
+	lastCommitMsg, err = workTree.CommitMessage("HEAD")
+	require.NoError(t, err)
+	require.Equal(t, "No-Op commit\n", lastCommitMsg)
 }


### PR DESCRIPTION
Closes https://github.com/akuity/kargo/issues/4247

One other way that to fix the same problem would be to add a status field as a part of `git commit` step that shows whether the step was skipped or not. 