### PR TITLE
chore: Updated grpc health probe to v0.4.41

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ARG TARGETARCH
 
 WORKDIR /tools
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.41 && \
     curl -fL -o /tools/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
     chmod +x /tools/grpc_health_probe
 


### PR DESCRIPTION
the GRPC Health probe version that we are currently using has some CVEs, this updates us to the latest one.