### PR TITLE
feat(promotion): add ignoreMissingValueFiles to helm-template step

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-template.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-template.md
@@ -22,6 +22,7 @@ commonly preceded by a [`git-clear` step](git-clear.md) and followed by
 | `useReleaseName` | `boolean` | N | Whether to use the release name in the output path (instead of the chart name). This is `false` by default, and only has an effect when `outPath` is set to a directory. |
 | `namespace` | `string` | N | Optional namespace to use when rendering the manifests. This is commonly omitted. GitOps agents such as Argo CD will generally ensure the installation of manifests into the namespace specified by their own configuration. |
 | `valuesFiles` | `[]string` | N | Helm values files (apart from the chart's default `values.yaml`) to be used when rendering the manifests.  |
+| `ignoreMissingValueFiles` | `boolean` | N | Whether to skip value files that do not exist instead of returning an error. Useful for optional stage-specific overlays. This is `false` by default. |
 | `buildDependencies` | `bool` | N | Whether to build dependencies before rendering the manifests. If no Chart.lock file is present, the dependencies will be built from the Chart.yaml file (and may be updated). This is `false` by default. |
 | `includeCRDs` | `boolean` | N | Whether to include CRDs in the rendered manifests. This is `false` by default. |
 | `disableHooks` | `boolean` | N | Whether to disable hooks in the rendered manifests. This is `false` by default. |

--- a/pkg/promotion/runner/builtin/helm_template_runner.go
+++ b/pkg/promotion/runner/builtin/helm_template_runner.go
@@ -185,6 +185,11 @@ func (h *helmTemplateRunner) composeValues(
 		if err != nil {
 			return nil, fmt.Errorf("failed to join path %q: %w", p, err)
 		}
+		if cfg.IgnoreMissingValueFiles {
+			if _, err := os.Stat(absValuesPath); os.IsNotExist(err) {
+				continue
+			}
+		}
 		valueOpts.ValueFiles = append(valueOpts.ValueFiles, absValuesPath)
 	}
 

--- a/pkg/promotion/runner/builtin/helm_template_runner_test.go
+++ b/pkg/promotion/runner/builtin/helm_template_runner_test.go
@@ -830,6 +830,55 @@ func Test_helmTemplateRunner_composeValues(t *testing.T) {
 			},
 		},
 		{
+			name:    "ignore missing value files - file missing",
+			workDir: t.TempDir(),
+			cfg: builtin.HelmTemplateConfig{
+				ValuesFiles:             []string{"non_existent.yaml"},
+				IgnoreMissingValueFiles: true,
+				SetValues:               []builtin.SetValues{{Key: "key1", Value: "value1"}},
+			},
+			assertions: func(t *testing.T, result map[string]any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]any{
+					"key1": "value1",
+				}, result)
+			},
+		},
+		{
+			name:    "ignore missing value files - file exists",
+			workDir: t.TempDir(),
+			cfg: builtin.HelmTemplateConfig{
+				ValuesFiles:             []string{"values.yaml"},
+				IgnoreMissingValueFiles: true,
+			},
+			valuesContents: map[string]string{
+				"values.yaml": "key1: value1",
+			},
+			assertions: func(t *testing.T, result map[string]any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]any{
+					"key1": "value1",
+				}, result)
+			},
+		},
+		{
+			name:    "ignore missing value files - mixed existing and missing",
+			workDir: t.TempDir(),
+			cfg: builtin.HelmTemplateConfig{
+				ValuesFiles:             []string{"values.yaml", "missing.yaml"},
+				IgnoreMissingValueFiles: true,
+			},
+			valuesContents: map[string]string{
+				"values.yaml": "key1: value1",
+			},
+			assertions: func(t *testing.T, result map[string]any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]any{
+					"key1": "value1",
+				}, result)
+			},
+		},
+		{
 			name:    "composition with literal values",
 			workDir: t.TempDir(),
 			cfg: builtin.HelmTemplateConfig{

--- a/pkg/promotion/runner/builtin/schemas/helm-template-config.json
+++ b/pkg/promotion/runner/builtin/schemas/helm-template-config.json
@@ -67,6 +67,11 @@
         "minLength": 1
       }
     },
+    "ignoreMissingValueFiles": {
+      "type": "boolean",
+      "description": "Whether to skip value files that do not exist instead of returning an error. Useful for optional stage-specific overlays.",
+      "default": false
+    },
     "setValues": {
       "type": "array",
       "description": "Allows for amending chart configuration inline as one would with the `helm template` command's `--set` flag.",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -300,6 +300,9 @@ type HelmTemplateConfig struct {
 	BuildDependencies bool `json:"buildDependencies,omitempty"`
 	// Whether to disable hooks in the rendered manifests.
 	DisableHooks bool `json:"disableHooks,omitempty"`
+	// Whether to skip value files that do not exist instead of returning an error. Useful for
+	// optional stage-specific overlays.
+	IgnoreMissingValueFiles bool `json:"ignoreMissingValueFiles,omitempty"`
 	// Whether to include CRDs in the rendered manifests.
 	IncludeCRDs bool `json:"includeCRDs,omitempty"`
 	// KubeVersion allows for passing a specific Kubernetes version to use when rendering the

--- a/ui/src/gen/directives/helm-template-config.json
+++ b/ui/src/gen/directives/helm-template-config.json
@@ -66,6 +66,11 @@
     "minLength": 1
    }
   },
+  "ignoreMissingValueFiles": {
+   "type": "boolean",
+   "description": "Whether to skip value files that do not exist instead of returning an error. Useful for optional stage-specific overlays.",
+   "default": false
+  },
   "setValues": {
    "type": "array",
    "description": "Allows for amending chart configuration inline as one would with the `helm template` command's `--set` flag.",


### PR DESCRIPTION
## Summary
- Adds `ignoreMissingValueFiles` boolean option to the `helm-template` promotion step
- When enabled, missing value files are silently skipped instead of causing an error
- Eliminates the need for empty placeholder YAML files per stage

Closes #4349