### PR TITLE
fix(chart): grant mgmt controller permission to delete namespaces

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   verbs:
   - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
Prior to #4229, the management controller did not explicitly delete Project namespaces. Projects owned namespaces and deletion of a Project simply cascaded naturally to its namespace.

#4229 gave the management controller more control over whether a namespace is or isn't deleted when the Project that owns it has been deleted. This means that when namespace deletion _is_ required, the management controller now must handle that explicitly.

This PR adds a missing permission required to facilitate that.