### PR TITLE
docs: Update description of `description` parameter

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -24,7 +24,7 @@ GitLab pull/merge requests.
 | `targetBranch` | `string` | N | The branch to which the changes should be merged. |
 | `createTargetBranch` | `boolean` | N | Indicates whether a new, empty orphaned branch should be created and pushed to the remote if the target branch does not already exist there. Default is `false`. |
 | `title` | `string` | N | The title for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified. |
-| `description` | `string` | N | The description for the pull request. Kargo generates a title based on the commit messages if it is not explicitly specified. |
+| `description` | `string` | N | The description for the pull request. |
 | `labels` | `[]string` | N | Labels to add to the pull request. |
 
 ## Output


### PR DESCRIPTION
### Changes:
- Update description of `description` parameter as the default behaviour is if the description parameter is empty PR description will also be empty.

### Doc link:
- https://docs.kargo.io/user-guide/reference-docs/promotion-steps/git-open-pr/#configuration