### PR TITLE
feat: validate webhook receiver name uniqueness + add webhook receiver name to hashed path

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -938,9 +938,6 @@ message ProjectConfigSpec {
 
   // WebhookReceivers describes Project-specific webhook receivers used for
   // processing events from various external platforms
-  //
-  // +kubebuilder:validation:MaxItems=5
-  // +kubebuilder:validation:XValidation:message="WebhookReceiverConfig must have a unique name",rule="self.all(i, size(self.filter(j, i.name == j.name)) == 1)"
   repeated WebhookReceiverConfig receivers = 2;
 }
 

--- a/api/v1alpha1/project_config_types.go
+++ b/api/v1alpha1/project_config_types.go
@@ -43,9 +43,6 @@ type ProjectConfigSpec struct {
 	PromotionPolicies []PromotionPolicy `json:"promotionPolicies,omitempty" protobuf:"bytes,1,rep,name=promotionPolicies"`
 	// WebhookReceivers describes Project-specific webhook receivers used for
 	// processing events from various external platforms
-	//
-	// +kubebuilder:validation:MaxItems=5
-	// +kubebuilder:validation:XValidation:message="WebhookReceiverConfig must have a unique name",rule="self.all(i, size(self.filter(j, i.name == j.name)) == 1)"
 	WebhookReceivers []WebhookReceiverConfig `json:"webhookReceivers,omitempty" protobuf:"bytes,2,rep,name=receivers"`
 }
 

--- a/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
@@ -193,11 +193,7 @@ spec:
                   required:
                   - github
                   type: object
-                maxItems: 5
                 type: array
-                x-kubernetes-validations:
-                - message: WebhookReceiverConfig must have a unique name
-                  rule: self.all(i, size(self.filter(j, i.name == j.name)) == 1)
             type: object
           status:
             description: Status describes the current status of a ProjectConfig.

--- a/charts/kargo/resources/crds/kargo.akuity.io_projects.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_projects.yaml
@@ -198,11 +198,7 @@ spec:
                   required:
                   - github
                   type: object
-                maxItems: 5
                 type: array
-                x-kubernetes-validations:
-                - message: WebhookReceiverConfig must have a unique name
-                  rule: self.all(i, size(self.filter(j, i.name == j.name)) == 1)
             type: object
           status:
             description: Status describes the Project's current status.

