### PR TITLE
fix: application recorded in promotion event's annotation may be incorrect

### DIFF
--- a/internal/event/promotion.go
+++ b/internal/event/promotion.go
@@ -126,7 +126,9 @@ func NewPromotionAnnotations(
 						"name": f.Origin.Name,
 					}
 				}
-				env["ctx"].(map[string]any)["targetFreight"] = targetFreight
+				if ctx, ok := env["ctx"].(map[string]any); ok {
+					ctx["targetFreight"] = targetFreight
+				}
 			}
 
 			if evaled, err := expressions.EvaluateTemplate(string(data), env); err == nil {

--- a/internal/event/promotion.go
+++ b/internal/event/promotion.go
@@ -121,30 +121,14 @@ func NewPromotionAnnotations(
 		stepVars := calculateStepVars(step, stepEnv)
 		setVar(stepEnv, stepVars)
 
-		stepConfigData, err := json.Marshal(step.Config)
-		if err != nil {
-			logger.Error(err, "marshal step config")
-			continue
-		}
-		evaledConfig, err := expressions.EvaluateTemplate(string(stepConfigData), stepEnv)
+		evaledConfig, err := expressions.EvaluateJSONTemplate(step.Config.Raw, stepEnv)
 		if err != nil {
 			logger.Error(err, "evaluate step config template")
 			continue
 		}
 
-		var evaledConfigBytes []byte
-		if v, ok := evaledConfig.(string); ok {
-			evaledConfigBytes = []byte(v)
-		} else {
-			evaledConfigBytes, err = json.Marshal(evaledConfig)
-			if err != nil {
-				logger.Error(err, "marshal evaluated step config")
-				continue
-			}
-		}
-
 		var cfg builtin.ArgoCDUpdateConfig
-		if err := json.Unmarshal(evaledConfigBytes, &cfg); err != nil {
+		if err := json.Unmarshal(evaledConfig, &cfg); err != nil {
 			logger.Error(err, "unmarshal evaluated ArgoCD update config")
 			continue
 		}

--- a/internal/event/promotion.go
+++ b/internal/event/promotion.go
@@ -112,8 +112,11 @@ func NewPromotionAnnotations(
 				}(),
 			}
 			if evaled, err := expressions.EvaluateTemplate(string(data), env); err == nil {
-				if evaledBytes, err := json.Marshal(evaled); err == nil {
-					result = string(evaledBytes)
+				// may be the same string after evaluation
+				if _, ok := evaled.(string); !ok {
+					if evaledBytes, err := json.Marshal(evaled); err == nil {
+						result = string(evaledBytes)
+					}
 				}
 			}
 			annotations[kargoapi.AnnotationKeyEventApplications] = result

--- a/internal/event/promotion_test.go
+++ b/internal/event/promotion_test.go
@@ -154,6 +154,38 @@ func TestNewPromotionAnnotations(t *testing.T) {
   ]
 }`)},
 						},
+						{
+							Uses: "argocd-update",
+							Vars: []v1alpha1.ExpressionVariable{
+								{
+									Name:  "myApp",
+									Value: "same-app-var-1",
+								},
+							},
+							Config: &v1.JSON{Raw: []byte(`{
+  "apps": [
+    {
+      "name": "${{ vars.myApp }}"
+    }
+  ]
+}`)},
+						},
+						{
+							Uses: "argocd-update",
+							Vars: []v1alpha1.ExpressionVariable{
+								{
+									Name:  "myApp",
+									Value: "same-app-var-2",
+								},
+							},
+							Config: &v1.JSON{Raw: []byte(`{
+  "apps": [
+    {
+      "name": "${{ vars.myApp }}"
+    }
+  ]
+}`)},
+						},
 					},
 				},
 			},
@@ -180,8 +212,10 @@ func TestNewPromotionAnnotations(t *testing.T) {
 				v1alpha1.AnnotationKeyEventFreightCreateTime:   "2024-10-22T00:00:00Z",
 				v1alpha1.AnnotationKeyEventApplications: `[{"name":"kargo-demo-test","namespace":"argocd"},` +
 					`{"name":"my-application","namespace":"argocd"},` +
-					`{"name":"my-application-test","namespace":"test-namespace"},` +
+					`{"name":"same-app-var-1","namespace":"argocd"},` +
+					`{"name":"same-app-var-2","namespace":"argocd"},` +
 					`{"name":"test-promotion-admin","namespace":"test-freight-test-warehouse"},` +
+					`{"name":"my-application-test","namespace":"test-namespace"},` +
 					`{"name":"step-level-value","namespace":"test-namespace-additional"}]`,
 			},
 		},

--- a/internal/event/promotion_test.go
+++ b/internal/event/promotion_test.go
@@ -42,16 +42,16 @@ func TestNewPromotionAnnotations(t *testing.T) {
 						{
 							Uses: "argocd-update",
 							Config: &v1.JSON{Raw: []byte(`{
-  "apps": [
-    {
-      "name": "test-app-1"
-    },
-    {
-      "name": "test-app-2",
-      "namespace": "test-namespace"
-    }
-  ]
-}`)},
+								"apps": [
+									{
+										"name": "test-app-1"
+									},
+									{
+										"name": "test-app-2",
+										"namespace": "test-namespace"
+									}
+								]
+							}`)},
 						},
 					},
 				},
