### PR TITLE
fix(webhook): gitlab ssh url warehouse not refreshed

### DIFF
--- a/pkg/webhook/external/gitlab.go
+++ b/pkg/webhook/external/gitlab.go
@@ -120,7 +120,10 @@ func (g *gitlabWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 		case *gl.PushEvent:
 			var repoURLs []string
 			if e.Repository != nil {
-				repoURLs = []string{urls.NormalizeGit(e.Repository.GitHTTPURL)}
+				repoURLs = []string{
+					urls.NormalizeGit(e.Repository.GitHTTPURL),
+					urls.NormalizeGit(e.Repository.GitSSHURL),
+				}
 			}
 			logger = logger.WithValues(
 				"repoURLs", repoURLs,
@@ -131,7 +134,10 @@ func (g *gitlabWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 		case *gl.TagEvent:
 			var repoURLs []string
 			if e.Repository != nil {
-				repoURLs = []string{urls.NormalizeGit(e.Repository.GitHTTPURL)}
+				repoURLs = []string{
+					urls.NormalizeGit(e.Repository.GitHTTPURL),
+					urls.NormalizeGit(e.Repository.GitSSHURL),
+				}
 			}
 			logger = logger.WithValues(
 				"repoURLs", repoURLs,

--- a/pkg/webhook/external/gitlab_test.go
+++ b/pkg/webhook/external/gitlab_test.go
@@ -22,7 +22,8 @@ const gitlabPushEventRequestBody = `
 {
 	"ref": "refs/heads/main",
 	"repository":{
-		"git_http_url": "https://gitlab.com/example/repo"
+		"git_http_url": "https://gitlab.com/example/repo.git",
+		"git_ssh_url": "git@gitlab.com:example/repo.git"
 	}
 }`
 
@@ -30,7 +31,8 @@ const gitlabTagPushEventRequestBody = `
 {
 	"ref": "refs/tags/v1.0.0",
 	"repository":{
-		"git_http_url": "https://gitlab.com/example/repo"
+		"git_http_url": "https://gitlab.com/example/repo.git",
+		"git_ssh_url": "git@gitlab.com:example/repo.git"
 	}
 }`
 
@@ -152,7 +154,7 @@ func TestGitLabHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "warehouse refreshed (push event)",
+			name:       "warehouse refreshed (push event, https)",
 			secretData: testSecretData,
 			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 				&kargoapi.Warehouse{
@@ -164,6 +166,47 @@ func TestGitLabHandler(t *testing.T) {
 						Subscriptions: []kargoapi.RepoSubscription{{
 							Git: &kargoapi.GitSubscription{
 								RepoURL: "https://gitlab.com/example/repo",
+								Branch:  "main",
+							},
+						}},
+					},
+				},
+			).WithIndex(
+				&kargoapi.Warehouse{},
+				indexer.WarehousesBySubscribedURLsField,
+				indexer.WarehousesBySubscribedURLs,
+			).Build(),
+			req: func() *http.Request {
+				bodyBuf := bytes.NewBuffer([]byte(gitlabPushEventRequestBody))
+				req := httptest.NewRequest(
+					http.MethodPost,
+					testURL,
+					bodyBuf,
+				)
+				req.Header.Set(gitlabTokenHeader, testToken)
+				req.Header.Set(gitlabEventHeader, string(gl.EventTypePush))
+				return req
+			},
+			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, rr.Code)
+				require.JSONEq(
+					t, `{"msg":"refreshed 1 warehouse(s)"}`, rr.Body.String(),
+				)
+			},
+		},
+		{
+			name:       "warehouse refreshed (push event, ssh)",
+			secretData: testSecretData,
+			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProjectName,
+						Name:      "fake-warehouse",
+					},
+					Spec: kargoapi.WarehouseSpec{
+						Subscriptions: []kargoapi.RepoSubscription{{
+							Git: &kargoapi.GitSubscription{
+								RepoURL: "git@gitlab.com:example/repo",
 								Branch:  "main",
 							},
 						}},
@@ -238,7 +281,7 @@ func TestGitLabHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "warehouse refreshed (tag event)",
+			name:       "warehouse refreshed (tag event, https)",
 			secretData: testSecretData,
 			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 				&kargoapi.Warehouse{
@@ -250,6 +293,48 @@ func TestGitLabHandler(t *testing.T) {
 						Subscriptions: []kargoapi.RepoSubscription{{
 							Git: &kargoapi.GitSubscription{
 								RepoURL:                 "https://gitlab.com/example/repo",
+								CommitSelectionStrategy: kargoapi.CommitSelectionStrategySemVer,
+								SemverConstraint:        "^1.0.0",
+							},
+						}},
+					},
+				},
+			).WithIndex(
+				&kargoapi.Warehouse{},
+				indexer.WarehousesBySubscribedURLsField,
+				indexer.WarehousesBySubscribedURLs,
+			).Build(),
+			req: func() *http.Request {
+				bodyBuf := bytes.NewBuffer([]byte(gitlabTagPushEventRequestBody))
+				req := httptest.NewRequest(
+					http.MethodPost,
+					testURL,
+					bodyBuf,
+				)
+				req.Header.Set(gitlabTokenHeader, testToken)
+				req.Header.Set(gitlabEventHeader, string(gl.EventTypeTagPush))
+				return req
+			},
+			assertions: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, rr.Code)
+				require.JSONEq(
+					t, `{"msg":"refreshed 1 warehouse(s)"}`, rr.Body.String(),
+				)
+			},
+		},
+		{
+			name:       "warehouse refreshed (tag event, ssh)",
+			secretData: testSecretData,
+			client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProjectName,
+						Name:      "fake-warehouse",
+					},
+					Spec: kargoapi.WarehouseSpec{
+						Subscriptions: []kargoapi.RepoSubscription{{
+							Git: &kargoapi.GitSubscription{
+								RepoURL:                 "git@gitlab.com:example/repo",
 								CommitSelectionStrategy: kargoapi.CommitSelectionStrategySemVer,
 								SemverConstraint:        "^1.0.0",
 							},


### PR DESCRIPTION
GitLab equivalent fix of https://github.com/akuity/kargo/pull/5432 

https://docs.gitlab.com/user/project/integrations/webhook_events/#push-events