### PR TITLE
fix: typo on stage health change message

### DIFF
--- a/pkg/controller/management/projects/event_handlers.go
+++ b/pkg/controller/management/projects/event_handlers.go
@@ -148,7 +148,7 @@ func (e *projectStageHealthEnqueuer[T]) Update(
 	case oldCond == nil || newCond == nil:
 		fallthrough
 	case oldCond.Status != newCond.Status:
-		logger.Info("Warehouse health changed, enqueueing Project")
+		logger.Info("Stage health changed, enqueueing Project")
 		wq.Add(reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: oldStage.Namespace},
 		})


### PR DESCRIPTION
Message was identical to the message for Warehouse health change  - Probably a copy-paste error.