### PR TITLE
fix(cli): fix api version used by hand-written watch client

### DIFF
--- a/pkg/client/watch/watch.go
+++ b/pkg/client/watch/watch.go
@@ -56,7 +56,7 @@ func (c *Client) WatchStage(
 	project string,
 	stage string,
 ) (<-chan Event[*kargoapi.Stage], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/stages/%s?watch=true", c.baseURL, project, stage)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/stages/%s?watch=true", c.baseURL, project, stage)
 	return watchResource[*kargoapi.Stage](ctx, c, url)
 }
 
@@ -66,7 +66,7 @@ func (c *Client) WatchWarehouses(
 	ctx context.Context,
 	project string,
 ) (<-chan Event[*kargoapi.Warehouse], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/warehouses?watch=true", c.baseURL, project)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/warehouses?watch=true", c.baseURL, project)
 	return watchResource[*kargoapi.Warehouse](ctx, c, url)
 }
 
@@ -76,7 +76,7 @@ func (c *Client) WatchStages(
 	ctx context.Context,
 	project string,
 ) (<-chan Event[*kargoapi.Stage], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/stages?watch=true", c.baseURL, project)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/stages?watch=true", c.baseURL, project)
 	return watchResource[*kargoapi.Stage](ctx, c, url)
 }
 
@@ -86,7 +86,7 @@ func (c *Client) WatchPromotions(
 	ctx context.Context,
 	project string,
 ) (<-chan Event[*kargoapi.Promotion], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/promotions?watch=true", c.baseURL, project)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/promotions?watch=true", c.baseURL, project)
 	return watchResource[*kargoapi.Promotion](ctx, c, url)
 }
 
@@ -97,7 +97,7 @@ func (c *Client) WatchWarehouse(
 	project string,
 	warehouse string,
 ) (<-chan Event[*kargoapi.Warehouse], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/warehouses/%s?watch=true", c.baseURL, project, warehouse)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/warehouses/%s?watch=true", c.baseURL, project, warehouse)
 	return watchResource[*kargoapi.Warehouse](ctx, c, url)
 }
 
@@ -108,7 +108,7 @@ func (c *Client) WatchPromotion(
 	project string,
 	promotion string,
 ) (<-chan Event[*kargoapi.Promotion], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/promotions/%s?watch=true", c.baseURL, project, promotion)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/promotions/%s?watch=true", c.baseURL, project, promotion)
 	return watchResource[*kargoapi.Promotion](ctx, c, url)
 }
 
@@ -118,7 +118,7 @@ func (c *Client) WatchProjectConfig(
 	ctx context.Context,
 	project string,
 ) (<-chan Event[*kargoapi.ProjectConfig], <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/config?watch=true", c.baseURL, project)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/config?watch=true", c.baseURL, project)
 	return watchResource[*kargoapi.ProjectConfig](ctx, c, url)
 }
 
@@ -127,7 +127,7 @@ func (c *Client) WatchProjectConfig(
 func (c *Client) WatchClusterConfig(
 	ctx context.Context,
 ) (<-chan Event[*kargoapi.ClusterConfig], <-chan error) {
-	url := fmt.Sprintf("%s/v2/cluster-config?watch=true", c.baseURL)
+	url := fmt.Sprintf("%s/v1beta1/cluster-config?watch=true", c.baseURL)
 	return watchResource[*kargoapi.ClusterConfig](ctx, c, url)
 }
 
@@ -298,7 +298,7 @@ func (c *Client) StreamAnalysisRunLogs(
 	metricName string,
 	containerName string,
 ) (<-chan string, <-chan error) {
-	url := fmt.Sprintf("%s/v2/projects/%s/analysis-runs/%s/logs", c.baseURL, project, analysisRun)
+	url := fmt.Sprintf("%s/v1beta1/projects/%s/analysis-runs/%s/logs", c.baseURL, project, analysisRun)
 
 	// Add query parameters if provided
 	params := make([]string, 0)

--- a/pkg/client/watch/watch_test.go
+++ b/pkg/client/watch/watch_test.go
@@ -74,7 +74,7 @@ func TestWatchStage(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/stages/test-stage", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/stages/test-stage", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 		assert.Equal(t, "text/event-stream", r.Header.Get("Accept"))
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
@@ -117,7 +117,7 @@ func TestWatchStages(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/stages", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/stages", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -158,7 +158,7 @@ func TestWatchWarehouse(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/warehouses/test-warehouse", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/warehouses/test-warehouse", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -199,7 +199,7 @@ func TestWatchWarehouses(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/warehouses", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/warehouses", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -240,7 +240,7 @@ func TestWatchPromotion(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/promotions/test-promotion", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/promotions/test-promotion", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -281,7 +281,7 @@ func TestWatchPromotions(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/promotions", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/promotions", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -322,7 +322,7 @@ func TestWatchProjectConfig(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/projects/test-project/config", r.URL.Path)
+		assert.Equal(t, "/v1beta1/projects/test-project/config", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -362,7 +362,7 @@ func TestWatchClusterConfig(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/cluster-config", r.URL.Path)
+		assert.Equal(t, "/v1beta1/cluster-config", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("watch"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -581,28 +581,28 @@ func TestStreamAnalysisRunLogs(t *testing.T) {
 			name:          "no query params",
 			metricName:    "",
 			containerName: "",
-			expectedPath:  "/v2/projects/test-project/analysis-runs/test-run/logs",
+			expectedPath:  "/v1beta1/projects/test-project/analysis-runs/test-run/logs",
 			expectedQuery: "",
 		},
 		{
 			name:          "with metric name",
 			metricName:    "my-metric",
 			containerName: "",
-			expectedPath:  "/v2/projects/test-project/analysis-runs/test-run/logs",
+			expectedPath:  "/v1beta1/projects/test-project/analysis-runs/test-run/logs",
 			expectedQuery: "metricName=my-metric",
 		},
 		{
 			name:          "with container name",
 			metricName:    "",
 			containerName: "my-container",
-			expectedPath:  "/v2/projects/test-project/analysis-runs/test-run/logs",
+			expectedPath:  "/v1beta1/projects/test-project/analysis-runs/test-run/logs",
 			expectedQuery: "containerName=my-container",
 		},
 		{
 			name:          "with both params",
 			metricName:    "my-metric",
 			containerName: "my-container",
-			expectedPath:  "/v2/projects/test-project/analysis-runs/test-run/logs",
+			expectedPath:  "/v1beta1/projects/test-project/analysis-runs/test-run/logs",
 			expectedQuery: "metricName=my-metric&containerName=my-container",
 		},
 	}


### PR DESCRIPTION
The change from placeholder "v2" to "v1beta1" was a late change to #5614.

The corresponding change to the hand-written watch client used by the CLI for log streaming was overlooked.