### PR TITLE
fix(api): fix undesired project field validation in repo creds update endpoint

### DIFF
--- a/pkg/server/update_repo_credentials_v1alpha1.go
+++ b/pkg/server/update_repo_credentials_v1alpha1.go
@@ -26,10 +26,6 @@ func (s *server) UpdateRepoCredentials(
 		return nil, connect.NewError(connect.CodeUnimplemented, errSecretManagementDisabled)
 	}
 
-	if err := validateFieldNotEmpty("project", req.Msg.Project); err != nil {
-		return nil, err
-	}
-
 	project := req.Msg.GetProject()
 	if project != "" {
 		if err := s.validateProjectExists(ctx, project); err != nil {


### PR DESCRIPTION
Project is an optional field now. No project specified == shared. This validation doesn't belong anymore.