### PR TITLE
refactor: switch Bitbucket auth from OAuth bearer token to Basic Auth

### DIFF
--- a/internal/gitprovider/bitbucket/bitbucket.go
+++ b/internal/gitprovider/bitbucket/bitbucket.go
@@ -91,7 +91,7 @@ func NewProvider(
 		return nil, fmt.Errorf("unsupported Bitbucket host %q", host)
 	}
 
-	client := bitbucket.NewOAuthbearerToken(opts.Token)
+	client := bitbucket.NewBasicAuth(opts.Username, opts.Token)
 	client.HttpClient = cleanhttp.DefaultClient()
 
 	return &provider{

--- a/internal/gitprovider/gitprovider.go
+++ b/internal/gitprovider/gitprovider.go
@@ -28,8 +28,9 @@ type Options struct {
 	// Name specifies which Git provider to use when that information cannot be
 	// inferred from the repository URL.
 	Name string
-	// Token is the access token used to authenticate against the Git provider's
-	// API.
+	// Username used for authentication with the Git provider's API.
+	Username string
+	// Token or password used to authenticate against the Git provider's API.
 	Token string
 	// InsecureSkipTLSVerify specifies whether certificate verification errors
 	// should be ignored when connecting to the Git provider's API.

--- a/internal/promotion/runner/builtin/git_pr_opener.go
+++ b/internal/promotion/runner/builtin/git_pr_opener.go
@@ -121,6 +121,7 @@ func (g *gitPROpener) run(
 	}
 	if repoCreds != nil {
 		gpOpts.Token = repoCreds.Password
+		gpOpts.Username = repoCreds.Username
 	}
 	if cfg.Provider != nil {
 		gpOpts.Name = string(*cfg.Provider)

--- a/internal/promotion/runner/builtin/git_pr_waiter.go
+++ b/internal/promotion/runner/builtin/git_pr_waiter.go
@@ -92,6 +92,7 @@ func (g *gitPRWaiter) run(
 	}
 	if repoCreds != nil {
 		gpOpts.Token = repoCreds.Password
+		gpOpts.Username = repoCreds.Username
 	}
 	if cfg.Provider != nil {
 		gpOpts.Name = string(*cfg.Provider)


### PR DESCRIPTION
This minimal change provides partial support for Bitbucket Cloud by enabling authentication using [App Passwords](https://bitbucket.org/account/settings/app-passwords/).  Partially solving https://github.com/akuity/kargo/issues/4654.

It allows `kargo` to authenticate successfully for both Git operations and REST API calls when using this mechanism:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: kargo-https-creds
  namespace: kargo-promotion
  labels:
    kargo.akuity.io/cred-type: git
type: Opaque
stringData:
  repoURL: https://bitbucket.org/MY-WORKSPACE/MY-REPO.git
  username: ${USERNAME}
  password: ${APP_PASSWORD}
```

However, Bitbucket App Passwords are being deprecated, and [Bitbucket API Tokens](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/) are the new standard. API tokens introduce a challenge:

- **Git operations** require:  
  `username: 'x-token-auth'` **or** `<Atlassian username>` + `password: <API_TOKEN>`

- **REST API operations** (e.g., creating or checking pull requests) require:  
  `username: <Atlassian email>` + `password: <API_TOKEN>`

Currently, Kargo allows specifying only one `username/password` combination, used across both Git and REST API operations. This limitation makes it incompatible with Bitbucket API Tokens, where two different usernames are required.

### Next Steps

This PR resolves the immediate use case with App Passwords. Full support for Bitbucket API Tokens will require additional logic to:

- Accept separate usernames for Git and REST operations, or
- Implement a Bitbucket-specific authentication strategy.