@@ -131,28 +131,28 @@ func TestNewPromotionAnnotations(t *testing.T) {
 								},
 							},
 							Config: &v1.JSON{Raw: []byte(`{
-  "apps": [
-    {
-      "name": "kargo-demo-${{ ctx.stage }}"
-    },
-    {
-      "name": "${{ vars.argocdApp }}",
-      "namespace": "argocd"
-    },
-    {
-      "name": "${{ vars.argocdApp }}-${{ ctx.stage }}",
-      "namespace": "${{ vars.appNamespace }}"
-    },
-    {
-      "name": "${{ ctx.promotion }}-${{ ctx.meta.promotion.actor }}",
-      "namespace": "${{ ctx.targetFreight.name }}-${{ ctx.targetFreight.origin.name }}"
-    },
-    {
-      "name": "${{ vars.overrideVar }}",
-      "namespace": "${{ vars.stepOnlyVar }}"
-    }
-  ]
-}`)},
+								"apps": [
+									{
+										"name": "kargo-demo-${{ ctx.stage }}"
+									},
+									{
+										"name": "${{ vars.argocdApp }}",
+										"namespace": "argocd"
+									},
+									{
+										"name": "${{ vars.argocdApp }}-${{ ctx.stage }}",
+										"namespace": "${{ vars.appNamespace }}"
+									},
+									{
+										"name": "${{ ctx.promotion }}-${{ ctx.meta.promotion.actor }}",
+										"namespace": "${{ ctx.targetFreight.name }}-${{ ctx.targetFreight.origin.name }}"
+									},
+									{
+										"name": "${{ vars.overrideVar }}",
+										"namespace": "${{ vars.stepOnlyVar }}"
+									}
+								]
+							}`)},
 						},
 						{
 							Uses: "argocd-update",
@@ -163,12 +163,12 @@ func TestNewPromotionAnnotations(t *testing.T) {
 								},
 							},
 							Config: &v1.JSON{Raw: []byte(`{
-  "apps": [
-    {
-      "name": "${{ vars.myApp }}"
-    }
-  ]
-}`)},
+								"apps": [
+									{
+										"name": "${{ vars.myApp }}"
+									}
+								]
+							}`)},
 						},
 						{
 							Uses: "argocd-update",
@@ -179,12 +179,12 @@ func TestNewPromotionAnnotations(t *testing.T) {
 								},
 							},
 							Config: &v1.JSON{Raw: []byte(`{
-  "apps": [
-    {
-      "name": "${{ vars.myApp }}"
-    }
-  ]
-}`)},
+								"apps": [
+									{
+										"name": "${{ vars.myApp }}"
+									}
+								]
+							}`)},
 						},
 					},
 				},
@@ -236,8 +236,8 @@ func TestNewPromotionAnnotations(t *testing.T) {
 						{
 							Uses: "argocd-update",
 							Config: &v1.JSON{Raw: []byte(`{
-  "apps": [{"name": "${{ invalid.template.syntax }}"}]
-}`)},
+								"apps": [{"name": "${{ invalid.template.syntax }}"}]
+							}`)},
 						},
 					},
 				},


### PR DESCRIPTION
Before the fix, the annotation may look something like this:
```
    annotations:
      event.kargo.akuity.io/actor: admin
      event.kargo.akuity.io/applications: '[{"Namespace":"argocd","Name":"kargo-demo-${{
        ctx.stage }}"}]'
```
which was directly recorded before the evaluation with defined variables.