### PR TITLE
fix: shorten Stage label value exceeding max length

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -35,6 +35,13 @@ const (
 	// of the annotation should be in the format of "<project>:<stage>".
 	AnnotationKeyAuthorizedStage = "kargo.akuity.io/authorized-stage"
 
+	// AnnotationKeyStage is an annotation key that can be set on a resource to
+	// indicate that it is associated with a specific Stage. It compliments
+	// LabelKeyStage, which may contain the same value but in a (hash-)shortened
+	// form to fit within the Kubernetes label value length. The value of this
+	// annotation is expected to be the full name of the Stage.
+	AnnotationKeyStage = "kargo.akuity.io/stage"
+
 	// AnnotationKeyPromotion is an annotation key that can be set on a
 	// resource to indicate that it is related to a specific promotion.
 	AnnotationKeyPromotion = "kargo.akuity.io/promotion"

--- a/internal/controller/stages/control_flow_stages.go
+++ b/internal/controller/stages/control_flow_stages.go
@@ -24,6 +24,7 @@ import (
 	"github.com/akuity/kargo/internal/indexer"
 	"github.com/akuity/kargo/internal/kargo"
 	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/kubernetes"
 	libEvent "github.com/akuity/kargo/internal/kubernetes/event"
 	"github.com/akuity/kargo/internal/logging"
 	intpredicate "github.com/akuity/kargo/internal/predicate"
@@ -586,7 +587,7 @@ func (r *ControlFlowStageReconciler) clearAnalysisRuns(ctx context.Context, stag
 		&rollouts.AnalysisRun{},
 		client.InNamespace(stage.Namespace),
 		client.MatchingLabels(map[string]string{
-			kargoapi.LabelKeyStage: stage.Name,
+			kargoapi.LabelKeyStage: kubernetes.ShortenLabelValue(stage.Name),
 		}),
 	); err != nil {
 		return fmt.Errorf("error deleting AnalysisRuns for Stage %q in namespace %q: %w",

--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -41,6 +41,7 @@ import (
 	"github.com/akuity/kargo/internal/indexer"
 	"github.com/akuity/kargo/internal/kargo"
 	"github.com/akuity/kargo/internal/kubeclient"
+	"github.com/akuity/kargo/internal/kubernetes"
 	libEvent "github.com/akuity/kargo/internal/kubernetes/event"
 	"github.com/akuity/kargo/internal/logging"
 	"github.com/akuity/kargo/internal/pattern"
@@ -1347,7 +1348,7 @@ func (r *RegularStageReconciler) startVerification(
 		rollouts.WithNamePrefix(stage.Name),
 		rollouts.WithNameSuffix(freight.ID),
 		rollouts.WithExtraLabels(map[string]string{
-			kargoapi.LabelKeyStage:             stage.Name,
+			kargoapi.LabelKeyStage:             kubernetes.ShortenLabelValue(stage.Name),
 			kargoapi.LabelKeyFreightCollection: freight.ID,
 		}),
 		rollouts.WithArgumentEvaluationConfig{
@@ -1611,7 +1612,7 @@ func (r *RegularStageReconciler) findExistingAnalysisRun(
 		client.InNamespace(stage.Namespace),
 		client.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(map[string]string{
-				kargoapi.LabelKeyStage:             stage.Name,
+				kargoapi.LabelKeyStage:             kubernetes.ShortenLabelValue(stage.Name),
 				kargoapi.LabelKeyFreightCollection: freightColID,
 			}),
 		},
@@ -1987,7 +1988,7 @@ func (r *RegularStageReconciler) clearAnalysisRuns(ctx context.Context, stage *k
 		&rolloutsapi.AnalysisRun{},
 		client.InNamespace(stage.Namespace),
 		client.MatchingLabels(map[string]string{
-			kargoapi.LabelKeyStage: stage.Name,
+			kargoapi.LabelKeyStage: kubernetes.ShortenLabelValue(stage.Name),
 		}),
 	); err != nil {
 		return fmt.Errorf("error deleting AnalysisRuns for Stage %q in namespace %q: %w",

--- a/internal/controller/stages/regular_stages_test.go
+++ b/internal/controller/stages/regular_stages_test.go
@@ -3721,7 +3721,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 							kargoapi.LabelKeyFreightCollection: "test-collection",
 						},
 						Annotations: map[string]string{
-							kargoapi.AnnotationKeyStage: "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated",
+							kargoapi.AnnotationKeyStage: "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated", // nolint:lll
 						},
 					},
 					Status: rolloutsapi.AnalysisRunStatus{
@@ -3828,12 +3828,20 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				}, ar))
 
 				// Verify stage label was truncated correctly
-				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1", ar.Labels[kargoapi.LabelKeyStage])
+				assert.Equal(
+					t,
+					"this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1",
+					ar.Labels[kargoapi.LabelKeyStage],
+				)
 
 				// Verify annotation contains the full stage name
 				fullStageName, hasAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
-				assert.True(t, hasAnnotation, "Stage annotation should be present when stage name exceeds label length")
-				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated", fullStageName)
+				assert.True(t, hasAnnotation)
+				assert.Equal(
+					t,
+					"this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated",
+					fullStageName,
+				)
 			},
 		},
 		{
@@ -3893,7 +3901,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify no stage annotation is added since stage name doesn't need shortening
 				_, hasStageAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
-				assert.False(t, hasStageAnnotation, "Stage annotation should not be present when stage name doesn't need shortening")
+				assert.False(t, hasStageAnnotation)
 			},
 		},
 		{
@@ -3953,11 +3961,18 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				// Verify both promotion and stage annotations are present
 				assert.Equal(t, "test-promotion", ar.Annotations[kargoapi.AnnotationKeyPromotion])
 				fullStageName, hasStageAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
-				assert.True(t, hasStageAnnotation, "Stage annotation should be present when stage name exceeds label length")
-				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated", fullStageName)
+				assert.True(t, hasStageAnnotation)
+				assert.Equal(
+					t,
+					"this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated",
+					fullStageName,
+				)
 
 				// Verify stage label was truncated correctly
-				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1", ar.Labels[kargoapi.LabelKeyStage])
+				assert.Equal(t,
+					"this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1",
+					ar.Labels[kargoapi.LabelKeyStage],
+				)
 			},
 		},
 		{

--- a/internal/controller/stages/regular_stages_test.go
+++ b/internal/controller/stages/regular_stages_test.go
@@ -3720,6 +3720,9 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 							kargoapi.LabelKeyStage:             "this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1",
 							kargoapi.LabelKeyFreightCollection: "test-collection",
 						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyStage: "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated",
+						},
 					},
 					Status: rolloutsapi.AnalysisRunStatus{
 						Phase:   "Successful",
@@ -3775,10 +3778,17 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
+
+				// Verify stage label is not shortened since stage name is short
+				assert.Equal(t, "test-stage", ar.Labels[kargoapi.LabelKeyStage])
+
+				// Verify no annotation is added since stage name doesn't need shortening
+				_, hasAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
+				assert.False(t, hasAnnotation, "Stage annotation should not be present when stage name doesn't need shortening")
 			},
 		},
 		{
-			name: "creates new analysis run with with stage name exceeding max label length",
+			name: "creates new analysis run with stage name exceeding max label length",
 			stage: &kargoapi.Stage{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fake-project",
@@ -3819,6 +3829,11 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify stage label was truncated correctly
 				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1", ar.Labels[kargoapi.LabelKeyStage])
+
+				// Verify annotation contains the full stage name
+				fullStageName, hasAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
+				assert.True(t, hasAnnotation, "Stage annotation should be present when stage name exceeds label length")
+				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated", fullStageName)
 			},
 		},
 		{
@@ -3868,13 +3883,81 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.NotEmpty(t, vi.ID)
 				assert.Equal(t, "test-user", vi.Actor)
 
-				// Verify promotion label was added
+				// Verify promotion annotation was added
 				ar := &rolloutsapi.AnalysisRun{}
 				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
 				assert.Equal(t, "test-promotion", ar.Annotations[kargoapi.AnnotationKeyPromotion])
+
+				// Verify no stage annotation is added since stage name doesn't need shortening
+				_, hasStageAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
+				assert.False(t, hasStageAnnotation, "Stage annotation should not be present when stage name doesn't need shortening")
+			},
+		},
+		{
+			name: "handles reverification with control plane actor and long stage name",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated",
+				},
+				Spec: kargoapi.StageSpec{
+					Verification: &kargoapi.Verification{},
+				},
+				Status: kargoapi.StageStatus{
+					LastPromotion: &kargoapi.PromotionReference{
+						Name: "test-promotion",
+					},
+				},
+			},
+			freightCol: kargoapi.FreightCollection{
+				ID: "test-collection",
+				Freight: map[string]kargoapi.FreightReference{
+					"warehouse": {Name: "test-freight"},
+				},
+				VerificationHistory: []kargoapi.VerificationInfo{
+					{
+						ID: "prev-verification",
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-freight",
+					},
+				},
+			},
+			req: &kargoapi.VerificationRequest{
+				ID:           "prev-verification",
+				Actor:        "test-user",
+				ControlPlane: true,
+			},
+			assertions: func(t *testing.T, c client.Client, vi *kargoapi.VerificationInfo, err error) {
+				require.NoError(t, err)
+
+				require.NotNil(t, vi)
+				assert.NotEmpty(t, vi.ID)
+				assert.Equal(t, "test-user", vi.Actor)
+
+				// Verify analysis run was created
+				ar := &rolloutsapi.AnalysisRun{}
+				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+					Namespace: vi.AnalysisRun.Namespace,
+					Name:      vi.AnalysisRun.Name,
+				}, ar))
+
+				// Verify both promotion and stage annotations are present
+				assert.Equal(t, "test-promotion", ar.Annotations[kargoapi.AnnotationKeyPromotion])
+				fullStageName, hasStageAnnotation := ar.Annotations[kargoapi.AnnotationKeyStage]
+				assert.True(t, hasStageAnnotation, "Stage annotation should be present when stage name exceeds label length")
+				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-length-and-should-be-truncated", fullStageName)
+
+				// Verify stage label was truncated correctly
+				assert.Equal(t, "this-is-a-very-long-stage-name-that-exceeds-the-label-1c0a17e1", ar.Labels[kargoapi.LabelKeyStage])
 			},
 		},
 		{

--- a/internal/kubernetes/naming.go
+++ b/internal/kubernetes/naming.go
@@ -18,7 +18,7 @@ func ShortenResourceName(name string) string {
 }
 
 // ShortenLabelValue deterministically shortens the provided string value to the
-// maximum allowed length for the the value of a Kubernetes label by retaining
+// maximum allowed length for the value of a Kubernetes label by retaining
 // as many of the leading characters as possible and replacing as many trailing
 // characters as necessary with a short hash of the entire input. The preserved
 // characters of the input value and the short hash will be separated by a dash.


### PR DESCRIPTION
Fixes #4600

In a follow-up, the garbage collection logic will be factored out and/or owner references will be introduced to allow Kubernetes itself to handle the lifecycle.