### PR TITLE
webhook receiver type enums

### DIFF
--- a/api/v1alpha1/project_config_types.go
+++ b/api/v1alpha1/project_config_types.go
@@ -5,15 +5,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	WebhookReceiverTypeGitHub = "GitHub"
-	// TODO(fuskovic): Add more receiver enum types(e.g. Dockerhub, Quay, Gitlab, etc...)
-)
-
-const (
-	WebhookReceiverSecretKeyGithub = "token"
-)
-
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status

--- a/internal/api/webhook_receivers.go
+++ b/internal/api/webhook_receivers.go
@@ -1,0 +1,30 @@
+package api
+
+// WebhookReceiverType is an enum representing the type of a webhook receiver.
+// It is used to identify the platform or service that the webhook receiver is
+// associated with, such as GitHub or Quay.
+type WebhookReceiverType string
+
+func (w WebhookReceiverType) String() string {
+	return string(w)
+}
+
+const (
+	WebhookReceiverTypeGitHub WebhookReceiverType = "GitHub"
+	WebhookReceiverTypeQuay   WebhookReceiverType = "Quay"
+	// TODO(fuskovic): Add more receiver enum types(e.g. Dockerhub, Quay, Gitlab, etc...)
+)
+
+// WebhookReceiverSecretKey is an enum representing the key used in a secret
+// for a webhook receiver. It is used to identify the specific key that contains
+// the secret data required for the webhook receiver to function properly.
+type WebhookReceiverSecretKey string
+
+func (w WebhookReceiverSecretKey) String() string {
+	return string(w)
+}
+
+const (
+	WebhookReceiverSecretKeyGithub WebhookReceiverSecretKey = "token"
+	WebhookReceiverSecretKeyQuay   WebhookReceiverSecretKey = "quay-secret"
+)

--- a/internal/controller/management/projectconfigs/project_configs.go
+++ b/internal/controller/management/projectconfigs/project_configs.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/conditions"
 	"github.com/akuity/kargo/internal/controller"
 	"github.com/akuity/kargo/internal/kubeclient"
@@ -257,7 +258,7 @@ func (r *reconciler) newWebhookReceiver(
 	}
 	logger.Debug("secret found", "secret", cfg.secretName)
 
-	secret, ok := s.Data[cfg.targetKey]
+	secret, ok := s.Data[cfg.targetKey.String()]
 	if !ok {
 		logger.Error(err, "target key not found in secret data",
 			"target-key", cfg.targetKey,
@@ -294,8 +295,8 @@ func (r *reconciler) newWebhookReceiver(
 
 type providerConfig struct {
 	secretName   string
-	targetKey    string
-	receiverType string
+	targetKey    api.WebhookReceiverSecretKey
+	receiverType api.WebhookReceiverType
 }
 
 func getProviderConfig(rc kargoapi.WebhookReceiverConfig) (*providerConfig, error) {
@@ -306,8 +307,8 @@ func getProviderConfig(rc kargoapi.WebhookReceiverConfig) (*providerConfig, erro
 		}
 		return &providerConfig{
 			secretName:   rc.GitHub.SecretRef.Name,
-			targetKey:    kargoapi.WebhookReceiverSecretKeyGithub,
-			receiverType: kargoapi.WebhookReceiverTypeGitHub,
+			targetKey:    api.WebhookReceiverSecretKeyGithub,
+			receiverType: api.WebhookReceiverTypeGitHub,
 		}, nil
 	default:
 		return nil, errors.New("webhook receiver config has no valid entry")

--- a/internal/controller/management/projectconfigs/project_configs_test.go
+++ b/internal/controller/management/projectconfigs/project_configs_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/webhook/external"
 )
@@ -272,7 +273,7 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 					external.GenerateWebhookPath(
 						"fake-webhook-receiver-name",
 						pc.Name,
-						kargoapi.WebhookReceiverTypeGitHub,
+						api.WebhookReceiverTypeGitHub,
 						"fake-secret-data",
 					),
 					pc.Status.WebhookReceivers[0].Path,

--- a/internal/webhook/external/github.go
+++ b/internal/webhook/external/github.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	xhttp "github.com/akuity/kargo/internal/http"
 	"github.com/akuity/kargo/internal/io"
 	"github.com/akuity/kargo/internal/logging"
@@ -43,12 +43,12 @@ func githubHandler(
 			xhttp.WriteErrorJSON(w, errors.New("configuration error"))
 			return
 		}
-		token, ok := secret.Data[kargoapi.WebhookReceiverSecretKeyGithub]
+		token, ok := secret.Data[api.WebhookReceiverSecretKeyGithub.String()]
 		if !ok {
 			logger.Error(
 				errors.New("invalid secret data"),
 				"no value for target key",
-				"target-key", kargoapi.WebhookReceiverSecretKeyGithub,
+				"target-key", api.WebhookReceiverSecretKeyGithub,
 			)
 			xhttp.WriteErrorJSON(w, errors.New("configuration error"))
 			return

--- a/internal/webhook/external/github_test.go
+++ b/internal/webhook/external/github_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/indexer"
 	"github.com/akuity/kargo/internal/logging"
 )
@@ -66,7 +67,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"fakesecret",
 										),
 									},
@@ -138,7 +139,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"fakesecret",
 										),
 									},
@@ -210,7 +211,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -282,7 +283,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -355,7 +356,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -425,7 +426,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -496,7 +497,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -568,7 +569,7 @@ func TestGithubHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},

--- a/internal/webhook/external/path.go
+++ b/internal/webhook/external/path.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+
+	"github.com/akuity/kargo/internal/api"
 )
 
 // GenerateWebhookPath generates a unique path for a webhook based on the
@@ -11,11 +13,18 @@ import (
 // The path is formatted as "/webhook/{kind}/{hash}" where the hash is
 // a SHA-256 hash of the concatenated webhook receiver name, project name,
 // and secret.
-func GenerateWebhookPath(name, project, kind, secret string) string {
+func GenerateWebhookPath(
+	name string,
+	project string,
+	kind api.WebhookReceiverType,
+	secret string,
+) string {
 	// Warning: Changes to this line could alter URLs that existing users may
 	// already be using
 	input := []byte(name + project + secret)
 	h := sha256.New()
 	_, _ = h.Write(input)
-	return fmt.Sprintf("/webhook/%s/%x", strings.ToLower(kind), h.Sum(nil))
+	return fmt.Sprintf("/webhook/%s/%x",
+		strings.ToLower(kind.String()), h.Sum(nil),
+	)
 }

--- a/internal/webhook/external/server_test.go
+++ b/internal/webhook/external/server_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/api"
 	"github.com/akuity/kargo/internal/indexer"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/server/kubernetes"
@@ -131,7 +132,7 @@ func TestRouteHandler(t *testing.T) {
 										Path: GenerateWebhookPath(
 											"fake-webhook-receiver-name",
 											"fakename",
-											kargoapi.WebhookReceiverTypeGitHub,
+											api.WebhookReceiverTypeGitHub,
 											"mysupersecrettoken",
 										),
 									},
@@ -172,7 +173,7 @@ func TestRouteHandler(t *testing.T) {
 			path: GenerateWebhookPath(
 				"fake-webhook-receiver-name",
 				"fakename",
-				kargoapi.WebhookReceiverTypeGitHub,
+				api.WebhookReceiverTypeGitHub,
 				"mysupersecrettoken",
 			),
 			code: http.StatusOK,


### PR DESCRIPTION
Refactors `WebhookReceiverType` and `WebhookReceiverSecretKey` into enum types per: 

https://github.com/akuity/kargo/pull/4000#discussion_r2112004749
