### PR TITLE
fix(chart): Fixup indentation level for imagePullSecrets in garbage-collector CronJob

### DIFF
--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -54,7 +54,7 @@ spec:
           {{- end }}
           {{- with .Values.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: garbage-collector


### PR DESCRIPTION
It seems the incorrect indentation level was used in #4682. In this change I have updated the indentation level for the templated values to match that of other blocks at the same level (e.g., `affinity`, directly above).

Before this change, running `helm template --debug` with `--set 'image.pullSecrets[0].name=secret-name'` results in the following output (irrelevant content stripped for brevity)


```yaml
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: kargo-garbage-collector
  namespace: kargo
spec:
  jobTemplate:
    spec:
      template:
        spec:
          imagePullSecrets:
        - name: secret-name   # <--- incorrect YAML
```

With this change:

```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: kargo-garbage-collector
  namespace: external-dns
spec:
  jobTemplate:
    spec:
      template:
        spec:
          imagePullSecrets:
            - name: secret-name
```