### PR TITLE
feat: add ability to add extra clients in dex

### DIFF
--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -36,6 +36,9 @@ stringData:
     - id: {{ .Values.api.host }}-cli
       name: Kargo CLI
       public: true
+    {{- range .Values.api.oidc.dex.extra_clients }}
+    - {{ toYaml . | nindent 6 | trim | trimPrefix "\n" }}
+    {{- end }}
 
     connectors:
     {{- toYaml .Values.api.oidc.dex.connectors | nindent 4 }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -263,6 +263,9 @@ api:
       #     redirectURI: <http(s)>://<api.host>/dex/callback
       #     tenant: <tenant ID>
 
+      ## @param api.oidc.dex.extra_clients Configure extra Dex clients
+      extra_clients: []
+
       ## ServiceAccount specific settings
       serviceAccount:
         ## @param api.oidc.dex.serviceAccount.labels Additional labels to add to the Dex server ServiceAccount.


### PR DESCRIPTION
I'm trying to connect more clients to the kargo API server to do a little bit more interactions. It would be helpful, if it would be possible to setup extra oidc clients in the dex, so other apps can authenticate too.