### PR TITLE
docs: clarify where build time is derived from for NewestBuild

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -198,6 +198,11 @@ strategies are:
 - `NewestBuild`: This strategy selects the image with the most recent build
   time.
 
+  The build time is evaluated using the labels 
+  `org.opencontainers.image.created` or `org.label-schema.build-date`. If 
+  neither label is set, Kargo will fall back to using the `config.Created` time 
+  of the image.
+
     :::warning
     `NewestBuild` requires retrieving metadata for every eligible tag, which can
     be slow and is likely to exceed the registry's rate limits. __This can


### PR DESCRIPTION
Updates the docs to clarify where the build time comes from for NewestBuild. Relates to https://github.com/akuity/kargo/pull/4636