### PR TITLE
fix(controller): Avoid panic when config is not set

### DIFF
--- a/pkg/event/promotion.go
+++ b/pkg/event/promotion.go
@@ -425,6 +425,10 @@ func newPromotion(
 			continue
 		}
 		var cfg builtin.ArgoCDUpdateConfig
+		if step.Config == nil {
+			continue
+		}
+
 		if err := json.Unmarshal(step.Config.Raw, &cfg); err != nil {
 			continue
 		}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -224,11 +224,16 @@ func RunningPromotionsByArgoCDApplications(
 				continue
 			}
 
+			var rawConfig []byte
+			if step.Config != nil {
+				rawConfig = step.Config.Raw
+			}
+
 			dirStep := promotion.Step{
 				Kind:   step.Uses,
 				Alias:  step.As,
 				Vars:   step.Vars,
-				Config: step.Config.Raw,
+				Config: rawConfig,
 			}
 
 			evaluator := promotion.NewStepEvaluator(cl, nil)

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -263,6 +263,10 @@ type Step struct {
 func NewSteps(promo *kargoapi.Promotion) []Step {
 	result := make([]Step, len(promo.Spec.Steps))
 	for i, step := range promo.Spec.Steps {
+		var rawConfig []byte
+		if step.Config != nil {
+			rawConfig = step.Config.Raw
+		}
 		result[i] = Step{
 			Kind:            step.Uses,
 			Alias:           step.As,
@@ -270,7 +274,7 @@ func NewSteps(promo *kargoapi.Promotion) []Step {
 			ContinueOnError: step.ContinueOnError,
 			Retry:           step.Retry,
 			Vars:            step.Vars,
-			Config:          step.Config.Raw,
+			Config:          rawConfig,
 		}
 	}
 	return result


### PR DESCRIPTION
When I accidentally munged a step config recently and it was omitted, it triggered a step panic. This makes sure to check if a step's `Config` field is not `nil` before trying to do anything with it