### PR TITLE
chore(backport release-1.8): fix: temporarily revert `--filter` on Git clone 

### DIFF
--- a/pkg/controller/git/repo.go
+++ b/pkg/controller/git/repo.go
@@ -128,9 +128,12 @@ func (r *repo) clone(opts *CloneOptions) error {
 	if opts.Depth > 0 {
 		args = append(args, "--depth", fmt.Sprint(opts.Depth))
 	}
-	if opts.Filter != "" {
-		args = append(args, "--filter", opts.Filter)
-	}
+	// NOTE(hidde): Temporarily disabled until we figure out why this can result
+	// in "could not fetch <commit> from promisor remote" errors.
+	//
+	// if opts.Filter != "" {
+	//  	args = append(args, "--filter", opts.Filter)
+	// }
 	args = append(args, r.accessURL, r.dir)
 	cmd := r.buildGitCommand(args...)
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()


### PR DESCRIPTION
We have seen reports about the enabling of this causing issues, which present themselves with the following error: "could not fetch <commit> from promisor remote"

Disable until we figure out the culprit, and can ensure it works reliably for everyone.