### PR TITLE
fix(ui): correct format of max-age directive

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -28,7 +28,7 @@ func SetCacheHeaders(w http.ResponseWriter, maxAge time.Duration, timeUntilExpir
 		return
 	}
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(maxAge.Seconds())))
-	w.Header().Set("Expires", time.Now().Add(timeUntilExpiry).Format(time.RFC1123))
+	w.Header().Set("Expires", time.Now().UTC().Add(timeUntilExpiry).Format(http.TimeFormat))
 }
 
 func WriteResponseJSON(w http.ResponseWriter, code int, body any) {

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -43,5 +43,6 @@ func TestSetCacheHeaders(t *testing.T) {
 	SetCacheHeaders(w, 30*24*time.Hour, 7*24*time.Hour)
 	headers := w.Result().Header
 	require.Equal(t, "public, max-age=2592000", headers.Get("Cache-Control"))
-	require.NotEmpty(t, headers.Get("Expires"))
+	expires := headers.Get("Expires")
+	require.Equal(t, expires[len(expires)-4:], " GMT", "Expires header must end with ' GMT', got '%s'.", expires)
 }


### PR DESCRIPTION
The cache-control response header returns `public, max-age=720h0m0s`. The max-age directive is not spec-compliant.  After this change, the max-age correctly specifies 2592000.

Anecdotally, this was not a problem in Chrome (it seems to fall back to the Expires header).  It seems to affect Firefox, causing Firefox to download the 6Mb javascript file e.g. /assets/index-LxV79Jo9.js.

This should dramatically improve the experience of using Kargo on Firefox.