### PR TITLE
fix(runner)!: improve error handling `http` step

### DIFF
--- a/internal/promotion/runner/builtin/http_requester.go
+++ b/internal/promotion/runner/builtin/http_requester.go
@@ -239,16 +239,12 @@ func (h *httpRequester) wasRequestSuccessful(
 		}
 		successAny, err := expr.Run(program, env)
 		if err != nil {
-			return false, &promotion.TerminalError{
-				Err: fmt.Errorf("error evaluating success expression %q: %w", cfg.SuccessExpression, err),
-			}
+			return false, fmt.Errorf("error evaluating success expression %q: %w", cfg.SuccessExpression, err)
 		}
 		if success, ok := successAny.(bool); ok {
 			return success, nil
 		}
-		return false, &promotion.TerminalError{
-			Err: fmt.Errorf("success expression %q did not evaluate to a boolean (got %T)", cfg.SuccessExpression, successAny),
-		}
+		return false, fmt.Errorf("success expression %q did not evaluate to a boolean (got %T)", cfg.SuccessExpression, successAny)
 	case cfg.FailureExpression != "":
 		failure, err := h.didRequestFail(cfg, statusCode, env)
 		if err != nil {
@@ -277,16 +273,12 @@ func (h *httpRequester) didRequestFail(
 		}
 		failureAny, err := expr.Run(program, env)
 		if err != nil {
-			return true, &promotion.TerminalError{
-				Err: fmt.Errorf("error evaluating failure expression %q: %w", cfg.FailureExpression, err),
-			}
+			return true, fmt.Errorf("error evaluating failure expression %q: %w", cfg.FailureExpression, err)
 		}
 		if failure, ok := failureAny.(bool); ok {
 			return failure, nil
 		}
-		return true, &promotion.TerminalError{
-			Err: fmt.Errorf("failure expression %q did not evaluate to a boolean (got %T)", cfg.FailureExpression, failureAny),
-		}
+		return true, fmt.Errorf("failure expression %q did not evaluate to a boolean (got %T)", cfg.FailureExpression, failureAny)
 	case cfg.SuccessExpression != "":
 		success, err := h.wasRequestSuccessful(cfg, statusCode, env)
 		if err != nil {
@@ -313,9 +305,7 @@ func (h *httpRequester) buildOutputs(
 			}
 		}
 		if outputs[output.Name], err = expr.Run(program, env); err != nil {
-			return nil, &promotion.TerminalError{
-				Err: fmt.Errorf("error evaluating output expression %q: %w", output.Name, err),
-			}
+			return nil, fmt.Errorf("error evaluating output expression %q: %w", output.Name, err)
 		}
 	}
 	return outputs, nil

--- a/internal/promotion/runner/builtin/http_requester_test.go
+++ b/internal/promotion/runner/builtin/http_requester_test.go
@@ -626,7 +626,7 @@ func Test_httpRequester_wasRequestSuccessful(t *testing.T) {
 			cfg:  builtin.HTTPConfig{SuccessExpression: "invalid()"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error evaluating success expression")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -635,7 +635,7 @@ func Test_httpRequester_wasRequestSuccessful(t *testing.T) {
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "success expression")
 				require.ErrorContains(t, err, "did not evaluate to a boolean")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -708,7 +708,7 @@ func Test_httpRequester_didRequestFail(t *testing.T) {
 			cfg:  builtin.HTTPConfig{FailureExpression: "invalid()"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error evaluating failure expression")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -716,7 +716,7 @@ func Test_httpRequester_didRequestFail(t *testing.T) {
 			cfg:  builtin.HTTPConfig{FailureExpression: `"foo"`},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "did not evaluate to a boolean")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -801,7 +801,7 @@ func Test_httpRequester_buildOutputs(t *testing.T) {
 			}},
 			assertions: func(t *testing.T, _ map[string]any, err error) {
 				require.ErrorContains(t, err, "error evaluating output expression")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 			},
 		},
 		{

--- a/internal/promotion/runner/builtin/http_requester_test.go
+++ b/internal/promotion/runner/builtin/http_requester_test.go
@@ -369,7 +369,7 @@ func Test_httpRequester_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				require.ErrorContains(t, err, "HTTP (404) response met failure criteria")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 				require.Equal(t, kargoapi.PromotionStepStatusFailed, res.Status)
 			},
 		},
@@ -382,7 +382,7 @@ func Test_httpRequester_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				require.ErrorContains(t, err, "HTTP (200) response met failure criteria")
-				require.True(t, promotion.IsTerminal(err))
+				require.False(t, promotion.IsTerminal(err))
 				require.Equal(t, kargoapi.PromotionStepStatusFailed, res.Status)
 			},
 		},
@@ -618,6 +618,7 @@ func Test_httpRequester_wasRequestSuccessful(t *testing.T) {
 			cfg:  builtin.HTTPConfig{SuccessExpression: "(1 + 2"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error compiling success expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -625,13 +626,16 @@ func Test_httpRequester_wasRequestSuccessful(t *testing.T) {
 			cfg:  builtin.HTTPConfig{SuccessExpression: "invalid()"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error evaluating success expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
 			name: "success expression evaluates to non-boolean",
 			cfg:  builtin.HTTPConfig{SuccessExpression: `"foo"`},
 			assertions: func(t *testing.T, _ bool, err error) {
-				require.ErrorContains(t, err, "success expression did not evaluate to a boolean")
+				require.ErrorContains(t, err, "success expression")
+				require.ErrorContains(t, err, "did not evaluate to a boolean")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -696,6 +700,7 @@ func Test_httpRequester_didRequestFail(t *testing.T) {
 			cfg:  builtin.HTTPConfig{FailureExpression: "(1 + 2"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error compiling failure expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -703,13 +708,15 @@ func Test_httpRequester_didRequestFail(t *testing.T) {
 			cfg:  builtin.HTTPConfig{FailureExpression: "invalid()"},
 			assertions: func(t *testing.T, _ bool, err error) {
 				require.ErrorContains(t, err, "error evaluating failure expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
 			name: "failure expression evaluates to non-boolean",
 			cfg:  builtin.HTTPConfig{FailureExpression: `"foo"`},
 			assertions: func(t *testing.T, _ bool, err error) {
-				require.ErrorContains(t, err, "failure expression did not evaluate to a boolean")
+				require.ErrorContains(t, err, "did not evaluate to a boolean")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -782,7 +789,8 @@ func Test_httpRequester_buildOutputs(t *testing.T) {
 				FromExpression: "(1 + 2",
 			}},
 			assertions: func(t *testing.T, _ map[string]any, err error) {
-				require.ErrorContains(t, err, "error compiling expression")
+				require.ErrorContains(t, err, "error compiling output expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{
@@ -792,7 +800,8 @@ func Test_httpRequester_buildOutputs(t *testing.T) {
 				FromExpression: "invalid()",
 			}},
 			assertions: func(t *testing.T, _ map[string]any, err error) {
-				require.ErrorContains(t, err, "error evaluating expression")
+				require.ErrorContains(t, err, "error evaluating output expression")
+				require.True(t, promotion.IsTerminal(err))
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes a bug where `http` Promotion steps that failed due to failure criteria being met would never retry, even when configured with thresholds.

The issue was that these failures were incorrectly wrapped as `TerminalError`, causing the engine to treat them as unrecoverable errors rather than retryable failures. This meant that transient HTTP issues (like temporary server errors, network timeouts, or unexpected responses) would immediately fail instead of being retried according to the step's error threshold.