### PR TITLE
feat: support `no_proxy` environment variable for Git operations

### DIFF
--- a/internal/controller/git/base_repo.go
+++ b/internal/controller/git/base_repo.go
@@ -306,6 +306,9 @@ func (b *baseRepo) buildGitCommand(arg ...string) *exec.Cmd {
 	if httpsProxy := os.Getenv("https_proxy"); httpsProxy != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", httpsProxy))
 	}
+	if noProxy := os.Getenv("no_proxy"); noProxy != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("no_proxy=%s", noProxy))
+	}
 	return cmd
 }
 


### PR DESCRIPTION
I found an issue with the proxy settings used by Git. I saw this was missing in the code and it seemed like a relatively easy fix.

I have tested this on our Kubernetes cluster with success.