### PR TITLE
fix: fix documentation promotion script

### DIFF
--- a/hack/docs/promote.sh
+++ b/hack/docs/promote.sh
@@ -107,7 +107,7 @@ display_summary() {
     echo "Use the Netlify Dashboard to follow up on build + deployment progress: https://app.netlify.com/sites/$NETLIFY_SITE_ID"
     echo "=================================================================="
 }
-=
+
 main() {
     local new_prod_branch="${1:-}"
 


### PR DESCRIPTION
There was somehow an errant `=` on what should have been a blank line.