### PR TITLE
chore(ui): adjust shortVersion function length check

### DIFF
--- a/ui/src/features/project/pipelines/freight/short-version-utils.ts
+++ b/ui/src/features/project/pipelines/freight/short-version-utils.ts
@@ -1,5 +1,5 @@
 export const shortVersion = (version: string = '', length = 12) => {
-  if (version.length <= length) {
+  if (version.length <= length + 3) {
     return version;
   }
 


### PR DESCRIPTION
`shortVersion` adds `...` in the middle, making some strings longer.
`15.12.25-1030` Docker tag, for example, becomes `15.12....5-1030`.
This change makes it so `shortVersion` only applies when it actually shortens the string.