### PR TITLE
refactor: make task output propagation a promotion step capability

### DIFF
--- a/internal/promotion/runner/builtin/output_composer.go
+++ b/internal/promotion/runner/builtin/output_composer.go
@@ -18,11 +18,12 @@ func init() {
 	intpromo.RegisterStepRunner(
 		stepKindComposeOutput,
 		promotion.StepRunnerRegistration{
-			Factory: func(
-				promotion.StepRunnerCapabilities,
-			) promotion.StepRunner {
-				return promotion.NewTaskLevelOutputStepRunner(newOutputComposer())
+			Metadata: &promotion.StepRunnerMetadata{
+				RequiredCapabilities: []promotion.StepRunnerCapability{
+					promotion.StepCapabilityTaskOutputPropagation,
+				},
 			},
+			Factory: newOutputComposer,
 		},
 	)
 }
@@ -54,7 +55,7 @@ type outputComposer struct {
 
 // newOutputComposer returns an implementation of the promotion.StepRunner
 // interface that composes output from previous steps into new output.
-func newOutputComposer() promotion.StepRunner {
+func newOutputComposer(_ promotion.StepRunnerCapabilities) promotion.StepRunner {
 	return &outputComposer{
 		schemaLoader: getConfigSchemaLoader(stepKindComposeOutput),
 	}

--- a/internal/promotion/simple_engine.go
+++ b/internal/promotion/simple_engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 
 	gocache "github.com/patrickmn/go-cache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,7 +168,7 @@ func (e *simpleEngine) executeSteps(
 		result, err := e.executeStep(ctx, exprDataCache, promoCtx, step, runner, workDir)
 
 		// Propagate the output of the step to the state.
-		e.propagateStepOutput(promoCtx, step, runner, result)
+		e.propagateStepOutput(promoCtx, step, *registration, result)
 
 		// Confirm that the step has a valid status.
 		if !isValidStepStatus(result.Status) {
@@ -274,7 +275,7 @@ func (e *simpleEngine) shouldSkipStep(
 func (e *simpleEngine) propagateStepOutput(
 	promoCtx Context,
 	step Step,
-	runner promotion.StepRunner,
+	stepReg promotion.StepRunnerRegistration,
 	result promotion.StepResult,
 ) {
 	// Update the state with the output of the step.
@@ -282,7 +283,10 @@ func (e *simpleEngine) propagateStepOutput(
 
 	// If the step instructs that the output should be propagated to the
 	// task namespace, do so.
-	if p, ok := runner.(promotion.TaskLevelOutputStepRunner); ok && p.TaskLevelOutput() {
+	if stepReg.Metadata != nil && slices.Contains(
+		stepReg.Metadata.RequiredCapabilities,
+		promotion.StepCapabilityTaskOutputPropagation,
+	) {
 		if aliasNamespace := getAliasNamespace(step.Alias); aliasNamespace != "" {
 			if promoCtx.State[aliasNamespace] == nil {
 				promoCtx.State[aliasNamespace] = make(map[string]any)

--- a/internal/promotion/simple_engine_test.go
+++ b/internal/promotion/simple_engine_test.go
@@ -497,15 +497,18 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 				registry.register(
 					"task-level-output-step",
 					promotion.StepRunnerRegistration{
+						Metadata: &promotion.StepRunnerMetadata{
+							RequiredCapabilities: []promotion.StepRunnerCapability{
+								promotion.StepCapabilityTaskOutputPropagation,
+							},
+						},
 						Factory: func(promotion.StepRunnerCapabilities) promotion.StepRunner {
-							return promotion.NewTaskLevelOutputStepRunner(
-								&promotion.MockStepRunner{
-									RunResult: promotion.StepResult{
-										Status: kargoapi.PromotionStepStatusSucceeded,
-										Output: map[string]any{"test": "value"},
-									},
+							return &promotion.MockStepRunner{
+								RunResult: promotion.StepResult{
+									Status: kargoapi.PromotionStepStatusSucceeded,
+									Output: map[string]any{"test": "value"},
 								},
-							)
+							}
 						},
 					},
 				)
@@ -542,6 +545,11 @@ func TestSimpleEngine_executeSteps(t *testing.T) {
 				registry.register(
 					"task-level-output-step",
 					promotion.StepRunnerRegistration{
+						Metadata: &promotion.StepRunnerMetadata{
+							RequiredCapabilities: []promotion.StepRunnerCapability{
+								promotion.StepCapabilityTaskOutputPropagation,
+							},
+						},
 						Factory: func(promotion.StepRunnerCapabilities) promotion.StepRunner {
 							return &promotion.MockStepRunner{
 								RunResult: promotion.StepResult{

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -17,44 +17,6 @@ type StepRunner interface {
 	Run(context.Context, *StepContext) (StepResult, error)
 }
 
-// TaskLevelOutputStepRunner is an interface that defines a method to instruct
-// the engine to propagate the output of a step to the task namespace in the
-// shared state of the promotion result.
-type TaskLevelOutputStepRunner interface {
-	StepRunner
-	// TaskLevelOutput returns true if the StepRunner produces output that
-	// should be propagated to the task namespace in the state of the promotion
-	// result by the engine after the step is executed.
-	TaskLevelOutput() bool
-}
-
-// NewTaskLevelOutputStepRunner returns a wrapper around a StepRunner that
-// implements TaskLevelOutputStepRunner.
-func NewTaskLevelOutputStepRunner(runner StepRunner) TaskLevelOutputStepRunner {
-	return &taskLevelOutputStepRunner{
-		runner: runner,
-	}
-}
-
-// taskLevelOutputStepRunner is a wrapper around a StepRunner that implements
-// TaskLevelOutputStepRunner.
-type taskLevelOutputStepRunner struct {
-	runner StepRunner
-}
-
-// Run implements StepRunner.
-func (r *taskLevelOutputStepRunner) Run(
-	ctx context.Context,
-	stepCtx *StepContext,
-) (StepResult, error) {
-	return r.runner.Run(ctx, stepCtx)
-}
-
-// TaskLevelOutput implements TaskLevelOutputStepRunner.
-func (r *taskLevelOutputStepRunner) TaskLevelOutput() bool {
-	return true
-}
-
 // StepContext is a type that represents the context in which a
 // single promotion step is executed by a StepRunner.
 type StepContext struct {

--- a/pkg/promotion/registration.go
+++ b/pkg/promotion/registration.go
@@ -64,14 +64,18 @@ type StepRunnerMetadata struct {
 type StepRunnerCapability string
 
 const (
-	// StepCapabilityAccessControlPlane represents the capability of interacting
-	// with the Kargo control plane via a Kubernetes client.
-	StepCapabilityAccessControlPlane StepRunnerCapability = "access-control-plane"
 	// StepCapabilityAccessArgoCD represents the capability of interacting with
 	// an Argo CD control plane via a Kubernetes client.
 	StepCapabilityAccessArgoCD StepRunnerCapability = "access-argocd"
+	// StepCapabilityAccessControlPlane represents the capability of interacting
+	// with the Kargo control plane via a Kubernetes client.
+	StepCapabilityAccessControlPlane StepRunnerCapability = "access-control-plane"
 	// StepCapabilityAccessCredentials represents the capability to obtain
 	// repository credentials through a lookup by credential type and repository
 	// URL.
 	StepCapabilityAccessCredentials StepRunnerCapability = "access-credentials"
+	// StepCapabilityTaskOutputPropagation represents the capability of a step,
+	// when executed as part of a task, to propagate its output directly to the
+	// Promotion's shared state, in addition to the task's own state.
+	StepCapabilityTaskOutputPropagation StepRunnerCapability = "task-output-propagation"
 )


### PR DESCRIPTION
@hiddeco, as we discussed, this is a follow-up to #5079 that eliminates the need for a wrapper around the compose-output step that implements the `TaskLevelOutputStepRunner` interface. By doing that we will no longer need to instantiate a runner to know it has this capability.

Please feel free to tweak the wording on the capability's docstring.