### PR TITLE
refactor: misc. webhook receiver test cleanup

### DIFF
--- a/internal/webhook/external/gitea.go
+++ b/internal/webhook/external/gitea.go
@@ -16,11 +16,13 @@ import (
 )
 
 const (
+	gitea = "gitea"
+
 	giteaEventTypeHeader = "X-Gitea-Event"
 	giteaSignatureHeader = "X-Hub-Signature-256"
 	giteaSecretDataKey   = "secret"
 
-	gitea = "gitea"
+	giteaEventTypePush = "push"
 )
 
 func init() {
@@ -88,7 +90,7 @@ func (g *giteaWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 
 		eventType := r.Header.Get(giteaEventTypeHeader)
 		switch eventType {
-		case "push":
+		case giteaEventTypePush:
 		default:
 			xhttp.WriteErrorJSON(
 				w,

--- a/internal/webhook/external/github.go
+++ b/internal/webhook/external/github.go
@@ -150,7 +150,8 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 
 		switch e := event.(type) {
 		case *gh.PackageEvent:
-			switch e.GetAction() {
+			action := e.GetAction()
+			switch action {
 			// These are the only actions that should refresh Warehouses.
 			case "published", "updated":
 			default:
@@ -219,7 +220,8 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			logger = logger.WithValues("ref", ref)
 
 		case *gh.RegistryPackageEvent:
-			switch e.GetAction() {
+			action := e.GetAction()
+			switch action {
 			// These are the only actions that should refresh Warehouses.
 			case "published", "updated":
 			default:

--- a/internal/webhook/external/gitlab.go
+++ b/internal/webhook/external/gitlab.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	gitlab              = "gitlab"
+	gitlab = "gitlab"
+
 	gitLabSecretDataKey = "secret-token"
 
 	gitlabTokenHeader = "X-Gitlab-Token" // nolint: gosec

--- a/internal/webhook/external/refresh_test.go
+++ b/internal/webhook/external/refresh_test.go
@@ -228,13 +228,13 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Git subscription with matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Git: &kargoapi.GitSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
 							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
 							RepoURL:                 "https://github.com/username/repo",
 							Branch:                  "main",
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "https://github.com/username/repo",
@@ -245,13 +245,13 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Git subscription with non-matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Git: &kargoapi.GitSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
 							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
 							RepoURL:                 "https://github.com/username/repo.git",
 							Branch:                  "main",
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "https://github.com/username/repo",
@@ -262,14 +262,14 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Image subscription with matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Image: &kargoapi.ImageSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Image: &kargoapi.ImageSubscription{
 							RepoURL:                "docker.io/example/repo",
 							ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 							SemverConstraint:       "^1.0.0",
 							StrictSemvers:          true,
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "example/repo",
@@ -280,14 +280,14 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Image subscription with non-matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Image: &kargoapi.ImageSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Image: &kargoapi.ImageSubscription{
 							RepoURL:                "docker.io/example/repo",
 							ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 							SemverConstraint:       "^1.0.0",
 							StrictSemvers:          true,
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "docker.io/example/repo",
@@ -298,12 +298,12 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Chart subscription with matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Chart: &kargoapi.ChartSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Chart: &kargoapi.ChartSubscription{
 							RepoURL:          "oci://example.com/charts",
 							SemverConstraint: "^1.0.0",
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "example.com/charts",
@@ -314,12 +314,12 @@ func TestShouldRefresh(t *testing.T) {
 			name: "Chart subscription with non-matching qualifier",
 			wh: kargoapi.Warehouse{
 				Spec: kargoapi.WarehouseSpec{
-					Subscriptions: []kargoapi.RepoSubscription{
-						{Chart: &kargoapi.ChartSubscription{
+					Subscriptions: []kargoapi.RepoSubscription{{
+						Chart: &kargoapi.ChartSubscription{
 							RepoURL:          "oci://example.com/charts",
 							SemverConstraint: "^2.0.0",
-						}},
-					},
+						},
+					}},
 				},
 			},
 			repoURL:    "example.com/charts",


### PR DESCRIPTION
This adds a substantial number of new test cases -- most of them aimed at testing that tags, versions, refs, etc. that any sort of Warehouse subscription is _not_ interested in do not trigger a refresh even if all other conditions for refresh are met.

i.e. This adds the "miss" cases for #4560.

I did quite a bit of miscellaneous cleanup as well. I improved how test cases are named, which became necessary due to the volume of specific, new permutations introduced by new cases.

Removed explicit setting of default selection strategies -- it ensures there are no gaps of something not working correctly when one _isn't_ specified. e.g. Wrong default strategy used or no default being applied at all.

Replaced many repeated string literals with constants, etc., etc.