### PR TITLE
docs: Fix typo in argocd-update targetRevision --> desiredRevision

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -147,6 +147,7 @@ steps:
       - repoURL: ${{ chartRepo }}
         chart: my-chart
         desiredRevision: ${{ chartFrom(chartRepo, "my-chart").Version }}
+        updateTargetRevision: true
 ```
 
 ### Updating an Image with Kustomize


### PR DESCRIPTION
The docs seems to indicate that the correct field in `apps[].sources[]` for the `argocd-update` promotion step is `desiredRevision` rather than `targetRevision`. This change fixes an apparent typo in the examples.

Also adds the missing `updateTargetRevision` field.