### PR TITLE
feat: commits in git clone output

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
@@ -29,7 +29,7 @@ multiple working trees.
 | `author.email` | `string` | Y | The committer's email address. |
 | `author.signingKey` | `string` | N | The GPG signing key for the author. This field is optional. |
 | `checkout` | `[]object` | Y | The commits, branches, or tags to check out from the repository and the paths where they should be checked out. At least one must be specified. |
-| `checkout[].as` | `string` | N | If provided, it will be used as the key in the `commits` output map instead of `path`. Useful for referencing checkouts in downstream steps with a stable name. |
+| `checkout[].as` | `string` | N | Used as the key in the `commits` output map. If not specified, the value of the `path` field is used as a key instead. Providing a value for this field is useful when expressions in downstream steps may need to reference specific commits checked out by this step. |
 | `checkout[].branch` | `string` | N | A branch to check out. Mutually exclusive with `commit` and `tag`. If none of these is specified, the default branch will be checked out. |
 | `checkout[].create` | `boolean` | N | In the event `branch` does not already exist on the remote, whether a new, empty, orphaned branch should be created. Default is `false`, but should commonly be set to `true` for Stage-specific branches, which may not exist yet at the time of a Stage's first promotion. |
 | `checkout[].commit` | `string` | N | A specific commit to check out. Mutually exclusive with `branch` and `tag`. If none of these is specified, the default branch will be checked out. |
@@ -40,7 +40,7 @@ multiple working trees.
 
 | Name    | Type                | Description                                                                                      |
 |---------|---------------------|--------------------------------------------------------------------------------------------------|
-| `commits` | `object` | A map of checkout keys (either the `as` alias or the `path` if `as` is not set) to the HEAD commit hash checked out at each path. This allows downstream steps to reference the exact commit checked out for each working tree. |
+| `commits` | `map[string]string` | A map of checkout keys (either the `as` alias or the `path` if `as` is not set) to the HEAD commit hash checked out at each path. This allows downstream steps to reference the exact commit checked out for each working tree. |
 
 ## Examples
 

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
@@ -29,11 +29,18 @@ multiple working trees.
 | `author.email` | `string` | Y | The committer's email address. |
 | `author.signingKey` | `string` | N | The GPG signing key for the author. This field is optional. |
 | `checkout` | `[]object` | Y | The commits, branches, or tags to check out from the repository and the paths where they should be checked out. At least one must be specified. |
+| `checkout[].as` | `string` | N | If provided, it will be used as the key in the `commits` output map instead of `path`. Useful for referencing checkouts in downstream steps with a stable name. |
 | `checkout[].branch` | `string` | N | A branch to check out. Mutually exclusive with `commit` and `tag`. If none of these is specified, the default branch will be checked out. |
 | `checkout[].create` | `boolean` | N | In the event `branch` does not already exist on the remote, whether a new, empty, orphaned branch should be created. Default is `false`, but should commonly be set to `true` for Stage-specific branches, which may not exist yet at the time of a Stage's first promotion. |
 | `checkout[].commit` | `string` | N | A specific commit to check out. Mutually exclusive with `branch` and `tag`. If none of these is specified, the default branch will be checked out. |
-| `checkout[].tag` | `string` | N | A tag to check out. Mutually exclusive with `branch` and `commit`. If none of these is specified, the default branch will be checked out. |
 | `checkout[].path` | `string` | Y | The path for a working tree that will be created from the checked out revision. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `checkout[].tag` | `string` | N | A tag to check out. Mutually exclusive with `branch` and `commit`. If none of these is specified, the default branch will be checked out. |
+
+## Output
+
+| Name    | Type                | Description                                                                                      |
+|---------|---------------------|--------------------------------------------------------------------------------------------------|
+| `commits` | `object` | A map of checkout keys (either the `as` alias or the `path` if `as` is not set) to the HEAD commit hash checked out at each path. This allows downstream steps to reference the exact commit checked out for each working tree. |
 
 ## Examples
 

--- a/internal/promotion/runner/builtin/git_cloner.go
+++ b/internal/promotion/runner/builtin/git_cloner.go
@@ -59,44 +59,43 @@ func (g *gitCloner) Name() string {
 	return "git-clone"
 }
 
