### PR TITLE
refactor(api-server): dry up api endpoints

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	sigyaml "sigs.k8s.io/yaml"
+
+	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestObjectOrRaw(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := kargoapi.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	testStageName := "test-stage"
+	testStage := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testStageName,
+			Namespace: "test-project",
+		},
+	}
+
+	testUnstructuredData := map[string]any{
+		"apiVersion": kargoapi.GroupVersion.String(),
+		"kind":       "Stage",
+		"metadata": map[string]any{
+			"name":      testStageName,
+			"namespace": "test-project",
+		},
+	}
+	testUnstructured := &unstructured.Unstructured{Object: testUnstructuredData}
+
+	testJSON, err := json.Marshal(testUnstructuredData)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{
+			name: "unstructured to JSON",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testUnstructured,
+					svcv1alpha1.RawFormat_RAW_FORMAT_JSON,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, stage)
+				require.JSONEq(t, string(testJSON), string(raw))
+			},
+		},
+		{
+			name: "unstructured to YAML",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testUnstructured,
+					svcv1alpha1.RawFormat_RAW_FORMAT_YAML,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, stage)
+				require.YAMLEq(
+					t,
+					string(testJSON), // Valid JSON is also valid YAML
+					string(raw),
+				)
+			},
+		},
+		{
+			name: "unstructured to structured",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testUnstructured,
+					svcv1alpha1.RawFormat_RAW_FORMAT_UNSPECIFIED,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, raw)
+				require.Equal(t, testStageName, stage.GetName())
+			},
+		},
+		{
+			name: "structured to JSON",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testStage,
+					svcv1alpha1.RawFormat_RAW_FORMAT_JSON,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, stage)
+				obj := map[string]any{}
+				err = json.Unmarshal(raw, &obj)
+				require.NoError(t, err)
+				// Ensure GVK was not lost
+				require.Equal(t, kargoapi.GroupVersion.String(), obj["apiVersion"])
+				require.Equal(t, "Stage", obj["kind"])
+				// Ensure metadata was not lost
+				metadata, ok := obj["metadata"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, testStageName, metadata["name"])
+			},
+		},
+		{
+			name: "structured to YAML",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testStage,
+					svcv1alpha1.RawFormat_RAW_FORMAT_YAML,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, stage)
+				obj := map[string]any{}
+				err = sigyaml.Unmarshal(raw, &obj)
+				require.NoError(t, err)
+
+				// Ensure GVK was not lost
+				require.Equal(t, kargoapi.GroupVersion.String(), obj["apiVersion"])
+				require.Equal(t, "Stage", obj["kind"])
+				// Ensure metadata was not lost
+				metadata, ok := obj["metadata"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, testStageName, metadata["name"])
+			},
+		},
+		{
+			name: "structured to structured",
+			test: func(*testing.T) {
+				stage, raw, err := objectOrRaw(
+					client,
+					testStage,
+					svcv1alpha1.RawFormat_RAW_FORMAT_UNSPECIFIED,
+					&kargoapi.Stage{},
+				)
+				require.NoError(t, err)
+				require.Nil(t, raw)
+				require.Same(t, testStage, stage)
+			},
+		},
+		{
+			name: "structured to structured with type mismatch",
+			test: func(*testing.T) {
+				_, _, err := objectOrRaw(
+					client,
+					testStage,
+					svcv1alpha1.RawFormat_RAW_FORMAT_UNSPECIFIED,
+					&kargoapi.Project{},
+				)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "type mismatch")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, testCase.test)
+	}
+}

--- a/internal/server/get_analysistemplate_v1alpha1.go
+++ b/internal/server/get_analysistemplate_v1alpha1.go
@@ -7,8 +7,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -44,16 +42,15 @@ func (s *server) GetAnalysisTemplate(
 	// Get the AnalysisTemplate from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": rolloutsapi.GroupVersion.String(),
 			"kind":       "AnalysisTemplate",
 		},
 	}
-	if err := s.client.Get(ctx, types.NamespacedName{
-		Namespace: project,
-		Name:      name,
-	}, &u); err != nil {
+	if err := s.client.Get(
+		ctx, client.ObjectKey{Namespace: project, Name: name}, u,
+	); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			err = fmt.Errorf("AnalysisTemplate %q not found in namespace %q", name, project)
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -61,30 +58,20 @@ func (s *server) GetAnalysisTemplate(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	at, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &rolloutsapi.AnalysisTemplate{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
-			Result: &svcv1alpha1.GetAnalysisTemplateResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		at := rolloutsapi.AnalysisTemplate{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &at); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&at, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
-			Result: &svcv1alpha1.GetAnalysisTemplateResponse_AnalysisTemplate{
-				AnalysisTemplate: obj,
-			},
+			Result: &svcv1alpha1.GetAnalysisTemplateResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetAnalysisTemplateResponse{
+		Result: &svcv1alpha1.GetAnalysisTemplateResponse_AnalysisTemplate{
+			AnalysisTemplate: at,
+		},
+	}), nil
 }

--- a/internal/server/get_clusteranalysistemplate_v1alpha1.go
+++ b/internal/server/get_clusteranalysistemplate_v1alpha1.go
@@ -7,8 +7,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -35,15 +33,13 @@ func (s *server) GetClusterAnalysisTemplate(
 	// Get the ClusterAnalysisTemplate from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": rolloutsapi.GroupVersion.String(),
 			"kind":       "ClusterAnalysisTemplate",
 		},
 	}
