### PR TITLE
fix(promotion): log format `argocd-update` step

### DIFF
--- a/pkg/promotion/runner/builtin/argocd_updater.go
+++ b/pkg/promotion/runner/builtin/argocd_updater.go
@@ -182,20 +182,14 @@ func (a *argocdUpdater) run(
 			DesiredRevisions: desiredRevisions,
 		}
 
+		appLogger := logger.WithValues("app", app.Name, "namespace", app.Namespace)
+
 		// Check if the update needs to be performed and retrieve its phase.
 		phase, mustUpdate, err := a.mustPerformUpdateFn(ctx, stepCtx, update, app)
 		if mustUpdate {
-			logger.Info(
-				"Argo CD Application requires update",
-				"name", app.Name,
-				"namespace", app.Namespace,
-			)
+			appLogger.Info("Argo CD Application requires update")
 		} else {
-			logger.Info(
-				"Argo CD Application does not require update",
-				"name", app.Name,
-				"namespace", app.Namespace,
-			)
+			logger.Info("Argo CD Application does not require update")
 		}
 
 		// If we have a phase, append it to the results.
@@ -212,13 +206,9 @@ func (a *argocdUpdater) run(
 					// this update by waiting.
 					return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
 				}
-				// Log the error as a warning, but continue to the next update.
-				logger.Info(
-					"reason for not updating",
-					"name", app.Name,
-					"namespace", app.Namespace,
-					"reason", err.Error(),
-				)
+				// Log the error for observability but continue processing other
+				// updates.
+				appLogger.Info("Argo CD Application update cannot be performed", "reason", err.Error())
 			}
 			if phase.Failed() {
 				// Record the reason for the failure if available.
@@ -242,10 +232,7 @@ func (a *argocdUpdater) run(
 		// Log the error, as it contains information about why we need to
 		// perform an update.
 		if err != nil {
-			logger.Info(
-				"reason for updating Argo CD Application %q in namespace %q: %s",
-				app.Name, app.Namespace, err.Error(),
-			)
+			appLogger.Info("performing update of Argo CD Application", "reason", err.Error())
 		}
 
 		// Build the desired source(s) for the Argo CD Application.


### PR DESCRIPTION
Without this, the following is logged:

```json
{
  "level": "DPANIC",
  "ts": "2025-10-30T12:30:17Z",
  "caller": "builtin/argocd_updater.go:245",
  "msg": "odd number of arguments passed as key-value pairs for logging",
  "ignored key": "sync result revisions [90f98ef8bf8f4ccc4088df3e9bd53409175621dc] do not match desired revisions [09/stage/test]",
  "stacktrace": "github.com/akuity/kargo/pkg/promotion/runner/builtin.(*argocdUpdater).run\n\t/pkg/promotion/runner/builtin/argocd_updater.go:245\ngithub.com/akuity/kargo/pkg/promotion/runner/builtin.(*argocdUpdater).Run\n\t/pkg/promotion/runner/builtin/argocd_updater.go:133\ngithub.com/akuity/kargo/pkg/promotion.(*LocalStepExecutor).ExecuteStep.func1\n\t/pkg/promotion/local_executor.go:79\ngithub.com/akuity/kargo/pkg/promotion.(*LocalStepExecutor).ExecuteStep\n\t/pkg/promotion/local_executor.go:80\ngithub.com/akuityio/kargo-enterprise/internal/promotion.(*FileStepExecutor).executeStepWithAbortMonitoring.func1\n\t/internal/promotion/file_executor.go:414"
}
{
  "level": "DEBUG",
  "ts": "2025-10-30T12:30:17Z",
  "caller": "builtin/argocd_updater.go:597",
  "msg": "patched Argo CD Application",
  "app": "kargo-demo-09-test"
}
```

Follow up to: #5297