### PR TITLE
feat: show PR approval link for git-wait-for-pr steps while running

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
@@ -23,6 +23,11 @@ and is commonly followed by an `argocd-update` step.
 | Name | Type | Description |
 |------|------|-------------|
 | `commit` | `string` | The ID (SHA) of the new commit at the head of the target branch after merge. Typically, a subsequent [`argocd-update` step](argocd-update.md) will reference this output to learn the ID of the commit that an applicable Argo CD `ApplicationSource` should be observably synced to under healthy conditions. |
+| `pr` | `object` | An object containing details about the pull request being monitored. |
+| `pr.id` | `number` | The numeric identifier of the pull request. |
+| `pr.url` | `string` | The URL of the pull request. |
+| `pr.open` | `boolean` | Whether the pull request is still open. |
+| `pr.merged` | `boolean` | Whether the pull request has been merged. |
 
 ## Examples
 

--- a/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
+++ b/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
@@ -41,7 +41,7 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
   );
 
   const indexOfPullRequest = promotion?.spec?.steps?.findIndex(
-    (step) => step?.uses === 'git-open-pr'
+    (step: { uses?: string }) => step?.uses === 'git-open-pr' || step?.uses === 'git-wait-for-pr'
   );
 
   if (getPromotionQuery.isFetching) {
@@ -57,23 +57,33 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
     return null;
   }
 
-  const hasPullRequestStepSucceeded =
-    promotion?.status?.stepExecutionMetadata[indexOfPullRequest]?.status === 'Succeeded';
+  const step = promotion.spec.steps[indexOfPullRequest];
+  const stepType = step?.uses;
+  const stepMetadata = promotion?.status?.stepExecutionMetadata?.[indexOfPullRequest];
+  const stepStatus = stepMetadata?.status;
 
-  if (!hasPullRequestStepSucceeded) {
-    return null;
-  }
-
-  const aliasOfPullRequestStep = getPromotionStepAlias(
-    promotion.spec.steps[indexOfPullRequest],
-    indexOfPullRequest
-  );
+  const aliasOfPullRequestStep = getPromotionStepAlias(step, indexOfPullRequest);
 
   const outputOfPullRequestStep = outputsByStepAlias?.[aliasOfPullRequestStep];
 
-  const pullRequestLink = (outputOfPullRequestStep as { pr?: { url?: string } }).pr?.url;
+  const pullRequestLink = (outputOfPullRequestStep as { pr?: { url?: string } })?.pr?.url;
 
   if (!pullRequestLink) {
+    return null;
+  }
+
+  // For git-open-pr: only show when succeeded
+  // For git-wait-for-pr: show when running (has PR URL) or succeeded
+  const isGitWaitForPr = stepType === 'git-wait-for-pr';
+  const isGitOpenPr = stepType === 'git-open-pr';
+  const hasPullRequestStepSucceeded = stepStatus === 'Succeeded';
+  const hasPullRequestStepRunning = stepStatus === 'Running';
+
+  const isStatusAcceptable =
+    (isGitOpenPr && hasPullRequestStepSucceeded) ||
+    (isGitWaitForPr && (hasPullRequestStepSucceeded || hasPullRequestStepRunning));
+
+  if (!isStatusAcceptable) {
     return null;
   }
 

--- a/ui/src/plugins/pr-plugin/deep-link/promotion.tsx
+++ b/ui/src/plugins/pr-plugin/deep-link/promotion.tsx
@@ -5,11 +5,13 @@ import { Dropdown, Space } from 'antd';
 import { getPromotionState, getPromotionStepAlias } from '@ui/plugins/atoms/plugin-helper';
 import { DeepLinkPluginsInstallation } from '@ui/plugins/atoms/plugin-interfaces';
 
-import { getPullRequestLink } from '../get-pr-link';
+import { getPullRequestLink, PR_STEP_TYPES } from '../get-pr-link';
+
+const isPRStep = (stepType: string | undefined): boolean => PR_STEP_TYPES.includes(stepType || '');
 
 const plugin: DeepLinkPluginsInstallation['Promotion'] = {
   shouldRender(opts) {
-    return Boolean(opts.promotion?.spec?.steps?.find((step) => step?.uses === 'git-open-pr'));
+    return Boolean(opts.promotion?.spec?.steps?.find((step) => isPRStep(step?.uses)));
   },
   render(props) {
     // array of [step-alias, deep-link]
@@ -18,7 +20,7 @@ const plugin: DeepLinkPluginsInstallation['Promotion'] = {
     const promotionState = getPromotionState(props.promotion);
 
     for (const [idx, step] of Object.entries(props.promotion?.spec?.steps || [])) {
-      if (step?.uses === 'git-open-pr') {
+      if (isPRStep(step?.uses)) {
         const alias = getPromotionStepAlias(step, idx);
 
         try {

--- a/ui/src/plugins/pr-plugin/get-pr-link.ts
+++ b/ui/src/plugins/pr-plugin/get-pr-link.ts
@@ -5,6 +5,9 @@ type gitOpenPrOutput = {
   };
 };
 
+// Steps that can produce PR deep links
+export const PR_STEP_TYPES = ['git-open-pr', 'git-wait-for-pr'];
+
 export const getPullRequestLink = (promotionStepOutput: Record<string, unknown>) =>
   (promotionStepOutput as gitOpenPrOutput)?.pr?.url;
 


### PR DESCRIPTION
Previously, the "Waiting for Approval" component only appeared when promotion steps had a 'Succeeded' status and only for git-open-pr steps. This created a poor user experience for git-wait-for-pr steps, when they're not in the same stage as git-open-pr. They did not have a PR url attached and remain in 'Running' status while waiting for PR approval or merge.

The fix differentiates between step types:
- git-open-pr: Link appears only when step succeeds (PR is created)
- git-wait-for-pr: Link appears when step is running or succeeded (PR exists and is waiting for approval/merge)

This ensures users can access the PR for review/approval as soon as it's available, improving the GitOps workflow efficiency.

WHY: Users need immediate access to the PR link during the approval waiting period, not just after the step completes. The PR URL is already available from the preceding git-open-pr step output, so there's no reason to hide the link until the wait step succeeds.