### PR TITLE
refactor: DRY up webhook receivers

### DIFF
--- a/internal/webhook/external/bitbucket_test.go
+++ b/internal/webhook/external/bitbucket_test.go
@@ -2,9 +2,6 @@ package external
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/indexer"
@@ -79,27 +75,6 @@ func TestBitbucketHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "request body too large",
-			secretData: testSecretData,
-			req: func() *http.Request {
-				body := make([]byte, 2<<20+1)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					io.NopCloser(bytes.NewBuffer(body)),
-				)
-				req.Header.Set("X-Event-Key", bitbucketPushEvent)
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
-				res := map[string]string{}
-				err := json.Unmarshal(rr.Body.Bytes(), &res)
-				require.NoError(t, err)
-				require.Contains(t, res["error"], "content exceeds limit")
-			},
-		},
-		{
 			name:       "missing signature",
 			secretData: testSecretData,
 			req: func() *http.Request {
@@ -142,71 +117,7 @@ func TestBitbucketHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "partial success",
-			secretData: testSecretData,
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://bitbucket.org/example/repo",
-							},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://bitbucket.org/example/repo",
-							},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
-			req: func() *http.Request {
-				bodyBuf := bytes.NewBuffer([]byte(pushEventRequestBody))
-				req := httptest.NewRequest(http.MethodPost, testURL, bodyBuf)
-				req.Header.Set("X-Event-Key", bitbucketPushEvent)
-				req.Header.Set("X-Hub-Signature", sign(bodyBuf.Bytes()))
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
-			},
-		},
-		{
-			name:       "complete success -- push event",
+			name:       "success",
 			secretData: testSecretData,
 			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 				&kargoapi.Warehouse{
@@ -246,6 +157,10 @@ func TestBitbucketHandler(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			requestBody, err := io.ReadAll(testCase.req().Body)
+			require.NoError(t, err)
+			defer testCase.req().Body.Close()
+
 			w := httptest.NewRecorder()
 			(&bitbucketWebhookReceiver{
 				baseWebhookReceiver: &baseWebhookReceiver{
@@ -253,7 +168,8 @@ func TestBitbucketHandler(t *testing.T) {
 					project:    testProjectName,
 					secretData: testCase.secretData,
 				},
-			}).GetHandler()(w, testCase.req())
+			}).getHandler(requestBody)(w, testCase.req())
+
 			testCase.assertions(t, w)
 		})
 	}

