### PR TITLE
feat(promotion): allow output format configuration `kustomize-build`

### DIFF
--- a/pkg/promotion/runner/builtin/schemas/kustomize-build-config.json
+++ b/pkg/promotion/runner/builtin/schemas/kustomize-build-config.json
@@ -11,9 +11,14 @@
       "minLength": 1
     },
     "outPath": {
-        "type": "string",
-        "description": "OutPath is the file path to write the built manifests to.",
-        "minLength": 1
+      "type": "string",
+      "description": "OutPath is the file path to write the built manifests to.",
+      "minLength": 1
+    },
+    "outputFormat": {
+      "type": "string",
+      "description": "Specifies the naming convention for output files when writing to a directory. 'kargo' (default) uses '[namespace-]kind-name.yaml' format (e.g., 'deployment-myapp.yaml'). 'kustomize' matches the naming convention of 'kustomize build -o dir/', using '[namespace_]group_version_kind_name.yaml' format (e.g., 'apps_v1_deployment_myapp.yaml').",
+      "enum": ["kargo", "kustomize"]
     },
     "plugin": {
       "type": "object",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -466,6 +466,11 @@ type JSONUpdate struct {
 type KustomizeBuildConfig struct {
 	// OutPath is the file path to write the built manifests to.
 	OutPath string `json:"outPath"`
+	// Specifies the naming convention for output files when writing to a directory. 'kargo'
+	// (default) uses '[namespace-]kind-name.yaml' format (e.g., 'deployment-myapp.yaml').
+	// 'kustomize' matches the naming convention of 'kustomize build -o dir/', using
+	// '[namespace_]group_version_kind_name.yaml' format (e.g., 'apps_v1_deployment_myapp.yaml').
+	OutputFormat *OutputFormat `json:"outputFormat,omitempty"`
 	// Path to the directory containing the Kustomization file.
 	Path string `json:"path"`
 	// Plugin contains configuration for customizing the behavior of builtin Kustomize plugins.
@@ -627,6 +632,17 @@ type OutLayout string
 const (
 	Flat OutLayout = "flat"
 	Helm OutLayout = "helm"
+)
+
+// Specifies the naming convention for output files when writing to a directory. 'kargo'
+// (default) uses '[namespace-]kind-name.yaml' format (e.g., 'deployment-myapp.yaml').
+// 'kustomize' matches the naming convention of 'kustomize build -o dir/', using
+// '[namespace_]group_version_kind_name.yaml' format (e.g., 'apps_v1_deployment_myapp.yaml').
+type OutputFormat string
+
+const (
+	Kargo     OutputFormat = "kargo"
+	Kustomize OutputFormat = "kustomize"
 )
 
 // Kind of resource to update metadata for

--- a/ui/src/gen/directives/kustomize-build-config.json
+++ b/ui/src/gen/directives/kustomize-build-config.json
@@ -14,6 +14,14 @@
    "description": "OutPath is the file path to write the built manifests to.",
    "minLength": 1
   },
+  "outputFormat": {
+   "type": "string",
+   "description": "Specifies the naming convention for output files when writing to a directory. 'kargo' (default) uses '[namespace-]kind-name.yaml' format (e.g., 'deployment-myapp.yaml'). 'kustomize' matches the naming convention of 'kustomize build -o dir/', using '[namespace_]group_version_kind_name.yaml' format (e.g., 'apps_v1_deployment_myapp.yaml').",
+   "enum": [
+    "kargo",
+    "kustomize"
+   ]
+  },
   "plugin": {
    "type": "object",
    "description": "Plugin contains configuration for customizing the behavior of builtin Kustomize plugins.",


### PR DESCRIPTION
Fixes: #5434

By adding the option to define an `outputFormat` as part of the `kustomize-build` step configuration. When set to `kustomize`, this will produce the same output as `kustomize-build -o dir/` (i.e., `[namespace_]group_version_kind_name.yaml`).

The default continues to be the "Kargo invented" format of `[namespace-]kind-name`.