### PR TITLE
docs: missing mention of variables at stage level

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
@@ -22,8 +22,8 @@ A `Stage` resource's `spec` field is itself composed of four main areas of conce
 
 * Verification
 
-The following sections will explore each of these `spec` sections as well as `status`
-in greater detail.
+The following sections will explore each of these as well as `status` in
+greater detail.
 
 ### Variables
 

--- a/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
@@ -28,8 +28,8 @@ in greater detail.
 ### Variables
 
 The `spec.vars` field allows you to define variables that can be referenced anywhere
-in the `Stage` specification that supports expressions, including the promotion
-template and verification configuration.
+in the `Stage` specification that supports expressions, including the
+[promotion template](#promotion-templates) and [verification configuration](#verification).
 
 ```yaml
 apiVersion: kargo.akuity.io/v1alpha1
@@ -51,7 +51,7 @@ spec:
 Stage-level variables are merged with promotion template-level variables, with
 promotion template variables taking precedence for any conflicting names.
 This allows you to define common variables at the `Stage` level while still being
-able to override or supplement them at the promotion level when needed.
+able to override or supplement them at the promotion level as needed.
 
 :::info
 Variables defined at the Stage level can be referenced using

--- a/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
@@ -29,7 +29,8 @@ in greater detail.
 
 The `spec.vars` field allows you to define variables that can be referenced anywhere
 in the `Stage` specification that supports expressions, including the
-[promotion template](#promotion-templates) and [verification configuration](#verification).
+[promotion template](#promotion-templates) and
+[verification configuration](#verification).
 
 ```yaml
 apiVersion: kargo.akuity.io/v1alpha1

--- a/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/40-working-with-stages.md
@@ -12,7 +12,9 @@ Each Kargo Stage is represented by a Kubernetes resource of type `Stage`.
 Like most Kubernetes resources, a `Stage` is composed of a user-defined `spec` field
 and a system-populated `status` field.
 
-A `Stage` resource's `spec` field is itself composed of three main areas of concern:
+A `Stage` resource's `spec` field is itself composed of four main areas of concern:
+
+* Variables
 
 * Requested Freight
 
@@ -20,7 +22,42 @@ A `Stage` resource's `spec` field is itself composed of three main areas of conc
 
 * Verification
 
-The following sections will explore each of these `spec` sections as well as `status` in greater detail.
+The following sections will explore each of these `spec` sections as well as `status`
+in greater detail.
+
+### Variables
+
+The `spec.vars` field allows you to define variables that can be referenced anywhere
+in the `Stage` specification that supports expressions, including the promotion
+template and verification configuration.
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: test
+  namespace: kargo-demo
+spec:
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/example/kargo-demo.git
+    - name: targetBranch
+      value: stage/test
+    - name: imageRepo
+      value: public.ecr.aws/nginx/nginx
+  # ...
+```
+
+Stage-level variables are merged with promotion template-level variables, with
+promotion template variables taking precedence for any conflicting names.
+This allows you to define common variables at the `Stage` level while still being
+able to override or supplement them at the promotion level when needed.
+
+:::info
+Variables defined at the Stage level can be referenced using
+`${{ vars.<variable-name> }}` syntax throughout the `Stage` specification,
+including in promotion templates and verification arguments.
+:::
 
 ### Requested Freight
 

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -243,6 +243,15 @@ definition of the static variables).
 
 ### Verification Variables
 
+:::note
+Verification processes evaluate a `Stage`'s current state and, while frequently
+executed immediately following a promotion, are not intrinsically part of the
+promotion process itself. Therefore, promotion-level variables (such as those defined
+in `spec.promotionTemplate.spec.vars`) and promotion context (like `outputs` from
+promotion steps) are not accessible during verification. Only Stage-level variables
+and Stage context are available.
+:::
+
 | Name | Type | Description |
 |------|------|-------------|
 | `ctx` | `object` | Contains contextual information about the stage. See structure below. |

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -249,7 +249,7 @@ executed immediately following a promotion, are not intrinsically part of the
 promotion process itself. Therefore, promotion-level variables (such as those defined
 in `spec.promotionTemplate.spec.vars`) and promotion context (like `outputs` from
 promotion steps) are not accessible during verification. Only Stage-level variables
-and Stage context are available.
+and context are available.
 :::
 
 | Name | Type | Description |

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -243,6 +243,11 @@ definition of the static variables).
 
 ### Verification Variables
 
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx` | `object` | Contains contextual information about the stage. See structure below. |
+| `vars` | `object` | A user-defined map of variable names to static values of any type. The map is derived from the `Stage`'s `spec.vars` field. Variable names must observe standard Go variable-naming rules. Stage-level variables can be referenced in verification arguments to pass dynamic values to AnalysisRuns. |
+
 :::note
 Verification processes evaluate a `Stage`'s current state and, while frequently
 executed immediately following a promotion, are not intrinsically part of the
@@ -251,11 +256,6 @@ in `spec.promotionTemplate.spec.vars`) and promotion context (like `outputs` fro
 promotion steps) are not accessible during verification. Only Stage-level variables
 and context are available.
 :::
