### PR TITLE
fix: Fixed chart repoURL pattern regex

### DIFF
--- a/pkg/subscription/schemas/chart.json
+++ b/pkg/subscription/schemas/chart.json
@@ -8,7 +8,7 @@
         "repoURL": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*$",
+            "pattern": "^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*)$",
             "description": "RepoURL specifies the URL of a Helm chart repository. It may be a classic chart repository (using HTTP/S) OR a repository within an OCI registry. Classic chart repositories can contain differently named charts. When this field points to such a repository, the name field MUST also be used to specify the name of the desired chart within that repository. In the case of a repository within an OCI registry, the URL implicitly points to a specific chart and the name field MUST NOT be used. This field is required."
         },
         "name": {

--- a/ui/src/gen/subscriptions/chart.json
+++ b/ui/src/gen/subscriptions/chart.json
@@ -7,7 +7,7 @@
   "repoURL": {
    "type": "string",
    "minLength": 1,
-   "pattern": "^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*$",
+   "pattern": "^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*)$",
    "description": "RepoURL specifies the URL of a Helm chart repository. It may be a classic chart repository (using HTTP/S) OR a repository within an OCI registry. Classic chart repositories can contain differently named charts. When this field points to such a repository, the name field MUST also be used to specify the name of the desired chart within that repository. In the case of a repository within an OCI registry, the URL implicitly points to a specific chart and the name field MUST NOT be used. This field is required."
   },
   "name": {


### PR DESCRIPTION
## Issue

When trying to create a new Warehouse with a chart Subscription, the form will not allow any submissions, even with proper values entered. It always shows the error `unterminated parenthetical` when hitting "Add Subscription". The issue is the regex that backs that field is missing a closing parenthesis.

<img width="1530" height="885" alt="Screenshot_20260206_223619" src="https://github.com/user-attachments/assets/c1e85355-1113-4214-80f3-3cb5c992c44a" />

## Solution

Added parenthesis to end of regex to close domain and port clause.

`^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*$`

vs.

`^(((https?)|(oci))://)(([\\w\\d\\.\\-]+)(:([\\d]+)?)?(/.*)*)$`