### PR TITLE
chart: fix bug in kargo.baseURL helper

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Generate base URL for a service.
 {{- define "kargo.baseURL" -}}
 {{- $service := .service -}}
 {{- $host := .host -}}
-{{- if include "kargo.useTLS" $service -}}
+{{- if eq (include "kargo.useTLS" $service) "true" -}}
 {{- printf "https://%s" $host -}}
 {{- else -}}
 {{- printf "http://%s" $host -}}


### PR DESCRIPTION
`include` always returns a string and all non-empty strings (including `"false"`) are truthy.

The result is that URLs were _always_ using HTTPS.