### PR TITLE
fix(api/webhook): move part of Stage step validation to webhook

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -1554,7 +1554,6 @@ message PromotionTemplateSpec {
   //
   // +kubebuilder:validation:MinItems=1
   // +kubebuilder:validation:items:XValidation:message="PromotionTemplate step must have exactly one of uses or task set",rule="(has(self.uses) ? !has(self.task) : has(self.task))"
-  // +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set if",rule="!has(self.task) || !has(self.if)"
   // +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set continueOnError",rule="!has(self.task) || !has(self.continueOnError)"
   // +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set retry",rule="!has(self.task) || !has(self.retry)"
   repeated PromotionStep steps = 1;

--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -333,7 +333,6 @@ type PromotionTemplateSpec struct {
 	//
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:items:XValidation:message="PromotionTemplate step must have exactly one of uses or task set",rule="(has(self.uses) ? !has(self.task) : has(self.task))"
-	// +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set if",rule="!has(self.task) || !has(self.if)"
 	// +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set continueOnError",rule="!has(self.task) || !has(self.continueOnError)"
 	// +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set retry",rule="!has(self.task) || !has(self.retry)"
 	Steps []PromotionStep `json:"steps,omitempty" protobuf:"bytes,1,rep,name=steps"`

--- a/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_stages.yaml
@@ -211,9 +211,6 @@ spec:
                               of uses or task set
                             rule: '(has(self.uses) ? !has(self.task) : has(self.task))'
                           - message: PromotionTemplate step referencing a task cannot
-                              set if
-                            rule: '!has(self.task) || !has(self.if)'
-                          - message: PromotionTemplate step referencing a task cannot
                               set continueOnError
                             rule: '!has(self.task) || !has(self.continueOnError)'
                           - message: PromotionTemplate step referencing a task cannot

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -3128,7 +3128,6 @@ export type PromotionTemplateSpec = Message<"github.com.akuity.kargo.api.v1alpha
    *
    * +kubebuilder:validation:MinItems=1
    * +kubebuilder:validation:items:XValidation:message="PromotionTemplate step must have exactly one of uses or task set",rule="(has(self.uses) ? !has(self.task) : has(self.task))"
-   * +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set if",rule="!has(self.task) || !has(self.if)"
    * +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set continueOnError",rule="!has(self.task) || !has(self.continueOnError)"
    * +kubebuilder:validation:items:XValidation:message="PromotionTemplate step referencing a task cannot set retry",rule="!has(self.task) || !has(self.retry)"
    *

--- a/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/stages.kargo.akuity.io_v1alpha1.json
@@ -120,10 +120,6 @@
                         "rule": "(has(self.uses) ? !has(self.task) : has(self.task))"
                       },
                       {
-                        "message": "PromotionTemplate step referencing a task cannot set if",
-                        "rule": "!has(self.task) || !has(self.if)"
-                      },
-                      {
                         "message": "PromotionTemplate step referencing a task cannot set continueOnError",
                         "rule": "!has(self.task) || !has(self.continueOnError)"
                       },


### PR DESCRIPTION
Follow up to #4732

As `if` is a reserved CEL keyword, the expression is not allowed to reference a field with that name in Kubernetes versions below 1.32.x. Because of this, we need to temporarily resort to validating it using a webhook, and reintroduce it once these versions have reached EOL.