### PR TITLE
feat(mgmt-controller): rely on GC of NS through owner ref and finalizer

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -13,7 +13,6 @@ rules:
   - namespaces
   verbs:
   - create
-  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
This avoids requiring explicit delete permissions for namespaces for the management controller role by relying purely on the cascade delete for owner references, and the existence of the finalizer to still allow this reference to be dropped when the namespace has to be kept around.

Follow up to: #4229 #4499