### PR TITLE
fix(mgmt-ctrl): improve secret migration

### DIFF
--- a/docs/docs/40-operator-guide/40-security/40-managing-secrets.md
+++ b/docs/docs/40-operator-guide/40-security/40-managing-secrets.md
@@ -376,6 +376,29 @@ new locations, with a few exceptions:
 Kargo v1.12.0 will remove the automatic migration and upgrades to that version
 or greater will **fail** if values are detected for any of the old settings.
 
+**Sync Behavior:**
+
+The automatic sync from old to new locations works as follows:
+
+* **Unmodified secrets:** If a `Secret` in the new location has not been
+  modified since it was synced, updates from the old location will continue to
+  propagate. Deleting from the old location will also delete from the new
+  location.
+
+* **Modified secrets:** If you modify a `Secret` in the new location (via the
+  Kargo UI or otherwise), those changes are protected. Updates from the old
+  location will _not_ overwrite your modifications. Similarly, deleting from the
+  old location will _not_ delete a modified secret from the new location.
+
+* **Deleting from the new location:** If you delete a `Secret` from the new
+  location while it still exists in the old location, it will be recreated on
+  the next sync. To permanently remove a secret, delete it from the old
+  location.
+
+* **Namespace cleanup:** When the old namespace itself is deleted (bulk
+  cleanup), all secrets in the new location are preserved, regardless of whether
+  they were modified.
+
 **What this means, practically speaking:**
 
 * New installations of Kargo need not be concerned with any of this.
@@ -385,9 +408,11 @@ or greater will **fail** if values are detected for any of the old settings.
   * If you manually manage credentials using the Kargo UI, everything will just
     work. Post upgrade, `Secret`s will automatically sync from their old
     locations to their new locations. Kargo will use and manage `Secret`s in
-    their new locations. With due caution, you may manually delete the old
-    namespaces using `kubectl`.
-  
+    their new locations. Any modifications you make via the UI to secrets in the
+    new location will be preserved and not overwritten by subsequent syncs. When
+    you are ready, you may delete the old namespaces using `kubectl` -- all
+    secrets in the new locations will be preserved.
+
   * If you are a more advanced operator who GitOps'es your `Secret`s, you do
     not need to act with any urgency.
 


### PR DESCRIPTION
The Secret migration reconciler has a bit of a problem.

It syncs from a source namespace to a destination namespace on a continuous basis. (This facilitates the migration from "global creds" to "shared resources" and from "cluster secrets" to "cluster resources.)

The continuous sync was deliberate. This way if you're GitOps'ing your Secrets, you do not urgently need to change your manifests to reference the new namespaces. You can keep on GitOps'ing them into their original location and Kargo will silently sync them to the new location. You can update your manifests at your leisure. (Well, before v1.12.0, really.)

But this continuous sync is a bit of a problem for any clickops'ing their Secrets. If you update a Secret via UI, the next sync will overwrite it with a copy of the corresponding Secret from the source namespace.

Deleting Secrets from the source namespace could also be a problem for both GitOps'ers and clickops'ers. For the benefit of the GitOps crowd, if you delete a Secret from the old namespace, it's deleted from the new one as well. This can make cleanup a bit of a problem. Everything synced. You're happy. You go to delete the old Secrets... and they disappear from their new location. 😢

This PR modifies the migration reconciler in a few key ways to avoid this slate of problems:

1. When the sync process creates a Secret in the destination namespace, it's annotated with a hash of its data map.

1. Subsequent updates and deletes will be skipped if the the destination lacks the hash annotation or a hash of its current data map no longer matches that annotation's value. This means hands off all Secrets created via the UI or modified by the UI after an initial sync.

1. When reconciling a deleted Secret from the source namespace, the delete will be skipped if the source namespace is also pending deletion. This means bulk cleanup by deleting the old namespaces will not delete Secrets from the destination namespaces.

The one remaining unusual behavior is that Secrets _deleted_ from the new namespace will eventually be restored by the migration reconciler. This behavior, along with all of the above, is documented.

Release notes will be updated to link to the migration section of the docs.