### PR TITLE
chore: manual cherry pick #4723 -- Add semverDiff function for semantic version comparison in expressions

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -512,3 +512,61 @@ config:
 config:
   chartVersion: ${{ chartFrom("https://example.com/charts", "my-chart", warehouse("my-warehouse")).Version }}
 ```
+
+### `semverDiff(version1, version2)`
+
+The `semverDiff()` function compares two semantic version strings and returns
+a string indicating the magnitude of difference between them. Possible return
+values include, and are limited to:
+
+| Return Value | Description |
+|--------------|-------------|
+| `Major` | The major version components differ. |
+| `Minor` | The minor version components differ (major versions are the same). |
+| `Patch` | The patch version components differ (major and minor versions are the same). |
+| `Metadata` | Only the build metadata differs (major, minor, and patch versions are the same). |
+| `None` | The versions are identical. |
+| `Incomparable` | One or both arguments are not valid semantic versions. |
+
+:::info
+The function uses the [Semantic Versioning](https://semver.org/) specification
+to parse and compare versions. It supports versions with or without the `v`
+prefix, as well as prerelease and build metadata components.
+:::
+
+Example:
+
+```yaml
+# Open a pull request for major version changes of an image; push directly
+# otherwise...
+
+# Presume steps not shown have read and updated the version number of the image
+# referenced by some manifest.
+
+- uses: git-push
+  as: direct-push
+  if: ${{ semverDiff(imageFrom(vars.imageRepo).Tag, outputs['read-version'].currentVersion) != 'Major' }}
+  config:
+    repoURL: ${{ vars.gitRepo }}
+    targetBranch: stage/${{ ctx.stage }}
+    message: ${{ semverDiff(imageFrom(vars.imageRepo).Tag, outputs['read-version'].currentVersion) }} update of ${{ vars.imageRepo }}
+
+- uses: git-push
+  as: indirect-push
+  if: ${{ semverDiff(imageFrom(vars.imageRepo).Tag, outputs['read-version'].currentVersion) == 'Major' }}
+  config:
+    repoURL: ${{ vars.gitRepo }}
+    generateTargetBranch: true
+    message: Major update of ${{ vars.imageRepo }}
+
+- uses: git-open-pr
+  if: ${{ semverDiff(imageFrom(vars.imageRepo).Tag, outputs['read-version'].currentVersion) == 'Major' }}
+  config:
+    repoURL: https://github.com/example/config-repo.git
+    sourceBranch: ${{ outputs['indirect-push'].branch }}
+    targetBranch: stage/${{ ctx.stage }}
+    title: Major update of ${{ vars.imageRepo }}
+    labels:
+    - breaking-change
+    - needs-review
+```

--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -1359,7 +1359,13 @@ func (r *RegularStageReconciler) startVerification(
 					"stage":   stage.Name,
 				},
 			},
-			Options: append(
+			Options: slices.Concat(
+				exprfn.DataOperations(
+					ctx,
+					r.client,
+					gocache.New(gocache.NoExpiration, gocache.NoExpiration),
+					stage.Namespace,
+				),
 				exprfn.FreightOperations(
 					ctx,
 					r.client,
@@ -1367,12 +1373,7 @@ func (r *RegularStageReconciler) startVerification(
 					stage.Spec.RequestedFreight,
 					freight.References(),
 				),
-				exprfn.DataOperations(
-					ctx,
-					r.client,
-					gocache.New(gocache.NoExpiration, gocache.NoExpiration),
-					stage.Namespace,
-				)...,
+				exprfn.UtilityOperations(),
 			),
 			Vars: stage.Spec.Vars,
 		},

--- a/internal/expressions/function/functions.go
+++ b/internal/expressions/function/functions.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/expr-lang/expr"
 	gocache "github.com/patrickmn/go-cache"
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +54,14 @@ func DataOperations(ctx context.Context, c client.Client, cache *gocache.Cache, 
 	return []expr.Option{
 		ConfigMap(ctx, c, cache, project),
 		Secret(ctx, c, cache, project),
+	}
+}
+
+// UtilityOperations returns a slice of expr.Option containing functions for
+// utility operations, such as semantic version comparisons.
+func UtilityOperations() []expr.Option {
+	return []expr.Option{
+		SemverDiff(),
 	}
 }
 
@@ -225,6 +234,21 @@ func Secret(ctx context.Context, c client.Client, cache *gocache.Cache, project 
 		"secret",
 		getSecret(ctx, c, cache, project),
 		new(func(name string) map[string]string),
+	)
+}
+
+// SemverDiff returns an expr.Option that provides a `semverDiff()` function for
+// use in expressions.
+//
+// The semverDiff function compares two semantic version strings and returns a
+// string indicating the magnitude of difference between them -- one of:
+// "Major", "Minor", "Patch", "Metadata", "None", or "Incomparable" if either or
+// both arguments are not valid semantic versions.
+func SemverDiff() expr.Option {
+	return expr.Function(
+		"semverDiff",
+		semverDiff,
+		new(func(ver1Str, ver2Str string) string),
 	)
 }
 
@@ -607,6 +631,48 @@ func getStatus(
 		}
 		return "", nil
 	}
+}
+
+// semverDiff compares two semantic version strings and returns a string
+// indicating the magnitude of difference between them -- one of: "Major",
+// "Minor", "Patch", "Metadata", "None", or "Incomparable" if either or both
+// arguments are not valid semantic versions.
+func semverDiff(a ...any) (any, error) {
+	if len(a) != 2 {
+		return nil, fmt.Errorf("expected 2 arguments, got %d", len(a))
+	}
+
+	ver1Str, ok := a[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("first argument must be string, got %T", a[0])
+	}
+
+	ver2Str, ok := a[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("second argument must be string, got %T", a[1])
+	}
+
+	ver1, err := semver.NewVersion(ver1Str)
+	if err != nil {
+		return "Incomparable", nil
+	}
+	ver2, err := semver.NewVersion(ver2Str)
+	if err != nil {
+		return "Incomparable", nil
+	}
+	if ver1.Major() != ver2.Major() {
+		return "Major", nil
+	}
+	if ver1.Minor() != ver2.Minor() {
+		return "Minor", nil
+	}
+	if ver1.Patch() != ver2.Patch() {
+		return "Patch", nil
+	}
+	if ver1.Metadata() != ver2.Metadata() {
+		return "Metadata", nil
+	}
+	return "None", nil
 }
 
 const (

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -263,18 +263,17 @@ func (s *Step) Skip(
 	v, err := expressions.EvaluateTemplate(
 		s.If,
 		env,
-		append(
-			append(
-				exprfn.FreightOperations(
-					ctx,
-					cl,
-					promoCtx.Project,
-					promoCtx.FreightRequests,
-					promoCtx.Freight.References(),
-				),
-				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
+		slices.Concat(
+			exprfn.DataOperations(ctx, cl, cache, promoCtx.Project),
+			exprfn.FreightOperations(
+				ctx,
+				cl,
+				promoCtx.Project,
+				promoCtx.FreightRequests,
+				promoCtx.Freight.References(),
 			),
-			exprfn.StatusOperations(s.Alias, promoCtx.StepExecutionMetadata)...,
+			exprfn.StatusOperations(s.Alias, promoCtx.StepExecutionMetadata),
+			exprfn.UtilityOperations(),
 		)...,
 	)
 	if err != nil {
@@ -317,7 +316,8 @@ func (s *Step) GetConfig(
 	evaledCfgJSON, err := expressions.EvaluateJSONTemplate(
 		s.Config,
 		env,
-		append(
+		slices.Concat(
+			exprfn.DataOperations(ctx, cl, cache, promoCtx.Project),
 			exprfn.FreightOperations(
 				ctx,
 				cl,
@@ -325,7 +325,7 @@ func (s *Step) GetConfig(
 				promoCtx.FreightRequests,
 				promoCtx.Freight.References(),
 			),
-			exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
+			exprfn.UtilityOperations(),
 		)...,
 	)
 	if err != nil {
@@ -354,9 +354,16 @@ func (s *Step) GetVars(
 		newVar, err := expressions.EvaluateTemplate(
 			v.Value,
 			s.BuildEnv(promoCtx, StepEnvWithVars(vars)),
-			append(
-				exprfn.FreightOperations(ctx, cl, promoCtx.Project, promoCtx.FreightRequests, promoCtx.Freight.References()),
-				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
+			slices.Concat(
+				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project),
+				exprfn.FreightOperations(
+					ctx,
+					cl,
+					promoCtx.Project,
+					promoCtx.FreightRequests,
+					promoCtx.Freight.References(),
+				),
+				exprfn.UtilityOperations(),
 			)...,
 		)
 		if err != nil {
@@ -377,9 +384,16 @@ func (s *Step) GetVars(
 				StepEnvWithTaskOutputs(s.Alias, promoCtx.State),
 				StepEnvWithVars(vars),
 			),
-			append(
-				exprfn.FreightOperations(ctx, cl, promoCtx.Project, promoCtx.FreightRequests, promoCtx.Freight.References()),
-				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project)...,
+			slices.Concat(
+				exprfn.DataOperations(ctx, cl, cache, promoCtx.Project),
+				exprfn.FreightOperations(
+					ctx,
+					cl,
+					promoCtx.Project,
+					promoCtx.FreightRequests,
+					promoCtx.Freight.References(),
+				),
+				exprfn.UtilityOperations(),
 			)...,
 		)
 		if err != nil {


### PR DESCRIPTION
Manual backport of #4723

The merge conflict centered around status-related functions not yet being available within the context of a promotion in 1.7.x. That is currently only in main.