### PR TITLE
fix: sharded kargo setup analysisRun indexer

### DIFF
--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -277,7 +277,7 @@ func (r *RegularStageReconciler) SetupWithManager(
 			ctx,
 			&kargoapi.Stage{},
 			indexer.StagesByAnalysisRunField,
-			indexer.StagesByAnalysisRun(r.cfg.RolloutsControllerInstanceID),
+			indexer.StagesByAnalysisRun(r.cfg.ShardName),
 		); err != nil {
 			return fmt.Errorf("error setting up index for Stages by AnalysisRun: %w", err)
 		}


### PR DESCRIPTION
The indexer was using the rollout controller instance ID instead of the shardName, looking at the underlying function the parameter is called shardName and is used to be checked against the shard label.

This fixes https://github.com/akuity/kargo/issues/4312

I tested it on our live setup and we had no more waiting time after the verification was successful.