### PR TITLE
chore: small README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ promotion of software artifacts through the many stages of their lifecycle.
 
 Read about Kargo in our [docs](https://docs.kargo.io), get hands-on right away
 with our [Quickstart](https://docs.kargo.io/quickstart) tutorial, or watch the
-*Multi-Stage Deployment Pipelines the GitOps Way* talk by Jesse Suen & Kent
-Rancourt of [Akuity](https://akuity.io/) at GitOpsCon EU 2024:
+*Multi-Stage Deployment Pipelines the GitOps Way* talk presented by Jesse Suen &
+Kent Rancourt of [Akuity](https://akuity.io/) at GitOpsCon EU 2024:
 
 [![Multi-Stage Deployment Pipelines the GitOps Way - Kargo](https://img.youtube.com/vi/0B_JODxyK0w/0.jpg)](https://youtu.be/0B_JODxyK0w)
 

--- a/README.md
+++ b/README.md
@@ -8,41 +8,42 @@
 [![Discord](https://img.shields.io/discord/1138942074998235187?logo=discord&logoColor=ffffff&label=discord
 )](https://akuity.community)
 
-
-Kargo is a next-generation continuous delivery and application lifecycle
-orchestration platform for Kubernetes. It builds upon
-[GitOps](https://opengitops.dev/) principles and integrates with existing
-technologies, like [Argo CD](https://argoproj.github.io/cd/), to streamline and
-automate the progressive rollout of changes across the many stages of an
-application's lifecycle.
+Kargo builds upon
+[GitOps](https://opengitops.dev/) principles to manage and automate the
+promotion of software artifacts through the many stages of their lifecycle.
 
 ![Kargo Dashboard](./docs/static/img/kargo-ui.png)
 
 ## Getting Started
 
-Read more about Kargo in our [docs](https://docs.kargo.io) or get hands-on
-right away by following our 
-[Quickstart documentation](https://docs.kargo.io/quickstart) or watch the *Multi-Stage Deployment Pipelines the GitOps Way* talk by Jesse Suen & Kent Rancourt of Akuity at GitOpsCon EU 2024:
+Read about Kargo in our [docs](https://docs.kargo.io), get hands-on right away
+with our [Quickstart](https://docs.kargo.io/quickstart) tutorial, or watch the
+*Multi-Stage Deployment Pipelines the GitOps Way* talk by Jesse Suen & Kent
+Rancourt of [Akuity](https://akuity.io/) at GitOpsCon EU 2024:
 
 [![Multi-Stage Deployment Pipelines the GitOps Way - Kargo](https://img.youtube.com/vi/0B_JODxyK0w/0.jpg)](https://youtu.be/0B_JODxyK0w)
 
-This documentation is very new, so please open issues against this repository if
-you encounter any difficulties.
+## Support & Feedback
+
+To report a bug or request a feature, please open an
+[issue](https://github.com/akuity/kargo/issues). For general questions, please
+start a [discussion](https://github.com/akuity/kargo/discussions) instead.
+
+Please also feel free to join fellow users in discusions in our
+[Discord Community](https://akuity.community)!
+
+If you are interested in enterprise-scale Kargo hosted, managed, and
+professionally supported by Akuity, inquire at https://akuity.io/kargo-enterprise.
 
 ## Contributing
 
-The Kargo project accepts contributions via GitHub pull requests.
+The Kargo project accepts contributions via GitHub pull requests. If you wish to
+implement a bug fix or new feature, please engage our maintainers by opening an
+[issue](https://github.com/akuity/kargo/issues) first.
 
 Visit our
 [Kargo Contributor Guide](https://docs.kargo.io/contributor-guide/) for more
-info on how to get started quickly and easily.
-
-## Support & Feedback
-
-To report an issue, request a feature, or ask a question, please open an issue
-[here](https://github.com/akuity/kargo/issues).
-
-Please also feel free to join us on [Discord](https://akuity.community)!
+info on how to start hacking on Kargo quickly and easily.
 
 ## Code of Conduct
 


### PR DESCRIPTION
@thomastaylor312 pointed out certain stale elements of the `README.md` yesterday. I took the opportunity to make some other small improvements while addressing them:

* Introductory line updated with simpler language that also more closely reflects how we _currently_ talk about Kargo. I've also:
  * Dropped the use of the word "application" in favor of more general "software artifacts" because we've seen so many cases of Kargo being used to manage infrastructure, especially cluster "add-ons."
  * Made the word Akuity a link.
  * Removed the disclaimer that the docs are very new.

* Moved Support and Feedback section above the Contributing section. I also reworded this section to:
  * Make the distinction that the issue queue is for bugs and feature requests while _questions_ should be posed by opening a discussion.
  * Make it more clear that the Discord community _is community space_. (Because official project business more properly belongs on GitHub.)
  * Non-aggressively mention the existence of Kargo Enterprise.

* Updated the Contributing section with language that suggests engaging maintainers by opening an issue _before_ voluntarily contributing a fix or feature. (To reduce the possibility of overlapping efforts or the waste of effort on a feature not aligned with project vision.)

Specifically seeking @jessesuen's review on this PR. @jessesuen I welcome any and all refinements you may suggest and please feel free to amend the PR with those directly.