### PR TITLE
fix(ci): set permissions for linters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
 
   lint-go:
     permissions:
+      contents: read # Permissions to read the repository, required because we override the default permissions
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
@@ -124,6 +125,7 @@ jobs:
 
   lint-proto:
     permissions:
+      contents: read # Permissions to read the repository, required because we override the default permissions
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
If permissions are set at the job level, the default permissions are no longer applied. Explicitly define `read` permissions for `contents` in these places to ensure the CI works in all scenarios (e.g., when the repository is not public).