### PR TITLE
feat: make image/oci webhook receivers also work for charts

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -13,6 +13,8 @@ import (
 	"oras.land/oras-go/pkg/registry"
 	"oras.land/oras-go/pkg/registry/remote"
 	"oras.land/oras-go/pkg/registry/remote/auth"
+
+	"github.com/akuity/kargo/internal/image"
 )
 
 // DiscoverChartVersions connects to the specified Helm chart repository and
@@ -241,10 +243,15 @@ func filterSemVers(semvers semver.Collection, semverConstraint string) (semver.C
 // of comparison. Crucially, this function removes the oci:// prefix from the
 // URL if there is one.
 func NormalizeChartRepositoryURL(repo string) string {
-	return strings.TrimPrefix(
-		strings.ToLower(
-			strings.TrimSpace(repo),
+	// Note: We lean a bit on image.NormalizeURL() because it is excellent at
+	// normalizing the many different forms of equivalent URLs for Docker Hub
+	// repositories.
+	return image.NormalizeURL(
+		strings.TrimPrefix(
+			strings.ToLower(
+				strings.TrimSpace(repo),
+			),
+			"oci://",
 		),
-		"oci://",
 	)
 }

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -346,6 +346,37 @@ func TestNormalizeChartRepositoryURL(t *testing.T) {
 			input:    "OCI://Repo",
 			expected: "repo",
 		},
+		// Check correct normalization of Docker Hub URLs
+		{
+			name:     "docker.io URL with oci prefix",
+			input:    "oci://docker.io/example/repo",
+			expected: "example/repo",
+		},
+		{
+			name:     "docker.io URL without oci prefix",
+			input:    "docker.io/example/repo",
+			expected: "example/repo",
+		},
+		{
+			name:     "index.docker.io URL with oci prefix",
+			input:    "oci://index.docker.io/example/repo",
+			expected: "example/repo",
+		},
+		{
+			name:     "index.docker.io URL without oci prefix",
+			input:    "index.docker.io/example/repo",
+			expected: "example/repo",
+		},
+		{
+			name:     "registry-1.docker.io URL with oci prefix",
+			input:    "oci://registry-1.docker.io/example/repo",
+			expected: "example/repo",
+		},
+		{
+			name:     "registry-1.docker.io URL without oci prefix",
+			input:    "registry-1.docker.io/example/repo",
+			expected: "example/repo",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/webhook/external/github.go
+++ b/internal/webhook/external/github.go
@@ -166,17 +166,10 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 				return
 			}
 			manifest := pkg.GetPackageVersion().GetContainerMetadata().GetManifest()
-			// Determine if the package was a Helm chart
-			if cfgAny, ok := manifest["config"]; ok {
-				if cfg, ok := cfgAny.(map[string]any); ok {
-					if mediaTypeAny, ok := cfg["media_type"]; ok {
-						if mediaType, ok := mediaTypeAny.(string); ok {
-
-							if mediaType == helmChartMediaType {
-								repoURL = helm.NormalizeChartRepositoryURL(ref.Context().Name())
-							}
-						}
-					}
+			// Determine if the package is a Helm chart
+			if cfg, ok := manifest["config"].(map[string]any); ok {
+				if mediaType, ok := cfg["media_type"].(string); ok && mediaType == helmChartMediaType {
+					repoURL = helm.NormalizeChartRepositoryURL(ref.Context().Name())
 				}
 			}
 			if repoURL == "" {

--- a/internal/webhook/external/quay.go
+++ b/internal/webhook/external/quay.go
@@ -91,6 +91,12 @@ func (q *quayWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 			return
 		}
 
+		// Payloads from Quay contain no information about media type, so we
+		// normalize the URL BOTH as if it were an image repo URL and as if it were
+		// a chart repository URL. These will coincidentally be the same, but by
+		// doing this, we safeguard against future changes to normalization logic.
+		// Note: The refresh logic will dedupe the URLs, so this does not create
+		// the possibility of a double refresh.
 		repoURLs := []string{
 			image.NormalizeURL(payload.DockerURL),
 			helm.NormalizeChartRepositoryURL(payload.DockerURL),

--- a/internal/webhook/external/quay.go
+++ b/internal/webhook/external/quay.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/internal/helm"
 	xhttp "github.com/akuity/kargo/internal/http"
 	"github.com/akuity/kargo/internal/image"
 	"github.com/akuity/kargo/internal/logging"
@@ -90,11 +91,14 @@ func (q *quayWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 			return
 		}
 
-		repoURL := image.NormalizeURL(payload.DockerURL)
+		repoURLs := []string{
+			image.NormalizeURL(payload.DockerURL),
+			helm.NormalizeChartRepositoryURL(payload.DockerURL),
+		}
 
-		logger = logger.WithValues("repoURL", repoURL)
+		logger = logger.WithValues("repoURLs", repoURLs)
 		ctx = logging.ContextWithLogger(ctx, logger)
 
-		refreshWarehouses(ctx, w, q.client, q.project, repoURL)
+		refreshWarehouses(ctx, w, q.client, q.project, repoURLs...)
 	})
 }

--- a/internal/webhook/external/receiver.go
+++ b/internal/webhook/external/receiver.go
@@ -14,6 +14,8 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 )
 
+const helmChartMediaType = "application/vnd.cncf.helm.config.v1+json"
+
 // WebhookReceiver is an interface for components that handle inbound webhooks.
 type WebhookReceiver interface {
 	// getReceiverType returns the type of this receiver.

--- a/internal/webhook/external/refresh.go
+++ b/internal/webhook/external/refresh.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/akuity/kargo/api/v1alpha1"
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/api"
 	xhttp "github.com/akuity/kargo/internal/http"
 	"github.com/akuity/kargo/internal/indexer"
@@ -15,38 +18,57 @@ import (
 )
 
 // refreshWarehouses refreshes all Warehouses in the given namespace that are
-// subscribed to the given repository URL. If the namespace is empty, all
-// Warehouses in the cluster subscribed to the given repository URL are
+// subscribed to any of the given repository URLs. If the namespace is empty,
+// all Warehouses in the cluster subscribed to the given repository URLs are
 // refreshed. Note: Callers are responsible for normalizing the provided
-// repository URL.
+// repository URLs.
 func refreshWarehouses(
 	ctx context.Context,
 	w http.ResponseWriter,
 	c client.Client,
 	project string,
-	repoURL string,
+	repoURLs ...string,
 ) {
 	logger := logging.LoggerFromContext(ctx)
 
-	listOpts := make([]client.ListOption, 1, 2)
-	listOpts[0] = client.MatchingFields{
-		indexer.WarehousesBySubscribedURLsField: repoURL,
-	}
-	if project != "" {
-		listOpts = append(listOpts, client.InNamespace(project))
+	// De-dupe repository URLs
+	slices.Sort(repoURLs)
+	repoURLs = slices.Compact(repoURLs)
+
+	warehouses := []kargoapi.Warehouse{}
+
+	for _, repoURL := range repoURLs {
+		repoLogger := logger.WithValues("repositoryURL", repoURL)
+
+		listOpts := make([]client.ListOption, 1, 2)
+		listOpts[0] = client.MatchingFields{
+			indexer.WarehousesBySubscribedURLsField: repoURL,
+		}
+		if project != "" {
+			listOpts = append(listOpts, client.InNamespace(project))
+		}
+
+		ws := v1alpha1.WarehouseList{}
+		if err := c.List(ctx, &ws, listOpts...); err != nil {
+			repoLogger.Error(err, "error listing subscribed Warehouses")
+			xhttp.WriteErrorJSON(w, err)
+			return
+		}
+
+		warehouses = append(warehouses, ws.Items...)
 	}
 
-	warehouses := v1alpha1.WarehouseList{}
-	if err := c.List(ctx, &warehouses, listOpts...); err != nil {
-		logger.Error(err, "error listing Warehouses")
-		xhttp.WriteErrorJSON(w, err)
-		return
-	}
+	slices.SortFunc(warehouses, func(lhs, rhs kargoapi.Warehouse) int {
+		return strings.Compare(lhs.Namespace+lhs.Name, rhs.Namespace+rhs.Name)
+	})
+	warehouses = slices.CompactFunc(warehouses, func(lhs, rhs kargoapi.Warehouse) bool {
+		return lhs.Namespace == rhs.Namespace && lhs.Name == rhs.Name
+	})
 
-	logger.Debug("found Warehouses to refresh", "count", len(warehouses.Items))
+	logger.Debug("found Warehouses to refresh", "count", len(warehouses))
 
 	var failures int
-	for _, wh := range warehouses.Items {
+	for _, wh := range warehouses {
 		objKey := client.ObjectKeyFromObject(&wh)
 		if _, err := api.RefreshWarehouse(ctx, c, objKey); err != nil {
 			logger.Error(err, "error refreshing Warehouse", "objectKey", objKey)
@@ -63,7 +85,7 @@ func refreshWarehouses(
 			map[string]string{
 				"error": fmt.Sprintf("failed to refresh %d of %d warehouses",
 					failures,
-					len(warehouses.Items),
+					len(warehouses),
 				),
 			},
 		)
@@ -73,7 +95,7 @@ func refreshWarehouses(
 		w,
 		http.StatusOK,
 		map[string]string{
-			"msg": fmt.Sprintf("refreshed %d warehouse(s)", len(warehouses.Items)),
+			"msg": fmt.Sprintf("refreshed %d warehouse(s)", len(warehouses)),
 		},
 	)
 }


### PR DESCRIPTION
Warehouses subscribed to charts in Docker Hub could not successfully be refreshed.

For GitHub/GHCR and Quay, this _did_ work, but only coincidentally. We didn't design for it.

We now check the media type conveyed by payloads from GitHub/GHCR and Docker Hub to determine what kind of normalization logic to apply to the URL we extract from the payload before requesting a refresh of Warehouses subscribed to that URL.

Quay doesn't send media type information, so we normalize the URL _both_ as if it were an image URL and as if it were a chart URL, then refresh Warehouses subscribed to either. This currently results in two identical URLs, but I don't want to take it for granted that normalization logic will never change. To account for this, the refresh logic is also updated to de-dupe URLs.