### PR TITLE
feat: support status operation expressions in config context

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -505,7 +505,8 @@ config:
 
 ### `success()`
 
-The `success()` function checks the status of all preceding steps and returns true if none of them have failed or errored and false otherwise.
+The `success()` function checks the status of all preceding steps and returns 
+true if none of them have failed or errored and false otherwise.
 
 Examples:
 

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -516,7 +516,8 @@ config:
 
 ### `failure()`
 
-The `failure()` function checks the status of all preceding steps and returns true if any of them have failed or errored and false otherwise.
+The `failure()` function checks the status of all preceding steps and returns 
+true if any of them have failed or errored and false otherwise.
 
 Examples:
 
@@ -536,15 +537,14 @@ config:
   alwaysTrue: ${{ always() }}
 ```
 
-### `status(stepName)`
+### `status(stepAlias)`
 
-The `status(stepName)` function retrieves the status of a specific step by its alias
-within the current promotion context; returning its value as a string.
+The `status(stepAlias)` function retrieves the status of a specific step by its 
+alias within the current promotion context; returning its value as a string.
 
 Examples:
 
 ```yaml
 config:
-  status: ${{ status(stepName) }}
+  status: ${{ status("my-step-alias") }}
 ```
-

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -502,3 +502,49 @@ config:
 config:
   chartVersion: ${{ chartFrom("https://example.com/charts", "my-chart", warehouse("my-warehouse")).Version }}
 ```
+
+### `success()`
+
+The `success()` function checks the status of all preceding steps and returns true if none of them have failed or errored and false otherwise.
+
+Examples:
+
+```yaml
+config:
+  wasSuccessful: ${{ success() }}
+```
+
+### `failure()`
+
+The `failure()` function checks the status of all preceding steps and returns true if any of them have failed or errored and false otherwise.
+
+Examples:
+
+```yaml
+config:
+  wasFailure: ${{ failure() }}
+```
+
+### `always()`
+
+The `always()` function unconditionally returns true.
+
+Examples:
+
+```yaml
+config:
+  alwaysTrue: ${{ always() }}
+```
+
+### `status(stepName)`
+
+The `status(stepName)` function retrieves the status of a specific step by its alias
+within the current promotion context; returning its value as a string.
+
+Examples:
+
+```yaml
+config:
+  status: ${{ status(stepName) }}
+```
+

--- a/internal/expressions/function/functions.go
+++ b/internal/expressions/function/functions.go
@@ -267,6 +267,11 @@ func Success(stepExecMetas kargoapi.StepExecutionMetadataList) expr.Option {
 	)
 }
 
+// Status returns an expr.Option that provides a `status()` function
+// for use in expressions.
+//
+// The `status()` function retrieves the status of a specific step by its alias
+// within the current promotion context; returning its value as a string.
 func Status(
 	currentStepAlias string,
 	stepExecMetas kargoapi.StepExecutionMetadataList,

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -318,14 +318,17 @@ func (s *Step) GetConfig(
 		s.Config,
 		env,
 		append(
-			exprfn.FreightOperations(
-				ctx,
-				cl,
-				promoCtx.Project,
-				promoCtx.FreightRequests,
-				promoCtx.Freight.References(),
+			append(
+				exprfn.FreightOperations(
+					ctx,
+					cl,
+					promoCtx.Project,
+					promoCtx.FreightRequests,
+					promoCtx.Freight.References(),
+				),
+				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
 			),
-			exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
+			exprfn.StatusOperations(s.Alias, promoCtx.StepExecutionMetadata)...,
 		)...,
 	)
 	if err != nil {

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -468,6 +468,18 @@ func TestStep_GetConfig(t *testing.T) {
 				"chartVersion8": "fake-chart-version",
 			},
 		},
+		{
+			name:        "test success function",
+			promoCtx:    Context{},
+			rawCfg:      []byte(`{"wasSuccessful": "${{ success() }}"}`),
+			expectedCfg: promotion.Config{"wasSuccessful": true},
+		},
+		{
+			name:        "test failure function",
+			promoCtx:    Context{},
+			rawCfg:      []byte(`{"wasFailure": "${{ failure() }}"}`),
+			expectedCfg: promotion.Config{"wasFailure": false},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -480,6 +480,25 @@ func TestStep_GetConfig(t *testing.T) {
 			rawCfg:      []byte(`{"wasFailure": "${{ failure() }}"}`),
 			expectedCfg: promotion.Config{"wasFailure": false},
 		},
+		{
+			name:        "test always function",
+			promoCtx:    Context{},
+			rawCfg:      []byte(`{"alwaysTrue": "${{ always() }}"}`),
+			expectedCfg: promotion.Config{"alwaysTrue": true},
+		},
+		{
+			name: "test status function",
+			promoCtx: Context{
+				StepExecutionMetadata: kargoapi.StepExecutionMetadataList{
+					{
+						Alias:  "test-step",
+						Status: kargoapi.PromotionStepStatusFailed,
+					},
+				},
+			},
+			rawCfg:      []byte(`{"status": "${{ status(\"test-step\") }}"}`),
+			expectedCfg: promotion.Config{"status": "Failed"},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/4537

NOTE:

An alternative way of testing this is by reverting the change to `internal/promotion/promotion.go` without reverting `internal/promotion/promotion_test.go`.

Then, when you run the test, you will reproduce the error documented in https://github.com/akuity/kargo/issues/4537.

e.g.

```
=== RUN   TestStep_GetConfig/test_success_function
    promotion_test.go:501: 
                Error Trace:    /Users/faris/go/src/github.com/akuity/kargo/internal/promotion/promotion_test.go:501
                Error:          Received unexpected error:
                                reflect: call of reflect.Value.Call on zero Value (1:2)
                                 |  success() 
                                 | .^
                Test:           TestStep_GetConfig/test_success_function
```

Keeping the change applied results in passing tests

I will include the doc update in this PR as well