--- a/internal/webhook/external/bitbucket_test.go
+++ b/internal/webhook/external/bitbucket_test.go
@@ -159,7 +159,9 @@ func TestBitbucketHandler(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestBody, err := io.ReadAll(testCase.req().Body)
 			require.NoError(t, err)
-			defer testCase.req().Body.Close()
+			t.Cleanup(func() {
+				_ = testCase.req().Body.Close()
+			})
 
 			w := httptest.NewRecorder()
 			(&bitbucketWebhookReceiver{

--- a/internal/webhook/external/dockerhub_test.go
+++ b/internal/webhook/external/dockerhub_test.go
@@ -2,9 +2,6 @@ package external
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/indexer"
@@ -49,25 +45,6 @@ func TestDockerHubHandler(t *testing.T) {
 		assertions func(*testing.T, *httptest.ResponseRecorder)
 	}{
 		{
-			name:       "request body too large",
-			secretData: testSecretData,
-			req: func() *http.Request {
-				body := make([]byte, 2<<20+1)
-				return httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					io.NopCloser(bytes.NewBuffer(body)),
-				)
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
-				res := map[string]string{}
-				err := json.Unmarshal(rr.Body.Bytes(), &res)
-				require.NoError(t, err)
-				require.Contains(t, res["error"], "content exceeds limit")
-			},
-		},
-		{
 			name:       "malformed request body",
 			secretData: testSecretData,
 			req: func() *http.Request {
@@ -77,63 +54,6 @@ func TestDockerHubHandler(t *testing.T) {
 			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusBadRequest, rr.Code)
 				require.JSONEq(t, `{"error":"invalid request body"}`, rr.Body.String())
-			},
-		},
-		{
-			name:       "partial success",
-			secretData: testSecretData,
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{RepoURL: "example/repo"},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{RepoURL: "example/repo"},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
-			req: func() *http.Request {
-				bodyBuf := bytes.NewBuffer([]byte(dockerhubWebhookRequestBody))
-				return httptest.NewRequest(http.MethodPost, testURL, bodyBuf)
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
 			},
 		},
 		{
@@ -171,6 +91,10 @@ func TestDockerHubHandler(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			requestBody, err := io.ReadAll(testCase.req().Body)
+			require.NoError(t, err)
+			defer testCase.req().Body.Close()
+
 			w := httptest.NewRecorder()
 			(&dockerhubWebhookReceiver{
 				baseWebhookReceiver: &baseWebhookReceiver{
@@ -178,7 +102,8 @@ func TestDockerHubHandler(t *testing.T) {
 					project:    testProjectName,
 					secretData: testCase.secretData,
 				},
-			}).GetHandler()(w, testCase.req())
+			}).getHandler(requestBody)(w, testCase.req())
+
 			testCase.assertions(t, w)
 		})
 	}

--- a/internal/webhook/external/dockerhub_test.go
+++ b/internal/webhook/external/dockerhub_test.go
@@ -93,7 +93,9 @@ func TestDockerHubHandler(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestBody, err := io.ReadAll(testCase.req().Body)
 			require.NoError(t, err)
-			defer testCase.req().Body.Close()
+			t.Cleanup(func() {
+				_ = testCase.req().Body.Close()
+			})
 
 			w := httptest.NewRecorder()
 			(&dockerhubWebhookReceiver{

--- a/internal/webhook/external/github_test.go
+++ b/internal/webhook/external/github_test.go
@@ -297,7 +297,9 @@ func TestGithubHandler(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestBody, err := io.ReadAll(testCase.req().Body)
 			require.NoError(t, err)
-			defer testCase.req().Body.Close()
+			t.Cleanup(func() {
+				_ = testCase.req().Body.Close()
+			})
 
 			w := httptest.NewRecorder()
 			(&githubWebhookReceiver{

--- a/internal/webhook/external/github_test.go
+++ b/internal/webhook/external/github_test.go
@@ -2,9 +2,7 @@ package external
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/indexer"
@@ -84,27 +81,6 @@ func TestGithubHandler(t *testing.T) {
 					`{"error":"event type nonsense is not supported"}`,
 					rr.Body.String(),
 				)
-			},
-		},
-		{
-			name:       "request body too large",
-			secretData: testSecretData,
-			req: func() *http.Request {
-				body := make([]byte, githubWebhookBodyMaxBytes+1)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					io.NopCloser(bytes.NewBuffer(body)),
-				)
-				req.Header.Set("X-GitHub-Event", "push")
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
-				res := map[string]string{}
-				err := json.Unmarshal(rr.Body.Bytes(), &res)
-				require.NoError(t, err)
-				require.Contains(t, res["error"], "content exceeds limit")
 			},
 		},
 		{
@@ -241,72 +217,7 @@ func TestGithubHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "partial success -- package event",
-			secretData: testSecretData,
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{RepoURL: "ghcr.io/example/repo"},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{RepoURL: "ghcr.io/example/repo"},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
-			req: func() *http.Request {
-				bodyBytes, err := json.Marshal(validPackageEvent)
-				require.NoError(t, err)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					bytes.NewBuffer(bodyBytes),
-				)
-				req.Header.Set("X-Hub-Signature-256", sign(bodyBytes))
-				req.Header.Set("X-GitHub-Event", "package")
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
-			},
-		},
-		{
-			name:       "complete success -- package event",
+			name:       "success -- package event",
 			secretData: testSecretData,
 			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 				&kargoapi.Warehouse{
@@ -343,76 +254,7 @@ func TestGithubHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "partial success -- push event",
-			secretData: testSecretData,
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://github.com/example/repo",
-							},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://github.com/example/repo",
-							},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
-			req: func() *http.Request {
-				bodyBytes, err := json.Marshal(validPushEvent)
-				require.NoError(t, err)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					bytes.NewBuffer(bodyBytes),
-				)
-				req.Header.Set("X-Hub-Signature-256", sign(bodyBytes))
-				req.Header.Set("X-GitHub-Event", "push")
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
-			},
-		},
-		{
-			name:       "complete success -- push event",
+			name:       "success -- push event",
 			secretData: testSecretData,
 			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 				&kargoapi.Warehouse{
@@ -453,6 +295,10 @@ func TestGithubHandler(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			requestBody, err := io.ReadAll(testCase.req().Body)
+			require.NoError(t, err)
+			defer testCase.req().Body.Close()
+
 			w := httptest.NewRecorder()
 			(&githubWebhookReceiver{
 				baseWebhookReceiver: &baseWebhookReceiver{
@@ -460,7 +306,8 @@ func TestGithubHandler(t *testing.T) {
 					project:    testProjectName,
 					secretData: testCase.secretData,
 				},
-			}).GetHandler()(w, testCase.req())
+			}).getHandler(requestBody)(w, testCase.req())
+
 			testCase.assertions(t, w)
 		})
 	}

