### PR TITLE
feat(promotion): allow ssh urls into pr builtins

### DIFF
--- a/pkg/promotion/runner/builtin/schemas/git-merge-pr-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-merge-pr-config.json
@@ -8,8 +8,7 @@
       "repoURL": {
         "type": "string",
         "description": "The URL of the remote Git repository containing the pull request.",
-        "minLength": 1,
-        "format": "uri"
+        "minLength": 1
       },
       "prNumber": {
         "type": "integer",

--- a/pkg/promotion/runner/builtin/schemas/git-open-pr-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-open-pr-config.json
@@ -21,8 +21,7 @@
     "repoURL": {
       "type": "string",
       "description": "The URL of a remote Git repository to clone.",
-      "minLength": 1,
-      "format": "uri"
+      "minLength": 1
     },
     "sourceBranch": {
       "type": "string",

--- a/pkg/promotion/runner/builtin/schemas/git-wait-for-pr-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-wait-for-pr-config.json
@@ -22,8 +22,7 @@
     "repoURL": {
       "type": "string",
       "description": "The URL of a remote Git repository to clone.",
-      "minLength": 1,
-      "format": "uri"
+      "minLength": 1
     }
   }
 }

--- a/ui/src/gen/directives/git-merge-pr-config.json
+++ b/ui/src/gen/directives/git-merge-pr-config.json
@@ -7,8 +7,7 @@
   "repoURL": {
    "type": "string",
    "description": "The URL of the remote Git repository containing the pull request.",
-   "minLength": 1,
-   "format": "uri"
+   "minLength": 1
   },
   "prNumber": {
    "type": "integer",

--- a/ui/src/gen/directives/git-open-pr-config.json
+++ b/ui/src/gen/directives/git-open-pr-config.json
@@ -26,8 +26,7 @@
   "repoURL": {
    "type": "string",
    "description": "The URL of a remote Git repository to clone.",
-   "minLength": 1,
-   "format": "uri"
+   "minLength": 1
   },
   "sourceBranch": {
    "type": "string",

--- a/ui/src/gen/directives/git-wait-for-pr-config.json
+++ b/ui/src/gen/directives/git-wait-for-pr-config.json
@@ -27,8 +27,7 @@
   "repoURL": {
    "type": "string",
    "description": "The URL of a remote Git repository to clone.",
-   "minLength": 1,
-   "format": "uri"
+   "minLength": 1
   }
  }
 }


### PR DESCRIPTION
Remove 'uri' validation for repoURI as it does not match `git@example.com:org/repo.git` syntax.