### PR TITLE
chore: Fix tag positioning for beta/prod tags

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-dispatch-workflow.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-dispatch-workflow.md
@@ -3,9 +3,10 @@ sidebar_label: gha-dispatch-workflow
 description: Dispatches GitHub Actions workflows using the workflow_dispatch event.
 ---
 
+# `gha-dispatch-workflow`
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-# `gha-dispatch-workflow`
 
 :::info
 This promotion step is only available in Kargo on the [Akuity Platform](https://akuity.io/akuity-platform), versions v1.8 and above.
@@ -17,9 +18,9 @@ The `gha-dispatch-workflow` promotion step provides integration with GitHub Acti
 
 All GitHub Actions operations require proper authentication credentials stored in a Kubernetes `Secret`.
 
-| Name                       | Type     | Required | Description                                                                          |
-|----------------------------|----------|----------|--------------------------------------------------------------------------------------|
-| `credentials.secretName`   | `string` | Y        | Name of the `Secret` containing the GitHub credentials in the project namespace.     |
+| Name                     | Type     | Required | Description                                                                      |
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------------- |
+| `credentials.secretName` | `string` | Y        | Name of the `Secret` containing the GitHub credentials in the project namespace. |
 
 The referenced `Secret` should contain the following keys:
 
@@ -40,19 +41,19 @@ The GitHub token must have the following permissions:
 
 ## Configuration
 
-| Name            | Type      | Required | Description                                                                                                 |
-|-----------------|-----------|----------|-------------------------------------------------------------------------------------------------------------|
-| `owner`         | `string`  | Y        | The owner of the repository (user or organization).                                                         |
-| `repo`          | `string`  | Y        | The name of the repository.                                                                                 |
-| `workflowFile`  | `string`  | Y        | The workflow filename in .github/workflows (e.g., 'deploy.yml').                                                                |
-| `ref`           | `string`  | Y        | The git reference (branch or tag) to run the workflow on.                                                  |
-| `inputs`        | `object`  | N        | Input parameters to pass to the workflow as defined in the workflow's `workflow_dispatch` inputs.          |
-| `timeout`       | `integer` | N        | Timeout in seconds to wait for the workflow run to be created after dispatch (default: 60, max: 300).     |
+| Name           | Type      | Required | Description                                                                                           |
+| -------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `owner`        | `string`  | Y        | The owner of the repository (user or organization).                                                   |
+| `repo`         | `string`  | Y        | The name of the repository.                                                                           |
+| `workflowFile` | `string`  | Y        | The workflow filename in .github/workflows (e.g., 'deploy.yml').                                      |
+| `ref`          | `string`  | Y        | The git reference (branch or tag) to run the workflow on.                                             |
+| `inputs`       | `object`  | N        | Input parameters to pass to the workflow as defined in the workflow's `workflow_dispatch` inputs.     |
+| `timeout`      | `integer` | N        | Timeout in seconds to wait for the workflow run to be created after dispatch (default: 60, max: 300). |
 
 ## Output
 
-| Name    | Type      | Description                                                               |
-|---------|-----------|---------------------------------------------------------------------------|
+| Name    | Type      | Description                                                                 |
+| ------- | --------- | --------------------------------------------------------------------------- |
 | `runID` | `integer` | The ID of the dispatched workflow run that can be used for status tracking. |
 
 ## Example

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
@@ -3,9 +3,10 @@ sidebar_label: gha-wait-for-workflow
 description: Waits for GitHub Actions workflow runs to complete with optional status validation.
 ---
 
+# `gha-wait-for-workflow`
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-# `gha-wait-for-workflow`
 
 :::info
 This promotion step is only available in Kargo on the [Akuity Platform](https://akuity.io/akuity-platform), versions v1.8 and above.
@@ -17,9 +18,9 @@ The `gha-wait-for-workflow` promotion step provides integration with GitHub Acti
 
 All GitHub Actions operations require proper authentication credentials stored in a Kubernetes `Secret`.
 
-| Name                       | Type     | Required | Description                                                                          |
-|----------------------------|----------|----------|--------------------------------------------------------------------------------------|
-| `credentials.secretName`   | `string` | Y        | Name of the `Secret` containing the GitHub credentials in the project namespace.     |
+| Name                     | Type     | Required | Description                                                                      |
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------------- |
+| `credentials.secretName` | `string` | Y        | Name of the `Secret` containing the GitHub credentials in the project namespace. |
 
 The referenced `Secret` should contain the following keys:
 
@@ -39,11 +40,11 @@ The GitHub token must have the following permissions:
 
 ## Configuration
 
-| Name                 | Type      | Required | Description                                                                         |
-|----------------------|-----------|----------|-------------------------------------------------------------------------------------|
-| `owner`              | `string`  | Y        | The owner of the repository (user or organization).                                 |
-| `repo`               | `string`  | Y        | The name of the repository.                                                         |
-| `runID`              | `integer` | Y        | The workflow run ID to wait for.                                                    |
+| Name                 | Type      | Required | Description                                                                                |
+| -------------------- | --------- | -------- | ------------------------------------------------------------------------------------------ |
+| `owner`              | `string`  | Y        | The owner of the repository (user or organization).                                        |
+| `repo`               | `string`  | Y        | The name of the repository.                                                                |
+| `runID`              | `integer` | Y        | The workflow run ID to wait for.                                                           |
 | `expectedConclusion` | `string`  | N        | The expected final conclusion status. If not provided, conclusion status is not validated. |
 
 Valid values for `expectedConclusion`:
@@ -58,8 +59,8 @@ Valid values for `expectedConclusion`:
 
 ## Output
 
-| Name         | Type     | Description                                                    |
-|--------------|----------|----------------------------------------------------------------|
+| Name         | Type     | Description                                                       |
+| ------------ | -------- | ----------------------------------------------------------------- |
 | `conclusion` | `string` | The final conclusion status of the workflow run after completion. |
 
 ## Example

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-merge-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-merge-pr.md
@@ -3,21 +3,22 @@ sidebar_label: git-merge-pr
 description: Merges an open pull request.
 ---
 
-<span class="tag beta"></span>
 # `git-merge-pr`
+
+<span class="tag beta"></span>
 
 `git-merge-pr` merges an open pull request. This step commonly follows a
 [`git-open-pr`](git-open-pr.md) step.
 
 ## Configuration
 
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `repoURL` | `string` | Y | The URL of a remote Git repository. |
-| `provider` | `string` | N | The name of the Git provider to use. Currently `azure`, `bitbucket`, `gitea`, `github`, and `gitlab` are supported. Kargo will try to infer the provider if it is not explicitly specified. |
-| `insecureSkipTLSVerify` | `boolean` | N | Indicates whether to bypass TLS certificate verification when interfacing with the Git provider. Setting this to `true` is highly discouraged in production. |
-| `prNumber` | `integer` | Y | The pull request number to merge. |
-| `wait` | `boolean` | N | If `true`, the step will return a running status instead of failing when the PR is not yet mergeable. The merge will be retried on the next reconciliation until it succeeds or times out. Default is `false`. |
+| Name                    | Type      | Required | Description                                                                                                                                                                                                    |
+| ----------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repoURL`               | `string`  | Y        | The URL of a remote Git repository.                                                                                                                                                                            |
+| `provider`              | `string`  | N        | The name of the Git provider to use. Currently `azure`, `bitbucket`, `gitea`, `github`, and `gitlab` are supported. Kargo will try to infer the provider if it is not explicitly specified.                    |
+| `insecureSkipTLSVerify` | `boolean` | N        | Indicates whether to bypass TLS certificate verification when interfacing with the Git provider. Setting this to `true` is highly discouraged in production.                                                   |
+| `prNumber`              | `integer` | Y        | The pull request number to merge.                                                                                                                                                                              |
+| `wait`                  | `boolean` | N        | If `true`, the step will return a running status instead of failing when the PR is not yet mergeable. The merge will be retried on the next reconciliation until it succeeds or times out. Default is `false`. |
 
 :::warning
 The `wait` option is unreliable for repositories hosted by Bitbucket due to API limitations.
@@ -25,8 +26,8 @@ The `wait` option is unreliable for repositories hosted by Bitbucket due to API 
 
 ## Output
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name     | Type     | Description                                                                                                                                                                                                                                                                                                             |
+| -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `commit` | `string` | The ID (SHA) of the merge commit created after successfully merging the pull request. Typically, a subsequent [`argocd-update`](argocd-update.md) step will reference this output to learn the ID of the commit that an applicable Argo CD `ApplicationSource` should be observably synced to under healthy conditions. |
 
 ## Examples

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
@@ -3,9 +3,10 @@ sidebar_label: jfrog-evidence
 description: Manages evidence creation, verification, and deletion for artifacts in JFrog Artifactory.
 ---
 
+# `jfrog-evidence`
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-# `jfrog-evidence`
 
 :::info
 This promotion step is only available in Kargo on the [Akuity Platform](https://akuity.io/akuity-platform), versions v1.7 and above.
@@ -22,9 +23,9 @@ For more information about JFrog's Evidence feature, see the [official JFrog Evi
 
 All JFrog Evidence operations require proper authentication credentials stored in a Kubernetes `Secret`.
 
-| Name                     | Type     | Required | Description                                                                                                                  |
-| ------------------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `credentials.secretName` | `string` | Y        | Name of the `Secret` containing the JFrog credentials in the project namespace.                                                                        |
+| Name                     | Type     | Required | Description                                                                     |
+| ------------------------ | -------- | -------- | ------------------------------------------------------------------------------- |
+| `credentials.secretName` | `string` | Y        | Name of the `Secret` containing the JFrog credentials in the project namespace. |
 
 The referenced `Secret` should contain the following keys:
 
@@ -40,20 +41,20 @@ Creates cryptographically signed kargo promotion evidence for an artifact in JFr
 
 #### Configuration
 
-| Name                      | Type     | Required | Description                                                                                                     |
-| ------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `create.privateKey`       | `string` | Y        | The private key to sign the evidence.                                                                           |
-| `create.packageRepo`      | `string` | Y        | The package repository name of the artifact.                                                                    |
-| `create.packageName`      | `string` | Y        | The package name of the artifact inside the repository.                                                         |
-| `create.packageVersion`   | `string` | Y        | The package version of the artifact.                                                                            |
-| `create.promotionStatus`  | `string` | Y        | Status indicating the promotion state. Valid values: `Pending`, `Running`, `Succeeded`, `Failed`, `Errored`, `Aborted`. |
-| `create.privateKeyAlias`  | `string` | N        | Name for the public key created from the private key. Used for verification. If omitted, verification is skipped. |
-| `create.metadata`         | `object` | N        | JSON metadata that will be stored inside the evidence predicate.                                                |
+| Name                     | Type     | Required | Description                                                                                                             |
+| ------------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `create.privateKey`      | `string` | Y        | The private key to sign the evidence.                                                                                   |
+| `create.packageRepo`     | `string` | Y        | The package repository name of the artifact.                                                                            |
+| `create.packageName`     | `string` | Y        | The package name of the artifact inside the repository.                                                                 |
+| `create.packageVersion`  | `string` | Y        | The package version of the artifact.                                                                                    |
+| `create.promotionStatus` | `string` | Y        | Status indicating the promotion state. Valid values: `Pending`, `Running`, `Succeeded`, `Failed`, `Errored`, `Aborted`. |
+| `create.privateKeyAlias` | `string` | N        | Name for the public key created from the private key. Used for verification. If omitted, verification is skipped.       |
+| `create.metadata`        | `object` | N        | JSON metadata that will be stored inside the evidence predicate.                                                        |
 
 #### Output
 
-| Name   | Type     | Description                                                   |
-| ------ | -------- | ------------------------------------------------------------- |
+| Name   | Type     | Description                                                      |
+| ------ | -------- | ---------------------------------------------------------------- |
 | `name` | `string` | The name/identifier of the created evidence for later reference. |
 
 
@@ -109,12 +110,12 @@ Removes specific evidence from an artifact in JFrog Artifactory. This is typical
 
 #### Configuration
 
-| Name                     | Type     | Required | Description                                       |
-| ------------------------ | -------- | -------- | ------------------------------------------------- |
-| `delete.packageRepo`     | `string` | Y        | The package repository name of the artifact.      |
-| `delete.packageName`     | `string` | Y        | The package name of the artifact inside the repository. |
-| `delete.packageVersion`  | `string` | Y        | The package version of the artifact.              |
-| `delete.evidenceName`    | `string` | Y        | Evidence name/identifier to delete.               |
+| Name                    | Type     | Required | Description                                             |
+| ----------------------- | -------- | -------- | ------------------------------------------------------- |
+| `delete.packageRepo`    | `string` | Y        | The package repository name of the artifact.            |
+| `delete.packageName`    | `string` | Y        | The package name of the artifact inside the repository. |
+| `delete.packageVersion` | `string` | Y        | The package version of the artifact.                    |
+| `delete.evidenceName`   | `string` | Y        | Evidence name/identifier to delete.                     |
 
 #### Output
 
@@ -145,19 +146,19 @@ Queries for existing evidence and verifies its authenticity and content. This op
 
 #### Configuration
 
-| Name                                  | Type      | Required | Description                                                                                                    |
-| ------------------------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| `process.query.packageRepo`           | `string`  | Y        | The package repository name of the artifact.                                                                   |
-| `process.query.packageName`           | `string`  | Y        | The package name of the artifact inside the repository.                                                        |
-| `process.query.packageVersion`        | `string`  | Y        | The package version of the artifact.                                                                           |
-| `process.query.evidenceNameRegex`     | `string`  | N*       | Regular expression to match evidence names. *Either this or `predicateType` is required.                       |
-| `process.query.predicateType`         | `string`  | N*       | The predicate type to query for. *Either this or `evidenceNameRegex` is required.                             |
-| `process.verify.verifyExpression`     | `string`  | N**      | Expr expression to evaluate on the predicate. Must return boolean. **One of the verify options is required.   |
-| `process.verify.localKeys`            | `array`   | N**      | Local private/public keys for signature verification. **One of the verify options is required.                |
-| `process.verify.useArtifactoryKeys`   | `boolean` | N**      | Use keys present in evidence data for verification. **One of the verify options is required.                  |
-| `process.outputs`                     | `array`   | N        | Output configurations to extract data from evidence results.                                                   |
-| `process.outputs[].name`              | `string`  | Y        | Name of the output variable.                                                                                   |
-| `process.outputs[].expression`        | `string`  | Y        | Expr expression to extract data from evidence query results.                                                   |
+| Name                                | Type      | Required | Description                                                                                                 |
+| ----------------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `process.query.packageRepo`         | `string`  | Y        | The package repository name of the artifact.                                                                |
+| `process.query.packageName`         | `string`  | Y        | The package name of the artifact inside the repository.                                                     |
+| `process.query.packageVersion`      | `string`  | Y        | The package version of the artifact.                                                                        |
+| `process.query.evidenceNameRegex`   | `string`  | N*       | Regular expression to match evidence names. *Either this or `predicateType` is required.                    |
+| `process.query.predicateType`       | `string`  | N*       | The predicate type to query for. *Either this or `evidenceNameRegex` is required.                           |
+| `process.verify.verifyExpression`   | `string`  | N**      | Expr expression to evaluate on the predicate. Must return boolean. **One of the verify options is required. |
+| `process.verify.localKeys`          | `array`   | N**      | Local private/public keys for signature verification. **One of the verify options is required.              |
+| `process.verify.useArtifactoryKeys` | `boolean` | N**      | Use keys present in evidence data for verification. **One of the verify options is required.                |
+| `process.outputs`                   | `array`   | N        | Output configurations to extract data from evidence results.                                                |
+| `process.outputs[].name`            | `string`  | Y        | Name of the output variable.                                                                                |
+| `process.outputs[].expression`      | `string`  | Y        | Expr expression to extract data from evidence query results.                                                |
 
 #### Available Data for Expressions
 

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
@@ -3,9 +3,10 @@ sidebar_label: jira
 description: Integrates with Jira to manage issues, comments, and track promotion workflows.
 ---
 
+# `jira`
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-# `jira`
 
 :::info
 This promotion step is only available in Kargo on the
@@ -27,7 +28,7 @@ All Jira operations require proper authentication credentials stored in a Kubern
 `Secret`.
 
 | Name                     | Type     | Required | Description                                                                      |
-|--------------------------|----------|----------|----------------------------------------------------------------------------------|
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------------- |
 | `credentials.secretName` | `string` | Y        | Name of the  `Secret`  containing the Jira credentials in the project namespace. |
 
 
@@ -184,12 +185,12 @@ Searches for Jira issues using JQL
 
 #### Configuration
 
-| Name                         | Type      | Required | Description                                                                                   |
-| ---------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------- |
-| `searchIssue.jql`            | `string`  | Y        | The JQL query to search for issues.                                                           |
+| Name                         | Type      | Required | Description                                                                                                                         |
+| ---------------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `searchIssue.jql`            | `string`  | Y        | The JQL query to search for issues.                                                                                                 |
 | `searchIssue.expectMultiple` | `boolean` | N        | If true, expects multiple results and returns the first matching result. If false, expects single result and fails with >1 results. |
-| `searchIssue.fields`         | `array`   | N        | List of fields to include in search results.                                                  |
-| `searchIssue.expands`        | `array`   | N        | List of fields to expand in search results.                                                   |
+| `searchIssue.fields`         | `array`   | N        | List of fields to include in search results.                                                                                        |
+| `searchIssue.expands`        | `array`   | N        | List of fields to expand in search results.                                                                                         |
 
 #### Output
 

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/00-overview.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/00-overview.md
@@ -1,12 +1,11 @@
 ---
-sidebar_label: Key Concepts
 description: An overview of Kargo notifications concepts and components.
 ---
 
+# Key Concepts
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-
-# Key Concepts
 
 :::info
 
@@ -34,11 +33,11 @@ step](../../30-promotion-steps/send-message.md) to send notifications when speci
 
 ## Event Routers
 
-At their core, `EventRouter`s are responsible for listening to specific events within Kargo and routing
-them to the appropriate channels based on defined criteria. They act as the bridge between events and
-channels, ensuring that notifications are sent to the right destinations when relevant events occur. Due to their design, the same event can be
-routed to multiple channels or different events can be routed to the same channel without duplicating
-notification logic.
+At their core, `EventRouter`s are responsible for listening to specific events within Kargo and
+routing them to the appropriate channels based on defined criteria. They act as the bridge between
+events and channels, ensuring that notifications are sent to the right destinations when relevant
+events occur. Due to their design, the same event can be routed to multiple channels or different
+events can be routed to the same channel without duplicating notification logic.
 
 The lack of "notification" in the name is intentional, as `EventRouter`s do not themselves send
 notifications. Instead, they route events to channels after rendering data from the event, which

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/10-configuring-routers.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/10-configuring-routers.md
@@ -1,12 +1,11 @@
 ---
-sidebar_label: Configuring Event Routers
 description: How to configure and use EventRouters for notifications
 ---
 
+# Configuring Event Routers
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-
-# Configuring Event Routers
 
 [Event Routers](./00-overview.md#event-routers) are used to route events to different destinations
 based on specified criteria. This document provides guidance on how to configure and use Event

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/20-message-formatting.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/20-message-formatting.md
@@ -1,12 +1,11 @@
 ---
-sidebar_label: Message Formatting
 description: Message formatting options for Kargo notifications.
 ---
 
+# Message Formatting
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-
-# Message Formatting
 
 ## Overview
 

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/index.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/100-notifications/index.md
@@ -1,12 +1,11 @@
 ---
-sidebar_label: Notifications
 description: An overview of Kargo notifications concepts and components.
 ---
 
+# Notifications
+
 <span class="tag professional"></span>
 <span class="tag beta"></span>
-
-# Notifications
 
 :::info
 


### PR DESCRIPTION
If the `<span>` for the tag goes above the first `h1`, this messes up docusaurus' automatic generation of page titles and sidebar labels. This PR now places all of these tags _below_ the first header on pages where all of the content is either `beta` or `pro`