--- a/internal/webhook/external/gitlab_test.go
+++ b/internal/webhook/external/gitlab_test.go
@@ -2,9 +2,6 @@ package external
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/indexer"
@@ -87,28 +83,6 @@ func TestGitLabHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "request body too large",
-			secretData: testSecretData,
-			req: func() *http.Request {
-				body := make([]byte, 2<<20+1)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					io.NopCloser(bytes.NewBuffer(body)),
-				)
-				req.Header.Set("X-Gitlab-Token", testToken)
-				req.Header.Set("X-Gitlab-Event", "Push Hook")
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
-				res := map[string]string{}
-				err := json.Unmarshal(rr.Body.Bytes(), &res)
-				require.NoError(t, err)
-				require.Contains(t, res["error"], "content exceeds limit")
-			},
-		},
-		{
 			name:       "malformed request body",
 			secretData: testSecretData,
 			req: func() *http.Request {
@@ -121,74 +95,6 @@ func TestGitLabHandler(t *testing.T) {
 			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusBadRequest, rr.Code)
 				require.JSONEq(t, `{"error":"invalid request body"}`, rr.Body.String())
-			},
-		},
-		{
-			name:       "partial success",
-			secretData: testSecretData,
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://gitlab.com/example/repo",
-							},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Git: &kargoapi.GitSubscription{
-								RepoURL: "https://gitlab.com/example/repo",
-							},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
-			req: func() *http.Request {
-				bodyBuf := bytes.NewBuffer([]byte(gitlabPushEventRequestBody))
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					bodyBuf,
-				)
-				req.Header.Set("X-Gitlab-Token", testToken)
-				req.Header.Set("X-Gitlab-Event", "Push Hook")
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
 			},
 		},
 		{
@@ -234,6 +140,10 @@ func TestGitLabHandler(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			requestBody, err := io.ReadAll(testCase.req().Body)
+			require.NoError(t, err)
+			defer testCase.req().Body.Close()
+
 			w := httptest.NewRecorder()
 			(&gitlabWebhookReceiver{
 				baseWebhookReceiver: &baseWebhookReceiver{
@@ -241,7 +151,8 @@ func TestGitLabHandler(t *testing.T) {
 					project:    testProjectName,
 					secretData: testCase.secretData,
 				},
-			}).GetHandler()(w, testCase.req())
+			}).getHandler(requestBody)(w, testCase.req())
+
 			testCase.assertions(t, w)
 		})
 	}

