### PR TITLE
refactor(ui): do not check code_challenge_methods_supported before oidc authorization code flow

### DIFF
--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -62,18 +62,7 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
       issuerUrl &&
       discoveryRequest(issuerUrl, {
         [allowInsecureRequests]: shouldAllowHttpRequest()
-      })
-        .then((response) => processDiscoveryResponse(issuerUrl, response))
-        .then((response) => {
-          if (
-            response.code_challenge_methods_supported?.includes('S256') !== true &&
-            !issuerUrl.toString().startsWith('https://login.microsoftonline.com')
-          ) {
-            throw new Error('OIDC config fetch error');
-          }
-
-          return response;
-        }),
+      }).then((response) => processDiscoveryResponse(issuerUrl, response)),
     enabled: !!issuerUrl
   });
 
@@ -110,7 +99,7 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
       const code_verifier = sessionStorage.getItem(codeVerifierKey);
       const searchParams = new URLSearchParams(location.search);
 
-      if (!as || !code_verifier || !searchParams.get('code') || !searchParams.get('code')) {
+      if (!as || !code_verifier || !searchParams.get('code')) {
         return;
       }
 

--- a/ui/src/features/auth/token-renew.tsx
+++ b/ui/src/features/auth/token-renew.tsx
@@ -53,18 +53,7 @@ export const TokenRenew = () => {
       issuerUrl &&
       discoveryRequest(issuerUrl, {
         [allowInsecureRequests]: shouldAllowHttpRequest()
-      })
-        .then((response) => processDiscoveryResponse(issuerUrl, response))
-        .then((response) => {
-          if (
-            response.code_challenge_methods_supported?.includes('S256') !== true &&
-            !issuerUrl.toString().startsWith('https://login.microsoftonline.com')
-          ) {
-            throw new Error('OIDC config fetch error');
-          }
-
-          return response;
-        }),
+      }).then((response) => processDiscoveryResponse(issuerUrl, response)),
     enabled: !!issuerUrl
   });
 


### PR DESCRIPTION
Fixes #4003

Cognito is the _second_ IDP we're aware of whose discovery endpoint does not properly advertise `S256` as one of its `code_challenge_methods_supported`, even thought it _does_. (The other we were aware of is Entra.)

This change stops the UI from checking for that in order to proceed with the OIDC authorization code flow. The CLI already was not checking for this.