+// validateAndUnmarshal validates the config and unmarshals it into a typed struct.
+func (g *gitCloner) validateAndUnmarshal(cfg promotion.Config) (builtin.GitCloneConfig, error) {
+	// Schema validation
+	if err := validate(g.schemaLoader, gojsonschema.NewGoLoader(cfg), g.Name()); err != nil {
+		return builtin.GitCloneConfig{}, err
+	}
+
+	// Unmarshal to typed config
+	typedCfg, err := promotion.ConfigToStruct[builtin.GitCloneConfig](cfg)
+	if err != nil {
+		return builtin.GitCloneConfig{}, fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
+	}
+
+	// Additional validation: ensure unique 'as' aliases in checkout
+	seen := make(map[string]struct{})
+	for i, c := range typedCfg.Checkout {
+		as := c.As
+		if as != "" {
+			if _, exists := seen[as]; exists {
+				return builtin.GitCloneConfig{}, fmt.Errorf("invalid git-clone config: duplicate checkout.as value %q at checkout[%d]", as, i)
+			}
+			seen[as] = struct{}{}
+		}
+	}
+	return typedCfg, nil
+}
+
 // Run implements the promotion.StepRunner interface.
 func (g *gitCloner) Run(
 	ctx context.Context,
 	stepCtx *promotion.StepContext,
 ) (promotion.StepResult, error) {
-	if err := g.validate(stepCtx.Config); err != nil {
+	cfg, err := g.validateAndUnmarshal(stepCtx.Config)
+	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
 	}
-	cfg, err := promotion.ConfigToStruct[builtin.GitCloneConfig](stepCtx.Config)
-	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("could not convert config into %s config: %w", g.Name(), err)
-	}
 	return g.run(ctx, stepCtx, cfg)
