### PR TITLE
chore(backport release-1.6): fix(runner): JSON response `http` without header

### DIFF
--- a/internal/promotion/runner/builtin/http_requester.go
+++ b/internal/promotion/runner/builtin/http_requester.go
@@ -208,7 +208,7 @@ func (h *httpRequester) buildExprEnv(
 		},
 	}
 	contentType, _, err := mime.ParseMediaType(resp.Header.Get(contentTypeHeader))
-	if len(bodyBytes) > 0 && contentType == contentTypeJSON {
+	if len(bodyBytes) > 0 && (contentType == contentTypeJSON || json.Valid(bodyBytes)) {
 		var parsedBody any
 		if err := json.Unmarshal(bodyBytes, &parsedBody); err != nil {
 			return nil, fmt.Errorf("failed to parse response: %w", err)


### PR DESCRIPTION
Manual backport of #4717 due to conflicts.