### PR TITLE
docs: `Cluster` -> `ClusterConfig`

### DIFF
--- a/docs/docs/40-operator-guide/35-cluster-configuration.md
+++ b/docs/docs/40-operator-guide/35-cluster-configuration.md
@@ -121,7 +121,7 @@ The following example `ClusterConfig` configures two webhook receivers:
 
 ```yaml
 apiVersion: kargo.akuity.io/v1alpha1
-kind: Cluster
+kind: ClusterConfig
 metadata:
   name: cluster
 spec:


### PR DESCRIPTION
this doc previously mentioned a `Cluster` crd, but it's actually `ClusterConfig`