### PR TITLE
fix(ui): pr link in promotion task

### DIFF
--- a/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
+++ b/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
@@ -29,11 +29,7 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
     getPromotion,
     { project: props.stage?.metadata?.namespace, name: currentPromotion },
     {
-      enabled:
-        !!currentPromotion &&
-        !!props.stage?.spec?.promotionTemplate?.spec?.steps?.find(
-          (step) => step?.uses === 'git-open-pr'
-        )
+      enabled: !!currentPromotion
     }
   );
 


### PR DESCRIPTION
the condition was falsy because we couldn't find git-open-pr step in raw promotion task, it was referenced in PromotionTask that UI didn't know