### PR TITLE
fix: show "Waiting for Approval" even if git-open-pr is the first step

### DIFF
--- a/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
+++ b/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
@@ -53,7 +53,7 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
     return null;
   }
 
-  if (!indexOfPullRequest || indexOfPullRequest < 0) {
+  if (indexOfPullRequest === undefined || indexOfPullRequest < 0) {
     return null;
   }
 


### PR DESCRIPTION
When `indexOfPullRequest` is zero, `!indexOfPullRequest` is true, skipping displaying the `PullRequestLink`.
