### PR TITLE
fix(api-server): write debug message instead of returning error when client hangs up on a watch

### DIFF
--- a/pkg/server/get_analysisrun_logs_v1alpha1.go
+++ b/pkg/server/get_analysisrun_logs_v1alpha1.go
@@ -21,6 +21,7 @@ import (
 	"github.com/akuity/kargo/pkg/api/stubs/rollouts"
 	libEncoding "github.com/akuity/kargo/pkg/encoding"
 	"github.com/akuity/kargo/pkg/expressions"
+	"github.com/akuity/kargo/pkg/logging"
 	"github.com/akuity/kargo/pkg/server/user"
 )
 
@@ -172,8 +173,9 @@ func (s *server) GetAnalysisRunLogs(
 				return fmt.Errorf("error sending log chunk: %w", err)
 			}
 		case <-ctx.Done():
-			// Context canceled or timed out
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		}
 	}
 }

--- a/pkg/server/watch_cluster_config_v1alpha1.go
+++ b/pkg/server/watch_cluster_config_v1alpha1.go
@@ -14,6 +14,7 @@ import (
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/api"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchClusterConfig(
@@ -38,7 +39,9 @@ func (s *server) WatchClusterConfig(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_freight_v1alpha1.go
+++ b/pkg/server/watch_freight_v1alpha1.go
@@ -11,6 +11,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchFreight(
@@ -37,7 +38,9 @@ func (s *server) WatchFreight(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_project_config_v1alpha1.go
+++ b/pkg/server/watch_project_config_v1alpha1.go
@@ -13,6 +13,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchProjectConfig(
@@ -47,7 +48,9 @@ func (s *server) WatchProjectConfig(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_promotion_v1alpha1.go
+++ b/pkg/server/watch_promotion_v1alpha1.go
@@ -13,6 +13,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchPromotion(
@@ -52,7 +53,9 @@ func (s *server) WatchPromotion(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_promotions_v1alpha1.go
+++ b/pkg/server/watch_promotions_v1alpha1.go
@@ -12,6 +12,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchPromotions(
@@ -47,7 +48,9 @@ func (s *server) WatchPromotions(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_stages_v1alpha1.go
+++ b/pkg/server/watch_stages_v1alpha1.go
@@ -13,6 +13,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchStages(
@@ -52,7 +53,9 @@ func (s *server) WatchStages(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil

--- a/pkg/server/watch_warehouses_v1alpha1.go
+++ b/pkg/server/watch_warehouses_v1alpha1.go
@@ -13,6 +13,7 @@ import (
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/logging"
 )
 
 func (s *server) WatchWarehouses(
@@ -52,7 +53,9 @@ func (s *server) WatchWarehouses(
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			logger := logging.LoggerFromContext(ctx)
+			logger.Debug(ctx.Err().Error())
+			return nil
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return nil


### PR DESCRIPTION
Fixes #5101 

I can't put my finger on _why_ we're all of the sudden seeing error messages we weren't before, but they're occurring anytime the client hangs up on a watch. As far as I can tell, everything is still working exactly as it ought to, so I think it's sensible to log a debug message when the client hangs up instead of returning an error. After all -- we expect clients to eventually hang up. This is normal.

Only reason I am even bothering to write a debug message instead of just ignoring the context cancellation entirely is on the off chance that there _was_ some legitimate problem that's being overlooked here, this will provide our future selves with a clue as to the cause.