### PR TITLE
fix: correct mouse wheel scroll direction in freight timeline

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -191,12 +191,11 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
             'overflow-hidden': !dndContext.active
           })}
           onWheel={(e) => {
-            if (e.deltaX > 0) {
+            if (e.deltaY > 0) {
               scrollCarouselRight();
-              return;
+            } else if (e.deltaY < 0) {
+              scrollCarouselLeft();
             }
-
-            scrollCarouselLeft();
           }}
         >
           <div className='flex gap-1 relative right-0' ref={freightListStyleRef}>


### PR DESCRIPTION
The onWheel handler was checking e.deltaX instead of e.deltaY, causing both wheel up and wheel down to scroll left.

Changed to check e.deltaY so:
- Wheel down (positive deltaY) scrolls right
- Wheel up (negative deltaY) scrolls left

Fixes #5271

I tested this command with using the DevTools in the browser with the following snippet of js:
```
const timeline = document.querySelector('.freightTimeline');
const newTimeline = timeline.cloneNode(true);
timeline.parentNode.replaceChild(newTimeline, timeline);

const movingElements = newTimeline.querySelectorAll('.flex.gap-1.relative');

newTimeline.addEventListener('wheel', (e) => {
  e.preventDefault();
  
  movingElements.forEach(el => {
    const currentRight = parseInt(el.style.right) || 0;
    // Correctly apply deltaY - positive scrolls left, negative scrolls right
    const newRight = Math.max(0, currentRight + (e.deltaY * 0.7));
    el.style.right = newRight + 'px';
  });
  
}, { passive: false });

console.log('Fixed freight timeline scroll direction!');
```

I was unable to test this locally. 