### PR TITLE
fix: two steps with empty alias are rejected by the webhook

### DIFF
--- a/internal/webhook/kubernetes/clusterpromotiontask/webhook_test.go
+++ b/internal/webhook/kubernetes/clusterpromotiontask/webhook_test.go
@@ -54,6 +54,8 @@ func Test_webhook_ValidateSpec(t *testing.T) {
 					{As: "foo"},
 					{As: "bar"},
 					{As: "baz"},
+					{As: ""},
+					{As: ""}, // optional not dup
 				},
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {

--- a/internal/webhook/kubernetes/promotion_steps.go
+++ b/internal/webhook/kubernetes/promotion_steps.go
@@ -18,6 +18,9 @@ func ValidatePromotionSteps(
 	indicesByAlias := make(map[string]int)
 	for i, step := range steps {
 		stepAlias := strings.TrimSpace(step.As)
+		if stepAlias == "" {
+			continue
+		}
 		if existingIndex, exists := indicesByAlias[stepAlias]; exists {
 			errs = append(
 				errs,

--- a/internal/webhook/kubernetes/promotion_steps_test.go
+++ b/internal/webhook/kubernetes/promotion_steps_test.go
@@ -19,6 +19,7 @@ func TestValidatePromotionSteps(t *testing.T) {
 			name: "steps are valid",
 			steps: []kargoapi.PromotionStep{
 				{},
+				{}, // optional not dup
 				{As: "fake-step"},
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {

--- a/internal/webhook/kubernetes/promotiontask/webhook_test.go
+++ b/internal/webhook/kubernetes/promotiontask/webhook_test.go
@@ -139,6 +139,8 @@ func Test_webhook_ValidateSpec(t *testing.T) {
 					{As: "foo"},
 					{As: "bar"},
 					{As: "baz"},
+					{As: ""},
+					{As: ""}, // optional not dup
 				},
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {

--- a/internal/webhook/kubernetes/stage/webhook_test.go
+++ b/internal/webhook/kubernetes/stage/webhook_test.go
@@ -1041,6 +1041,8 @@ func Test_webhook_ValidateSpec(t *testing.T) {
 							{As: "foo"},
 							{As: "bar"},
 							{As: "baz"},
+							{As: ""},
+							{As: ""}, // optional not dup
 						},
 					},
 				},


### PR DESCRIPTION
My pipeline which uses the Kargo resources from https://docs.kargo.io/quickstart#your-first-kargo-project is broken right now. Some steps don't have aliases, and the webhook rejects the resource with more than two steps that are missing the alias.