### PR TITLE
chore(deps): bump golang from 1.24.6-bookworm to 1.25.0-trixie

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in
@@ -80,7 +80,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -103,7 +103,7 @@ jobs:
   lint-charts:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -127,7 +127,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -150,7 +150,7 @@ jobs:
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -226,7 +226,7 @@ jobs:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,7 +177,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -256,7 +256,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24.6-bookworm
+      image: golang:1.25.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.24.6-bookworm AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm
+FROM golang:1.25.0-trixie
 
 ARG TARGETARCH
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/akuity/kargo/api
 
-go 1.24.3
+go 1.25.0
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/akuity/kargo
 
-go 1.24.3
+go 1.25.0
 
 replace (
 	github.com/akuity/kargo/api => ./api

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/bufbuild/buf v1.56.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/akuity/kargo/pkg
 
-go 1.24.3
+go 1.25.0
 
 replace github.com/akuity/kargo/api => ../api
 


### PR DESCRIPTION
This would unblock #4966, #4967, and #4968.