### PR TITLE
docs: fix discord invite link to the permalink

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     url: https://github.com/akuity/kargo/discussions/new
     about: Ask a question or start a discussion about Kargo
   - name: Chat on Discord
-    url: https://discord.gg/dHJBZw6ewT
+    url: https://akuity.community
     about: Maybe chatting with the community can help

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ info on how to get started quickly and easily.
 To report an issue, request a feature, or ask a question, please open an issue
 [here](https://github.com/akuity/kargo/issues).
 
-Please also feel free to join us on [Discord](https://discord.gg/dHJBZw6ewT)!
+Please also feel free to join us on [Discord](https://akuity.community)!
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes #4922

We were using the non-permalink Discord invite link in some places. This changes us to use the permalink, https://akuity.community, which will prevent us from having to update any future links going forward.