### PR TITLE
chore(manual backport release-1.6): fix: take greater care when examining media types (#4704)

### DIFF
--- a/internal/webhook/external/dockerhub.go
+++ b/internal/webhook/external/dockerhub.go
@@ -92,14 +92,17 @@ func (d *dockerhubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFu
 			return
 		}
 
-		repoURL := normalizeOCIRepoURL(
+		repoURLs := getNormalizedImageRepoURLs(
 			payload.Repository.RepoName,
 			payload.PushData.MediaType,
 		)
 
-		logger = logger.WithValues("repoURL", repoURL)
+		logger = logger.WithValues(
+			"repoURLs", repoURLs,
+			"mediaType", payload.PushData.MediaType,
+		)
 		ctx = logging.ContextWithLogger(ctx, logger)
 
-		refreshWarehouses(ctx, w, d.client, d.project, repoURL)
+		refreshWarehouses(ctx, w, d.client, d.project, repoURLs...)
 	})
 }

--- a/internal/webhook/external/dockerhub_test.go
+++ b/internal/webhook/external/dockerhub_test.go
@@ -20,7 +20,7 @@ import (
 const dockerhubWebhookRequestBodyImage = `
 {
 	"push_data": {
-		"media_type": "` + ociImageIndexMediaType + `"
+		"media_type": "` + dockerImageConfigBlobMediaType + `"
 	},
 	"repository": {
 		"repo_name": "example/repo"
@@ -30,7 +30,7 @@ const dockerhubWebhookRequestBodyImage = `
 const dockerhubWebhookRequestBodyChart = `
 {
 	"push_data": {
-		"media_type": "` + helmChartMediaType + `"
+		"media_type": "` + helmChartConfigBlobMediaType + `"
 	},
 	"repository": {
 		"repo_name": "example/repo"

--- a/internal/webhook/external/github.go
+++ b/internal/webhook/external/github.go
@@ -134,7 +134,8 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			return
 		}
 
-		var repoURL string
+		var repoURLs []string
+		var mediaType string
 
 		switch e := event.(type) {
 		case *gh.PackageEvent:
@@ -169,8 +170,8 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			}
 			manifest := pkg.GetPackageVersion().GetContainerMetadata().GetManifest()
 			if cfg, ok := manifest["config"].(map[string]any); ok {
-				if mediaType, ok := cfg["media_type"].(string); ok {
-					repoURL = normalizeOCIRepoURL(ref.Context().Name(), mediaType)
+				if mediaType, ok = cfg["media_type"].(string); ok {
+					repoURLs = getNormalizedImageRepoURLs(ref.Context().Name(), mediaType)
 				}
 			}
 
@@ -189,12 +190,15 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			// https://. By refreshing Warehouses using a normalized representation of
 			// that URL, we will miss any Warehouses that are subscribed to the same
 			// repository using a different URL format.
-			repoURL = git.NormalizeURL(e.GetRepo().GetCloneURL())
+			repoURLs = []string{git.NormalizeURL(e.GetRepo().GetCloneURL())}
 		}
 
-		logger = logger.WithValues("repoURL", repoURL)
+		logger = logger.WithValues(
+			"repoURLs", repoURLs,
+			"mediaType", mediaType,
+		)
 		ctx = logging.ContextWithLogger(ctx, logger)
 
-		refreshWarehouses(ctx, w, g.client, g.project, repoURL)
+		refreshWarehouses(ctx, w, g.client, g.project, repoURLs...)
 	})
 }

--- a/internal/webhook/external/github_test.go
+++ b/internal/webhook/external/github_test.go
@@ -41,7 +41,9 @@ func TestGithubHandler(t *testing.T) {
 				ContainerMetadata: &gh.PackageEventContainerMetadata{
 					Manifest: map[string]any{
 						"config": map[string]any{
-							"media_type": ociImageIndexMediaType,
+							// Real world testing shows this media type is what the payload
+							// will contain when an image has been pushed to GHCR.
+							"media_type": dockerImageConfigBlobMediaType,
 						},
 					},
 				},
@@ -57,7 +59,9 @@ func TestGithubHandler(t *testing.T) {
 				ContainerMetadata: &gh.PackageEventContainerMetadata{
 					Manifest: map[string]any{
 						"config": map[string]any{
-							"media_type": helmChartMediaType,
+							// Real world testing shows this media type is what the payload
+							// will contain when an image has been pushed to GHCR.
+							"media_type": helmChartConfigBlobMediaType,
 						},
 					},
 				},

--- a/internal/webhook/external/media_types.go
+++ b/internal/webhook/external/media_types.go
@@ -2,45 +2,97 @@ package external
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/akuity/kargo/internal/helm"
 	"github.com/akuity/kargo/internal/image"
 )
 
 const (
-	ociImageIndexMediaType    = "application/vnd.oci.image.index.v1+json"
-	ociImageManifestMediaType = "application/vnd.oci.image.manifest.v1+json"
+	ociImageIndexMediaType      = "application/vnd.oci.image.index.v1+json"
+	ociImageManifestMediaType   = "application/vnd.oci.image.manifest.v1+json"
+	ociImageConfigBlobMediaType = "application/vnd.oci.image.config.v1+json"
 
-	dockerManifestListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
-	dockerManifestMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
+	dockerManifestListMediaType    = "application/vnd.docker.distribution.manifest.list.v2+json"
+	dockerManifestMediaType        = "application/vnd.docker.distribution.manifest.v2+json"
+	dockerImageConfigBlobMediaType = "application/vnd.docker.container.image.v1+json"
 
-	helmChartMediaType = "application/vnd.cncf.helm.config.v1+json"
+	helmChartConfigBlobMediaType = "application/vnd.cncf.helm.config.v1+json"
 )
 
-var containerImageMediaTypes = []string{
+// probableContainerImageMediaTypes is a list of media types that, for our
+// purposes, are a dead giveaway that the URL they are associated with
+// represents a container image. Note this list deliberately omits
+// application/vnd.oci.image.manifest.v1+json because, for our purposes, it
+// does not definitively establish whether the URL associated with it represents
+// a container image, a Helm chart, or something else entirely.
+var probableContainerImageMediaTypes = []string{
 	ociImageIndexMediaType,
-	ociImageManifestMediaType,
 	dockerManifestListMediaType,
 	dockerManifestMediaType,
+	ociImageConfigBlobMediaType,
+	dockerImageConfigBlobMediaType,
 }
 
-func isContainerImageMediaType(mediaType string) bool {
-	return slices.Contains(containerImageMediaTypes, mediaType)
-}
-
-func isHelmChartMediaType(mediaType string) bool {
-	return mediaType == helmChartMediaType
-}
-
-// normalizeOCIRepoURL returns a normalized representation of the specified OCI
-// repository URL based on the specified media type. If the media type is not
-// recognized, an empty string is returned.
-func normalizeOCIRepoURL(repoURL, mediaType string) string {
-	switch {
-	case isContainerImageMediaType(mediaType):
-		return image.NormalizeURL(repoURL)
-	case isHelmChartMediaType(mediaType):
-		return helm.NormalizeChartRepositoryURL(repoURL)
+// getNormalizedImageRepoURLs returns exactly one or two normalized
+// representations of the specified repository URL based on whatever, if
+// anything, can be inferred from the specified media type.
+//
+// In this context, "image repo" could mean a repository in a Docker v2 registry
+// OR a repository in an OCI registry. This function assumes that the provided
+// repository URL falls into one of those two cases.
+//
+// Different webhook receivers invoking this function receive and pass on media
+// type information of varying degrees of specificity, so no assumptions are
+// made about what specific object the specified media type may be associated
+// with. The specified media type could reasonably (but non-exhaustively) be
+// that of any of the following:
+//
+//   - A v2 manifest list or an OCI manifest index. These commonly are
+//     indicative of a multi-arch container image and imply the specified URL
+//     does not reference a chart repository.
+//
+//   - A v2 or OCI manifest. A v2 manifest is exclusively indicative of a
+//     container image and implies the the specified URL references a container
+//     image repository. An OCI manifest, however, is more ambiguous and does
+//     not imply anything useful about what is referenced by the specified
+//     repository URL. That distinction could only be made by examining the
+//     mediate type of the config blob.
+//
+//   - A config blob. If the media type is readily recognizable as Helm-related,
+//     it can be inferred that the specified URL references a Helm chart
+//     repository. If it's readily recognizable as image-related, it can be
+//     inferred that the specified URL references a container image repository.
+//
+//   - Something entirely unexpected.
+//
+// If it can be inferred that the repository URL is associated with a container
+// image repository, the returned []string will contain only one item -- the
+// specified URL normalized as if it represented a container image repository.
+//
+// If it can be inferred that the repository URL is associated with a Helm chart
+// repository, the returned []string will contain only one item -- the specified
+// URL normalized as if it represented a Helm chart repository.
+//
+// In all other cases where it cannot be inferred from the specified media type
+// whether the specified URL references a container image repository or a
+// Helm chart repository, the returned []string will contain two items -- the
+// specified URL normalized both as if it represented a container image
+// repository and as if it represented a Helm chart repository. It is
+// exclusively the caller's responsibility to deal with this possibility.
+func getNormalizedImageRepoURLs(repoURL, mediaType string) []string {
+	if strings.HasPrefix(mediaType, "application/vnd.cncf.helm") {
+		return []string{helm.NormalizeChartRepositoryURL(repoURL)}
 	}
-	return ""
+	if slices.Contains(probableContainerImageMediaTypes, mediaType) {
+		return []string{image.NormalizeURL(repoURL)}
+	}
+	// The normalization process for image and chart URLs may change from time to
+	// time. At times, the URL normalized as if it were an image URL and the URL
+	// normalized as if it were a chart URL may turn out to be identical, in which
+	// case, compacting the slice is a cheap, but worthwhile optimization.
+	return slices.Compact([]string{
+		image.NormalizeURL(repoURL),
+		helm.NormalizeChartRepositoryURL(repoURL),
+	})
 }

--- a/internal/webhook/external/media_types_test.go
+++ b/internal/webhook/external/media_types_test.go
@@ -1,0 +1,123 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/akuity/kargo/internal/helm"
+	"github.com/akuity/kargo/internal/image"
+)
+
+func TestGetNormalizedImageRepoURLs(t *testing.T) {
+	testCases := []struct {
+		name       string
+		repoURL    string
+		mediaType  string
+		assertions func(t *testing.T, repoURLs []string)
+	}{
+		{
+			name:      "v2 manifest list",
+			repoURL:   "example/repo",
+			mediaType: dockerManifestListMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(t, []string{image.NormalizeURL("example/repo")}, repoURLs)
+			},
+		},
+		{
+			name:      "OCI manifest index",
+			repoURL:   "ghcr.io/example/repo",
+			mediaType: ociImageIndexMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(
+					t,
+					[]string{image.NormalizeURL("ghcr.io/example/repo")},
+					repoURLs,
+				)
+			},
+		},
+		{
+			name:      "v2 manifest",
+			repoURL:   "example/repo",
+			mediaType: dockerManifestMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(t, []string{image.NormalizeURL("example/repo")}, repoURLs)
+			},
+		},
+		{
+			name:      "OCI manifest",
+			repoURL:   "ghcr.io/example/repo",
+			mediaType: ociImageManifestMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				// Current image URL and chart URL normalization logic yield the same
+				// result for this input, so we expect that getNormalizedImageRepoURLs()
+				// will have compacted the results.
+				require.Len(t, repoURLs, 1)
+				require.Equal(t, image.NormalizeURL("ghcr.io/example/repo"), repoURLs[0])
+				require.Equal(
+					t,
+					helm.NormalizeChartRepositoryURL("ghcr.io/example/repo"),
+					repoURLs[0],
+				)
+			},
+		},
+		{
+			name:      "v2 image config blob",
+			repoURL:   "example/repo",
+			mediaType: dockerImageConfigBlobMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(t, []string{image.NormalizeURL("example/repo")}, repoURLs)
+			},
+		},
+		{
+			name:      "OCI image config blob",
+			repoURL:   "ghcr.io/example/repo",
+			mediaType: ociImageConfigBlobMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(
+					t,
+					[]string{image.NormalizeURL("ghcr.io/example/repo")},
+					repoURLs,
+				)
+			},
+		},
+		{
+			name:      "Helm chart config blob",
+			repoURL:   "ghcr.io/example/repo",
+			mediaType: helmChartConfigBlobMediaType,
+			assertions: func(t *testing.T, repoURLs []string) {
+				require.Equal(
+					t,
+					[]string{helm.NormalizeChartRepositoryURL("ghcr.io/example/repo")},
+					repoURLs,
+				)
+			},
+		},
+		{
+			name:      "something completely unexpected",
+			repoURL:   "ghcr.io/example/repo",
+			mediaType: "nonsense",
+			assertions: func(t *testing.T, repoURLs []string) {
+				// Current image URL and chart URL normalization logic yield the same
+				// result for this input, so we expect that getNormalizedImageRepoURLs()
+				// will have compacted the results.
+				require.Len(t, repoURLs, 1)
+				require.Equal(
+					t,
+					image.NormalizeURL("ghcr.io/example/repo"),
+					repoURLs[0],
+				)
+				require.Equal(
+					t,
+					helm.NormalizeChartRepositoryURL("ghcr.io/example/repo"),
+					repoURLs[0],
+				)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assertions(t, getNormalizedImageRepoURLs(tc.repoURL, tc.mediaType))
+		})
+	}
+}


### PR DESCRIPTION
#4704 contained changes to files that this branch does not have (Azure webhook receiver). Those were the only conflicts.