### PR TITLE
feat(ui): update trigger behavior for promotion dropdown

### DIFF
--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -279,7 +279,7 @@ export const StageNode = (props: { stage: Stage }) => {
             <span className='text-xs text-wrap mr-auto'>{props.stage.metadata?.name}</span>
             <Space>
               <Dropdown
-                trigger={['hover']}
+                trigger={['click']}
                 overlayClassName='w-fit'
                 menu={{
                   items: dropdownItems


### PR DESCRIPTION
The dropdown with one item looks like a tooltip, which may confuse some users.

<img width="151" height="142" alt="image" src="https://github.com/user-attachments/assets/ab9478a3-024d-4689-bb50-f06aa4db29c7" />
