### PR TITLE
fix(controller): be more intentional about treating unknown health status like an error

### DIFF
--- a/internal/controller/stages/regular_stages.go
+++ b/internal/controller/stages/regular_stages.go
@@ -437,11 +437,38 @@ func (r *RegularStageReconciler) reconcile(
 			reconcile: func() (kargoapi.StageStatus, error) {
 				status := r.assessHealth(ctx, stage)
 				if status.Health != nil && status.Health.Status == kargoapi.HealthStateUnknown {
-					// If Stage health evaluated to Unknown, we'll treat it as an error so
-					// that Stage health will be re-assessed with a progressive backoff.
-					return status,
-						errors.New("Stage health evaluated to Unknown") // nolint: staticcheck
+					// If Stage health has evaluated to Unknown, there are two specific
+					// scenarios between which we must distinguish and handle differently
+					// from one another:
+					//
+					//  1. If Stage health is unknown specifically because the last
+					//     Promotion did not succeed, we know we cannot obtain a more
+					//     definitive assessment of Stage health until a new Promotion has
+					//     restored the Stage to a consistent state by executing to
+					//     completion. In such a case, we're DONE reconciling the Stage,
+					//     for now. We would like the Stage's conditions to reflect that
+					//     and for the next reconciliation attempt to occur after the
+					//     usual interval. This can be accomplished by returning a nil
+					//     error.
+					//
+					//  2. If Stage health is unknown for any other reason, we MAY
+					//     possibly obtain a more definitive assessment simply by
+					//     re-attempting reconciliation. In such a case, we would like
+					//     the Stage's conditions to reflect that we're still trying to
+					//     reconcile, with subsequent attempts observing a progressive
+					//     backoff. This can be accomplished by returning an error.
+					if lastPromo := status.LastPromotion; lastPromo == nil ||
+						lastPromo.Status == nil ||
+						!lastPromo.Status.Phase.IsTerminal() ||
+						lastPromo.Status.Phase == kargoapi.PromotionPhaseSucceeded {
+						// Scenario 2: There was no last Promotion or there was and it was
+						// successful. Whatever the reason the Stage health evaluated to
+						// Unknown, an unsuccessful Promotion wasn't it.
+						return status, errors.New("Stage health evaluated to Unknown") // nolint: staticcheck
+					}
 				}
+				// Health assessment was definitive OR scenario 1: Stage health is
+				// unknown specifically because the last Promotion did not succeed.
 				return status, nil
 			},
 		},
@@ -747,6 +774,24 @@ func (r *RegularStageReconciler) syncPromotions(
 func (r *RegularStageReconciler) assessHealth(ctx context.Context, stage *kargoapi.Stage) kargoapi.StageStatus {
 	logger := logging.LoggerFromContext(ctx)
 	newStatus := *stage.Status.DeepCopy()
+
+	if currentPromo := stage.Status.CurrentPromotion; currentPromo != nil {
+		logger.Debug("Promotion is in progress: no health checks to perform")
+		conditions.Set(&newStatus, &metav1.Condition{
+			Type:               kargoapi.ConditionTypeHealthy,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "ActivePromotion",
+			Message:            "Stage has a Promotion in progress",
+			ObservedGeneration: stage.Generation,
+		})
+		newStatus.Health = &kargoapi.Health{
+			Status: kargoapi.HealthStateUnknown,
+			Issues: []string{
+				"Cannot assess health because a Promotion is currently in progress",
+			},
+		}
+		return newStatus
+	}
 
 	lastPromo := stage.Status.LastPromotion
 	if lastPromo == nil {


### PR DESCRIPTION
#4674 was only partially correct in treating it as an error anytime a Stage's health was evaluated as Unknown.

This PR supersedes #4869, which swings too hard in the opposite direction -- _never_ treating Unknown health as an error.

The correct, more nuanced logic:

* If a Stage's health is unknown specifically because the last Promotion did not succeed, we know that no amount of re-reconciling is going to produce a different result until a new Promotion executes to completion. This should _not_ be treated as an error.

* If a Stage's health is unknown for any other reason, the possibility exists that a subsequent reconciliation attempt may obtain a more definitive assessment of its health. This _should_ be treated as an error.

Comments in the code explain this in greater detail than the above.

@fuskovic @hiddeco and @jessesuen all have the full context on this. It was a team effort to diagnose and solve this figure this out. I only took it the last mile.

I changed one additional thing in this PR as it was prudent to do so. As I was testing this e2e, I encountered a scenario where I had a Promotion in progress, but health was unknown on account of the _last_ Promotion having failed. This wasn't what I would have expected...

With a Promotion in progress, a Stage is in a transitional state and its health cannot be accurately assessed. This would be the primary reason health is Unkown. The status of the last Promotion would be immaterial.

This is now fixed.