-	if err := s.client.Get(ctx, types.NamespacedName{
-		Name: name,
-	}, &u); err != nil {
+	if err := s.client.Get(ctx, client.ObjectKey{Name: name}, u); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			err = fmt.Errorf("ClusterAnalysisTemplate %q not found", name)
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -51,30 +47,20 @@ func (s *server) GetClusterAnalysisTemplate(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	at, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &rolloutsapi.ClusterAnalysisTemplate{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetClusterAnalysisTemplateResponse{
-			Result: &svcv1alpha1.GetClusterAnalysisTemplateResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		at := rolloutsapi.ClusterAnalysisTemplate{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &at); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&at, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetClusterAnalysisTemplateResponse{
-			Result: &svcv1alpha1.GetClusterAnalysisTemplateResponse_ClusterAnalysisTemplate{
-				ClusterAnalysisTemplate: obj,
-			},
+			Result: &svcv1alpha1.GetClusterAnalysisTemplateResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetClusterAnalysisTemplateResponse{
+		Result: &svcv1alpha1.GetClusterAnalysisTemplateResponse_ClusterAnalysisTemplate{
+			ClusterAnalysisTemplate: at,
+		},
+	}), nil
 }

--- a/internal/server/get_config_map_v1alpha1.go
+++ b/internal/server/get_config_map_v1alpha1.go
@@ -7,7 +7,6 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -30,13 +29,15 @@ func (s *server) GetConfigMap(
 	// Get the ConfigMap from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
 		},
 	}
-	if err := s.client.Get(ctx, client.ObjectKey{Name: name, Namespace: project}, &u); err != nil {
+	if err := s.client.Get(
+		ctx, client.ObjectKey{Name: name, Namespace: project}, u,
+	); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			err = fmt.Errorf("ConfigMap %q not found", name)
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -44,30 +45,21 @@ func (s *server) GetConfigMap(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	cfg, raw, err := objectOrRaw(
+		s.client,
+		u,
+		req.Msg.GetFormat(),
+		&corev1.ConfigMap{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetConfigMapResponse{
-			Result: &svcv1alpha1.GetConfigMapResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		p := corev1.ConfigMap{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &p); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&p, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetConfigMapResponse{
-			Result: &svcv1alpha1.GetConfigMapResponse_ConfigMap{
-				ConfigMap: obj,
-			},
+			Result: &svcv1alpha1.GetConfigMapResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetConfigMapResponse{
+		Result: &svcv1alpha1.GetConfigMapResponse_ConfigMap{ConfigMap: cfg},
+	}), nil
 }

--- a/internal/server/get_project_config_v1alpha1.go
+++ b/internal/server/get_project_config_v1alpha1.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -29,13 +28,15 @@ func (s *server) GetProjectConfig(
 	// Get the ProjectConfig from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": kargoapi.GroupVersion.String(),
 			"kind":       "ProjectConfig",
 		},
 	}
-	if err := s.client.Get(ctx, client.ObjectKey{Name: project, Namespace: project}, &u); err != nil {
+	if err := s.client.Get(
+		ctx, client.ObjectKey{Name: project, Namespace: project}, u,
+	); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			err = fmt.Errorf("ProjectConfig %q not found", project)
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -43,30 +44,20 @@ func (s *server) GetProjectConfig(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	p, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &kargoapi.ProjectConfig{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetProjectConfigResponse{
-			Result: &svcv1alpha1.GetProjectConfigResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		p := kargoapi.ProjectConfig{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &p); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&p, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetProjectConfigResponse{
-			Result: &svcv1alpha1.GetProjectConfigResponse_ProjectConfig{
-				ProjectConfig: obj,
-			},
+			Result: &svcv1alpha1.GetProjectConfigResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetProjectConfigResponse{
+		Result: &svcv1alpha1.GetProjectConfigResponse_ProjectConfig{
+			ProjectConfig: p,
+		},
+	}), nil
 }

--- a/internal/server/get_project_v1alpha1.go
+++ b/internal/server/get_project_v1alpha1.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -25,13 +24,13 @@ func (s *server) GetProject(
 	// Get the Project from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": kargoapi.GroupVersion.String(),
 			"kind":       "Project",
 		},
 	}
-	if err := s.client.Get(ctx, client.ObjectKey{Name: name}, &u); err != nil {
+	if err := s.client.Get(ctx, client.ObjectKey{Name: name}, u); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			// nolint:staticcheck
 			err = fmt.Errorf("Project %q not found", name)
@@ -40,30 +39,18 @@ func (s *server) GetProject(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	p, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &kargoapi.Project{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
-			Result: &svcv1alpha1.GetProjectResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		p := kargoapi.Project{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &p); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&p, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
-			Result: &svcv1alpha1.GetProjectResponse_Project{
-				Project: obj,
-			},
+			Result: &svcv1alpha1.GetProjectResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetProjectResponse{
+		Result: &svcv1alpha1.GetProjectResponse_Project{Project: p},
+	}), nil
 }

--- a/internal/server/get_stage_v1alpha1.go
+++ b/internal/server/get_stage_v1alpha1.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -34,16 +33,15 @@ func (s *server) GetStage(
 	// Get the Stage from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": kargoapi.GroupVersion.String(),
 			"kind":       "Stage",
 		},
 	}
-	if err := s.client.Get(ctx, client.ObjectKey{
-		Name:      name,
-		Namespace: project,
-	}, &u); err != nil {
+	if err := s.client.Get(
+		ctx, client.ObjectKey{Name: name, Namespace: project}, u,
+	); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			// nolint:staticcheck
 			err = fmt.Errorf("Stage %q not found in project %q", name, project)
@@ -52,30 +50,18 @@ func (s *server) GetStage(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	stage, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &kargoapi.Stage{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetStageResponse{
-			Result: &svcv1alpha1.GetStageResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		stage := kargoapi.Stage{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &stage); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&stage, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetStageResponse{
-			Result: &svcv1alpha1.GetStageResponse_Stage{
-				Stage: obj,
-			},
+			Result: &svcv1alpha1.GetStageResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetStageResponse{
+		Result: &svcv1alpha1.GetStageResponse_Stage{Stage: stage},
+	}), nil
 }

--- a/internal/server/get_warehouse_v1alpha1.go
+++ b/internal/server/get_warehouse_v1alpha1.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
@@ -34,16 +33,15 @@ func (s *server) GetWarehouse(
 	// Get the Warehouse from the Kubernetes API as an unstructured object.
 	// Using an unstructured object allows us to return the object _as presented
 	// by the API_ if a raw format is requested.
-	u := unstructured.Unstructured{
+	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": kargoapi.GroupVersion.String(),
 			"kind":       "Warehouse",
 		},
 	}
-	if err := s.client.Get(ctx, client.ObjectKey{
-		Name:      name,
-		Namespace: project,
-	}, &u); err != nil {
+	if err := s.client.Get(
+		ctx, client.ObjectKey{Name: name, Namespace: project}, u,
+	); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			// nolint:staticcheck
 			err = fmt.Errorf("Warehouse %q not found in project %q", name, project)
@@ -52,30 +50,18 @@ func (s *server) GetWarehouse(
 		return nil, err
 	}
 
-	switch req.Msg.GetFormat() {
-	case svcv1alpha1.RawFormat_RAW_FORMAT_JSON, svcv1alpha1.RawFormat_RAW_FORMAT_YAML:
-		_, raw, err := objectOrRaw(&u, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+	w, raw, err := objectOrRaw(
+		s.client, u, req.Msg.GetFormat(), &kargoapi.Warehouse{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
 		return connect.NewResponse(&svcv1alpha1.GetWarehouseResponse{
-			Result: &svcv1alpha1.GetWarehouseResponse_Raw{
-				Raw: raw,
-			},
-		}), nil
-	default:
-		w := kargoapi.Warehouse{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &w); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		obj, _, err := objectOrRaw(&w, req.Msg.GetFormat())
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		return connect.NewResponse(&svcv1alpha1.GetWarehouseResponse{
-			Result: &svcv1alpha1.GetWarehouseResponse_Warehouse{
-				Warehouse: obj,
-			},
+			Result: &svcv1alpha1.GetWarehouseResponse_Raw{Raw: raw},
 		}), nil
 	}
+	return connect.NewResponse(&svcv1alpha1.GetWarehouseResponse{
+		Result: &svcv1alpha1.GetWarehouseResponse_Warehouse{Warehouse: w},
+	}), nil
 }


### PR DESCRIPTION
I was bugged non-DRYness of the API endpoints and redundant checks for desired format (endpoint checks and `objectOrRaw()` also does).

This also ensures GVK info is not lost when marshaling a structured object to JSON or YAML.