### PR TITLE
refactor: terminal error on step configuration validation 

### DIFF
--- a/internal/promotion/runner/builtin/argocd_updater_test.go
+++ b/internal/promotion/runner/builtin/argocd_updater_test.go
@@ -35,7 +35,7 @@ func Test_newArgocdUpdater(t *testing.T) {
 	require.NotNil(t, runner.logAppEventFn)
 }
 
-func Test_argoCDUpdater_validate(t *testing.T) {
+func Test_argoCDUpdater_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -321,7 +321,7 @@ func Test_argoCDUpdater_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/argocd_updater_test.go
+++ b/internal/promotion/runner/builtin/argocd_updater_test.go
@@ -36,11 +36,7 @@ func Test_newArgocdUpdater(t *testing.T) {
 }
 
 func Test_argoCDUpdater_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "apps not specified",
 			config: promotion.Config{},
@@ -318,19 +314,7 @@ func Test_argoCDUpdater_convert(t *testing.T) {
 	}
 
 	runner := newArgocdUpdater(nil)
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_argoCDUpdater_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/file_copier.go
+++ b/internal/promotion/runner/builtin/file_copier.go
@@ -49,19 +49,19 @@ func (f *fileCopier) Run(
 	ctx context.Context,
 	stepCtx *promotion.StepContext,
 ) (promotion.StepResult, error) {
-	// Validate the configuration against the JSON Schema.
-	if err := validate(f.schemaLoader, gojsonschema.NewGoLoader(stepCtx.Config), f.Name()); err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
-	}
-
-	// Convert the configuration into a typed object.
-	cfg, err := promotion.ConfigToStruct[builtin.CopyConfig](stepCtx.Config)
+	cfg, err := f.convert(stepCtx.Config)
 	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("could not convert config into %s config: %w", f.Name(), err)
+		return promotion.StepResult{
+			Status: kargoapi.PromotionStepStatusFailed,
+		}, &promotion.TerminalError{Err: err}
 	}
-
 	return f.run(ctx, stepCtx, cfg)
