### PR TITLE
feat: support fallback to local cluster when searching for cred secrets

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -259,7 +259,7 @@ func (o *controllerOptions) setupKargoManager(
 
 	// Build a separate client for the local cluster...
 	if restCfg, err =
-		kubernetes.GetRestConfig(ctx, o.ControlPlaneKubeConfig); err != nil {
+		kubernetes.GetRestConfig(ctx, ""); err != nil {
 		return nil, nil, stagesReconcilerCfg,
 			fmt.Errorf("error loading REST config for local cluster client: %w", err)
 	}

--- a/internal/credentials/kubernetes/database.go
+++ b/internal/credentials/kubernetes/database.go
@@ -26,7 +26,8 @@ import (
 // utilizes a Kubernetes controller runtime client to retrieve credentials
 // stored in Kubernetes Secrets.
 type database struct {
-	kargoClient         client.Client
+	controlPlaneClient  client.Client
+	localClusterClient  client.Client
 	credentialProviders []credentials.Provider
 	cfg                 DatabaseConfig
 }
@@ -50,7 +51,8 @@ func DatabaseConfigFromEnv() DatabaseConfig {
 // client to retrieve Credentials stored in Kubernetes Secrets.
 func NewDatabase(
 	ctx context.Context,
-	kargoClient client.Client,
+	controlPlaneClient client.Client,
+	localClusterClient client.Client,
 	cfg DatabaseConfig,
 ) credentials.Database {
 	var credentialProviders = []credentials.Provider{
@@ -63,8 +65,9 @@ func NewDatabase(
 	}
 
 	db := &database{
-		kargoClient: kargoClient,
-		cfg:         cfg,
+		controlPlaneClient: controlPlaneClient,
+		localClusterClient: localClusterClient,
+		cfg:                cfg,
 	}
 
 	for _, p := range credentialProviders {
@@ -92,24 +95,35 @@ func (k *database) Get(
 		return nil, nil
 	}
 
+	clients := make([]client.Client, 1, 2)
+	clients[0] = k.controlPlaneClient
+	if k.localClusterClient != nil {
+		clients = append(clients, k.localClusterClient)
+	}
+
 	var secret *corev1.Secret
 	var err error
 
-	// Check namespace for credentials
-	if secret, err = k.getCredentialsSecret(
-		ctx,
-		namespace,
-		credType,
-		repoURL,
-	); err != nil {
-		return nil, err
-	}
-
-	if secret == nil {
+clientLoop:
+	for _, c := range clients {
+		// Check namespace for credentials
+		if secret, err = k.getCredentialsSecret(
+			ctx,
+			c,
+			namespace,
+			credType,
+			repoURL,
+		); err != nil {
+			return nil, err
+		}
+		if secret != nil {
+			break clientLoop
+		}
 		// Check global credentials namespaces for credentials
 		for _, globalCredsNamespace := range k.cfg.GlobalCredentialsNamespaces {
 			if secret, err = k.getCredentialsSecret(
 				ctx,
+				c,
 				globalCredsNamespace,
 				credType,
 				repoURL,
@@ -117,7 +131,7 @@ func (k *database) Get(
 				return nil, err
 			}
 			if secret != nil {
-				break
+				break clientLoop
 			}
 		}
 	}
@@ -142,6 +156,7 @@ func (k *database) Get(
 
 func (k *database) getCredentialsSecret(
 	ctx context.Context,
+	c client.Client,
 	namespace string,
 	credType credentials.Type,
 	repoURL string,
@@ -149,7 +164,7 @@ func (k *database) getCredentialsSecret(
 	// List all secrets in the namespace that are labeled with the credential
 	// type.
 	secrets := corev1.SecretList{}
-	if err := k.kargoClient.List(
+	if err := c.List(
 		ctx,
 		&secrets,
 		&client.ListOptions{

--- a/internal/credentials/kubernetes/database_test.go
+++ b/internal/credentials/kubernetes/database_test.go
@@ -15,15 +15,22 @@ import (
 )
 
 func TestNewKubernetesDatabase(t *testing.T) {
-	testClient := fake.NewClientBuilder().Build()
+	testControlPlaneClient := fake.NewClientBuilder().Build()
+	testLocalClusterClient := fake.NewClientBuilder().Build()
 	testCfg := DatabaseConfig{
 		GlobalCredentialsNamespaces: []string{"fake-namespace"},
 	}
-	d := NewDatabase(context.Background(), testClient, testCfg)
+	d := NewDatabase(
+		context.Background(),
+		testControlPlaneClient,
+		testLocalClusterClient,
+		testCfg,
+	)
 	require.NotNil(t, d)
 	k, ok := d.(*database)
 	require.True(t, ok)
-	require.Same(t, testClient, k.kargoClient)
+	require.Same(t, testControlPlaneClient, k.controlPlaneClient)
+	require.Same(t, testLocalClusterClient, k.localClusterClient)
 	require.Equal(t, testCfg, k.cfg)
 }
 
@@ -330,6 +337,7 @@ func TestGet(t *testing.T) {
 			creds, err := NewDatabase(
 				context.Background(),
 				fake.NewClientBuilder().WithObjects(testCase.secrets...).Build(),
+				nil,
 				testCase.cfg,
 			).Get(
 				context.Background(),


### PR DESCRIPTION
@jessesuen @hiddeco this is a possible solution to the extremely outlying use case we discussed offline of wanting to fall back on searching for creds in the local cluster if none are discovered in the control plane's cluster.

The big, BIG caveat to this is that managing credential Secrets on each shard and the permissions that allow the controller on each shard to access those Secrets is completely left to the operator. There is no feature of Kargo's chart or Kargo itself to facilitate any of this.