### PR TITLE
perf: Use git log -- <path1> <path2>, instead of iterating over batches of commits

### DIFF
--- a/internal/controller/git/work_tree.go
+++ b/internal/controller/git/work_tree.go
@@ -72,7 +72,7 @@ type WorkTree interface {
 	ListTags() ([]TagMetadata, error)
 	// ListCommits returns a slice of commits in the current branch with
 	// metadata such as commit ID, commit date, and subject.
-	ListCommits(limit, skip uint) ([]CommitMetadata, error)
+	ListCommits(limit, skip uint, paths []string) ([]CommitMetadata, error)
 	// CommitMessage returns the text of the most recent commit message associated
 	// with the specified commit ID.
 	CommitMessage(id string) (string, error)
@@ -391,7 +391,7 @@ type CommitMetadata struct {
 	Subject string
 }
 
-func (w *workTree) ListCommits(limit, skip uint) ([]CommitMetadata, error) {
+func (w *workTree) ListCommits(limit, skip uint, paths []string) ([]CommitMetadata, error) {
 	args := []string{
 		"log",
 		// This format is designed to output the following fields, separated by
@@ -409,6 +409,11 @@ func (w *workTree) ListCommits(limit, skip uint) ([]CommitMetadata, error) {
 	}
 	if skip > 0 {
 		args = append(args, fmt.Sprintf("--skip=%d", skip))
+	}
+
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
 	}
 
 	commitsBytes, err := libExec.Exec(w.buildGitCommand(args...))

--- a/internal/controller/warehouses/git.go
+++ b/internal/controller/warehouses/git.go
@@ -223,7 +223,7 @@ func (r *reconciler) discoverBranchHistory(repo git.Repo, sub kargoapi.GitSubscr
 	limit := int(sub.DiscoveryLimit)
 	var filteredCommits = make([]git.CommitMetadata, 0, limit)
 	for skip := uint(0); ; skip += uint(limit) { // nolint: gosec
-		commits, err := r.listCommitsFn(repo, uint(limit), skip) // nolint: gosec
+		commits, err := r.listCommitsFn(repo, uint(limit), skip, sub.IncludePaths) // nolint: gosec
 		if err != nil {
 			return nil, fmt.Errorf("error listing commits from git repo %q: %w", sub.RepoURL, err)
 		}
@@ -571,8 +571,8 @@ func selectSemVerTags(tags []git.TagMetadata, strict bool, constraint string) ([
 	return semverTags, nil
 }
 
-func (r *reconciler) listCommits(repo git.Repo, limit, skip uint) ([]git.CommitMetadata, error) {
-	return repo.ListCommits(limit, skip)
+func (r *reconciler) listCommits(repo git.Repo, limit, skip uint, paths []string) ([]git.CommitMetadata, error) {
+	return repo.ListCommits(limit, skip, paths)
 }
 
 func (r *reconciler) listTags(repo git.Repo) ([]git.TagMetadata, error) {

--- a/internal/controller/warehouses/git_test.go
+++ b/internal/controller/warehouses/git_test.go
@@ -240,7 +240,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 		{
 			name: "error listing commits",
 			reconciler: &reconciler{
-				listCommitsFn: func(git.Repo, uint, uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(git.Repo, uint, uint, []string) ([]git.CommitMetadata, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -255,7 +255,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				ExpressionFilter: "invalid expression (",
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(git.Repo, uint, uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(git.Repo, uint, uint, []string) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "abc"},
 					}, nil
@@ -272,7 +272,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				DiscoveryLimit:   10,
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(_ git.Repo, _ uint, skip uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(_ git.Repo, _ uint, skip uint, _ []string) ([]git.CommitMetadata, error) {
 					if skip > 0 {
 						return nil, nil
 					}
@@ -293,7 +293,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				ExpressionFilter: "id == 'abc'",
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(git.Repo, uint, uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(git.Repo, uint, uint, []string) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "abc"},
 						{ID: "xyz"},
@@ -310,7 +310,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 		{
 			name: "without path filters or expression",
 			reconciler: &reconciler{
-				listCommitsFn: func(git.Repo, uint, uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(git.Repo, uint, uint, []string) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "abc"},
 						{ID: "xyz"},
@@ -331,7 +331,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				IncludePaths: []string{regexpPrefix + "^.*third_path_to_a/file$"},
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(git.Repo, uint, uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(git.Repo, uint, uint, []string) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "abc"},
 						{ID: "xyz"},
@@ -352,7 +352,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				IncludePaths: []string{regexpPrefix + "^.*third_path_to_a/file$"},
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(_ git.Repo, _ uint, skip uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(_ git.Repo, _ uint, skip uint, _ []string) ([]git.CommitMetadata, error) {
 					if skip > 0 {
 						return nil, nil
 					}
@@ -382,7 +382,7 @@ func TestDiscoverBranchHistory(t *testing.T) {
 				IncludePaths:     []string{regexpPrefix + "^.*third_path_to_a/file$"},
 			},
 			reconciler: &reconciler{
-				listCommitsFn: func(_ git.Repo, _ uint, skip uint) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(_ git.Repo, _ uint, skip uint, _ []string) ([]git.CommitMetadata, error) {
 					if skip > 0 {
 						return nil, nil
 					}

--- a/internal/controller/warehouses/warehouses.go
+++ b/internal/controller/warehouses/warehouses.go
@@ -64,7 +64,7 @@ type reconciler struct {
 
 	gitCloneFn func(string, *git.ClientOptions, *git.CloneOptions) (git.Repo, error)
 
-	listCommitsFn func(repo git.Repo, limit, skip uint) ([]git.CommitMetadata, error)
+	listCommitsFn func(repo git.Repo, limit, skip uint, paths []string) ([]git.CommitMetadata, error)
 
 	listTagsFn func(repo git.Repo) ([]git.TagMetadata, error)
 


### PR DESCRIPTION
## Context

Git commit discovery takes a significant amount of time because Kargo Controller pulls commits using `git log --skip=% --max-count=%`, which means it needs to spawn a new OS process to get a small group of commits (in our case, 3 commits). It might be "expensive" if the desired commits are located 1000 commits below the HEAD.

## Fix

Instead of listing all the commits and checking if the commit contains subscription `IncludePaths`, use native `git log -- <path1> <path2>`.

This PR fixes - https://github.com/akuity/kargo/issues/4465