### PR TITLE
fix(runner): parse JSON response `http` step without `Content-Type` header

### DIFF
--- a/internal/promotion/runner/builtin/http_requester.go
+++ b/internal/promotion/runner/builtin/http_requester.go
@@ -295,7 +295,7 @@ func (h *httpRequester) buildExprEnv(
 		},
 	}
 	contentType, _, _ := mime.ParseMediaType(resp.Header.Get(contentTypeHeader))
-	if len(bodyBytes) > 0 && contentType == contentTypeJSON {
+	if len(bodyBytes) > 0 && (contentType == contentTypeJSON || json.Valid(bodyBytes)) {
 		var parsedBody any
 		if err := json.Unmarshal(bodyBytes, &parsedBody); err != nil {
 			return nil, fmt.Errorf("failed to parse response: %w", err)

--- a/internal/promotion/runner/builtin/http_requester_test.go
+++ b/internal/promotion/runner/builtin/http_requester_test.go
@@ -263,8 +263,8 @@ func Test_httpRequester_run(t *testing.T) {
 		{
 			name: "success and not failed; non-json body",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
-				// This is JSON, but the content type is not set to application/json
-				_, err := w.Write([]byte(`{"theMeaningOfLife": 42}`))
+				// This is a non-JSON body
+				_, err := w.Write([]byte(`this is just a regular string`))
 				require.NoError(t, err)
 			},
 			cfg: builtin.HTTPConfig{
@@ -611,7 +611,7 @@ func Test_httpRequester_buildExprEnv(t *testing.T) {
 			},
 		},
 		{
-			name: "valid JSON but unexpected type string",
+			name: "JSON content-type but unexpected string body",
 			resp: &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
@@ -620,6 +620,23 @@ func Test_httpRequester_buildExprEnv(t *testing.T) {
 			assertions: func(t *testing.T, _ map[string]any, err error) {
 				require.Error(t, err)
 				require.ErrorContains(t, err, "unexpected type when unmarshaling")
+			},
+		},
+		{
+			name: "missing content-type but valid JSON body",
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{}, // No Content-Type header
+				Body:       io.NopCloser(strings.NewReader(`{"foo": "bar"}`)),
+			},
+			assertions: func(t *testing.T, env map[string]any, err error) {
+				require.NoError(t, err)
+				bodyAny, ok := env["response"].(map[string]any)["body"]
+				require.True(t, ok)
+
+				body, ok := bodyAny.(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, map[string]any{"foo": "bar"}, body)
 			},
 		},
 	}


### PR DESCRIPTION
In certain scenarios, APIs serve valid JSON content but incorrectly set the `Content-Type` response header to `text/plain` or other non-JSON types. This is common with endpoints like GitHub's `raw.github.com` and `gist.githubusercontent.com`.

Currently, the `http` step only attempts JSON parsing when the `Content-Type` header indicates JSON, which means these valid JSON responses get ignored even though they could be properly parsed.

This change adds `json.Valid()` as a fallback check, so we parse as JSON when either the `Content-Type` indicates JSON or the content is actually valid JSON. This makes the `http` step work with a broader range of real-world APIs that don't set their headers correctly.