### PR TITLE
fix(api): force custom marshaling of warehouses in watch endpoint

### DIFF
--- a/pkg/server/watch_warehouses_v1alpha1.go
+++ b/pkg/server/watch_warehouses_v1alpha1.go
@@ -60,6 +60,12 @@ func (s *server) WatchWarehouses(
 			if !ok {
 				return fmt.Errorf("unexpected object type %T", e.Object)
 			}
+			// Necessary because serializing a Warehouse as part of a protobuf
+			// message does not apply custom marshaling. The call to this helper
+			// compensates for that.
+			if err := prepareOutboundWarehouse(warehouse); err != nil {
+				return fmt.Errorf("prepare outbound warehouse: %w", err)
+			}
 			if err := stream.Send(&svcv1alpha1.WatchWarehousesResponse{
 				Warehouse: warehouse,
 				Type:      string(e.Type),


### PR DESCRIPTION
Fixes #5663 

Supersedes #5664

This forces custom marshaling on Warehouses returned as protobuf in a watch stream in the same way as is already done for the get and list Warehouse endpoints.

<img width="956" height="550" alt="Screenshot 2026-01-29 at 1 20 08 PM" src="https://github.com/user-attachments/assets/3fb8b50a-904d-4722-82c3-1223dee902ff" />