+}
+
+// convert validates fileCopier configuration against a JSON schema and
+// converts it into a builtin.CopyConfig struct.
+func (f *fileCopier) convert(cfg promotion.Config) (builtin.CopyConfig, error) {
+	return validateAndConvert[builtin.CopyConfig](f.schemaLoader, cfg, f.Name())
 }
 
 func (f *fileCopier) run(

--- a/internal/promotion/runner/builtin/file_deleter_test.go
+++ b/internal/promotion/runner/builtin/file_deleter_test.go
@@ -14,6 +14,72 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
+func Test_fileDeleter_convert(t *testing.T) {
+	tests := []validationTestCase{
+		{
+			name:   "path not specified",
+			config: promotion.Config{},
+			expectedProblems: []string{
+				"(root): path is required",
+			},
+		},
+		{
+			name: "path is empty string",
+			config: promotion.Config{
+				"path": "",
+			},
+			expectedProblems: []string{
+				"path: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "strict is not specified",
+			config: promotion.Config{
+				"path": "/path/to/delete",
+			},
+			// No expected problems because strict is optional with default: false
+			expectedProblems: nil,
+		},
+		{
+			name: "valid minimal config",
+			config: promotion.Config{
+				"path": "/path/to/delete",
+			},
+			expectedProblems: nil,
+		},
+		{
+			name: "valid config with strict=false",
+			config: promotion.Config{
+				"path":   "/path/to/delete",
+				"strict": false,
+			},
+			expectedProblems: nil,
+		},
+		{
+			name: "valid config with strict=true",
+			config: promotion.Config{
+				"path":   "/path/to/delete",
+				"strict": true,
+			},
+			expectedProblems: nil,
+		},
+		{
+			name: "valid kitchen sink",
+			config: promotion.Config{
+				"path":   "/path/to/file/or/directory/to/delete",
+				"strict": true,
+			},
+			expectedProblems: nil,
+		},
+	}
+
+	r := newFileDeleter()
+	runner, ok := r.(*fileDeleter)
+	require.True(t, ok)
+
+	runValidationTests(t, runner.convert, tests)
+}
+
 func Test_fileDeleter_run(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -19,11 +19,7 @@ import (
 )
 
 func Test_gitCloner_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "repoURL not specified",
 			config: promotion.Config{},
@@ -307,18 +303,7 @@ func Test_gitCloner_convert(t *testing.T) {
 	runner, ok := r.(*gitCloner)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitCloner_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_cloner_test.go
+++ b/internal/promotion/runner/builtin/git_cloner_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitCloner_validateAndUnmarshal(t *testing.T) {
+func Test_gitCloner_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -309,7 +309,7 @@ func Test_gitCloner_validateAndUnmarshal(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.validateAndUnmarshal(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_commiter_test.go
+++ b/internal/promotion/runner/builtin/git_commiter_test.go
@@ -18,11 +18,7 @@ import (
 )
 
 func Test_gitCommitter_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name: "path not specified",
 			config: promotion.Config{
@@ -164,18 +160,7 @@ func Test_gitCommitter_convert(t *testing.T) {
 	runner, ok := r.(*gitCommitter)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitCommitter_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_commiter_test.go
+++ b/internal/promotion/runner/builtin/git_commiter_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitCommitter_validate(t *testing.T) {
+func Test_gitCommitter_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -166,7 +166,7 @@ func Test_gitCommitter_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_pr_opener_test.go
+++ b/internal/promotion/runner/builtin/git_pr_opener_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitPROpener_validate(t *testing.T) {
+func Test_gitPROpener_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -146,7 +146,7 @@ func Test_gitPROpener_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_pr_opener_test.go
+++ b/internal/promotion/runner/builtin/git_pr_opener_test.go
@@ -20,11 +20,7 @@ import (
 )
 
 func Test_gitPROpener_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "repoURL not specified",
 			config: promotion.Config{},
@@ -144,18 +140,7 @@ func Test_gitPROpener_convert(t *testing.T) {
 	runner, ok := r.(*gitPROpener)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitPROpener_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_pr_waiter_test.go
+++ b/internal/promotion/runner/builtin/git_pr_waiter_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitPRWaiter_validate(t *testing.T) {
+func Test_gitPRWaiter_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -88,7 +88,7 @@ func Test_gitPRWaiter_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_pr_waiter_test.go
+++ b/internal/promotion/runner/builtin/git_pr_waiter_test.go
@@ -17,11 +17,7 @@ import (
 )
 
 func Test_gitPRWaiter_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "repoURL not specified",
 			config: promotion.Config{},
@@ -86,18 +82,7 @@ func Test_gitPRWaiter_convert(t *testing.T) {
 	runner, ok := r.(*gitPRWaiter)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitPRWaiter_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_pusher_test.go
+++ b/internal/promotion/runner/builtin/git_pusher_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func Test_gitPusher_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path not specified",
 			config: promotion.Config{},
@@ -136,18 +132,7 @@ func Test_gitPusher_convert(t *testing.T) {
 	runner, ok := r.(*gitPushPusher)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitPusher_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_pusher_test.go
+++ b/internal/promotion/runner/builtin/git_pusher_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitPusher_validate(t *testing.T) {
+func Test_gitPusher_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -138,7 +138,7 @@ func Test_gitPusher_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/git_tree_clearer_test.go
+++ b/internal/promotion/runner/builtin/git_tree_clearer_test.go
@@ -18,11 +18,7 @@ import (
 )
 
 func Test_gitTreeOverwriter_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path not specified",
 			config: promotion.Config{},
@@ -45,18 +41,7 @@ func Test_gitTreeOverwriter_convert(t *testing.T) {
 	runner, ok := r.(*gitTreeClearer)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_gitTreeOverwriter_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/git_tree_clearer_test.go
+++ b/internal/promotion/runner/builtin/git_tree_clearer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_gitTreeOverwriter_validate(t *testing.T) {
+func Test_gitTreeOverwriter_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -47,7 +47,7 @@ func Test_gitTreeOverwriter_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/helm_chart_updater_test.go
+++ b/internal/promotion/runner/builtin/helm_chart_updater_test.go
@@ -24,11 +24,7 @@ import (
 )
 
 func Test_helmChartUpdater_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path is not specified",
 			config: promotion.Config{},
@@ -139,18 +135,7 @@ func Test_helmChartUpdater_convert(t *testing.T) {
 	runner, ok := r.(*helmChartUpdater)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_helmChartUpdater_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/helm_chart_updater_test.go
+++ b/internal/promotion/runner/builtin/helm_chart_updater_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_helmChartUpdater_validate(t *testing.T) {
+func Test_helmChartUpdater_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -141,7 +141,7 @@ func Test_helmChartUpdater_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/http_downloader_test.go
+++ b/internal/promotion/runner/builtin/http_downloader_test.go
@@ -21,11 +21,7 @@ import (
 )
 
 func Test_httpDownloader_validate(t *testing.T) {
-	tests := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "url not specified",
 			config: promotion.Config{},
@@ -188,22 +184,11 @@ func Test_httpDownloader_validate(t *testing.T) {
 		},
 	}
 
-	d := newHTTPDownloader()
-	downloader, ok := d.(*httpDownloader)
+	r := newHTTPDownloader()
+	runner, ok := r.(*httpDownloader)
 	require.True(t, ok)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := downloader.validate(tt.config)
-			if len(tt.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range tt.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_httpDownloader_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/http_requester_test.go
+++ b/internal/promotion/runner/builtin/http_requester_test.go
@@ -16,11 +16,7 @@ import (
 )
 
 func Test_httpRequester_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "url not specified",
 			config: promotion.Config{},
@@ -210,18 +206,7 @@ func Test_httpRequester_convert(t *testing.T) {
 	runner, ok := r.(*httpRequester)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_httpRequester_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/http_requester_test.go
+++ b/internal/promotion/runner/builtin/http_requester_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_httpRequester_validate(t *testing.T) {
+func Test_httpRequester_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -212,7 +212,7 @@ func Test_httpRequester_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/json_parser_test.go
+++ b/internal/promotion/runner/builtin/json_parser_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_jsonParser_validate(t *testing.T) {
+func Test_jsonParser_convert(t *testing.T) {
 	tests := []struct {
 		name          string
 		config        map[string]any
@@ -114,7 +114,7 @@ func Test_jsonParser_validate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := runner.validate(tc.config)
+			_, err := runner.convert(tc.config)
 			if tc.expectedError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/json_parser_test.go
+++ b/internal/promotion/runner/builtin/json_parser_test.go
@@ -17,94 +17,106 @@ import (
 )
 
 func Test_jsonParser_convert(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        map[string]any
-		expectedError string
-	}{
+	tests := []validationTestCase{
 		{
 			name: "path not specified (missing path field)",
-			config: map[string]any{
+			config: promotion.Config{
 				"outputs": []map[string]any{
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "(root): path is required",
+			expectedProblems: []string{
+				"(root): path is required",
+			},
 		},
 		{
 			name: "path is empty string",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "",
 				"outputs": []map[string]any{
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "path: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"path: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "outputs field is missing",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 			},
-			expectedError: "(root): outputs is required",
+			expectedProblems: []string{
+				"(root): outputs is required",
+			},
 		},
 		{
 			name: "outputs field is an empty array",
-			config: map[string]any{
+			config: promotion.Config{
 				"path":    "valid.json",
 				"outputs": []map[string]any{},
 			},
-			expectedError: "outputs: Array must have at least 1 items",
+			expectedProblems: []string{
+				"outputs: Array must have at least 1 items",
+			},
 		},
 		{
 			name: "name is not specified",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 				"outputs": []map[string]any{
 					{"fromExpression": "$.data"},
 				},
 			},
-			expectedError: "outputs.0: name is required",
+			expectedProblems: []string{
+				"outputs.0: name is required",
+			},
 		},
 		{
 			name: "name is empty",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 				"outputs": []map[string]any{
 					{"name": "", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "name: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"name: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "FromExpression is not specified",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 				"outputs": []map[string]any{
 					{"name": "output1"},
 				},
 			},
-			expectedError: "outputs.0: fromExpression is required",
+			expectedProblems: []string{
+				"outputs.0: fromExpression is required",
+			},
 		},
 		{
 			name: "FromExpression is empty",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 				"outputs": []map[string]any{
 					{"name": "output1", "fromExpression": ""},
 				},
 			},
-			expectedError: "fromExpression: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"fromExpression: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "valid configuration (path + outputs present)",
-			config: map[string]any{
+			config: promotion.Config{
 				"path": "valid.json",
 				"outputs": []map[string]any{
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "",
+			expectedProblems: nil,
 		},
 	}
 
@@ -112,17 +124,7 @@ func Test_jsonParser_convert(t *testing.T) {
 	runner, ok := r.(*jsonParser)
 	require.True(t, ok)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := runner.convert(tc.config)
-			if tc.expectedError == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_jsonParser_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/json_updater_test.go
+++ b/internal/promotion/runner/builtin/json_updater_test.go
@@ -16,11 +16,7 @@ import (
 )
 
 func Test_jsonUpdater_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path is not specified",
 			config: promotion.Config{},
@@ -104,18 +100,7 @@ func Test_jsonUpdater_convert(t *testing.T) {
 	runner, ok := r.(*jsonUpdater)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_jsonUpdater_updateValuesFile(t *testing.T) {

--- a/internal/promotion/runner/builtin/json_updater_test.go
+++ b/internal/promotion/runner/builtin/json_updater_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_jsonUpdater_validate(t *testing.T) {
+func Test_jsonUpdater_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -106,7 +106,7 @@ func Test_jsonUpdater_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/kustomize_image_setter_test.go
+++ b/internal/promotion/runner/builtin/kustomize_image_setter_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_kustomizeImageSetter_validate(t *testing.T) {
+func Test_kustomizeImageSetter_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -134,7 +134,7 @@ func Test_kustomizeImageSetter_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/kustomize_image_setter_test.go
+++ b/internal/promotion/runner/builtin/kustomize_image_setter_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func Test_kustomizeImageSetter_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path is not specified",
 			config: promotion.Config{},
@@ -132,18 +128,7 @@ func Test_kustomizeImageSetter_convert(t *testing.T) {
 	runner, ok := r.(*kustomizeImageSetter)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_kustomizeImageSetter_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/tar_extractor_test.go
+++ b/internal/promotion/runner/builtin/tar_extractor_test.go
@@ -174,7 +174,7 @@ func Test_tarExtractor_run(t *testing.T) {
 				defer tw.Close()
 
 				// Add a file that exceeds the size limit
-				largeFileSize := MaxDecompressedFileSize + 1
+				largeFileSize := maxDecompressedFileSize + 1
 				hdr := &tar.Header{
 					Name: "large_file.bin",
 					Mode: 0o600,
@@ -685,7 +685,7 @@ func Test_tarExtractor_extractToDir(t *testing.T) {
 				defer tw.Close()
 
 				// Mock large file that exceeds the size limit
-				largeFileSize := MaxDecompressedFileSize + 1
+				largeFileSize := maxDecompressedFileSize + 1
 				hdr := &tar.Header{
 					Name: "large_file.bin",
 					Mode: 0o600,
@@ -724,17 +724,17 @@ func Test_tarExtractor_extractToDir(t *testing.T) {
 				tw := tar.NewWriter(tarFile)
 				defer tw.Close()
 
-				nbFiles := (MaxDecompressedTarSize / MaxDecompressedFileSize) + 1
+				nbFiles := (maxDecompressedTarSize / maxDecompressedFileSize) + 1
 				for i := range int(nbFiles) {
 					hdr := &tar.Header{
 						Name: fmt.Sprintf("file%d.bin", i),
 						Mode: 0o600,
-						Size: MaxDecompressedFileSize - 1,
+						Size: maxDecompressedFileSize - 1,
 					}
 					require.NoError(t, tw.WriteHeader(hdr))
 
 					// Write zeros to the file
-					_, err = tw.Write(make([]byte, MaxDecompressedFileSize-1))
+					_, err = tw.Write(make([]byte, maxDecompressedFileSize-1))
 					require.NoError(t, err)
 				}
 

--- a/internal/promotion/runner/builtin/validation.go
+++ b/internal/promotion/runner/builtin/validation.go
@@ -5,23 +5,52 @@ import (
 	"fmt"
 
 	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/akuity/kargo/pkg/promotion"
 )
 
+// validateAndConvert validates the given configuration document against the
+// provided JSON schema loader and converts it into the specified type T. It
+// returns an error if the validation fails or if there is an error during
+// conversion. If the validation is successful and the conversion is successful,
+// it returns the converted configuration of type T.
+func validateAndConvert[T any](
+	schemaLoader gojsonschema.JSONLoader,
+	config promotion.Config,
+	stepName string,
+) (T, error) {
+	var zero T
+
+	if err := validate(schemaLoader, gojsonschema.NewGoLoader(config), stepName); err != nil {
+		return zero, err
+	}
+
+	cfg, err := promotion.ConfigToStruct[T](config)
+	if err != nil {
+		return zero, fmt.Errorf("could not convert config into %s config: %w", stepName, err)
+	}
+
+	return cfg, nil
+}
+
+// validate validates the given configuration document against the provided JSON
+// schema loader. It returns an error if the validation fails or if there is an
+// error during validation. If the validation is successful, it returns nil.
 func validate(
 	schemaLoader gojsonschema.JSONLoader,
 	docLoader gojsonschema.JSONLoader,
-	configKind string,
+	stepName string,
 ) error {
 	result, err := gojsonschema.Validate(schemaLoader, docLoader)
 	if err != nil {
-		return fmt.Errorf("could not validate %s config: %w", configKind, err)
+		return fmt.Errorf("could not validate %s config: %w", stepName, err)
 	}
 	if !result.Valid() {
 		errs := make([]error, len(result.Errors()))
 		for i, err := range result.Errors() {
 			errs[i] = errors.New(err.String())
 		}
-		return fmt.Errorf("invalid %s config: %w", configKind, errors.Join(errs...))
+		return fmt.Errorf("invalid %s config: %w", stepName, errors.Join(errs...))
 	}
 	return nil
 }

--- a/internal/promotion/runner/builtin/validation_test.go
+++ b/internal/promotion/runner/builtin/validation_test.go
@@ -1,0 +1,46 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/akuity/kargo/pkg/promotion"
+)
+
+// validationTestCase is a struct that represents a test case for validating
+// a promotion step configuration. It includes the name of the test,
+// the configuration to validate, and the expected problems that should
+// be reported if the validation fails.
+type validationTestCase struct {
+	name             string
+	config           promotion.Config
+	expectedProblems []string
+}
+
+// runValidationTests runs a set of validation tests for a given promotion step
+// configuration converter function. It takes a testing.T instance, a converter
+// function that converts a promotion.Config to a specific type T, and a slice
+// of validationTestCase instances. Each test case is run in parallel, and the
+// results are asserted using require and assert from the testify package.
+func runValidationTests[T any](t *testing.T, converter func(promotion.Config) (T, error), tests []validationTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := converter(tt.config)
+			if len(tt.expectedProblems) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, problem := range tt.expectedProblems {
+				assert.ErrorContains(t, err, problem)
+			}
+		})
+	}
+}

--- a/internal/promotion/runner/builtin/yaml_parser_test.go
+++ b/internal/promotion/runner/builtin/yaml_parser_test.go
@@ -17,11 +17,7 @@ import (
 )
 
 func Test_yamlParser_convert(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        map[string]any
-		expectedError string
-	}{
+	tests := []validationTestCase{
 		{
 			name: "path not specified (missing path field)",
 			config: map[string]any{
@@ -29,7 +25,9 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "(root): path is required",
+			expectedProblems: []string{
+				"(root): path is required",
+			},
 		},
 		{
 			name: "path is empty string",
@@ -39,14 +37,18 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "path: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"path: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "outputs field is missing",
 			config: map[string]any{
 				"path": "valid.yaml",
 			},
-			expectedError: "(root): outputs is required",
+			expectedProblems: []string{
+				"(root): outputs is required",
+			},
 		},
 		{
 			name: "outputs field is an empty array",
@@ -54,7 +56,9 @@ func Test_yamlParser_convert(t *testing.T) {
 				"path":    "valid.yaml",
 				"outputs": []map[string]any{},
 			},
-			expectedError: "outputs: Array must have at least 1 items",
+			expectedProblems: []string{
+				"outputs: Array must have at least 1 items",
+			},
 		},
 		{
 			name: "name is not specified",
@@ -64,7 +68,9 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"fromExpression": "$.data"},
 				},
 			},
-			expectedError: "outputs.0: name is required",
+			expectedProblems: []string{
+				"outputs.0: name is required",
+			},
 		},
 		{
 			name: "name is empty",
@@ -74,7 +80,9 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "name: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"name: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "FromExpression is not specified",
@@ -84,7 +92,9 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "output1"},
 				},
 			},
-			expectedError: "outputs.0: fromExpression is required",
+			expectedProblems: []string{
+				"outputs.0: fromExpression is required",
+			},
 		},
 		{
 			name: "FromExpression is empty",
@@ -94,7 +104,9 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "output1", "fromExpression": ""},
 				},
 			},
-			expectedError: "fromExpression: String length must be greater than or equal to 1",
+			expectedProblems: []string{
+				"fromExpression: String length must be greater than or equal to 1",
+			},
 		},
 		{
 			name: "valid configuration (path + outputs present)",
@@ -104,7 +116,7 @@ func Test_yamlParser_convert(t *testing.T) {
 					{"name": "output1", "fromExpression": "$.data"},
 				},
 			},
-			expectedError: "",
+			expectedProblems: nil,
 		},
 	}
 
@@ -112,17 +124,7 @@ func Test_yamlParser_convert(t *testing.T) {
 	runner, ok := r.(*yamlParser)
 	require.True(t, ok)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := runner.convert(tc.config)
-			if tc.expectedError == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_yamlParser_run(t *testing.T) {

--- a/internal/promotion/runner/builtin/yaml_parser_test.go
+++ b/internal/promotion/runner/builtin/yaml_parser_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_yamlParser_validate(t *testing.T) {
+func Test_yamlParser_convert(t *testing.T) {
 	tests := []struct {
 		name          string
 		config        map[string]any
@@ -114,7 +114,7 @@ func Test_yamlParser_validate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := runner.validate(tc.config)
+			_, err := runner.convert(tc.config)
 			if tc.expectedError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/yaml_updater_test.go
+++ b/internal/promotion/runner/builtin/yaml_updater_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_yamlUpdater_validate(t *testing.T) {
+func Test_yamlUpdater_convert(t *testing.T) {
 	testCases := []struct {
 		name             string
 		config           promotion.Config
@@ -110,7 +110,7 @@ func Test_yamlUpdater_validate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := runner.validate(testCase.config)
+			_, err := runner.convert(testCase.config)
 			if len(testCase.expectedProblems) == 0 {
 				require.NoError(t, err)
 			} else {

--- a/internal/promotion/runner/builtin/yaml_updater_test.go
+++ b/internal/promotion/runner/builtin/yaml_updater_test.go
@@ -16,11 +16,7 @@ import (
 )
 
 func Test_yamlUpdater_convert(t *testing.T) {
-	testCases := []struct {
-		name             string
-		config           promotion.Config
-		expectedProblems []string
-	}{
+	tests := []validationTestCase{
 		{
 			name:   "path is not specified",
 			config: promotion.Config{},
@@ -108,18 +104,7 @@ func Test_yamlUpdater_convert(t *testing.T) {
 	runner, ok := r.(*yamlUpdater)
 	require.True(t, ok)
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			_, err := runner.convert(testCase.config)
-			if len(testCase.expectedProblems) == 0 {
-				require.NoError(t, err)
-			} else {
-				for _, problem := range testCase.expectedProblems {
-					require.ErrorContains(t, err, problem)
-				}
-			}
-		})
-	}
+	runValidationTests(t, runner.convert, tests)
 }
 
 func Test_yamlUpdater_run(t *testing.T) {


### PR DESCRIPTION
- Switch to a `TerminalError` on step configuration validation and conversion errors (https://github.com/akuity/kargo/pull/4544#discussion_r2180670316).
- Introduce a test helper to reduce the repeated testing logic we had for every step's validation tests.
- Backfill some validation tests.