-}
-
-// validate validates gitCloner configuration against a JSON schema.
-func (g *gitCloner) validate(cfg promotion.Config) error {
-	err := validate(g.schemaLoader, gojsonschema.NewGoLoader(cfg), g.Name())
-	if err != nil {
-		return err
-	}
-
-	// Additional validation: ensure unique 'as' aliases in checkout
-	checkouts, ok := cfg["checkout"].([]promotion.Config)
-	if ok {
-		seen := make(map[string]struct{})
-		for i, c := range checkouts {
-			as, hasAs := c["as"].(string)
-			if hasAs && as != "" {
-				if _, exists := seen[as]; exists {
-					return fmt.Errorf("invalid git-clone config: duplicate checkout.as value %q at checkout[%d]", as, i)
-				}
-				seen[as] = struct{}{}
-			}
-		}
-	}
-	return nil
 }
 
 func (g *gitCloner) run(

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -348,7 +348,7 @@ func Test_gitCloner_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.validateAndUnmarshal(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -116,6 +116,25 @@ func Test_gitCloner_validate(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate aliases",
+			config: promotion.Config{
+				"repoURL": "https://github.com/example/repo.git",
+				"checkout": []promotion.Config{
+					{
+						"path": "/fake/path/0",
+						"as":   "alias1",
+					},
+					{
+						"path": "/fake/path/1",
+						"as":   "alias1",
+					},
+				},
+			},
+			expectedProblems: []string{
+				"invalid git-clone config: duplicate checkout.as value \"alias1\" at checkout[1]",
+			},
+		},
+		{
 			name: "author name is missing",
 			config: promotion.Config{
 				"repoURL": "https://github.com/example/repo.git",
@@ -267,36 +286,24 @@ func Test_gitCloner_validate(t *testing.T) {
 					},
 					{
 						"path": "/fake/path/8",
+						"as":   "alias1", // unique as alias
 					},
 					{
 						"branch": "",
 						"commit": "",
 						"tag":    "",
 						"path":   "/fake/path/9",
+						"as":     "alias2", // another unique as alias
 					},
 					{
 						"path": "/fake/path/10",
-					},
-				},
-			},
-		},
-		{
-			name: "duplicate as aliases",
-			config: promotion.Config{
-				"repoURL": "https://github.com/example/repo.git",
-				"checkout": []promotion.Config{
-					{
-						"path": "/fake/path/0",
-						"as":   "alias1",
+						"as":   "", // empty as field
 					},
 					{
-						"path": "/fake/path/1",
-						"as":   "alias1",
+						"path": "/fake/path/11",
+						"as":   "", // another empty as field
 					},
 				},
-			},
-			expectedProblems: []string{
-				"invalid git-clone config: duplicate checkout.as value \"alias1\" at checkout[1]",
 			},
 		},
 		{

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -423,4 +423,12 @@ func Test_gitCloner_run(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dirEntries, 1) // Just the .git file
 	require.FileExists(t, filepath.Join(stepCtx.WorkDir, "out", ".git"))
+
+	// Assert output map contains the expected commit hashes for each checkout key
+	commits, ok := res.Output["commits"].(map[string]string)
+	require.True(t, ok, "output.commits should be a map[string]string")
+	require.Contains(t, commits, "src")
+	require.Equal(t, commitID, commits["src"])
+	require.Contains(t, commits, "out")
+	require.NotEmpty(t, commits["out"])
 }

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitCloner_validate(t *testing.T) {
+func Test_gitCloner_validateAndUnmarshal(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -280,6 +280,59 @@ func Test_gitCloner_validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "duplicate as aliases",
+			config: promotion.Config{
+				"repoURL": "https://github.com/example/repo.git",
+				"checkout": []promotion.Config{
+					{
+						"path": "/fake/path/0",
+						"as":   "alias1",
+					},
+					{
+						"path": "/fake/path/1",
+						"as":   "alias1",
+					},
+				},
+			},
+			expectedProblems: []string{
+				"invalid git-clone config: duplicate checkout.as value \"alias1\" at checkout[1]",
+			},
+		},
+		{
+			name: "unique as aliases",
+			config: promotion.Config{
+				"repoURL": "https://github.com/example/repo.git",
+				"checkout": []promotion.Config{
+					{
+						"path": "/fake/path/0",
+						"as":   "alias1",
+					},
+					{
+						"path": "/fake/path/1",
+						"as":   "alias2",
+					},
+				},
+			},
+			// No expected problems
+		},
+		{
+			name: "empty as fields are ignored for uniqueness",
+			config: promotion.Config{
+				"repoURL": "https://github.com/example/repo.git",
+				"checkout": []promotion.Config{
+					{
+						"path": "/fake/path/0",
+						"as":   "",
+					},
+					{
+						"path": "/fake/path/1",
+						"as":   "",
+					},
+				},
+			},
+			// No expected problems
+		},
 	}
 
 	r := newGitCloner(nil)

--- a/internal/promotion/runner/builtin/schemas/git-clone-config.json
+++ b/internal/promotion/runner/builtin/schemas/git-clone-config.json
@@ -45,6 +45,10 @@
         "additionalProperties": false,
         "required": ["path"],
         "properties": {
+          "as": {
+            "type": "string",
+            "description": "Optional alias for this checkout. If provided, it will be used as the key in the 'commits' output map."
+          },
           "branch": {
             "type": "string",
             "description": "The branch to checkout. Mutually exclusive with 'commit' and 'tag'. If none of these are specified, the default branch is checked out."

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -131,6 +131,9 @@ type GitCloneConfigAuthor struct {
 }
 
 type Checkout struct {
+	// Optional alias for this checkout. If provided, it will be used as the key in the
+	// 'commits' output map.
+	As string `json:"as,omitempty"`
 	// The branch to checkout. Mutually exclusive with 'commit' and 'tag'. If none of these are
 	// specified, the default branch is checked out.
 	Branch string `json:"branch,omitempty"`

--- a/ui/src/gen/directives/git-clone-config.json
+++ b/ui/src/gen/directives/git-clone-config.json
@@ -41,6 +41,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+     "as": {
+      "type": "string",
+      "description": "Optional alias for this checkout. If provided, it will be used as the key in the 'commits' output map."
+     },
      "branch": {
       "type": "string",
       "description": "The branch to checkout. Mutually exclusive with 'commit' and 'tag'. If none of these are specified, the default branch is checked out."


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/4112

as a part of this I will extend the `git-clone` step to output the commit hash for each checkout. since a single `git-clone` operation can have multiple `checkout` entries (each potentially pointing to a different HEAD), we need a way to reference each commit individually:

1. adding an optional `as` field to each `checkout` block to define a logical alias:

 ```yaml
 checkout:
 - branch: main
  path: ./main
  as: source
 - branch: my-rendered-branch
  path: ./rendered
  create: true
  as: target
 ```

2. the `git-clone` step will emit an output map `commits` containing the resolved HEAD commit hash for each checkout, keyed by `as` if set, otherwise by the `path`:

 ```json
  "commits": {
   "source": "sdfsdfs",
   "target": "sdfsdfs"
  }
 ```

 or (fallback)

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/e31b88cf-6db2-4edd-9f13-3aa7a0e85ecf" />

-> this allows downstream steps to reference the correct commit using:

 ```yaml
 ${{ tasks.outputs['clone'].commits['source'] }}
 ```
