### PR TITLE
fix(controller): make git repo retain url suitable for use by external callers of URL() method

### DIFF
--- a/pkg/controller/git/bare_repo.go
+++ b/pkg/controller/git/bare_repo.go
@@ -98,10 +98,11 @@ func CloneBare(
 	}
 	b := &bareRepo{
 		baseRepo: &baseRepo{
-			creds:   clientOpts.Credentials,
-			dir:     filepath.Join(homeDir, "repo"),
-			homeDir: homeDir,
-			url:     repoURL,
+			creds:       clientOpts.Credentials,
+			dir:         filepath.Join(homeDir, "repo"),
+			homeDir:     homeDir,
+			originalURL: repoURL,
+			accessURL:   repoURL,
 		},
 	}
 	if err = b.setupClient(homeDir, clientOpts); err != nil {
@@ -113,14 +114,17 @@ func CloneBare(
 	if err = b.saveDirs(); err != nil {
 		return nil, err
 	}
+	if err = b.saveOriginalURL(); err != nil {
+		return nil, err
+	}
 	return b, nil
 }
 
 func (b *bareRepo) clone() error {
-	cmd := b.buildGitCommand("clone", "--bare", b.url, b.dir)
+	cmd := b.buildGitCommand("clone", "--bare", b.accessURL, b.dir)
 	cmd.Dir = b.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
-		return fmt.Errorf("error cloning repo %q into %q: %w", b.url, b.dir, err)
+		return fmt.Errorf("error cloning repo %q into %q: %w", b.originalURL, b.dir, err)
 	}
 	return nil
 }
@@ -142,7 +146,7 @@ func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
 	if err := b.loadHomeDir(); err != nil {
 		return nil, fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
-	if err := b.loadURL(); err != nil {
+	if err := b.loadURLs(); err != nil {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
@@ -192,10 +196,11 @@ func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree,
 	}
 	return &workTree{
 		baseRepo: &baseRepo{
-			creds:   b.creds,
-			dir:     path,
-			homeDir: b.homeDir,
-			url:     b.url,
+			creds:       b.creds,
+			dir:         path,
+			homeDir:     b.homeDir,
+			originalURL: b.originalURL,
+			accessURL:   b.accessURL,
 		},
 		bareRepo: b,
 	}, nil
@@ -242,10 +247,11 @@ func (b *bareRepo) WorkTrees() ([]WorkTree, error) {
 	for i, workTreePath := range workTreePaths {
 		workTrees[i] = &workTree{
 			baseRepo: &baseRepo{
-				creds:   b.creds,
-				dir:     workTreePath,
-				homeDir: b.homeDir,
-				url:     b.url,
+				creds:       b.creds,
+				dir:         workTreePath,
+				homeDir:     b.homeDir,
+				originalURL: b.originalURL,
+				accessURL:   b.accessURL,
 			},
 			bareRepo: b,
 		}

--- a/pkg/controller/git/bare_repo_test.go
+++ b/pkg/controller/git/bare_repo_test.go
@@ -79,11 +79,12 @@ func TestBareRepo(t *testing.T) {
 	require.True(t, ok)
 
 	t.Run("can clone", func(t *testing.T) {
-		var repoURL *url.URL
-		repoURL, err = url.Parse(r.url)
+		require.Equal(t, testRepoURL, r.originalURL)
+		var accessURL *url.URL
+		accessURL, err = url.Parse(r.accessURL)
 		require.NoError(t, err)
-		repoURL.User = nil
-		require.Equal(t, testRepoURL, repoURL.String())
+		accessURL.User = nil
+		require.Equal(t, testRepoURL, accessURL.String())
 		require.NotEmpty(t, r.homeDir)
 		var fi os.FileInfo
 		fi, err = os.Stat(r.homeDir)
@@ -96,7 +97,7 @@ func TestBareRepo(t *testing.T) {
 	})
 
 	t.Run("can get the repo url", func(t *testing.T) {
-		require.Equal(t, r.url, r.URL())
+		require.Equal(t, r.originalURL, r.URL())
 	})
 
 	t.Run("can get the home dir", func(t *testing.T) {

--- a/pkg/controller/git/repo_test.go
+++ b/pkg/controller/git/repo_test.go
@@ -58,11 +58,12 @@ func TestRepo(t *testing.T) {
 	require.True(t, ok)
 
 	t.Run("can clone", func(t *testing.T) {
-		var repoURL *url.URL
-		repoURL, err = url.Parse(r.url)
+		require.Equal(t, testRepoURL, r.originalURL)
+		var accessURL *url.URL
+		accessURL, err = url.Parse(r.accessURL)
 		require.NoError(t, err)
-		repoURL.User = nil
-		require.Equal(t, testRepoURL, repoURL.String())
+		accessURL.User = nil
+		require.Equal(t, testRepoURL, accessURL.String())
 		require.NotEmpty(t, r.homeDir)
 		var fi os.FileInfo
 		fi, err = os.Stat(r.homeDir)
@@ -75,7 +76,7 @@ func TestRepo(t *testing.T) {
 	})
 
 	t.Run("can get the repo url", func(t *testing.T) {
-		require.Equal(t, r.url, r.URL())
+		require.Equal(t, r.originalURL, r.URL())
 	})
 
 	t.Run("can get the home dir", func(t *testing.T) {


### PR DESCRIPTION
Fixes #5344

Internally, implementations of `git.Repo` hang on to URLs that often contain `@username`, but callers of the `URL()` method rightfully expect it to return the original URL that was provided to the `git.Clone()` or `git.CloneBare()` function.