### PR TITLE
refactor: derive Freight data context from Promotion

### DIFF
--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -521,7 +521,6 @@ func (r *reconciler) promote(
 	promoCtx := promotion.NewContext(
 		workingPromo,
 		stage,
-		targetFreightRef,
 		promotion.WithActor(api.CreateActorAnnotationValue(&promo)),
 		promotion.WithUIBaseURL(r.cfg.APIServerBaseURL),
 		promotion.WithWorkDir(filepath.Join(os.TempDir(), "promotion-"+string(workingPromo.UID))),

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -171,42 +171,9 @@ func RunningPromotionsByArgoCDApplications(
 			return nil
 		}
 
-		freight := &kargoapi.Freight{}
-		if err := cl.Get(ctx, client.ObjectKey{
-			Name:      promo.Spec.Freight,
-			Namespace: promo.Namespace,
-		}, freight); err != nil {
-			logger.Error(
-				err,
-				"failed to get Freight for Promotion",
-				"promo", promo.Name,
-				"namespace", promo.Namespace,
-				"freight", promo.Spec.Freight,
-				"stage", promo.Spec.Stage,
-			)
-		}
-
 		// Build just enough context to extract the relevant config from the
 		// argocd-update promotion step.
-		promoCtx := promotion.Context{
-			Project:         promo.Namespace,
-			Stage:           promo.Spec.Stage,
-			FreightRequests: stage.Spec.RequestedFreight,
-			TargetFreightRef: kargoapi.FreightReference{
-				Name:    freight.Name,
-				Commits: freight.Commits,
-				Images:  freight.Images,
-				Charts:  freight.Charts,
-				Origin:  freight.Origin,
-			},
-			Promotion: promo.Name,
-			State:     promo.Status.GetState(),
-			Vars:      promo.Spec.Vars,
-		}
-
-		if promo.Status.FreightCollection != nil {
-			promoCtx.Freight = *promo.Status.FreightCollection.DeepCopy()
-		}
+		promoCtx := promotion.NewContext(promo, stage)
 
 		// Extract the Argo CD Applications from the promotion steps.
 		//

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -134,7 +134,6 @@ func WithActor(actor string) ContextOption {
 func NewContext(
 	promo *kargoapi.Promotion,
 	stage *kargoapi.Stage,
-	targetFreightRef kargoapi.FreightReference,
 	opts ...ContextOption,
 ) Context {
 	ctx := Context{
@@ -142,12 +141,18 @@ func NewContext(
 		Stage:                 stage.Name,
 		Promotion:             promo.Name,
 		FreightRequests:       stage.Spec.RequestedFreight,
-		Freight:               *promo.Status.FreightCollection.DeepCopy(),
-		TargetFreightRef:      targetFreightRef,
 		StartFromStep:         promo.Status.CurrentStep,
 		StepExecutionMetadata: promo.Status.StepExecutionMetadata,
 		State:                 State(promo.Status.GetState()),
 		Vars:                  promo.Spec.Vars,
+	}
+
+	if promo.Status.Freight != nil {
+		ctx.TargetFreightRef = *promo.Status.Freight.DeepCopy()
+	}
+
+	if promo.Status.FreightCollection != nil {
+		ctx.Freight = *promo.Status.FreightCollection.DeepCopy()
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
This removes the requirement of the Freight itself for the construction of the Promotion context, as this data is already available on the Promotion object itself as soon as it reaches a Running state.