### PR TITLE
fix: make the ui service on 30082 available

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -67,6 +67,7 @@ k8s_yaml(
 # Normally the API server serves up the front end, but we want live updates
 # of the UI, so we're breaking it out into its own separate deployment here.
 k8s_yaml('hack/tilt/ui.yaml')
+k8s_yaml('hack/tilt/ui-service.yaml')
 
 # Setup a namespace and controller permissions for shared credentials.
 k8s_yaml('hack/tilt/shared-creds.yaml')

--- a/hack/tilt/ui-service.yaml
+++ b/hack/tilt/ui-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kargo-ui
+  namespace: kargo
+  labels:
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: kargo
+    app.kubernetes.io/name: kargo
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 3333
+    targetPort: 3333
+    nodePort: 30082
+    protocol: TCP
+  selector:
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: kargo
+    app.kubernetes.io/name: kargo


### PR DESCRIPTION
Without this change I was not able to complete the https://docs.kargo.io/contributor-guide/hacking-on-kargo/ guide (using kind).