### PR TITLE
fix: promo context creation and deepcopy

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -185,9 +185,6 @@ func RunningPromotionsByArgoCDApplications(
 			Project:         promo.Namespace,
 			Stage:           promo.Spec.Stage,
 			FreightRequests: stage.Spec.RequestedFreight,
-			Promotion:       promo.Name,
-			State:           promo.Status.GetState(),
-			Vars:            promo.Spec.Vars,
 			TargetFreightRef: kargoapi.FreightReference{
 				Name:    freight.Name,
 				Commits: freight.Commits,
@@ -195,6 +192,9 @@ func RunningPromotionsByArgoCDApplications(
 				Charts:  freight.Charts,
 				Origin:  freight.Origin,
 			},
+			Promotion: promo.Name,
+			State:     promo.Status.GetState(),
+			Vars:      promo.Spec.Vars,
 		}
 
 		if promo.Status.FreightCollection != nil {

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -79,12 +79,12 @@ func (c Context) DeepCopy() Context {
 		Stage:                 c.Stage,
 		Promotion:             c.Promotion,
 		Freight:               *c.Freight.DeepCopy(),
+		TargetFreightRef:      *c.TargetFreightRef.DeepCopy(),
 		StartFromStep:         c.StartFromStep,
 		StepExecutionMetadata: c.StepExecutionMetadata.DeepCopy(),
 		State:                 c.State.DeepCopy(),
 		Vars:                  slices.Clone(c.Vars),
 		Actor:                 c.Actor,
-		TargetFreightRef:      *c.TargetFreightRef.DeepCopy(),
 	}
 
 	if c.FreightRequests != nil {


### PR DESCRIPTION
This PR :

1. ensures promo context has target freight ref always
2. fixes deep copy to include target freight ref copy