### PR TITLE
docs: webhook receivers

### DIFF
--- a/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -410,6 +410,35 @@ For more information, refer to the
 
 ## Resource Management
 
+### Tuning Warehouse Reconciliation Intervals
+
+If your cluster contains many `Warehouse` resources, which periodically poll
+artifact repositories, or if developers have
+[configured any of those `Warehouse`s poorly](../../50-user-guide/20-how-to-guides/30-working-with-warehouses.md#performance-considerations),
+you may wish to reduce the frequency with which all `Warehouse`s execute their
+artifact discovery processes (i.e. You may wish to _increase_ the polling
+interval.)
+
+:::info
+Developers can tune this interval on individual `Warehouse` resources, but the
+effective interval for any `Warehouse` will be the _greater_ of any specified
+there and the one specified here. i.e. Developers cannot configure a
+`Warehouse`'s artifact discovery process to run more frequently than you permit.
+:::
+
+:::note
+If you do this, you will increase the average time required for every
+`Warehouse` to notice new artifacts. You can compensate for this by configuring
+`Warehouse` artifact discovery processes to be
+[triggered by webhooks](../35-cluster-configuration.md#triggering-artifact-discovery-using-webhooks).
+:::
+
+```yaml
+controller:
+  warehouses:
+    reconciliationInterval: 5m
+```
+
 ### Tuning Concurrent Reconciliation Limits
 
 By default, Kargo will reconcile up to four resources of the same kind

--- a/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -416,13 +416,13 @@ If your cluster contains many `Warehouse` resources, which periodically poll
 artifact repositories, or if developers have
 [configured any of those `Warehouse`s poorly](../../50-user-guide/20-how-to-guides/30-working-with-warehouses.md#performance-considerations),
 you may wish to reduce the frequency with which all `Warehouse`s execute their
-artifact discovery processes (i.e. You may wish to _increase_ the polling
-interval.)
+artifact discovery processes (i.e. You may wish to _increase_ the minimum
+polling interval.)
 
 :::info
 Developers can tune this interval on individual `Warehouse` resources, but the
 effective interval for any `Warehouse` will be the _greater_ of any specified
-there and the one specified here. i.e. Developers cannot configure a
+there and the minimum specified here. i.e. Developers cannot configure a
 `Warehouse`'s artifact discovery process to run more frequently than you permit.
 :::
 
@@ -435,8 +435,9 @@ If you do this, you will increase the average time required for every
 
 ```yaml
 controller:
-  warehouses:
-    reconciliationInterval: 5m
+  reconcilers:
+    warehouses:
+      minReconciliationInterval: 15m
 ```
 
 ### Tuning Concurrent Reconciliation Limits

--- a/docs/docs/40-operator-guide/35-cluster-configuration.md
+++ b/docs/docs/40-operator-guide/35-cluster-configuration.md
@@ -141,6 +141,8 @@ type: Opaque
 metadata:
   name: my-first-secret
   namespace: kargo-cluster-secrets
+  labels:
+    kargo.akuity.io/cred-type: generic
 data:
   secret: c295bGVudCBncmVlbiBpcyBwZW9wbGUK
 ---
@@ -150,9 +152,17 @@ type: Opaque
 metadata:
   name: my-second-secret
   namespace: kargo-cluster-secrets
+  labels:
+    kargo.akuity.io/cred-type: generic
 data:
   secret-token: cm9zZWJ1ZCB3YXMgYSBzbGVkCg==
 ```
+
+:::note
+The `kargo.akuity.io/cred-type: generic` label on `Secret`s referenced by
+webhook receivers is not strictly required, but we _strongly_ recommend
+including it.
+:::
 
 For each properly configured webhook receiver, Kargo will update the
 `ClusterConfig` resource's `status` to reflect the URLs that can be registered

--- a/docs/docs/40-operator-guide/35-cluster-configuration.md
+++ b/docs/docs/40-operator-guide/35-cluster-configuration.md
@@ -25,7 +25,7 @@ artifact repositories, or if developers have
 [configured any of those `Warehouse`s poorly](../50-user-guide/20-how-to-guides/30-working-with-warehouses.md#performance-considerations),
 you may have elected to reduce the frequency with which all `Warehouse`s execute
 their artifact discovery processes (i.e. You may have elected to _increase_ the
-polling interval. See
+minimum polling interval. See
 [Common Configurations](./20-advanced-installation/30-common-configurations.md/#tuning-warehouse-reconciliation-intervals).
 )
 

--- a/docs/docs/40-operator-guide/35-cluster-configuration.md
+++ b/docs/docs/40-operator-guide/35-cluster-configuration.md
@@ -26,7 +26,7 @@ artifact repositories, or if developers have
 you may have elected to reduce the frequency with which all `Warehouse`s execute
 their artifact discovery processes (i.e. You may have elected to _increase_ the
 minimum polling interval. See
-[Common Configurations](./20-advanced-installation/30-common-configurations.md/#tuning-warehouse-reconciliation-intervals).
+[Common Configurations](./20-advanced-installation/30-common-configurations.md#tuning-warehouse-reconciliation-intervals).
 )
 
 If you have done this, it may have relieved degraded performance and helped to
@@ -71,7 +71,7 @@ by the request payload.
 Most types of webhook receivers require you only to specify a unique name and a
 reference to a `Secret`. The expected keys and values for each kind of webhook
 receiver vary, and are documented on
-[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers).
+[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers/index.md).
 
 :::note
 Because `ClusterConfig` resources are _cluster-scoped_ resources and Kubernetes
@@ -200,7 +200,7 @@ endpoints to receive webhook requests from those platforms.
 :::info
 For more information about registering these endpoints with specific senders,
 refer to
-[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers).
+[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers/index.md).
 :::
 
 ### Receivers in Action

--- a/docs/docs/40-operator-guide/35-cluster-configuration.md
+++ b/docs/docs/40-operator-guide/35-cluster-configuration.md
@@ -1,0 +1,208 @@
+---
+sidebar_label: Cluster Level Configuration
+---
+
+# Cluster Level Configuration
+
+This document is a guide to Kargo configuration options that are available to
+operators _at runtime_. These are generally analogs to Project level
+configuration options available to developers.
+
+:::info
+__Not what you were looking for?__
+
+Most system level configuration options are exercised by operators at the time
+of installation or upgrade. For details, refer to
+[Common Configurations](./20-advanced-installation/30-common-configurations.md)
+and the
+[Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
+:::
+
+## Triggering Artifact Discovery Using Webhooks
+
+If your cluster contains many `Warehouse` resources, which periodically poll
+artifact repositories, or if developers have
+[configured any of those `Warehouse`s poorly](../50-user-guide/20-how-to-guides/30-working-with-warehouses.md#performance-considerations),
+you may have elected to reduce the frequency with which all `Warehouse`s execute
+their artifact discovery processes (i.e. You may have elected to _increase_ the
+polling interval. See
+[Common Configurations](./20-advanced-installation/30-common-configurations.md/#tuning-warehouse-reconciliation-intervals).
+)
+
+If you have done this, it may have relieved degraded performance and helped to
+avoid encountering rate limits, but it will have been accompanied by the
+undesired side effect of increasing the average time required for every
+`Warehouse` to notice new artifacts. _This can be overcome by configuring
+repositories to alert Kargo to the presence of new artifacts via webhooks._
+
+Developers are able to configure Kargo to listen for inbound webhook requests
+from various sources
+[at the Project level](../50-user-guide/20-how-to-guides/30-working-with-warehouses.md#triggering-artifact-discovery-using-webhooks),
+however, in an organization with many separate repositories in one (or a few)
+Git hosting providers or container image registries, it may make more sense for
+an operator to configure Kargo to listen for inbound webhook requests _at the
+cluster level_.
+
+To illustrate, consider a GitHub organization having many repositories belonging
+to different teams within the organization. Each team may have their own Kargo
+Project(s) for self-managing their promotion pipelines. Instead of every team
+configuring Project level GitHub webhook receivers that may trigger artifact
+discovery only for their own applicable `Warehouse`s, you, as the operator, can
+configure _one_ cluster-level GitHub webhook receiver to trigger the artifact
+discovery process of every applicable `Warehouse` across all Projects.
+
+This can be accomplished easily by updating your `ClusterConfig` resource's
+`spec.webhookReceivers` field. If your cluster does not already have a
+`ClusterConfig` resource, you can create one.
+
+:::note
+Every cluster hosting a Kargo control plane is permitted to have at most _one_
+`ClusterConfig` resource. This limit is enforced by requiring all
+`ClusterConfig` resources to be named `cluster`.
+:::
+
+A `ClusterConfig` resource's `spec.webhookReceivers` field may define one or
+more _webhook receivers_. A webhook receiver is an endpoint on a (typically)
+internet-facing HTTP server that is configured to receive and process requests
+from specific sources, and in response, trigger the discovery process of any
+`Warehouse` _across all Projects_ that subscribes to a repository URL referenced
+by the request payload.
+
+Most types of webhook receivers require you only to specify a unique name and a
+reference to a `Secret`. The expected keys and values for each kind of webhook
+receiver vary, and are documented on
+[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers).
+
+:::note
+Because `ClusterConfig` resources are _cluster-scoped_ resources and Kubernetes
+has no such thing as a "`ClusterSecret`" resource type (i.e. a cluster-scoped
+analog to `Secret`), Kargo will look for the referenced `Secret` in a designated
+namespace. By default, that namespace is `kargo-cluster-secrets`, but can be
+changed by the operator at the time of installation. (Refer to the
+[Kargo Helm Chart's README.md](https://github.com/akuity/kargo/tree/main/charts/kargo).
+)
+:::
+
+:::info
+`Secret`s referenced by a webhook receiver typically serve _two_ purposes.
+
+1. _Often_, some value(s) from the `Secret`'s data map are shared with the
+   webhook sender (GitHub, for instance) and used to help authenticate requests.
+   Some senders may use such "shared secrets" as bearer tokens. Others may use
+   them as keys for signing requests. In such cases, the corresponding webhook
+   receiver knows exactly what to do with this information in order to
+   authenticate inbound requests.
+
+1. _Always_, some value(s) from the `Secret`'s data map are used as a seed in
+   deterministically constructing a complex, hard-to-guess URL where the
+   receiver will listen for inbound requests.
+
+    Some webhook senders (Docker Hub, for instance), do not natively implement
+    any sort of authentication mechanism. No secret value(s) need to be shared
+    with such a sender and requests from the sender contain no bearer token, nor
+    are they signed. For cases such as these, a hard-to-guess URL is, itself,
+    a _de facto_ shared secret and authentication mechanism.
+
+    __Note that if a `Secret`'s value(s) are rotated, the URL where the receiver
+    listens for inbound requests will also change. This is by design.__
+
+    Kargo does not watch `Secret`s for changes because it lacks the permissions
+    to do so, so it can be some time _after_ its `Secret`'s value(s) are rotated
+    that a webhook receiver's URL will be updated. To expedite that update, your
+    `ClusterConfig` resource can be manually "refreshed" using the `kargo` CLI:
+
+    ```shell
+    kargo refresh clusterconfig
+    ```
+
+:::
+
+The following example `ClusterConfig` configures two webhook receivers:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+spec:
+  webhookReceivers:
+  - name: my-first-receiver
+    github:
+      secretRef:
+        name: my-first-secret
+  - name: my-second-receiver
+    gitlab:  
+      secretRef:
+        name: my-second-secret
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-first-secret
+  namespace: kargo-cluster-secrets
+data:
+  secret: c295bGVudCBncmVlbiBpcyBwZW9wbGUK
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-second-secret
+  namespace: kargo-cluster-secrets
+data:
+  secret-token: cm9zZWJ1ZCB3YXMgYSBzbGVkCg==
+```
+
+For each properly configured webhook receiver, Kargo will update the
+`ClusterConfig` resource's `status` to reflect the URLs that can be registered
+as endpoints with the senders.
+
+For instance, the `ClusterConfig` and `Secret`s above result in the following:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: cluster
+spec:
+  # ... omitted for brevity ...
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-11T22:53:21Z"
+    message: ProjectConfig is synced and ready for use
+    observedGeneration: 1
+    reason: Synced
+    status: "True"
+    type: Ready
+  webhookReceivers:
+  - name: my-first-receiver
+    path: /webhook/github/804b6f6bb40eb1f0e371f971d71dd95549be4bc9cbf868046941115f44073c67
+    url: https://kargo.example.com/webhook/github/804b6f6bb40eb1f0e371f971d71dd95549be4bc9cbf868046941115f44073c67
+  - name: my-second-receiver
+    path: /webhook/gitlab/0eba9ff2a91f04f7787404b8f8f0edaf8cf8c39add34082651a474803cc99015
+    url: https://kargo.example.com/webhook/gitlab/0eba9ff2a91f04f7787404b8f8f0edaf8cf8c39add34082651a474803cc99015
+```
+
+Above, you can see the URLs that can be registered with GitHub and GitLab as
+endpoints to receive webhook requests from those platforms.
+
+:::info
+For more information about registering these endpoints with specific senders,
+refer to
+[each receiver type's own page](../50-user-guide/60-reference-docs/80-webhook-receivers).
+:::
+
+### Receivers in Action
+
+Once a webhook receiver has been assigned a URL and that URL has been registered
+with a compatible sender, the receiver will begin receiving webhook requests in
+response to events in your repositories. The payload (body) of such a request
+contains structured information (usually JSON) the sender wishes to share about
+some event. Invariably, among this information, is the URL of the repository
+from which the event originated.
+
+A webhook receiver's only job is to extract a repository URL from the webhook
+request's payload, query for all `Warehouse` resources across all Projects
+having subscriptions to that repository, and request each to execute their
+artifact discovery process.

--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -776,7 +776,7 @@ the request payload.
 Most types of webhook receivers require you only to specify a unique (within the
 Project) name and a reference to a `Secret`. The expected keys and values for
 each kind of webhook receiver vary, and are documented on
-[each receiver type's own page](../60-reference-docs/80-webhook-receivers).
+[each receiver type's own page](../60-reference-docs/80-webhook-receivers/index.md).
 
 :::info
 `Secret`s referenced by a webhook receiver typically serve _two_ purposes.
@@ -897,7 +897,7 @@ endpoints to receive webhook requests from those platforms.
 :::info
 For more information about registering these endpoints with specific senders,
 refer to
-[each receiver type's own page](../60-reference-docs/80-webhook-receivers).
+[each receiver type's own page](../60-reference-docs/80-webhook-receivers/index.md).
 :::
 
 :::info

--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -709,16 +709,16 @@ the system-wide default. (i.e. You may wish to _increase_ the polling interval.)
 This can be done by tuning the `spec.interval` field of any `Warehouse`.
 
 :::note
-The effective polling interval is the _greater_ of the system-wide default and
+The effective polling interval is the _greater_ of a system-wide minimum and
 any interval specified by `spec.interval`. i.e. You can configure a `Warehouse`
 to execute its artifact discovery process _less_ frequently than the system-wide
-default, _but not more frequently._
+minimum, _but not more frequently._
 :::
 
 :::info
 If you're an operator wishing to reduce the frequency with which _all_
-`Warehouse`s execute their discovery processes (increase the polling interval),
-refer to the
+`Warehouse`s execute their discovery processes (increase the minimum polling
+interval), refer to the
 [Common Configurations](../../40-operator-guide/20-advanced-installation/30-common-configurations.md#tuning-warehouse-reconciliation-intervals)
 section of the of the Operator's Guide for more information.
 :::

--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -837,6 +837,8 @@ type: Opaque
 metadata:
   name: my-first-secret
   namespace: kargo-demo
+  labels:
+    kargo.akuity.io/cred-type: generic
 data:
   secret: c295bGVudCBncmVlbiBpcyBwZW9wbGUK
 ---
@@ -846,9 +848,17 @@ type: Opaque
 metadata:
   name: my-second-secret
   namespace: kargo-demo
+  labels:
+    kargo.akuity.io/cred-type: generic
 data:
   secret-token: cm9zZWJ1ZCB3YXMgYSBzbGVkCg==
 ```
+
+:::note
+The `kargo.akuity.io/cred-type: generic` label on `Secret`s referenced by
+webhook receivers is not strictly required, but we _strongly_ recommend
+including it.
+:::
 
 For each properly configured webhook receiver, Kargo will update the
 `ProjectConfig` resource's `status` to reflect the URLs that can be registered

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/_category_.json
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Webhook Receivers",
+  "link": {
+    "type": "doc",
+    "id": "index"
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/bitbucket.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/bitbucket.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Bitbucket
+---
+
+# The Bitbucket Webhook Receiver
+
+Placeholder

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/dockerhub.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/dockerhub.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Docker Hub
+---
+
+# The Docker Hub Webhook Receiver
+
+Placeholder

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/generic.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/generic.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Generic
+---
+
+# The Generic Webhook Receiver
+
+Placeholder

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/ghcr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/ghcr.md
@@ -1,0 +1,25 @@
+---
+sidebar_label: GHCR
+---
+
+# Receiving Webhooks from the GitHub Container Registry
+
+Webhooks cannot be registered directly on a GHCR image repository. Instead,
+`package` events are delivered from an associated source code repository as if
+the event precipitating the delivery had occurred there.
+
+Refer to documentation for the
+[GitHub Webhooks Receiver](./github.md) for further instructions.
+
+:::note
+If your GHCR image repository has not yet been associated with a source code
+repository,
+[refer to these instructions](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package).
+:::
+
+:::note
+GitHub can deliver webhooks _only_ for events occurring in a container image
+repository associated with a source code repository.
+
+This is a limitation of GitHub/GHCR and not a limitation of Kargo.
+:::

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/github.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/github.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: GitHub
+---
+
+# The GitHub Webhook Receiver
+
+Placeholder

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitlab.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitlab.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: GitLab
+---
+
+# The GitLab Webhook Receiver
+
+Placeholder

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/index.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/index.md
@@ -1,0 +1,20 @@
+# Webhook Receivers Reference
+
+Below is an index of documentation for specific webhook receivers that can be
+used to trigger applicable `Warehouse` discovery processes as new artifacts are
+published to your repositories.
+
+:::info
+__Not what you were looking for?__
+
+For more generalized coverage of Kargo's webhook receivers, developers may
+refer to the
+[webhooks section of the Working with Warehouses page](../../20-how-to-guides/30-working-with-warehouses.md#triggering-discovery-using-webhooks).
+
+Operator may refer to the
+[webhooks section of the Cluster Level Configuration page](../../../40-operator-guide/35-cluster-configuration.md#triggering-artifact-discovery-using-webhooks).
+:::
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/quay.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/quay.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Quay.io
+---
+
+# The Quay.io Webhook Receiver
+
+Placeholder


### PR DESCRIPTION
Part of #4150

Note: This documentation references a few features that are either not merged yet or will be implemented tomorrow -- namely, refresh of ProjectConfig and ClusterConfig resources (#4372) as well as configuring a system-wide Warehouse reconciliation interval via the chart.

cc @fuskovic @fykaa @nitishfy -- you can see where there are placeholders for the details of individual receivers.

@fuskovic' will document a receiver or two in a follow-up PR and then @fykaa and @nitishfy, could you please follow his format for documenting the receivers you each worked on?