### PR TITLE
chore: add note about niche chart options to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,6 +8,8 @@ labels:
 assignees: ''
 ---
 
+__Note:__ If you're requesting a Helm chart option that may be very niche and not useful to the community at large, please consider using Kustomize to apply "last mile" tweaks to the output of `helm template` to suit your needs instead.
+
 # Checklist
 
 * [ ] I've searched the issue queue to verify this is not a duplicate feature request.


### PR DESCRIPTION
Discussed during this morning's issue triage meeting. No one is keen on having to maintain a succession options used by only one or two users each to satisfy very niche use cases.