### PR TITLE
fix(api): nil pointers in `RemoveCurrentStage`

### DIFF
--- a/api/v1alpha1/freight_types.go
+++ b/api/v1alpha1/freight_types.go
@@ -196,11 +196,12 @@ func (f *FreightStatus) AddCurrentStage(stage string, since time.Time) {
 // necessary.
 func (f *FreightStatus) RemoveCurrentStage(stage string) {
 	if record, in := f.CurrentlyIn[stage]; in {
-		if _, verified := f.VerifiedIn[stage]; verified {
+		if record.Since != nil {
 			soak := time.Since(record.Since.Time)
-			if soak > f.VerifiedIn[stage].LongestCompletedSoak.Duration {
-				f.VerifiedIn[stage] = VerifiedStage{
-					LongestCompletedSoak: &metav1.Duration{Duration: soak},
+			if vi, verified := f.VerifiedIn[stage]; verified {
+				if vi.LongestCompletedSoak == nil || soak > vi.LongestCompletedSoak.Duration {
+					vi.LongestCompletedSoak = &metav1.Duration{Duration: soak}
+					f.VerifiedIn[stage] = vi
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: #4277

- Ensure `LongestCompletedSoak` is set based it does not have a value.
- Preservation of other fields, to avoid erasing the verification timestamp.

@krancour: please carefully check if this matches the idea you had when you originally implemented this, as I suspect (based on the API documentation) that the core of this bug originates from some mistake made at the time.