### PR TITLE
docs: Add example for using global service accounts

### DIFF
--- a/docs/docs/40-operator-guide/40-security/30-access-controls.md
+++ b/docs/docs/40-operator-guide/40-security/30-access-controls.md
@@ -210,3 +210,11 @@ by the operator:
 1. Configure Kargo to look for `ServiceAccount` resources in these designated
    namespaces, by setting `api.oidc.globalServiceAccounts.namespaces` at
    installation time. For example:
+
+   ```yaml
+   api:
+    oidc:
+      globalServiceAccounts:
+        namespaces:
+          - kargo-global-service-accounts
+   ```  

--- a/docs/docs/50-user-guide/50-security/20-access-controls/index.md
+++ b/docs/docs/50-user-guide/50-security/20-access-controls/index.md
@@ -424,3 +424,26 @@ control in the hands of the operator, and you should be aware of them.
     are not truly global because they are still mapped to users according to the
     rules described in the previous sections.
     :::
+
+    Example custom `RoleBinding` to a local `Project` role using a "global" `ServiceAccount` in a separate namespace:
+
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: kargo-demo-developer
+      namespace: kargo-demo
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: kargo-admin
+    subjects:
+    - kind: ServiceAccount
+      name: team-x-developers
+      namespace: kargo-global-service-accounts
+    ```
+
+    Which can also be created with:
+    ```shell
+    kubectl create rolebinding --serviceaccount kargo-global-service-account:team-x-developers --role kargo-admin -n kargo-demo kargo-demo-developer
+    ```


### PR DESCRIPTION
This adds:
- a missing example for enabling the global service account feature
- an example for using it with a manually created `RoleBinding` between a namespaced `Role` and a `ServiceAccount` in a separate "global" service account namespace

Verified to render nicely in Docusaurus.

I really missed examples like this myself when I fumbled around trying to use the feature :)
