### PR TITLE
fix: missing forward slash

### DIFF
--- a/internal/controller/management/projectconfigs/project_configs.go
+++ b/internal/controller/management/projectconfigs/project_configs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -276,7 +277,15 @@ func (r *reconciler) newWebhookReceiver(
 			string(secret),
 		),
 	}
-	wr.URL = r.cfg.ExternalWebhookServerBaseURL + wr.Path
+	wr.URL, err = url.JoinPath(r.cfg.ExternalWebhookServerBaseURL + wr.Path)
+	if err != nil {
+		logger.Error(err, "error generating webhook URL",
+			"base-url", r.cfg.ExternalWebhookServerBaseURL,
+			"path", wr.Path,
+		)
+		return nil, fmt.Errorf("error generating webhook URL: %w", err)
+	}
+
 	logger.Debug("webhook receiver initialized",
 		"webhook-receiver", wr,
 	)

--- a/internal/controller/management/projectconfigs/project_configs.go
+++ b/internal/controller/management/projectconfigs/project_configs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -277,7 +276,7 @@ func (r *reconciler) newWebhookReceiver(
 			string(secret),
 		),
 	}
-	wr.URL = path.Join(r.cfg.ExternalWebhookServerBaseURL, wr.Path)
+	wr.URL = r.cfg.ExternalWebhookServerBaseURL + wr.Path
 	logger.Debug("webhook receiver initialized",
 		"webhook-receiver", wr,
 	)


### PR DESCRIPTION
I noticed the webhook receiver URL rendering with a missing forward slash in the protocol scheme.

e.g.

`https:/...`

instead of:

`https://...`

I found `path.Join` was removing it and the URL rendered correctly after using `url.JoinPath` instead.

<img width="704" alt="Screenshot 2025-06-02 at 7 30 00 AM" src="https://github.com/user-attachments/assets/0cbfea29-699e-47cf-89a4-8d8e1a3522f5" />
