### PR TITLE
fix(promotion): use Stage from Promotion spec in context constructor

### DIFF
--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -128,9 +128,8 @@ func WithActor(actor string) ContextOption {
 }
 
 // NewContext creates a new Context for a user-defined promotion process
-// executed by the Engine. It initializes the Context with the provided
-// Promotion, Stage, and TargetFreightRef, and applies any additional options
-// provided.
+// executed by the Engine. It initializes the Context with the data from the
+// provided Promotion and Stage, applying any additional options provided.
 func NewContext(
 	promo *kargoapi.Promotion,
 	stage *kargoapi.Stage,
@@ -138,13 +137,19 @@ func NewContext(
 ) Context {
 	ctx := Context{
 		Project:               promo.Namespace,
-		Stage:                 stage.Name,
+		Stage:                 promo.Spec.Stage,
 		Promotion:             promo.Name,
-		FreightRequests:       stage.Spec.RequestedFreight,
 		StartFromStep:         promo.Status.CurrentStep,
 		StepExecutionMetadata: promo.Status.StepExecutionMetadata,
 		State:                 State(promo.Status.GetState()),
 		Vars:                  promo.Spec.Vars,
+	}
+
+	if stage != nil && len(stage.Spec.RequestedFreight) > 0 {
+		ctx.FreightRequests = make([]kargoapi.FreightRequest, len(stage.Spec.RequestedFreight))
+		for i, fr := range stage.Spec.RequestedFreight {
+			ctx.FreightRequests[i] = *fr.DeepCopy()
+		}
 	}
 
 	if promo.Status.Freight != nil {


### PR DESCRIPTION
The `NewContext` function now uses the Stage name from the Promotion spec rather than from the Stage paramter, and only sets `FreightRequests` if the Stage paremeter is non-`nil`.

This allows the function to work correctly even when the Stage parameter is `nil`. Which can be useful in scenarios where you need a minimal Promotion context without having the full Stage data at hand.