### PR TITLE
feat(devx): set up shared credentials ns when running with tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -68,6 +68,9 @@ k8s_yaml(
 # of the UI, so we're breaking it out into its own separate deployment here.
 k8s_yaml('hack/tilt/ui.yaml')
 
+# Setup a namespace and controller permissions for shared credentials.
+k8s_yaml('hack/tilt/shared-creds.yaml')
+
 k8s_resource(
   new_name = 'common',
   labels = ['kargo'],
@@ -133,7 +136,9 @@ k8s_resource(
     'kargo-controller-argocd:clusterrolebinding',
     'kargo-controller-read-secrets:clusterrole',
     'kargo-controller-rollouts:clusterrole',
-    'kargo-controller-rollouts:clusterrolebinding'
+    'kargo-controller-rollouts:clusterrolebinding',
+    'kargo-controller-read-secrets:rolebinding',
+    'kargo-shared-credentials:namespace'
   ],
   resource_deps=['back-end-compile', 'credential-helper-compile', ]
 )

--- a/hack/tilt/shared-creds.yaml
+++ b/hack/tilt/shared-creds.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kargo-shared-credentials
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kargo-controller-read-secrets
+    namespace: kargo-shared-credentials
+subjects:
+    - kind: ServiceAccount
+      name: kargo-controller
+      namespace: kargo
+roleRef:
+    kind: ClusterRole
+    name: kargo-controller-read-secrets
+    apiGroup: rbac.authorization.k8s.io

--- a/hack/tilt/values.dev.yaml
+++ b/hack/tilt/values.dev.yaml
@@ -33,6 +33,9 @@ api:
         - kilgore@kilgore.trout
 controller:
   logLevel: DEBUG
+  globalCredentials:
+    namespaces:
+    - kargo-shared-credentials
 crds:
   install: true
 externalWebhooksServer:


### PR DESCRIPTION
As a contributor convenience, this sets up a shared credentials namespace when running from source with Tilt.