### PR TITLE
docs: Fix chartFrom typo

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -633,7 +633,7 @@ spec:
       repoURL: oci://example.com/my-other-chart
   freightCreationCriteria:
     expression: |
-      chartFrom('oci://example.com/my-chart').Version == chartFrom('oci://example.com/my-other-chart').Tag
+      chartFrom('oci://example.com/my-chart').Version == chartFrom('oci://example.com/my-other-chart').Version
 ```
 
 :::info


### PR DESCRIPTION
The `chartFrom()` function returns RepoURL, Name, and Version but not Tag. 
Fix the example to use .Version instead of .Tag to avoid confusion.

From
```
  freightCreationCriteria:
    expression: |
      chartFrom('oci://example.com/my-chart').Version == chartFrom('oci://example.com/my-other-chart').Tag
```
to
```
  freightCreationCriteria:
    expression: |
      chartFrom('oci://example.com/my-chart').Version == chartFrom('oci://example.com/my-other-chart').Version
```