--- a/internal/controller/management/projectconfigs/project_configs.go
+++ b/internal/controller/management/projectconfigs/project_configs.go
@@ -271,6 +271,7 @@ func (r *reconciler) newWebhookReceiver(
 	wr := &kargoapi.WebhookReceiver{
 		Name: rc.Name,
 		Path: external.GenerateWebhookPath(
+			rc.Name,
 			pc.Name,
 			cfg.receiverType,
 			string(secret),

--- a/internal/controller/management/projectconfigs/project_configs_test.go
+++ b/internal/controller/management/projectconfigs/project_configs_test.go
@@ -254,6 +254,7 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 				Spec: kargoapi.ProjectConfigSpec{
 					WebhookReceivers: []kargoapi.WebhookReceiverConfig{
 						{
+							Name: "fake-webhook-receiver-name",
 							GitHub: &kargoapi.GitHubWebhookReceiver{
 								SecretRef: corev1.LocalObjectReference{
 									Name: "secret-that-exists",
@@ -269,6 +270,7 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 				require.NotNil(t, pc.Spec.WebhookReceivers[0].GitHub)
 				require.Equal(t,
 					external.GenerateWebhookPath(
+						"fake-webhook-receiver-name",
 						pc.Name,
 						kargoapi.WebhookReceiverTypeGitHub,
 						"fake-secret-data",

--- a/internal/webhook/external/github_test.go
+++ b/internal/webhook/external/github_test.go
@@ -64,6 +64,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"fakesecret",
@@ -135,6 +136,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"fakesecret",
@@ -206,6 +208,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -277,6 +280,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -349,6 +353,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -418,6 +423,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -488,6 +494,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -559,6 +566,7 @@ func TestGithubHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",

--- a/internal/webhook/external/path.go
+++ b/internal/webhook/external/path.go
@@ -8,11 +8,11 @@ import (
 
 // GenerateWebhookPath generates a unique path for a webhook based on the
 // provided webhook receiver name, project name, kind, and token.
-// The path is formatted as "/webhook/{provider}/{hash}" where the hash is
+// The path is formatted as "/webhook/{kind}/{hash}" where the hash is
 // a SHA-256 hash of the concatenated webhook receiver name, project name, and token.
-func GenerateWebhookPath(name, project, provider, token string) string {
+func GenerateWebhookPath(name, project, kind, token string) string {
 	input := []byte(name + project + token)
 	h := sha256.New()
 	h.Write(input)
-	return fmt.Sprintf("/webhook/%s/%x", strings.ToLower(provider), h.Sum(nil))
+	return fmt.Sprintf("/webhook/%s/%x", strings.ToLower(kind), h.Sum(nil))
 }

--- a/internal/webhook/external/path.go
+++ b/internal/webhook/external/path.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 )
 
-func GenerateWebhookPath(project, provider, token string) string {
-	input := []byte(project + token)
+// GenerateWebhookPath generates a unique path for a webhook based on the
+// provided webhook receiver name, project name, kind, and token.
+// The path is formatted as "/webhook/{provider}/{hash}" where the hash is
+// a SHA-256 hash of the concatenated webhook receiver name, project name, and token.
+func GenerateWebhookPath(name, project, provider, token string) string {
+	input := []byte(name + project + token)
 	h := sha256.New()
 	h.Write(input)
 	return fmt.Sprintf("/webhook/%s/%x", strings.ToLower(provider), h.Sum(nil))

--- a/internal/webhook/external/path.go
+++ b/internal/webhook/external/path.go
@@ -7,11 +7,12 @@ import (
 )
 
 // GenerateWebhookPath generates a unique path for a webhook based on the
-// provided webhook receiver name, project name, kind, and token.
+// provided webhook receiver name, project name, kind, and secret.
 // The path is formatted as "/webhook/{kind}/{hash}" where the hash is
-// a SHA-256 hash of the concatenated webhook receiver name, project name, and token.
-func GenerateWebhookPath(name, project, kind, token string) string {
-	input := []byte(name + project + token)
+// a SHA-256 hash of the concatenated webhook receiver name, project name, and secret.
+func GenerateWebhookPath(name, project, kind, secret string) string {
+	// Warning: Changes to this line could alter URLs that existing users may already be using
+	input := []byte(name + project + secret)
 	h := sha256.New()
 	h.Write(input)
 	return fmt.Sprintf("/webhook/%s/%x", strings.ToLower(kind), h.Sum(nil))

--- a/internal/webhook/external/server_test.go
+++ b/internal/webhook/external/server_test.go
@@ -129,6 +129,7 @@ func TestRouteHandler(t *testing.T) {
 								WebhookReceivers: []kargoapi.WebhookReceiver{
 									{
 										Path: GenerateWebhookPath(
+											"fake-webhook-receiver-name",
 											"fakename",
 											kargoapi.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
@@ -169,6 +170,7 @@ func TestRouteHandler(t *testing.T) {
 				return s
 			},
 			path: GenerateWebhookPath(
+				"fake-webhook-receiver-name",
 				"fakename",
 				kargoapi.WebhookReceiverTypeGitHub,
 				"mysupersecrettoken",

--- a/internal/webhook/kubernetes/projectconfig/webhook_test.go
+++ b/internal/webhook/kubernetes/projectconfig/webhook_test.go
@@ -68,6 +68,10 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 						{Stage: "stage-1"},
 						{Stage: "stage-2"},
 					},
+					WebhookReceivers: []kargoapi.WebhookReceiverConfig{
+						{Name: "receiver-1"},
+						{Name: "receiver-2"},
+					},
 				},
 			},
 			objects: []client.Object{testNs},
@@ -500,6 +504,46 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 				assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.ErrStatus.Details.Causes[1].Type)
 				assert.Contains(t, statusErr.ErrStatus.Details.Causes[1].Message,
 					`invalid pattern identifier "badpattern"`)
+			},
+		},
+		{
+			name: "duplicate webhook receiver names",
+			projectConfig: &kargoapi.ProjectConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testProjectName,
+					Namespace: testProjectName,
+				},
+				Spec: kargoapi.ProjectConfigSpec{
+					PromotionPolicies: []kargoapi.PromotionPolicy{
+						{Stage: "stage-1"},
+						{Stage: "stage-2"},
+					},
+					WebhookReceivers: []kargoapi.WebhookReceiverConfig{
+						{Name: "my-webhook-receiver"},
+						{Name: "my-webhook-receiver"},
+					},
+				},
+			},
+			objects: []client.Object{testNs},
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				require.Error(t, err)
+
+				var statusErr *apierrors.StatusError
+				require.True(t, errors.As(err, &statusErr))
+
+				assert.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+				assert.Equal(t, 1, len(statusErr.ErrStatus.Details.Causes))
+
+				// Sort errors for consistent testing
+				sort.Slice(statusErr.ErrStatus.Details.Causes, func(i, j int) bool {
+					return statusErr.ErrStatus.Details.Causes[i].Field < statusErr.ErrStatus.Details.Causes[j].Field
+				})
+
+				assert.Equal(t, "spec.webhookReceivers[1].name", statusErr.ErrStatus.Details.Causes[0].Field)
+				assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.ErrStatus.Details.Causes[0].Type)
+				assert.Contains(t, statusErr.ErrStatus.Details.Causes[0].Message,
+					"webhook receiver name already defined at spec.webhookReceivers[0]")
 			},
 		},
 	}

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -1908,9 +1908,6 @@ export type ProjectConfigSpec = Message<"github.com.akuity.kargo.api.v1alpha1.Pr
    * WebhookReceivers describes Project-specific webhook receivers used for
    * processing events from various external platforms
    *
-   * +kubebuilder:validation:MaxItems=5
-   * +kubebuilder:validation:XValidation:message="WebhookReceiverConfig must have a unique name",rule="self.all(i, size(self.filter(j, i.name == j.name)) == 1)"
-   *
    * @generated from field: repeated github.com.akuity.kargo.api.v1alpha1.WebhookReceiverConfig receivers = 2;
    */
   receivers: WebhookReceiverConfig[];

--- a/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
@@ -126,14 +126,7 @@
             ],
             "type": "object"
           },
-          "maxItems": 5,
-          "type": "array",
-          "x-kubernetes-validations": [
-            {
-              "message": "WebhookReceiverConfig must have a unique name",
-              "rule": "self.all(i, size(self.filter(j, i.name == j.name)) == 1)"
-            }
-          ]
+          "type": "array"
         }
       },
       "type": "object"

--- a/ui/src/gen/schema/projects.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/projects.kargo.akuity.io_v1alpha1.json
@@ -126,14 +126,7 @@
             ],
             "type": "object"
           },
-          "maxItems": 5,
-          "type": "array",
-          "x-kubernetes-validations": [
-            {
-              "message": "WebhookReceiverConfig must have a unique name",
-              "rule": "self.all(i, size(self.filter(j, i.name == j.name)) == 1)"
-            }
-          ]
+          "type": "array"
         }
       },
       "type": "object"


### PR DESCRIPTION
Closes https://github.com/akuity/kargo/issues/4227

<img width="1264" alt="Screenshot 2025-05-29 at 10 15 30 AM" src="https://github.com/user-attachments/assets/a9b65771-6ce4-481e-bb83-fc4893c069c3" />

Also Closes https://github.com/akuity/kargo/issues/4280