### PR TITLE
fix(docs): document dex callbacks

### DIFF
--- a/docs/docs/40-operator-guide/40-security/20-openid-connect/index.md
+++ b/docs/docs/40-operator-guide/40-security/20-openid-connect/index.md
@@ -90,7 +90,7 @@ When installing Kargo with Helm, all options related to OIDC are grouped under
 1. Only if your IDP supports _both_ OIDC and PKCE:
 
     :::caution
-    If your IDP does not support _both_ OIDC and PKCE,
+    If your IDP does not support _both_ OIDC and PKCE, the
     [Adapting Incompatible IDPs](#adapting-incompatible-idps) section provides
     alternate instructions for this step.
     :::


### PR DESCRIPTION
Alternative to #5035

This surfaces the same missing information that #5035 would have, but is more particular about preserving the existing structure of the page and not mixing Dex details into sections where there is a clearly stated assumption that you're working with a compatible IDP.