### PR TITLE
fix(git): address `git ls-remote` ambiguity in `RemoteBranchExists`

### DIFF
--- a/pkg/controller/git/base_repo.go
+++ b/pkg/controller/git/base_repo.go
@@ -359,7 +359,7 @@ func (b *baseRepo) RemoteBranchExists(branch string) (bool, error) {
 		"--heads",
 		"--exit-code", // Return 2 if not found
 		b.accessURL,
-		branch,
+		"refs/heads/"+branch,
 	))
 	var exitErr *libExec.ExitError
 	if errors.As(err, &exitErr) && exitErr.ExitCode == 2 {


### PR DESCRIPTION
Addresses #5557

Currently the check for whether a remote branch exists executes `git ls-remote --heads --exit-code  <repo> <branch>`.

This also matches other branches containing the branch name. I.e. querying `bug-repro` will also return a branch such as `prepare/bug-repro`, thus making the check successful and leading to #5557.

Prepending the branch with `refs/heads/` addresses this ambiguity.

See the difference here (`prepare/bug-repro` is an existent branch and `bug-repro` does not exist):
<img width="1041" height="359" alt="image" src="https://github.com/user-attachments/assets/fff6e5aa-556b-4553-8ea0-86b6aecbc88b" />