### PR TITLE
docs: Drop Duplicate `Freight` Output 

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/50-working-with-freight.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/50-working-with-freight.md
@@ -78,13 +78,6 @@ NAME                                       ALIAS              AGE
 f5f87aa23c9e97f43eb83dd63768ee41f5ba3766   mortal-dragonfly   35s
 ```
 
-Sample output:
-
-```shell
-NAME                                       ALIAS              AGE
-f5f87aa23c9e97f43eb83dd63768ee41f5ba3766   mortal-dragonfly   35s
-```
-
 :::info
 The Kargo UI, to make efficient use of screen real estate, displays aliases
 only, but a `Freight` resource's `name` can always be discovered by hovering


### PR DESCRIPTION
This pull request makes a minor update to the documentation by removing a redundant sample output block from the 'Working with Freight' user guide.