-
-| Name | Type | Description |
-|------|------|-------------|
-| `ctx` | `object` | Contains contextual information about the stage. See structure below. |
-| `vars` | `object` | A user-defined map of variable names to static values of any type. The map is derived from the `Stage`'s `spec.vars` field. Variable names must observe standard Go variable-naming rules. Stage-level variables can be referenced in verification arguments to pass dynamic values to AnalysisRuns. |
 
 #### Context (`ctx`) Object Structure for Verification
 

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -154,7 +154,7 @@ Expect other useful variables to be added in the future.
 |------|------|-------------|
 | `ctx` | `object` | Contains contextual information about the promotion. See detailed structure below. |
 | `outputs` | `object` | A map of output from previous promotion steps indexed by step aliases. |
-| `vars` | `object` | A user-defined map of variable names to static values of any type. The map is derived from a `Promotion`'s `spec.promotionTemplate.spec.vars` field. Variable names must observe standard Go variable-naming rules. Variables values may, themselves, be defined using an expression. `vars` (contains previously defined variables) and `ctx` are available to expressions defining the values of variables, however, `outputs` and `secrets` are not. |
+| `vars` | `object` | A user-defined map of variable names to static values of any type. The map is derived from both the `Stage`'s `spec.vars` field and the `Promotion`'s `spec.promotionTemplate.spec.vars` field, with promotion template variables taking precedence over Stage-level variables for any conflicting names. Variable names must observe standard Go variable-naming rules. Variables values may, themselves, be defined using an expression. `vars` (contains previously defined variables) and `ctx` are available to expressions defining the values of variables, however, `outputs` and `secrets` are not. |
 | `task` | `object` | A map containing output from previous steps within the same PromotionTask under the `outputs` field, indexed by step aliases. Only available within `(Cluster)PromotionTask` steps. |
 
 #### Context (`ctx`) Object Structure
@@ -246,6 +246,7 @@ definition of the static variables).
 | Name | Type | Description |
 |------|------|-------------|
 | `ctx` | `object` | Contains contextual information about the stage. See structure below. |
+| `vars` | `object` | A user-defined map of variable names to static values of any type. The map is derived from the `Stage`'s `spec.vars` field. Variable names must observe standard Go variable-naming rules. Stage-level variables can be referenced in verification arguments to pass dynamic values to AnalysisRuns. |
 
 #### Context (`ctx`) Object Structure for Verification
 


### PR DESCRIPTION
closes https://github.com/akuity/kargo/issues/4706

I believe this information will also be useful in the [Working with Stages](https://docs.kargo.io/user-guide/how-to-guides/working-with-stages#the-stage-resource-type) , as users engaging directly with stages can learn it on the spot. That’s why I added this commit cfd051d57c1183cd1fef30f08d8fbf01aa9cd434. (The commit can be reverted if it’s not needed)