### PR TITLE
chore(deps): bump golang from 1.25.2-trixie to 1.25.3-trixie

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in
@@ -81,7 +81,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -104,7 +104,7 @@ jobs:
   lint-charts:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -129,7 +129,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -152,7 +152,7 @@ jobs:
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -228,7 +228,7 @@ jobs:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,7 +177,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -256,7 +256,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.2-trixie
+      image: golang:1.25.3-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.25.2-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.3-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.2-trixie
+FROM golang:1.25.3-trixie
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Manual backport of #5246 due to workflow changes.