### PR TITLE
fix(yaml): Fixes an issue with the yaml updater failing on long lines

### DIFF
--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -106,6 +106,36 @@ characters:
 				)
 			},
 		},
+		{
+			name: "really long lines still work",
+			// nolint:lll
+			inBytes: []byte(`
+characters:
+- name: Anakin
+  affiliation: Light side
+  temptation: "` + strings.Repeat("Did you ever hear the tragedy of Darth Plagueis The Wise? I thought not. It's not a story the Jedi would tell you. It's a Sith legend. Darth Plagueis was a Dark Lord of the Sith, so powerful and so wise he could use the Force to influence the midichlorians to create life...He had such a knowledge of the dark side that he could even keep the ones he cared about from dying. The dark side of the Force is a pathway to many abilities some consider to be unnatural. He became so powerful...the only thing he was afraid of was losing his power, which eventually, of course, he did. Unfortunately, he taught his apprentice everything he knew, then his apprentice killed him in his sleep. Ironic. He could save others from death, but not himself.", 1000) + `"
+`),
+			updates: []Update{
+				{
+					Key:   "characters.0.affiliation",
+					Value: "Dark side",
+				},
+			},
+			assertions: func(t *testing.T, bytes []byte, err error) {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					// nolint:lll
+					[]byte(`
+characters:
+- name: Anakin
+  affiliation: Dark side
+  temptation: "`+strings.Repeat("Did you ever hear the tragedy of Darth Plagueis The Wise? I thought not. It's not a story the Jedi would tell you. It's a Sith legend. Darth Plagueis was a Dark Lord of the Sith, so powerful and so wise he could use the Force to influence the midichlorians to create life...He had such a knowledge of the dark side that he could even keep the ones he cared about from dying. The dark side of the Force is a pathway to many abilities some consider to be unnatural. He became so powerful...the only thing he was afraid of was losing his power, which eventually, of course, he did. Unfortunately, he taught his apprentice everything he knew, then his apprentice killed him in his sleep. Ironic. He could save others from death, but not himself.", 1000)+`"
+`),
+					bytes,
+				)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
This is a two pronged fix: First, we weren't checking for an error in the scanner when we were reading lines. So now we check the error and return it. Second, we needed to allocate a larger buffer if updating a file with a really long line