--- a/internal/webhook/external/gitlab_test.go
+++ b/internal/webhook/external/gitlab_test.go
@@ -142,7 +142,9 @@ func TestGitLabHandler(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestBody, err := io.ReadAll(testCase.req().Body)
 			require.NoError(t, err)
-			defer testCase.req().Body.Close()
+			t.Cleanup(func() {
+				_ = testCase.req().Body.Close()
+			})
 
 			w := httptest.NewRecorder()
 			(&gitlabWebhookReceiver{

--- a/internal/webhook/external/quay.go
+++ b/internal/webhook/external/quay.go
@@ -3,7 +3,6 @@ package external
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -11,14 +10,12 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	xhttp "github.com/akuity/kargo/internal/http"
 	"github.com/akuity/kargo/internal/image"
-	"github.com/akuity/kargo/internal/io"
 	"github.com/akuity/kargo/internal/logging"
 )
 
 const (
-	quaySecretDataKey       = "secret"
-	quay                    = "quay"
-	quayWebhookBodyMaxBytes = 2 << 20 // 2MB
+	quaySecretDataKey = "secret"
+	quay              = "quay"
 )
 
 func init() {
@@ -71,54 +68,22 @@ func (q *quayWebhookReceiver) getSecretValues(
 	return []string{string(secretValue)}, nil
 }
 
-// GetHandler implements WebhookReceiver.
-func (q *quayWebhookReceiver) GetHandler() http.HandlerFunc {
+// getHandler implements WebhookReceiver.
+func (q *quayWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		logger := logging.LoggerFromContext(ctx)
 		logger.Debug("identifying source repository")
-
-		if contentLength := r.ContentLength; contentLength > quayWebhookBodyMaxBytes {
-			xhttp.WriteErrorJSON(
-				w,
-				xhttp.Error(
-					fmt.Errorf("content exceeds limit of %d bytes", quayWebhookBodyMaxBytes),
-					http.StatusRequestEntityTooLarge,
-				),
-			)
-			return
-		}
-
-		b, err := io.LimitRead(r.Body, quayWebhookBodyMaxBytes)
-		if err != nil {
-			if errors.Is(err, &io.BodyTooLargeError{}) {
-				xhttp.WriteErrorJSON(
-					w,
-					xhttp.Error(err, http.StatusRequestEntityTooLarge),
-				)
-				return
-			}
-			xhttp.WriteErrorJSON(w, err)
-		}
 
 		payload := struct {
 			// format: quay.io/mynamespace/repository
 			DockerURL string `json:"docker_url"`
 		}{}
 
-		if err = json.Unmarshal(b, &payload); err != nil {
+		if err := json.Unmarshal(requestBody, &payload); err != nil {
 			xhttp.WriteErrorJSON(
 				w,
 				xhttp.Error(errors.New("invalid request body"),
-					http.StatusBadRequest,
-				),
-			)
-		}
-
-		if payload.DockerURL == "" {
-			xhttp.WriteErrorJSON(w,
-				xhttp.Error(
-					fmt.Errorf("missing repository web URL in request body"),
 					http.StatusBadRequest,
 				),
 			)
@@ -130,37 +95,6 @@ func (q *quayWebhookReceiver) GetHandler() http.HandlerFunc {
 		logger = logger.WithValues("repoURL", repoURL)
 		ctx = logging.ContextWithLogger(ctx, logger)
 
-		result, err := refreshWarehouses(ctx, q.client, q.project, repoURL)
-		if err != nil {
-			xhttp.WriteErrorJSON(w, err)
-			return
-		}
-
-		logger.Debug("execution complete",
-			"successes", result.successes,
-			"failures", result.failures,
-		)
-
-		if result.failures > 0 {
-			xhttp.WriteResponseJSON(w,
-				http.StatusInternalServerError,
-				map[string]string{
-					"error": fmt.Sprintf("failed to refresh %d of %d warehouses",
-						result.failures,
-						result.successes+result.failures,
-					),
-				},
-			)
-			return
-		}
-
-		xhttp.WriteResponseJSON(w,
-			http.StatusOK,
-			map[string]string{
-				"msg": fmt.Sprintf("refreshed %d warehouse(s)",
-					result.successes,
-				),
-			},
-		)
+		refreshWarehouses(ctx, w, q.client, q.project, repoURL)
 	})
 }

--- a/internal/webhook/external/quay_test.go
+++ b/internal/webhook/external/quay_test.go
@@ -87,7 +87,9 @@ func TestQuayHandler(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestBody, err := io.ReadAll(testCase.req().Body)
 			require.NoError(t, err)
-			defer testCase.req().Body.Close()
+			t.Cleanup(func() {
+				_ = testCase.req().Body.Close()
+			})
 
 			w := httptest.NewRecorder()
 			(&quayWebhookReceiver{

--- a/internal/webhook/external/quay_test.go
+++ b/internal/webhook/external/quay_test.go
@@ -2,9 +2,6 @@ package external
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/indexer"
@@ -29,93 +25,24 @@ func TestQuayHandler(t *testing.T) {
 	testScheme := runtime.NewScheme()
 	require.NoError(t, kargoapi.AddToScheme(testScheme))
 
-	for _, testCase := range []struct {
+	testCases := []struct {
 		name       string
 		client     client.Client
 		req        func() *http.Request
 		assertions func(*testing.T, *httptest.ResponseRecorder)
 	}{
 		{
-			name: "request body too large",
-			req: func() *http.Request {
-				body := make([]byte, quayWebhookBodyMaxBytes+1)
-				req := httptest.NewRequest(
-					http.MethodPost,
-					testURL,
-					io.NopCloser(bytes.NewBuffer(body)),
-				)
-				return req
-			},
-			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
-				res := map[string]string{}
-				err := json.Unmarshal(rr.Body.Bytes(), &res)
-				require.NoError(t, err)
-				require.Contains(t, res["error"], "content exceeds limit")
-			},
-		},
-		{
-			name: "partial success",
-			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{
-								RepoURL: "quay.io/mynamespace/repository",
-							},
-						}},
-					},
-				},
-				&kargoapi.Warehouse{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testProjectName,
-						Name:      "another-fake-warehouse",
-					},
-					Spec: kargoapi.WarehouseSpec{
-						Subscriptions: []kargoapi.RepoSubscription{{
-							Image: &kargoapi.ImageSubscription{
-								RepoURL: "quay.io/mynamespace/repository",
-							},
-						}},
-					},
-				},
-			).WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(
-					_ context.Context,
-					_ client.WithWatch,
-					obj client.Object,
-					_ client.Patch,
-					_ ...client.PatchOption,
-				) error {
-					println("object:", obj.GetName())
-					if obj.GetName() == "another-fake-warehouse" {
-						return errors.New("something went wrong")
-					}
-					return nil
-				},
-			}).WithIndex(
-				&kargoapi.Warehouse{},
-				indexer.WarehousesBySubscribedURLsField,
-				indexer.WarehousesBySubscribedURLs,
-			).Build(),
+			name: "malformed request body",
 			req: func() *http.Request {
 				return httptest.NewRequest(
 					http.MethodPost,
 					testURL,
-					newQuayPayload(),
+					bytes.NewBuffer([]byte("invalid json")),
 				)
 			},
 			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusInternalServerError, rr.Code)
-				require.JSONEq(
-					t,
-					`{"error":"failed to refresh 1 of 2 warehouses"}`,
-					rr.Body.String(),
-				)
+				require.Equal(t, http.StatusBadRequest, rr.Code)
+				require.JSONEq(t, `{"error":"invalid request body"}`, rr.Body.String())
 			},
 		},
 		{
@@ -155,15 +82,21 @@ func TestQuayHandler(t *testing.T) {
 				)
 			},
 		},
