### PR TITLE
docs: Add `kargo-promoter` Role Description to Access Controls Doc

### DIFF
--- a/docs/docs/50-user-guide/50-security/20-access-controls/index.md
+++ b/docs/docs/50-user-guide/50-security/20-access-controls/index.md
@@ -129,7 +129,7 @@ CLI users the convenience of a simplified interface for managing
 user-to-`ServiceAccount` mappings and the permissions associated with those
 `ServiceAccount` resources.
 
-Four such "Kargo roles" are pre-defined in a project's namespace when a new
+There are several "Kargo roles" pre-defined in a project's namespace when a new
 `Project` resource is created:
 
 1. `default`: This Kargo role exists by virtue of the existence of the `default`


### PR DESCRIPTION
Add mising description for `kargo-promoter` role to https://docs.kargo.io/user-guide/security/access-controls/. This was introduced in [v1.7.0](https://docs.kargo.io/release-notes/v1.7.0/#other-notable-changes).