### PR TITLE
fix(cmd): Fixes panic in controller startup

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -422,7 +422,7 @@ func (o *controllerOptions) setupReconcilers(
 		argocdMgr,
 		promotion.NewSimpleEngine(
 			kargoMgr.GetClient(),
-			argocdMgr.GetClient(),
+			argoCDClient,
 			credentialsDB,
 			promotion.DefaultExprDataCacheFn,
 		),


### PR DESCRIPTION
We were doing a proper nil check above this change, but then not using the result when setting things up