### PR TITLE
feat(ui): Increase Stage name visibility on bright bg colors

### DIFF
--- a/ui/src/features/project/pipelines/nodes/stage-meta-utils.ts
+++ b/ui/src/features/project/pipelines/nodes/stage-meta-utils.ts
@@ -3,6 +3,7 @@ import { CSSProperties, useContext, useMemo } from 'react';
 import { ColorContext } from '@ui/context/colors';
 import { ColorMapHex, parseColorAnnotation } from '@ui/features/stage/utils';
 import { Stage } from '@ui/gen/api/v1alpha1/generated_pb';
+import { getContrastTextColor } from '@ui/utils/get-contrast-text-color';
 
 import { IAction, useActionContext } from '../context/action-context';
 import { useDictionaryContext } from '../context/dictionary-context';
@@ -77,11 +78,10 @@ export const useStageHeaderStyle = (stage: Stage): CSSProperties => {
 
   if (stageColor && ColorMapHex[stageColor]) {
     stageColor = ColorMapHex[stageColor];
-    stageFontColor = 'white';
   }
 
   if (stageColor) {
-    stageFontColor = 'white';
+    stageFontColor = getContrastTextColor(ColorMapHex[stageColor] || stageColor);
   }
 
   return {

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -262,7 +262,10 @@ export const StageNode = (props: { stage: Stage }) => {
     >
       <Card
         styles={{
-          header: headerStyle,
+          header: {
+            ...headerStyle,
+            textShadow: '1px 1px 2px rgba(0, 0, 0, 0.15)'
+          },
           body: {
             height: '100%',
             position: 'relative'

--- a/ui/src/utils/get-contrast-text-color.test.ts
+++ b/ui/src/utils/get-contrast-text-color.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+
+import { getContrastTextColor } from './get-contrast-text-color';
+
+test('getContrastTextColor', () => {
+  expect(getContrastTextColor('')).toStrictEqual('white');
+  expect(getContrastTextColor('black')).toStrictEqual('white');
+  expect(getContrastTextColor('#ffffff')).toStrictEqual('black');
+  expect(getContrastTextColor('#000000')).toStrictEqual('white');
+  expect(getContrastTextColor('#ff0000')).toStrictEqual('white');
+});

--- a/ui/src/utils/get-contrast-text-color.ts
+++ b/ui/src/utils/get-contrast-text-color.ts
@@ -1,0 +1,8 @@
+export const getContrastTextColor = (bgColor: string) => {
+  const color = bgColor.replace('#', '');
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.75 ? 'black' : 'white';
+};


### PR DESCRIPTION
fixes #5017 

1.  Added light black text shadow
2. For very bright background colors, the font should be black now

Before:
<img width="546" height="207" alt="image" src="https://github.com/user-attachments/assets/ed33edef-4042-45df-8ff9-0c69f8811b42" />

After:
<img width="529" height="209" alt="image" src="https://github.com/user-attachments/assets/10951f0b-2c86-4626-a1f9-13b3f70c1cbe" />