-	} {
+	}
+	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			requestBody, err := io.ReadAll(testCase.req().Body)
+			require.NoError(t, err)
+			defer testCase.req().Body.Close()
+
 			w := httptest.NewRecorder()
 			(&quayWebhookReceiver{
 				baseWebhookReceiver: &baseWebhookReceiver{
 					client:  testCase.client,
 					project: testProjectName,
 				},
-			}).GetHandler()(w, testCase.req())
+			}).getHandler(requestBody)(w, testCase.req())
+
 			testCase.assertions(t, w)
 		})
 	}

--- a/internal/webhook/external/receiver.go
+++ b/internal/webhook/external/receiver.go
@@ -30,12 +30,15 @@ type WebhookReceiver interface {
 	// setDetails sets the details of the WebhookReceiver in the form of
 	// kargoapi.WebhookReceiverDetails.
 	setDetails(kargoapi.WebhookReceiverDetails)
+	// getMaxRequestBodyBytes returns the maximum allowed size for the request
+	// body.
+	getMaxRequestBodyBytes() int64
+	// getHandler returns an http.HandlerFunc for handling inbound webhook
+	// requests.
+	getHandler(requestBody []byte) http.HandlerFunc
 	// GetDetails returns the details of the WebhookReceiver in the form of
 	// kargoapi.WebhookReceiverDetails.
 	GetDetails() kargoapi.WebhookReceiverDetails
-	// GetHandler returns an http.HandlerFunc for handling inbound webhook
-	// requests.
-	GetHandler() http.HandlerFunc
 }
 
 // baseWebhookReceiver is a base implementation of WebhookReceiver that provides
@@ -69,6 +72,11 @@ func (b *baseWebhookReceiver) setDetails(
 // GetDetails implements WebhookReceiver.
 func (b *baseWebhookReceiver) GetDetails() kargoapi.WebhookReceiverDetails {
 	return b.details
+}
+
+// getMaxRequestBodyBytes
+func (b *baseWebhookReceiver) getMaxRequestBodyBytes() int64 {
+	return 2 << 20 // 2MB
 }
 
 // NewReceiver returns an appropriate implementation of WebhookReceiver based on

--- a/internal/webhook/external/receiver.go
+++ b/internal/webhook/external/receiver.go
@@ -74,7 +74,7 @@ func (b *baseWebhookReceiver) GetDetails() kargoapi.WebhookReceiverDetails {
 	return b.details
 }
 
-// getMaxRequestBodyBytes
+// getMaxRequestBodyBytes implements WebhookReceiver.
 func (b *baseWebhookReceiver) getMaxRequestBodyBytes() int64 {
 	return 2 << 20 // 2MB
 }


### PR DESCRIPTION
All receivers had identical logic for verifying the request body size didn't exceed some maximum and for returning the results of fully or partially successful Warehouse refreshes.

This PR resolves that.

