### PR TITLE
fix: wrong semver sorting

### DIFF
--- a/internal/image/semver_selector.go
+++ b/internal/image/semver_selector.go
@@ -121,9 +121,9 @@ func (s *semverSelector) Select(
 	)
 
 	logger.Trace("sorting tags semantically")
-	logger.Info("semver selector before sort", "tags", tags)
+	logger.Info("semver selector before sort", "tags", tags) // delete me
 	tags = s.sort(tags)
-	logger.Debug("semver selector after sort", "tags", tags)
+	logger.Debug("semver selector after sort", "tags", tags) // delete me
 
 	images, err := s.getImagesByTags(ctx, tags)
 	if err != nil {

--- a/internal/image/semver_selector_test.go
+++ b/internal/image/semver_selector_test.go
@@ -146,6 +146,10 @@ func Test_semverSelector_MatchesTag(t *testing.T) {
 
 func Test_semVerSelector_sort(t *testing.T) {
 	unsorted := []string{
+		"0.9.0-dev-9",
+		"0.8.0-dev-12",
+		"0.9.0-dev-12",
+		"0.8.0-dev-9",
 		"5.0.0",
 		"0.0.1",
 		"0.2.1",
@@ -166,6 +170,10 @@ func Test_semVerSelector_sort(t *testing.T) {
 			"1.1.1",
 			"1.0.2",
 			"1.0.0",
+			"0.9.0-dev-12",
+			"0.9.0-dev-9",
+			"0.8.0-dev-12",
+			"0.8.0-dev-9",
 			"0.2.1",
 			"0.1.1",
 			"0.0.1",


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/5018

### Before

<img width="352" height="288" alt="Screenshot 2025-09-20 at 9 25 46 AM" src="https://github.com/user-attachments/assets/77d37095-5a8b-4dad-8fa5-3bd00c55f2f0" />

```
2025-09-20T13:52:43Z	INFO	image/semver_selector.go:122	semver selector before sort	{"tags": ["0.8.0-dev-12", "0.8.0-dev-9", "0.9.0-dev-12", "0.9.0-dev-9"]}

2025-09-20T13:52:43Z	DEBUG	image/semver_selector.go:124	semver selector after sort	{"tags": ["0.9.0-dev-9", "0.9.0-dev-12", "0.8.0-dev-9", "0.8.0-dev-12"]}
```

### After

<img width="505" height="279" alt="Screenshot 2025-09-20 at 11 06 39 AM" src="https://github.com/user-attachments/assets/b117b61b-861c-4309-84db-b7f68acc7a88" />

```
2025-09-20T15:06:28Z	INFO	image/semver_selector.go:124	semver selector before sort	{"tags": ["0.8.0-dev-12", "0.8.0-dev-9", "0.9.0-dev-12", "0.9.0-dev-9"]}

2025-09-20T15:06:28Z	DEBUG	image/semver_selector.go:126	semver selector after sort	{"tags": ["0.9.0-dev-12", "0.9.0-dev-9", "0.8.0-dev-12", "0.8.0-dev-9"]}
```
