### PR TITLE
feat(helm): allow overriding parse-cabundle init container securityCo…

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -145,8 +145,13 @@ spec:
       - name: parse-cabundle
         image: {{ include "kargo.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.api.cabundle.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- else }}
         securityContext:
           runAsUser: 0
+        {{- end }}
         command:
         - "/bin/sh"
         - "-c"

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -117,8 +117,13 @@ spec:
         - name: parse-cabundle
           image: {{ include "kargo.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.controller.cabundle.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           securityContext:
             runAsUser: 0
+          {{- end }}
           command:
           - "/bin/sh"
           - "-c"

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -421,6 +421,8 @@ api:
     configMapName: ""
     ## @param api.cabundle.secretName Specifies the name of an optional Secret containing CA certs that is managed "out of band." Values in the Secret named here should each contain a single PEM-encoded CA cert. If defined, the value of this field takes precedence over any in configMapName.
     secretName: ""
+    ## @param api.cabundle.securityContext Security context for the parse-cabundle init container. Allows overriding the default securityContext which runs as root.
+    securityContext: {}
 
   probes:
     ## @param api.probes.enabled Whether liveness and readiness probes should be included in the API server deployment. It is sometimes advantageous to disable these during local development.
@@ -605,6 +607,8 @@ controller:
     configMapName: ""
     ## @param controller.cabundle.secretName Specifies the name of an optional Secret containing CA certs that is managed "out of band." Values in the Secret named here should each contain a single PEM-encoded CA cert. If defined, the value of this field takes precedence over any in configMapName.
     secretName: ""
+    ## @param controller.cabundle.securityContext Security context for the parse-cabundle init container. Allows overriding the default securityContext which runs as root.
+    securityContext: {}
 
 ## @section Garbage Collector
 garbageCollector:


### PR DESCRIPTION
…ntext

Add securityContext configuration option for the parse-cabundle init container under api.cabundle and controller.cabundle. This allows users in restricted environments (PodSecurity Standards, Kyverno policies) to override the default root security context.

The default behavior (runAsUser: 0) is preserved for backward compatibility.