### PR TITLE
fix: add SyncError condition to Argo CD application health checks

### DIFF
--- a/pkg/controller/argocd/api/v1alpha1/application_types.go
+++ b/pkg/controller/argocd/api/v1alpha1/application_types.go
@@ -161,6 +161,7 @@ type ApplicationConditionType string
 var (
 	ApplicationConditionInvalidSpecError ApplicationConditionType = "InvalidSpecError"
 	ApplicationConditionComparisonError  ApplicationConditionType = "ComparisonError"
+	ApplicationConditionSyncError        ApplicationConditionType = "SyncError"
 )
 
 type ApplicationCondition struct {

--- a/pkg/health/checker/builtin/argocd.go
+++ b/pkg/health/checker/builtin/argocd.go
@@ -159,6 +159,7 @@ func (a *argocdChecker) check(
 var healthErrorConditions = []argocd.ApplicationConditionType{
 	argocd.ApplicationConditionComparisonError,
 	argocd.ApplicationConditionInvalidSpecError,
+	argocd.ApplicationConditionSyncError,
 }
 
 // getApplicationHealth assesses the health of an Argo CD Application by looking


### PR DESCRIPTION
- Introduced ApplicationConditionSyncError to represent synchronization errors.
- Updated health checker tests to account for the new SyncError condition, increasing the issue count in assertions.
- Modified health assessment logic to include SyncError in the evaluation of application health.

This should fix #5166. Also noticed [this comment ](https://github.com/akuity/kargo/pull/1807/files#r1558263621) saying that we were not sure about all the error states that should be considered here and I think it's important to have [SyncError](https://github.com/argoproj/argo-cd/blob/d92ad4d5c88c7ee184fdea8030e86bcbca0ed98a/pkg/apis/application/v1alpha1/types.go#L1805-L1806C2) because that's the status we will get if we are using sync waves on argo and one of the "waves" fail (for example running database migrations in the first step, as I reference [here](https://github.com/akuity/kargo/issues/5166#issuecomment-3557397456)).