### PR TITLE
fix: Ensure each node is only traversed once using visited set to prevent UI freezing for large pipelines

### DIFF
--- a/ui/src/features/project/pipelines/graph/stack-nodes.ts
+++ b/ui/src/features/project/pipelines/graph/stack-nodes.ts
@@ -11,14 +11,6 @@ export const stackNodes = (
   graph: graphlib.Graph,
   stageByName: Record<string, Stage>
 ) => {
-  if (afterNodes.length === 0) {
-    return {
-      stackNodes: [],
-      ignoreList: new Set<string>(),
-      graph
-    };
-  }
-
   const sources = graph.sources();
 
   const stackNodes: Array<{
@@ -30,6 +22,14 @@ export const stackNodes = (
   const ignoreList = new Set<string>();
   const processedParents = new Set<string>();
   const visited = new Set<string>();
+
+  if (afterNodes.length === 0) {
+    return {
+      stackNodes,
+      ignoreList,
+      graph
+    };
+  }
 
   // @ts-expect-error it is string array
   const traverseQueue: string[] = [...sources];


### PR DESCRIPTION
Fixes https://github.com/akuity/kargo/issues/4396

A pipeline with 59 nodes is doing 690,794 iterations as nodes are being traversed multiple times. 
This change adds a set of visited nodes to reduce the number of iterations. Tested locally and it reduces the time from over 12 sec to less than 1 second.