### PR TITLE
fix(promotion): skip ShouldSkip eval started step

### DIFF
--- a/pkg/promotion/local_orchestrator_test.go
+++ b/pkg/promotion/local_orchestrator_test.go
@@ -459,6 +459,30 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 			},
 		},
 		{
+			name: "previously failed step does not skip on retry",
+			promoCtx: Context{
+				StepExecutionMetadata: kargoapi.StepExecutionMetadataList{{
+					Alias:     "step1",
+					StartedAt: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute))),
+					Status:    kargoapi.PromotionStepStatusFailed,
+					Message:   "previous failure",
+				}},
+			},
+			steps: []Step{
+				{Kind: "success-step", Alias: "step1"},
+			},
+			assertions: func(t *testing.T, result Result) {
+				assert.Equal(t, kargoapi.PromotionPhaseSucceeded, result.Status)
+				assert.Equal(t, int64(0), result.CurrentStep)
+
+				require.Len(t, result.StepExecutionMetadata, 1)
+
+				assert.Equal(t, kargoapi.PromotionStepStatusSucceeded, result.StepExecutionMetadata[0].Status)
+				assert.NotNil(t, result.StepExecutionMetadata[0].StartedAt)
+				assert.NotNil(t, result.StepExecutionMetadata[0].FinishedAt)
+			},
+		},
+		{
 			name: "panic during step execution",
 			registrations: []StepRunnerRegistration{
 				{


### PR DESCRIPTION
When a step fails but is eligible for retry, re-evaluating `ShouldSkip` on the next reconciliation causes the step's own Failed status to trigger `HasFailures()`, incorrectly marking the step as Skipped. This leads to promotions with failed steps being marked as Succeeded.

The fix skips the `ShouldSkip` evaluation if the step has already started (`meta.StartedAt != nil`). The skip decision is inherently a one-time decision made before a step begins execution.