### PR TITLE
feat(chart): allow for template on host input

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -45,10 +45,24 @@ Generate base URL for a service.
 {{- end -}}
 
 {{/*
+Generate the base HOST for the API service.
+*/}}
+{{- define "kargo.api.baseHost" -}}
+{{- (tpl .Values.api.host .) -}}
+{{- end -}}
+
+{{/*
 Generate the base URL for the API service.
 */}}
 {{- define "kargo.api.baseURL" -}}
-{{- include "kargo.baseURL" (dict "service" .Values.api "host" .Values.api.host) -}}
+{{- include "kargo.baseURL" (dict "service" .Values.api "host" (include "kargo.api.baseHost" .)) -}}
+{{- end -}}
+
+{{/*
+Generate the base HOST for the external webhook server.
+*/}}
+{{- define "kargo.externalWebhooksServer.baseHost" -}}
+{{- (tpl .Values.externalWebhooksServer.host .) -}}
 {{- end -}}
 
 {{/*
@@ -60,7 +74,7 @@ Generate the base URL for the external webhook server.
 {{- if and (not $webhookService.ingress.enabled) $apiService.enabled $apiService.ingress.enabled -}}
 {{- printf "%s/webhooks" (include "kargo.api.baseURL" .) -}}
 {{- else -}}
-{{- include "kargo.baseURL" (dict "service" $webhookService "host" $webhookService.host) -}}
+{{- include "kargo.baseURL" (dict "service" $webhookService "host" (include "kargo.externalWebhooksServer.baseHost" .)) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kargo/templates/api/cert.yaml
+++ b/charts/kargo/templates/api/cert.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kargo.api.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - {{ quote .Values.api.host }}
+  - {{ include "kargo.api.baseHost" . | quote }}
   issuerRef:
     kind: Issuer
     name: kargo-selfsigned-cert-issuer

--- a/charts/kargo/templates/api/configmap.yaml
+++ b/charts/kargo/templates/api/configmap.yaml
@@ -28,7 +28,7 @@ data:
   {{- if .Values.api.adminAccount.enabled }}
   ADMIN_ACCOUNT_ENABLED: "true"
   ADMIN_ACCOUNT_TOKEN_ISSUER: {{ include "kargo.api.baseURL" . }}
-  ADMIN_ACCOUNT_TOKEN_AUDIENCE: {{ quote .Values.api.host }}
+  ADMIN_ACCOUNT_TOKEN_AUDIENCE: {{ include "kargo.api.baseHost" . | quote }}
   ADMIN_ACCOUNT_TOKEN_TTL: {{ quote .Values.api.adminAccount.tokenTTL }}
   {{- end }}
   {{- if .Values.api.oidc.enabled }}
@@ -41,8 +41,8 @@ data:
   {{- end }}
   {{- if .Values.api.oidc.dex.enabled }}
   OIDC_ISSUER_URL: {{ include "kargo.api.baseURL" . }}/dex
-  OIDC_CLIENT_ID: {{ quote .Values.api.host }}
-  OIDC_CLI_CLIENT_ID: {{ .Values.api.host }}-cli
+  OIDC_CLIENT_ID: {{ include "kargo.api.baseHost" . | quote }}
+  OIDC_CLI_CLIENT_ID: {{ include "kargo.api.baseHost" . }}-cli
   DEX_ENABLED: "true"
   DEX_SERVER_ADDRESS: https://kargo-dex-server.{{ .Release.Namespace }}.svc
   DEX_CA_CERT_PATH: /etc/kargo/idp-ca.crt
@@ -57,7 +57,7 @@ data:
   {{- end }}
   {{- if .Values.api.argocd.urls }}
   ARGOCD_NAMESPACE: {{ .Values.controller.argocd.namespace | default "argocd" }}
-  ARGOCD_URLS: {{ range $key, $val := .Values.api.argocd.urls }}{{ $key }}={{ $val }},{{- end }}
+  ARGOCD_URLS: {{ range $key, $val := .Values.api.argocd.urls }}{{ $key }}={{ tpl $val $ }},{{- end }}
   {{- end }}
   ROLLOUTS_INTEGRATION_ENABLED: {{ quote .Values.api.rollouts.integrationEnabled }}
   {{- if and .Values.api.rollouts.integrationEnabled .Values.api.rollouts.logs.enabled }}

--- a/charts/kargo/templates/api/ingress-cert.yaml
+++ b/charts/kargo/templates/api/ingress-cert.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kargo.api.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - {{ quote .Values.api.host }}
+  - {{ include "kargo.api.baseHost" . | quote }}
   issuerRef:
     kind: Issuer
     name: kargo-selfsigned-cert-issuer

--- a/charts/kargo/templates/api/ingress.yaml
+++ b/charts/kargo/templates/api/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   ingressClassName: {{ .Values.api.ingress.ingressClassName }}
   {{- end }}
   rules:
-  - host: {{ quote .Values.api.host }}
+  - host: {{ include "kargo.api.baseHost" . | quote }}
     http:
       paths:
       - pathType: {{ .Values.api.ingress.pathType | default "ImplementationSpecific" }}
@@ -48,7 +48,7 @@ spec:
   {{- if .Values.api.ingress.tls.enabled }}
   tls:
   - hosts:
-    - {{ quote .Values.api.host }}
+    - {{ include "kargo.api.baseHost" . | quote }}
     secretName: {{ .Values.api.ingress.tls.secretName }}
   {{- end }}
 {{- end }}

--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -38,5 +38,5 @@ stringData:
       public: true
 
     connectors:
-    {{- toYaml .Values.api.oidc.dex.connectors | nindent 4 }}
+    {{- tpl (toYaml .Values.api.oidc.dex.connectors) . | nindent 4 }}
 {{- end }}

--- a/charts/kargo/templates/dex-server/secret.yaml
+++ b/charts/kargo/templates/dex-server/secret.yaml
@@ -26,14 +26,14 @@ stringData:
       skipApprovalScreen: {{ .Values.api.oidc.dex.skipApprovalScreen | default "true" }}
 
     staticClients:
-    - id: {{ quote .Values.api.host }}
+    - id: {{ include "kargo.api.baseHost" . | quote }}
       name: Kargo
       public: true
-      {{- if not (hasPrefix "localhost:" .Values.api.host) }}
+      {{- if not (hasPrefix "localhost:" (include "kargo.api.baseHost" .)) }}
       redirectURIs:
       - {{ include "kargo.api.baseURL" . }}/login
       {{- end }}
-    - id: {{ .Values.api.host }}-cli
+    - id: {{ include "kargo.api.baseHost" . }}-cli
       name: Kargo CLI
       public: true
 

--- a/charts/kargo/templates/external-webhooks-server/cert.yaml
+++ b/charts/kargo/templates/external-webhooks-server/cert.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kargo.externalWebhooksServer.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - {{ quote .Values.externalWebhooksServer.host }}
+  - {{ include "kargo.externalWebhooksServer.baseHost" . | quote }}
   issuerRef:
     kind: Issuer
     name: kargo-selfsigned-cert-issuer

--- a/charts/kargo/templates/external-webhooks-server/ingress-cert.yaml
+++ b/charts/kargo/templates/external-webhooks-server/ingress-cert.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kargo.externalWebhooksServer.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - {{ quote .Values.externalWebhooksServer.host }}
+  - {{ include "kargo.externalWebhooksServer.baseHost" . | quote }}
   issuerRef:
     kind: Issuer
     name: kargo-selfsigned-cert-issuer

--- a/charts/kargo/templates/external-webhooks-server/ingress.yaml
+++ b/charts/kargo/templates/external-webhooks-server/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   ingressClassName: {{ .Values.externalWebhooksServer.ingress.ingressClassName }}
   {{- end }}
   rules:
-  - host: {{ quote .Values.externalWebhooksServer.host }}
+  - host: {{ include "kargo.externalWebhooksServer.baseHost" . | quote }}
     http:
       paths:
       - pathType: {{ .Values.externalWebhooksServer.ingress.pathType | default "ImplementationSpecific" }}
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.externalWebhooksServer.ingress.tls.enabled }}
   tls:
   - hosts:
-    - {{ quote .Values.externalWebhooksServer.host }}
+    - {{ include "kargo.externalWebhooksServer.baseHost" . | quote }}
     secretName: {{ .Values.externalWebhooksServer.ingress.tls.secretName }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
- Allow for hostnames to be helm temptable
  - `api.host`
  - `api.argocd.urls{*}`
  - `externalWebhooksServer.host`
  
Previously the fields must have been set with
```yaml
api:
  host: kargo.example.com
externalWebhooksServer:
  host: webhooks.kargo.example.com
```

We can now do something like:

```yaml
global:
  baseDomain: 'example.com'

api:
  host: "kargo.{{ .Values.global.baseDomain }}"
externalWebhooksServer:
  host: "webhooks.kargo.{{ .Values.global.baseDomain }}"  
```

### Validation
Rendered before and after proposed changes and had no diff in the outcome templates
- `api.oidc.enabled` - `true` and `false`
- `api.oidc.dex.enabled` - `true` and `false`
- `api.tls.enabled.selfSignedCert` - `true` and `false`
- `externalWebhooksServer.tls.enabled` - `true` and `false`
- `externalWebhooksServer.tls.selfSignedCert` - `true` and `false`



Addresses #5630 