### PR TITLE
fix(chart): use .Values.image.pullSecrets in garbage collector CronJob

### DIFF
--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -52,6 +52,10 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           containers:
           - name: garbage-collector
             image: {{ include "kargo.image" . }}


### PR DESCRIPTION
We noticed the Kargo garbage collector was failing with imagePullBackoff error.

The cause was that it's missing imagePullSecrets in the CronJob.