### PR TITLE
chore: deal with deprecation of `sigs.k8s.io/yaml/goyaml.v3`

### DIFF
--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/expressions"

--- a/internal/promotion/runner/builtin/kustomize_image_setter.go
+++ b/internal/promotion/runner/builtin/kustomize_image_setter.go
@@ -12,11 +12,11 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/xeipuuv/gojsonschema"
+	"go.yaml.in/yaml/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/konfig"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/internal/controller/freight"

--- a/internal/promotion/runner/builtin/kustomize_image_setter_test.go
+++ b/internal/promotion/runner/builtin/kustomize_image_setter_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	kustypes "sigs.k8s.io/kustomize/api/types"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/promotion"

--- a/internal/yaml/decode.go
+++ b/internal/yaml/decode.go
@@ -3,7 +3,7 @@ package yaml
 import (
 	"fmt"
 
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // FieldNotFoundErr is an error type that is returned when a field is not found

--- a/internal/yaml/decode_test.go
+++ b/internal/yaml/decode_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestDecodeField(t *testing.T) {

--- a/internal/yaml/update.go
+++ b/internal/yaml/update.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // UpdateField updates the value of a field in a YAML document. The field is

--- a/internal/yaml/update_test.go
+++ b/internal/yaml/update_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestUpdateField(t *testing.T) {

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Update represents a discrete update to be made to a YAML document.

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSetValuesInBytes(t *testing.T) {


### PR DESCRIPTION
This primarily removes aliases, as the `sigs.k8s.io/yaml/goyaml.v3` package has been aliased internally to `go.yaml.in/yaml/v3` without any further changes.