### PR TITLE
fix: prevent named default controller from reconciling promotions meant for other shards

### DIFF
--- a/internal/controller/promotions/promotions_test.go
+++ b/internal/controller/promotions/promotions_test.go
@@ -112,6 +112,26 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:                  "Promotion doesn't belong to shard",
+			expectPromoteFnCalled: false,
+			expectedPhase:         kargoapi.PromotionPhasePending,
+			expectedEventRecorded: false,
+			promos: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-promo",
+						Namespace: "fake-namespace",
+						Labels: map[string]string{
+							kargoapi.LabelKeyShard: "wrong-shard",
+						},
+					},
+					Status: kargoapi.PromotionStatus{
+						Phase: kargoapi.PromotionPhasePending,
+					},
+				},
+			},
+		},
+		{
 			name:                  "promo already running",
 			expectPromoteFnCalled: true,
 			expectedPhase:         kargoapi.PromotionPhaseSucceeded,


### PR DESCRIPTION
Fixes #4924

#4708 enabled a named controller to also serve as the default controller. A default controller with a name needs to reconcile Stages and Promotions that are explicitly labeled for itself as well as those not explicitly labeled for any shard. Kubernetes has no such thing as a logical OR in a label selector, so this had to be achieved by allowing such a controller to "see" all Stages and Promotions. To compensate for that, additional checks were inserted into the code to ignore Stages and Promotions meant for other shards...

What was overlooked was one particular event handler that enqueues Promotions for reconciliation. TIL that when a handler programmatically enqueues resources for reconcilation, it bypasses whatever event filters (predicates) the reconciler used in its watches.

This PR corrects that.

As an additional safeguard, I've added a shard check to the Promotions reconciler itself as well. This has been done identically to how @fuskovic did the same thing for Stages and Warehouses in #4677. (#4677 had not addressed Promotions because it had been narrowly focused on the edge case of resources that had migrated from one shard to another due to deliberate user action -- which cannot happen for a Promotion resource.)