### PR TITLE
chore(backport release-1.8): fix(controller): Avoid panic when config is not set

### DIFF
--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -510,6 +510,10 @@ func (r *reconciler) promote(
 	// Prepare promotion steps and vars for the promotion execution engine.
 	steps := make([]promotion.Step, len(workingPromo.Spec.Steps))
 	for i, step := range workingPromo.Spec.Steps {
+		var rawConfig []byte
+		if step.Config != nil {
+			rawConfig = step.Config.Raw
+		}
 		steps[i] = promotion.Step{
 			Kind:            step.Uses,
 			Alias:           step.As,
@@ -517,7 +521,7 @@ func (r *reconciler) promote(
 			ContinueOnError: step.ContinueOnError,
 			Retry:           step.Retry,
 			Vars:            step.Vars,
-			Config:          step.Config.Raw,
+			Config:          rawConfig,
 		}
 	}
 

--- a/pkg/event/promotion.go
+++ b/pkg/event/promotion.go
@@ -425,6 +425,10 @@ func newPromotion(
 			continue
 		}
 		var cfg builtin.ArgoCDUpdateConfig
+		if step.Config == nil {
+			continue
+		}
+
 		if err := json.Unmarshal(step.Config.Raw, &cfg); err != nil {
 			continue
 		}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -224,11 +224,16 @@ func RunningPromotionsByArgoCDApplications(
 				continue
 			}
 
+			var rawConfig []byte
+			if step.Config != nil {
+				rawConfig = step.Config.Raw
+			}
+
 			dirStep := promotion.Step{
 				Kind:   step.Uses,
 				Alias:  step.As,
 				Vars:   step.Vars,
-				Config: step.Config.Raw,
+				Config: rawConfig,
 			}
 
 			// As step-level variables are allowed to reference to output, we


### PR DESCRIPTION
Manual backport of #5242 due to merge conflicts.