### PR TITLE
fix(controller): adapt ecr cred providers for the fact that repo urls are now pre-normalized

### DIFF
--- a/pkg/credentials/kubernetes/ecr/access_key.go
+++ b/pkg/credentials/kubernetes/ecr/access_key.go
@@ -49,10 +49,6 @@ func (p *AccessKeyProvider) Supports(
 		return false
 	}
 
-	if credType == credentials.TypeHelm && !strings.HasPrefix(repoURL, "oci://") {
-		return false
-	}
-
 	if matches := ecrURLRegex.FindStringSubmatch(repoURL); len(matches) != 2 {
 		return false
 	}

--- a/pkg/credentials/kubernetes/ecr/access_key_test.go
+++ b/pkg/credentials/kubernetes/ecr/access_key_test.go
@@ -21,8 +21,7 @@ func TestNewAccessKeyProvider(t *testing.T) {
 
 func TestAccessKeyProvider_Supports(t *testing.T) {
 	const (
-		fakeRepoURL    = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
-		fakeOCIRepoURL = "oci://123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
+		fakeRepoURL = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
 
 		fakeRegion = "us-west-2"
 		fakeID     = "AKIAIOSFODNN7EXAMPLE"                     // nolint:gosec
@@ -50,7 +49,7 @@ func TestAccessKeyProvider_Supports(t *testing.T) {
 		{
 			name:     "valid helm oci credentials",
 			credType: credentials.TypeHelm,
-			repoURL:  fakeOCIRepoURL,
+			repoURL:  fakeRepoURL,
 			data: map[string][]byte{
 				regionKey: []byte(fakeRegion),
 				idKey:     []byte(fakeID),

--- a/pkg/credentials/kubernetes/ecr/common.go
+++ b/pkg/credentials/kubernetes/ecr/common.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ecrURLRegex is a regex that matches ECR URLs.
-var ecrURLRegex = regexp.MustCompile(`^(?:oci://)?[0-9]{12}\.dkr\.ecr\.(.+)\.amazonaws\.com/`)
+var ecrURLRegex = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr\.(.+)\.amazonaws\.com/`)
 
 // tokenCacheKey returns a cache key in the form of a hash for the given parts.
 // Using a hash ensures that any sensitive data is not stored in a decodable

--- a/pkg/credentials/kubernetes/ecr/managed_identity.go
+++ b/pkg/credentials/kubernetes/ecr/managed_identity.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -82,7 +81,7 @@ func NewManagedIdentityProvider(ctx context.Context) credentials.Provider {
 
 func (p *ManagedIdentityProvider) Supports(
 	credType credentials.Type,
-	repoURL string,
+	_ string,
 	_ map[string][]byte,
 	_ map[string]string,
 ) bool {
@@ -91,10 +90,6 @@ func (p *ManagedIdentityProvider) Supports(
 	}
 
 	if credType != credentials.TypeImage && credType != credentials.TypeHelm {
-		return false
-	}
-
-	if credType == credentials.TypeHelm && !strings.HasPrefix(repoURL, "oci://") {
 		return false
 	}
 

--- a/pkg/credentials/kubernetes/ecr/managed_identity_test.go
+++ b/pkg/credentials/kubernetes/ecr/managed_identity_test.go
@@ -14,9 +14,8 @@ import (
 
 func TestManagedIdentityProvider_Supports(t *testing.T) {
 	const (
-		fakeAccountID  = "123456789012"
-		fakeRepoURL    = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
-		fakeOCIRepoURL = "oci://123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
+		fakeAccountID = "123456789012"
+		fakeRepoURL   = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
 	)
 
 	testCases := []struct {
@@ -45,22 +44,13 @@ func TestManagedIdentityProvider_Supports(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "OCI helm credentials supported",
+			name: "helm credentials supported",
 			provider: &ManagedIdentityProvider{
 				accountID: fakeAccountID,
 			},
 			credType: credentials.TypeHelm,
-			repoURL:  fakeOCIRepoURL,
+			repoURL:  fakeRepoURL,
 			expected: true,
-		},
-		{
-			name: "non-OCI helm credentials not supported",
-			provider: &ManagedIdentityProvider{
-				accountID: fakeAccountID,
-			},
-			credType: credentials.TypeHelm,
-			repoURL:  "https://123456789012.dkr.ecr.us-west-2.amazonaws.com/repo",
-			expected: false,
 		},
 		{
 			name: "git credentials not supported",


### PR DESCRIPTION
Fixes #5261 

Since #4995 we are normalizing repo URLs before passing them to credential providers. The credential providers for ECR "didn't get the memo." 

OCI chart repo normalization _drops_ any leading `oci://`. Provider predicates for the ECR providers, assuming they were still receiving not-yet-normalized repo URLs, were also still expecting that valid OCI chart repo URLs must begin with `oci://`. (This is how users enter such URLs to mirror how Helm does things.)

I plan to cut a v1.8.1 with this fix.