### PR TITLE
docs: Fix disabling Argo Rollouts integration in common config docs

### DIFF
--- a/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -334,8 +334,11 @@ Kargo to work with `Rollout` resources created by Argo Rollouts as part of the
 This can be disabled as follows:
 
 ```yaml
+api:
+  rollouts:
+    integrationEnabled: false
 controller:
-  argoRollouts:
+  rollouts:
     integrationEnabled: false
 ```
 


### PR DESCRIPTION
Changes the docs to use the correct Helm values for disabling ArgoCD Rollouts integration. Stumbled upon this when trying to disable it myself.

Correct Helm values variables:
- https://github.com/akuity/kargo/blob/main/charts/kargo/values.yaml#L321-L323
- https://github.com/akuity/kargo/blob/main/charts/kargo/values.yaml#L490-L492