### PR TITLE
fix: shared-expressions map access

### DIFF
--- a/pkg/expressions/function/functions.go
+++ b/pkg/expressions/function/functions.go
@@ -113,7 +113,7 @@ func SharedSecret(ctx context.Context, c client.Client, cache *gocache.Cache) ex
 	return expr.Function(
 		"sharedSecret",
 		getSecret(ctx, c, cache, os.Getenv("SHARED_RESOURCES_NAMESPACE"), false),
-		new(func(name string) *corev1.Secret),
+		new(func(name string) map[string]string),
 	)
 }
 
@@ -121,7 +121,7 @@ func SharedConfigMap(ctx context.Context, c client.Client, cache *gocache.Cache)
 	return expr.Function(
 		"sharedConfigMap",
 		getConfigMap(ctx, c, cache, os.Getenv("SHARED_RESOURCES_NAMESPACE")),
-		new(func(name string) *corev1.ConfigMap),
+		new(func(name string) map[string]string),
 	)
 }
 


### PR DESCRIPTION
### Promo

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: staging
  namespace: kargo-demo
spec:
  requestedFreight:
    - origin:
        kind: Warehouse
        name: my-warehouse
      sources:
        direct: true
        autoPromotionOptions:
          selectionPolicy: NewestFreight
  promotionTemplate:
    spec:
      vars:
        # Read a shared config map from the shared-resources namespace
        # and pull individual keys off the map.
        - name: shared_config_map
          value: ${{ sharedConfigMap("my-shared-configmap")['message'] }}

        # Read a shared secret value (e.g., API token)
        - name: shared_secret
          value: ${{ sharedSecret("my-public-shared-secret")['message'] }}

      steps:
        - uses: http
          config:
            url: https://webhook.site/73372338-8712-40fe-adae-27f5e716d32b
            method: POST
            headers:
              - name: Content-Type
                value: application/json
            body: |
              {
                "freight": "${{ ctx.targetFreight.name }}",
                "stage": "${{ ctx.stage }}",
                "secret": "${{ vars.shared_secret }}",
                "configmap": "${{ vars.shared_config_map }}"
              }
```

### Secret

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-public-shared-secret
  namespace: kargo-shared-resources
  labels:
    kargo.akuity.io/cred-type: generic
data:
  message: aGVsbG8gdGhlcmUK
```

### Config map

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-shared-configmap
  namespace: kargo-shared-resources
data:
  message: aGVsbG8gdGhlcmUK
```

### Result

<img width="696" height="307" alt="shared-payload" src="https://github.com/user-attachments/assets/abcc5022-d18d-47a7-87c6-b9b5aca31e2e" />
