### PR TITLE
feat(ui): quick promote from upstream

### DIFF
--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -213,7 +213,11 @@ export const StageNode = (props: { stage: Stage }) => {
     dropdownItems.push({
       key: 'quick-promote-upstream-freight-promo',
       label: 'Instant promote from upstream',
-      icon: <Typography.Text type='danger'><FontAwesomeIcon icon={faBoltLightning} /></Typography.Text>,
+      icon: (
+        <Typography.Text type='danger'>
+          <FontAwesomeIcon icon={faBoltLightning} />
+        </Typography.Text>
+      ),
       onClick:
         upstreamFreights?.length === 1
           ? () =>

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -3,6 +3,7 @@ import {
   faBarsStaggered,
   faBolt,
   faBoltLightning,
+  faCircleNotch,
   faExternalLink,
   faMinus,
   faTruckArrowRight
@@ -212,11 +213,17 @@ export const StageNode = (props: { stage: Stage }) => {
 
     dropdownItems.push({
       key: 'quick-promote-upstream-freight-promo',
-      label: 'Instant promote from upstream',
-      icon: (
-        <Typography.Text type='danger'>
-          <FontAwesomeIcon icon={faBoltLightning} />
-        </Typography.Text>
+      label: (
+        <>
+          {promoteActionMutation.isPending ? (
+            <FontAwesomeIcon icon={faCircleNotch} className='mr-1' spin />
+          ) : (
+            <Typography.Text type='danger' className='mr-2'>
+              <FontAwesomeIcon icon={faBoltLightning} />
+            </Typography.Text>
+          )}
+          Instant promote from upstream
+        </>
       ),
       onClick:
         upstreamFreights?.length === 1

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -2,7 +2,9 @@ import { useMutation } from '@connectrpc/connect-query';
 import {
   faBarsStaggered,
   faBolt,
+  faBoltLightning,
   faExternalLink,
+  faFire,
   faMinus,
   faTruckArrowRight
 } from '@fortawesome/free-solid-svg-icons';
@@ -22,7 +24,10 @@ import { getStagePhase } from '@ui/features/common/stage-status/utils';
 import { getCurrentFreight } from '@ui/features/common/utils';
 import { IAction, useActionContext } from '@ui/features/project/pipelines/context/action-context';
 import { ColorMapHex, parseColorAnnotation } from '@ui/features/stage/utils';
-import { approveFreight } from '@ui/gen/api/service/v1alpha1/service-KargoService_connectquery';
+import {
+  approveFreight,
+  promoteToStage
+} from '@ui/gen/api/service/v1alpha1/service-KargoService_connectquery';
 import { Stage } from '@ui/gen/api/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
 
@@ -34,6 +39,7 @@ import { stageIndexer } from '../graph/node-indexer';
 import './stage-node.less';
 import style from './node-size-source-of-truth.module.less';
 import { StageFreight } from './stage-freight';
+import { useGetUpstreamFreight } from './use-get-upstream-freight';
 
 export const StageNode = (props: { stage: Stage }) => {
   const navigate = useNavigate();
@@ -54,6 +60,19 @@ export const StageNode = (props: { stage: Stage }) => {
   const controlFlow = isStageControlFlow(props.stage);
 
   const hideStage = useHideStageIfInPromotionMode(props.stage);
+
+  const upstreamFreights = useGetUpstreamFreight(props.stage);
+
+  const promoteActionMutation = useMutation(promoteToStage, {
+    onSuccess: (response) => {
+      navigate(
+        generatePath(paths.promotion, {
+          name: props.stage?.metadata?.namespace,
+          promotionId: response.promotion?.metadata?.name
+        })
+      );
+    }
+  });
 
   const totalSubscribersToThisStage =
     dictionaryContext?.subscribersByStage?.[props.stage?.metadata?.name || '']?.size || 0;
@@ -160,6 +179,68 @@ export const StageNode = (props: { stage: Stage }) => {
     });
   }
 
+  if ((upstreamFreights?.length || 0) > 0) {
+    dropdownItems.push({
+      key: 'upstream-freight-promo',
+      label: 'Promote from upstream',
+      icon: <FontAwesomeIcon icon={faBoltLightning} className='mt-1' />,
+      onClick:
+        upstreamFreights?.length === 1
+          ? () =>
+              navigate(
+                generatePath(paths.promote, {
+                  name: props.stage?.metadata?.namespace,
+                  freight: upstreamFreights?.[0]?.name,
+                  stage: props.stage?.metadata?.name
+                })
+              )
+          : undefined,
+      children:
+        (upstreamFreights?.length || 0) > 1
+          ? upstreamFreights?.map((f) => ({
+              key: f?.name,
+              label: f?.origin?.name,
+              onClick: () =>
+                navigate(
+                  generatePath(paths.promote, {
+                    name: props.stage?.metadata?.namespace,
+                    freight: f?.name,
+                    stage: props.stage?.metadata?.name
+                  })
+                )
+            }))
+          : undefined
+    });
+
+    dropdownItems.push({
+      key: 'quick-promote-upstream-freight-promo',
+      label: <span className='text-orange-500'>Quick promote from upstream</span>,
+      icon: <FontAwesomeIcon icon={faFire} className='mt-1 text-orange-500' />,
+      onClick:
+        upstreamFreights?.length === 1
+          ? () =>
+              promoteActionMutation.mutate({
+                stage: props.stage?.metadata?.name,
+                project: props.stage?.metadata?.namespace,
+                freight: upstreamFreights?.[0]?.name
+              })
+          : undefined,
+      children:
+        (upstreamFreights?.length || 0) > 1
+          ? upstreamFreights?.map((f) => ({
+              key: f?.name,
+              label: f?.origin?.name,
+              onClick: () =>
+                promoteActionMutation.mutate({
+                  stage: props.stage?.metadata?.name,
+                  project: props.stage?.metadata?.namespace,
+                  freight: f?.name
+                })
+            }))
+          : undefined
+    });
+  }
+
   return (
     <Card
       styles={{
@@ -177,7 +258,7 @@ export const StageNode = (props: { stage: Stage }) => {
           <Space>
             <Dropdown
               trigger={['hover']}
-              overlayClassName='w-[220px]'
+              overlayClassName='w-fit'
               menu={{
                 items: dropdownItems
               }}

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -4,7 +4,6 @@ import {
   faBolt,
   faBoltLightning,
   faExternalLink,
-  faFire,
   faMinus,
   faTruckArrowRight
 } from '@fortawesome/free-solid-svg-icons';
@@ -183,7 +182,6 @@ export const StageNode = (props: { stage: Stage }) => {
     dropdownItems.push({
       key: 'upstream-freight-promo',
       label: 'Promote from upstream',
-      icon: <FontAwesomeIcon icon={faBoltLightning} className='mt-1' />,
       onClick:
         upstreamFreights?.length === 1
           ? () =>
@@ -214,8 +212,8 @@ export const StageNode = (props: { stage: Stage }) => {
 
     dropdownItems.push({
       key: 'quick-promote-upstream-freight-promo',
-      label: <span className='text-orange-500'>Quick promote from upstream</span>,
-      icon: <FontAwesomeIcon icon={faFire} className='mt-1 text-orange-500' />,
+      label: 'Instant promote from upstream',
+      icon: <Button icon={<FontAwesomeIcon icon={faBoltLightning} />} danger type='text' />,
       onClick:
         upstreamFreights?.length === 1
           ? () =>

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -213,7 +213,7 @@ export const StageNode = (props: { stage: Stage }) => {
     dropdownItems.push({
       key: 'quick-promote-upstream-freight-promo',
       label: 'Instant promote from upstream',
-      icon: <Button icon={<FontAwesomeIcon icon={faBoltLightning} />} danger type='text' />,
+      icon: <Typography.Text type='danger'><FontAwesomeIcon icon={faBoltLightning} /></Typography.Text>,
       onClick:
         upstreamFreights?.length === 1
           ? () =>

--- a/ui/src/features/project/pipelines/nodes/use-get-upstream-freight.ts
+++ b/ui/src/features/project/pipelines/nodes/use-get-upstream-freight.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+import { getCurrentFreight } from '@ui/features/common/utils';
+import { Stage } from '@ui/gen/api/v1alpha1/generated_pb';
+
+import { useDictionaryContext } from '../context/dictionary-context';
+
+export const useGetUpstreamFreight = (stage: Stage) => {
+  const dictionaryContext = useDictionaryContext();
+
+  return useMemo(() => {
+    const subscribersByStage = dictionaryContext?.subscribersByStage;
+
+    const stageName = stage?.metadata?.name || '';
+
+    const upstreamStages = [];
+
+    for (const [source, dests] of Object.entries(subscribersByStage || {})) {
+      if (dests.has(stageName)) {
+        upstreamStages.push(dictionaryContext?.stageByName[source]);
+      }
+    }
+
+    // feature: select from multiple stages
+    if (upstreamStages.length !== 1) {
+      return null;
+    }
+
+    if (!upstreamStages[0]) {
+      return null;
+    }
+
+    return getCurrentFreight(upstreamStages[0]);
+  }, [dictionaryContext?.subscribersByStage, dictionaryContext?.stageByName, stage]);
+};


### PR DESCRIPTION
fixes this https://github.com/akuity/kargo/issues/3224 but instead of downstream, it takes freight from upstream for the stage you want to be promoted at the moment

<img width="743" alt="Screenshot 2025-06-04 at 11 17 59 AM" src="https://github.com/user-attachments/assets/e9f6cf78-6a52-49d5-8067-260475f468f7" />

- Promote from upstream will give you promotion space to review
- Quick promote will just trigger promotion action instantly
- Multiple warehouses will get you option to select warehouse

![Screenshot 2025-06-03 at 3 27 17 PM (2)](https://github.com/user-attachments/assets/50dbd996-36f1-4fe0-8b37-a37357daef55)
