### PR TITLE
fix(api): fix issue with project exists middleware

### DIFF
--- a/pkg/server/project_middleware.go
+++ b/pkg/server/project_middleware.go
@@ -18,7 +18,11 @@ func (s *server) projectExistsMiddleware() gin.HandlerFunc {
 			return
 		}
 		p := &kargoapi.Project{}
-		if err := s.client.Get(
+		var cl client.Client = s.client
+		if s.client != nil && s.client.InternalClient() != nil {
+			cl = s.client.InternalClient()
+		}
+		if err := cl.Get(
 			c.Request.Context(),
 			client.ObjectKey{Name: project},
 			p,


### PR DESCRIPTION
This corrects middleware for the REST API that was incorrectly _not_ using the API server's internal k8s client for validating the existence of a Project.

The legacy, protocol-buffer-based API has always done it this way:

https://github.com/akuity/kargo/blob/f533d7037d432a2f8d00582ae7ecaf65a52716e4/pkg/server/validators.go#L44-L60

The consequence of this bug is principals lacking permission to get Projects receive unexpected 403s when attempting to access resources they _do_ have access to _within_ a Project when using the 1.9.0+ REST API directly either directly or via the CLI. In practice, most human users can get and list Projects. It is primarily Project-scoped API tokens that are affected.