### PR TITLE
docs: update CLI auth callback URL to use HTTP

### DIFF
--- a/docs/docs/40-operator-guide/40-security/20-openid-connect/30-aws-cognito/index.md
+++ b/docs/docs/40-operator-guide/40-security/20-openid-connect/30-aws-cognito/index.md
@@ -146,7 +146,7 @@ After completing the steps from either the
           This is where users of the Kargo UI will be redirected to after
           logging in.
 
-        * `https://localhost/auth/callback`
+        * `http://localhost/auth/callback`
 
            This is where users of the `kargo` CLI will be redirected to
            redirected to after logging in. (The CLI launches a server to serve

--- a/docs/docs/40-operator-guide/40-security/20-openid-connect/index.md
+++ b/docs/docs/40-operator-guide/40-security/20-openid-connect/index.md
@@ -64,7 +64,7 @@ supports both OIDC and PKCE:
 **With a compatible identity provider:**
 
   - `https://<hostname for api server>/login` (for the UI)
-  - `https://localhost/auth/callback` (for the CLI)
+  - `http://localhost/auth/callback` (for the CLI)
 
     <br/>
 


### PR DESCRIPTION
Kargo CLI is, understandably, setting an http url as a redirect.

Using https in the OIDC configuration fails CLI login with unauthorized redirect url.