### PR TITLE
docs: correct a misstatement about Kargo and Rollouts

### DIFF
--- a/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
+++ b/docs/docs/40-operator-guide/20-advanced-installation/30-common-configurations.md
@@ -328,7 +328,7 @@ namespace specified by `controller.argocd.namespace`.
 ### Disabling the Argo Rollouts Integration
 
 By default, Kargo will enable the Argo Rollouts integration, which configures
-Kargo to work with `Rollout` resources created by Argo Rollouts as part of the
+Kargo to work with `AnalysisRun` resources created as part of the
 [verification feature](../../50-user-guide/20-how-to-guides/40-working-with-stages.md#verification).
 
 This can be disabled as follows:


### PR DESCRIPTION
Kargo doesn't care about `Rollout` resources. It watches `AnalysisRun`s