### PR TITLE
fix: ensure kargo viewer sa is not created if api is disabled

### DIFF
--- a/charts/kargo/templates/users/service-accounts.yaml
+++ b/charts/kargo/templates/users/service-accounts.yaml
@@ -40,7 +40,6 @@ metadata:
     rbac.kargo.akuity.io/claim.{{ $claim }}: {{ quote (join "," $values) }}
     {{- end }}
   {{- end }}
-{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -55,3 +54,4 @@ metadata:
     rbac.kargo.akuity.io/claim.{{ $claim }}: {{ quote (join "," $values) }}
     {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Minor bug fix to ensure no user sa resources are created when api.enabled is false.