### PR TITLE
fix: make event actor formatting aware of default username claim

### DIFF
--- a/internal/api/event.go
+++ b/internal/api/event.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"os"
 
 	authnv1 "k8s.io/api/authentication/v1"
 
@@ -26,7 +25,7 @@ func FormatEventUserActor(u user.Info) string {
 		return kargoapi.EventActorAdmin
 	}
 	if u.Username != "" {
-		return formatOIDCUsername(u.Username)
+		return formatOIDCUsername(u)
 	}
 	if emailClaim, ok := u.Claims["email"]; ok {
 		if email, ok := emailClaim.(string); ok {
@@ -45,6 +44,6 @@ func FormatEventKubernetesUserActor(u authnv1.UserInfo) string {
 	return kargoapi.EventActorKubernetesUserPrefix + u.Username
 }
 
-func formatOIDCUsername(oidcUsername string) string {
-	return fmt.Sprintf("%s:%s", os.Getenv("OIDC_USERNAME_CLAIM"), oidcUsername)
+func formatOIDCUsername(u user.Info) string {
+	return fmt.Sprintf("%s:%s", u.UsernameClaim, u.Username)
 }

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -39,11 +39,9 @@ func TestFormatEventUserActor(t *testing.T) {
 			expected: kargoapi.EventActorEmailPrefix + "email@inbox.com",
 		},
 		{
-			name: "oidc-username",
-			user: user.Info{
-				Username: "oidc-username",
-			},
-			expected: formatOIDCUsername("oidc-username"),
+			name:     "oidc-username",
+			user:     user.Info{Username: "oidc-username"},
+			expected: formatOIDCUsername(user.Info{Username: "oidc-username"}),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/server/option/auth.go
+++ b/internal/server/option/auth.go
@@ -446,6 +446,7 @@ func (a *authInterceptor) authenticate(
 				Claims:                     c,
 				ServiceAccountsByNamespace: sa,
 				BearerToken:                rawToken,
+				UsernameClaim:              a.cfg.OIDCConfig.UsernameClaim,
 				Username:                   username,
 			},
 		), nil

--- a/internal/server/user/user.go
+++ b/internal/server/user/user.go
@@ -27,6 +27,9 @@ type Info struct {
 	// ServiceAccountsByNamespace is the mapping of namespace names to sets of
 	// ServiceAccounts that a user has been mapped to.
 	ServiceAccountsByNamespace map[string]map[types.NamespacedName]struct{}
+	// UsernameClaim identifies from which specific claim the user's uniquely
+	// identifying username was extracted from.
+	UsernameClaim string
 	// Username is the username of the user. This is often the email address
 	// of the user, but may be different depending on configuration.
 	Username string


### PR DESCRIPTION
This PR fixes a bug where the default username claim of `email` was being ignored by code that formats user info for inclusion in event data.

cc @gdsoumya 