### PR TITLE
fix: temporarily revert `--filter` on Git clone

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
@@ -37,7 +37,7 @@ multiple working trees.
 | `checkout[].commit` | `string` | N | A specific commit to check out. Mutually exclusive with `branch` and `tag`. If none of these is specified, the default branch will be checked out. |
 | `checkout[].path` | `string` | Y | The path for a working tree that will be created from the checked out revision. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `checkout[].tag` | `string` | N | A tag to check out. Mutually exclusive with `branch` and `commit`. If none of these is specified, the default branch will be checked out. |
-| `checkout[].sparse` | `[]string` | N | Directory paths for sparse checkout. Only the specified directories (and their contents) will be checked out. Paths must be relative to the repository root (e.g., `src/app`, `configs/prod`). Glob patterns are not supported. When all checkouts use sparse patterns, a [blobless clone][] is performed automatically to reduce clone time and disk usage. |
+| `checkout[].sparse` | `[]string` | N | Directory paths for sparse checkout. Only the specified directories (and their contents) will be checked out. Paths must be relative to the repository root (e.g., `src/app`, `configs/prod`). Glob patterns are not supported. |
 
 ## Output
 

--- a/pkg/controller/git/bare_repo.go
+++ b/pkg/controller/git/bare_repo.go
@@ -125,11 +125,14 @@ func CloneBare(
 	return b, nil
 }
 
-func (b *bareRepo) clone(opts *BareCloneOptions) error {
+func (b *bareRepo) clone(_ *BareCloneOptions) error {
 	args := []string{"clone", "--bare"}
-	if opts.Filter != "" {
-		args = append(args, "--filter", opts.Filter)
-	}
+	// NOTE(hidde): Temporarily disabled until we figure out why this can result
+	// in "could not fetch <commit> from promisor remote" errors.
+	//
+	// if opts.Filter != "" {
+	//  	args = append(args, "--filter", opts.Filter)
+	// }
 	args = append(args, b.accessURL, b.dir)
 	cmd := b.buildGitCommand(args...)
 	cmd.Dir = b.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()

--- a/pkg/controller/git/repo.go
+++ b/pkg/controller/git/repo.go
@@ -128,9 +128,12 @@ func (r *repo) clone(opts *CloneOptions) error {
 	if opts.Depth > 0 {
 		args = append(args, "--depth", fmt.Sprint(opts.Depth))
 	}
-	if opts.Filter != "" {
-		args = append(args, "--filter", opts.Filter)
-	}
+	// NOTE(hidde): Temporarily disabled until we figure out why this can result
+	// in "could not fetch <commit> from promisor remote" errors.
+	//
+	// if opts.Filter != "" {
+	//  	args = append(args, "--filter", opts.Filter)
+	// }
 	args = append(args, r.accessURL, r.dir)
 	cmd := r.buildGitCommand(args...)
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()


### PR DESCRIPTION
We have seen reports about the enabling of this causing issues, which present themselves with the following error: "could not fetch <commit> from promisor remote"

Disable until we figure out the culprit, and can ensure it works reliably for everyone.