### PR TITLE
chore(backport release-1.8): fix(promotion): propagate errors for backoff

### DIFF
--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -329,6 +329,7 @@ func (r *reconciler) Reconcile(
 	newStatus := promo.Status.DeepCopy()
 
 	var suggestedRequeueInterval *time.Duration
+	var promoteErr error
 
 	// Wrap the promoteFn() call in an anonymous function to recover() any panics, so
 	// we can update the promo's phase with Error if it does. This breaks an infinite
@@ -346,7 +347,6 @@ func (r *reconciler) Reconcile(
 			}
 		}()
 		var otherStatus *kargoapi.PromotionStatus
-		var promoteErr error
 		otherStatus, suggestedRequeueInterval, promoteErr = r.promoteFn(
 			promoCtx,
 			*promo,
@@ -357,7 +357,10 @@ func (r *reconciler) Reconcile(
 			newStatus = otherStatus
 		}
 		if promoteErr != nil {
-			newStatus.Phase = kargoapi.PromotionPhaseErrored
+			// Preserve Running status for progressive backoff on retryable errors.
+			if newStatus.Phase != kargoapi.PromotionPhaseRunning || otherStatus == nil {
+				newStatus.Phase = kargoapi.PromotionPhaseErrored
+			}
 			newStatus.Message = promoteErr.Error()
 			logger.Error(promoteErr, "error executing Promotion")
 		}
@@ -458,9 +461,13 @@ func (r *reconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	// If the promotion is still running, we'll need to periodically check on
-	// it.
+	// If the promotion is still running, we'll need to periodically check on it.
 	if newStatus.Phase == kargoapi.PromotionPhaseRunning {
+		if promoteErr != nil {
+			// Retryable error: use progressive backoff.
+			return ctrl.Result{}, promoteErr
+		}
+		// Waiting for external condition: use calculated interval.
 		return ctrl.Result{
 			RequeueAfter: calculateRequeueInterval(promo, suggestedRequeueInterval),
 		}, nil
@@ -584,7 +591,6 @@ func (r *reconciler) promote(
 		)
 	}
 	if err != nil {
-		workingPromo.Status.Phase = kargoapi.PromotionPhaseErrored
 		return &workingPromo.Status, nil, err
 	}
 

--- a/pkg/webhook/external/artifactory.go
+++ b/pkg/webhook/external/artifactory.go
@@ -109,7 +109,7 @@ func (a *artifactoryWebhookReceiver) getHandler(requestBody []byte) http.Handler
 		}
 
 		mac := hmac.New(sha256.New, token)
-		mac.Write(requestBody)
+		_, _ = mac.Write(requestBody)
 		computedSig := hex.EncodeToString(mac.Sum(nil))
 
 		if !hmac.Equal([]byte(sig), []byte(computedSig)) {


### PR DESCRIPTION
Manual backport of #5491 to `release-1.8`. ~Has to be tested together with #5510.~ Tested and confirmed to work as expected.