### PR TITLE
fix(chart): add clusterconfig permissions to clusterroles

### DIFF
--- a/charts/kargo/templates/users/cluster-roles.yaml
+++ b/charts/kargo/templates/users/cluster-roles.yaml
@@ -29,6 +29,7 @@ rules:
 - apiGroups:
   - kargo.akuity.io
   resources:
+  - clusterconfigs
   - clusterpromotiontasks
   - freights
   - projects
@@ -114,6 +115,7 @@ rules:
 - apiGroups:
   - kargo.akuity.io
   resources:
+  - clusterconfigs
   - clusterpromotiontasks
   - freights
   - projects


### PR DESCRIPTION
Missed in #4370 

This PR adds the appropriate level of ClusterConfig permissions for the existing kargo-admin and kargo-viewer ClusterRoles.