### PR TITLE
feat: add ui_for_url expression function for generating Kargo UI URLs (#4585)

### DIFF
--- a/pkg/expressions/function/functions_test.go
+++ b/pkg/expressions/function/functions_test.go
@@ -1870,7 +1870,40 @@ func Test_semverDiff(t *testing.T) {
 	}
 }
 
-func Test_uiForURL(t *testing.T) {
+func Test_linkForProject(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []any
+		assertions func(t *testing.T, result any, err error)
+	}{
+		{
+			name: "no arguments",
+			args: []any{},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://kargo.example.com/project/my-project", result)
+			},
+		},
+		{
+			name: "with arguments",
+			args: []any{"extra"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "expected 0 arguments, got 1")
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := getProjectLink("https://kargo.example.com", "my-project")
+			result, err := fn(tt.args...)
+			tt.assertions(t, result, err)
+		})
+	}
+}
+
+func Test_linkForStage(t *testing.T) {
 	tests := []struct {
 		name       string
 		args       []any
@@ -1920,7 +1953,121 @@ func Test_uiForURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fn := getUIForURL("https://kargo.example.com", "my-project", "my-stage")
+			fn := getStageLink("https://kargo.example.com", "my-project", "my-stage")
+			result, err := fn(tt.args...)
+			tt.assertions(t, result, err)
+		})
+	}
+}
+
+func Test_linkForFreight(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []any
+		assertions func(t *testing.T, result any, err error)
+	}{
+		{
+			name: "no arguments",
+			args: []any{},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://kargo.example.com/project/my-project/freight/freight-123", result)
+			},
+		},
+		{
+			name: "with freight ID",
+			args: []any{"freight-456"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://kargo.example.com/project/my-project/freight/freight-456", result)
+			},
+		},
+		{
+			name: "too many arguments",
+			args: []any{"freight1", "freight2"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "expected 0 or 1 arguments, got 2")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "invalid argument type",
+			args: []any{123},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "argument must be string, got int")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "empty freight ID",
+			args: []any{""},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "freight ID must not be empty")
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := getFreightLink("https://kargo.example.com", "my-project", "freight-123")
+			result, err := fn(tt.args...)
+			tt.assertions(t, result, err)
+		})
+	}
+}
+
+func Test_linkForPromotion(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []any
+		assertions func(t *testing.T, result any, err error)
+	}{
+		{
+			name: "no arguments",
+			args: []any{},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://kargo.example.com/project/my-project/promotion/my-promo", result)
+			},
+		},
+		{
+			name: "with promotion name",
+			args: []any{"promo-2"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://kargo.example.com/project/my-project/promotion/promo-2", result)
+			},
+		},
+		{
+			name: "too many arguments",
+			args: []any{"p1", "p2"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "expected 0 or 1 arguments, got 2")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "invalid argument type",
+			args: []any{123},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "argument must be string, got int")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "empty promotion name",
+			args: []any{""},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "promotion name must not be empty")
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := getPromotionLink("https://kargo.example.com", "my-project", "my-promo")
 			result, err := fn(tt.args...)
 			tt.assertions(t, result, err)
 		})

--- a/pkg/promotion/evaluator.go
+++ b/pkg/promotion/evaluator.go
@@ -145,7 +145,8 @@ func (p *StepEvaluator) Vars(ctx context.Context, promoCtx Context, step Step) (
 			ctx, p.client, promoCtx.Project, promoCtx.FreightRequests, promoCtx.Freight.References(),
 		),
 		exprfn.UtilityOperations(),
-		exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage),
+		exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage, promoCtx.TargetFreightRef.Name, promoCtx.Promotion),
+
 	)
 
 	// Evaluate the global variables defined in the Promotion itself, these
@@ -225,7 +226,9 @@ func (p *StepEvaluator) ShouldSkip(ctx context.Context, promoCtx Context, step S
 			),
 			exprfn.StatusOperations(step.Alias, promoCtx.StepExecutionMetadata),
 			exprfn.UtilityOperations(),
-			exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage),
+
+			exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage, promoCtx.TargetFreightRef.Name, promoCtx.Promotion),
+
 		)...,
 	)
 	if err != nil {
@@ -277,7 +280,9 @@ func (p *StepEvaluator) Config(ctx context.Context, promoCtx Context, step Step)
 			exprfn.DataOperations(ctx, p.client, p.cache, promoCtx.Project),
 			exprfn.StatusOperations(step.Alias, promoCtx.StepExecutionMetadata),
 			exprfn.UtilityOperations(),
-			exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage),
+
+			exprfn.PromotionOperations(promoCtx.UIBaseURL, promoCtx.Project, promoCtx.Stage, promoCtx.TargetFreightRef.Name, promoCtx.Promotion),
+
 		)...,
 	)
 	if err != nil {


### PR DESCRIPTION
## 🎯 Overview

This Pr Resolves #4585 , implements the `ui_for_url()` expression function as requested in [issue #4585](https://github.com/akuity/kargo/issues/4585) to enable dynamic URL generation for Kargo UI resources in promotion expressions.

## 🔧 Changes Made

### **Core Implementation**
- **Added `UIForURL` function** in `pkg/expressions/function/functions.go`
  - Supports zero or one argument: `ui_for_url()` or `ui_for_url(stageName)`
  - Uses closure pattern similar to `Secret` function for context access
  - Returns actual URLs, not templates

### **Context Integration**
- **Added `UIBaseURL` to promotion context** in `pkg/promotion/evaluator.go`
  - Makes `ctx.UIBaseURL` available in all expressions
  - Integrated with existing expression evaluation pipeline

### **Function Organization**
- **Created `PromotionOperations`** to group promotion-specific functions
  - Follows same pattern as `DataOperations` and `FreightOperations`
  - Added to all expression evaluation points



## 📝 Usage Examples

```yaml
# Using current stage from promotion context
"Freight ${{ ctx.targetFreight.name }} is being promoted to Stage <${{ ui_for_url() }}|${{ ctx.stage }}>"

# Using specific stage name
"Freight ${{ ctx.targetFreight.name }} is being promoted to Stage <${{ ui_for_url('production') }}|${{ ctx.stage }}>"

# Direct usage in Slack notifications
"Check the stage: ${{ ui_for_url() }}"
"Check production: ${{ ui_for_url('production') }}"
```


**Resolves:** [issue #4585](https://github.com/akuity/kargo/issues/4585)

**Related:** This implementation addresses the exact use case described in the issue for Slack deployment notifications with dynamic UI links.

