### PR TITLE
fix: allow v-prefix in OCI helm chart versions

### DIFF
--- a/pkg/helm/chart/oci_selector.go
+++ b/pkg/helm/chart/oci_selector.go
@@ -63,7 +63,7 @@ func (o *ociSelector) Select(ctx context.Context) ([]string, error) {
 			// OCI artifact tags are not allowed to contain the "+" character, which is
 			// used by SemVer to separate the version from the build metadata. To work
 			// around this, Helm uses "_" instead of "+".
-			if sv, err := semver.StrictNewVersion(strings.ReplaceAll(tag, "_", "+")); err == nil {
+			if sv, err := semver.NewVersion(strings.ReplaceAll(tag, "_", "+")); err == nil {
 				semvers = append(semvers, sv)
 			}
 		}

--- a/pkg/helm/chart/oci_selector_test.go
+++ b/pkg/helm/chart/oci_selector_test.go
@@ -70,3 +70,19 @@ func Test_ociSelector_Select(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, versions)
 }
+
+func Test_ociSelector_Select_WithVPrefix(t *testing.T) {
+	// Regression test for issue no. 5604: Ensure we can discover tags from OCI repositories
+	// that use v-prefixed versions (like "v1.12.0"), which were previously rejected
+	// by strict SemVer parsing.
+	s, err := newOCISelector(
+		kargoapi.ChartSubscription{
+			RepoURL: "oci://quay.io/jetstack/charts/cert-manager",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	versions, err := s.Select(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, versions)
+}


### PR DESCRIPTION
Fixes #5604

## Description
The OCI chart selector currently uses `semver.StrictNewVersion`, which fails to parse tags with a `v` prefix (e.g., `v1.2.3`), treating them as invalid versions. This prevents discovering versions from registries that use this naming convention (e.g., `quay.io/jetstack/charts/cert-manager`).

This PR changes the parsing logic to use `semver.NewVersion`, which automatically handles and trims the `v` prefix.

## Changes
- Replaced `semver.StrictNewVersion` with `semver.NewVersion` in `pkg/helm/chart/oci_selector.go`.
- Added a new integration test case in `pkg/helm/chart/oci_selector_test.go` targeting `quay.io/jetstack/charts/cert-manager` to verify v-prefixed tags are discovered.

## Verification
- [x] Ran `go test -v ./pkg/helm/chart` and verified all tests pass, including the new `Test_ociSelector_Select_WithVPrefix`.
- [x] Ran `make hack-lint-go` (No linting errors).