### PR TITLE
fix: prevent nil pointer dereference in buildTargetFreightCollection

### DIFF
--- a/internal/controller/promotions/promotions.go
+++ b/internal/controller/promotions/promotions.go
@@ -606,7 +606,7 @@ func (r *reconciler) buildTargetFreightCollection(
 	// longer requested by the Stage.
 	if len(stage.Spec.RequestedFreight) > 1 {
 		lastPromo := stage.Status.LastPromotion
-		if lastPromo.Status != nil && lastPromo.Status.FreightCollection != nil {
+		if lastPromo != nil && lastPromo.Status != nil && lastPromo.Status.FreightCollection != nil && lastPromo.Status.FreightCollection.Freight != nil {
 			for _, req := range stage.Spec.RequestedFreight {
 				if freight, ok := lastPromo.Status.FreightCollection.Freight[req.Origin.String()]; ok {
 					freightCol.UpdateOrPush(freight)


### PR DESCRIPTION

<img width="816" height="134" alt="Screenshot 2025-08-20 at 8 56 38 AM" src="https://github.com/user-attachments/assets/fde95d28-cb51-4267-8256-abf483063481" />
Add nil check for lastPromo in buildTargetFreightCollection method to prevent panic when accessing FreightCollection on stages with no previous promotions.

The panic occurred when stage.Status.LastPromotion was nil, but the code attempted to access lastPromo.Status without checking if lastPromo itself was nil first.

Fixes promotion controller panics with error:
"runtime error: invalid memory address or nil pointer dereference"

Changes:
- Add nil check for lastPromo before accessing its Status field
- Add additional safety check for FreightCollection.Freight map
- Maintain existing functionality while improving robustness