### PR TITLE
feat(ui): infer git provider for self-hosted deep links

### DIFF
--- a/ui/src/features/freight-timeline/open-container-initiative-utils.ts
+++ b/ui/src/features/freight-timeline/open-container-initiative-utils.ts
@@ -29,29 +29,38 @@ export const getImageSource = (annotation: Annotation) => {
 };
 
 export const getGitCommitURL = (url: string, revision: string) => {
-  let baseUrl;
-
-  if (url.includes('github.com')) {
-    baseUrl = url
-      .replace(/^git@github.com:/, 'https://github.com/')
-      .replace(/^https?:\/\/github.com\//, 'https://github.com/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/commit/${revision}`;
-  } else if (url.includes('gitlab.com')) {
-    baseUrl = url
-      .replace(/^git@gitlab.com:/, 'https://gitlab.com/')
-      .replace(/^https?:\/\/gitlab.com\//, 'https://gitlab.com/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/-/commit/${revision}`;
-  } else if (url.includes('bitbucket.org')) {
-    baseUrl = url
-      .replace(/^git@bitbucket.org:/, 'https://bitbucket.org/')
-      .replace(/^https?:\/\/bitbucket.org\//, 'https://bitbucket.org/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/commits/${revision}`;
+  if (!url) {
+    return '';
   }
 
-  return url;
+  let baseUrl = url;
+
+  if (baseUrl.startsWith('git@')) {
+    baseUrl = baseUrl.replace(':', '/').replace(/^git@/, 'https://');
+  } else if (!baseUrl.startsWith('http://') && !baseUrl.startsWith('https://')) {
+    baseUrl = `https://${baseUrl}`;
+  }
+
+  baseUrl = baseUrl.replace(/\.git$/, '');
+
+  try {
+    const urlObj = new URL(baseUrl);
+    const hostname = urlObj.hostname.toLowerCase();
+
+    if (hostname.includes('github')) {
+      return `${baseUrl}/commit/${revision}`;
+    }
+    if (hostname.includes('gitlab')) {
+      return `${baseUrl}/-/commit/${revision}`;
+    }
+    if (hostname.includes('bitbucket')) {
+      return `${baseUrl}/commits/${revision}`;
+    }
+  } catch {
+    // If URL parsing fails, we simply return the baseUrl below
+  }
+
+  return baseUrl;
 };
 
 export const getImageBuiltDate = (annotation: Annotation) => {


### PR DESCRIPTION
## Description
Fixes broken deep links for self-hosted and enterprise Git providers (e.g., GitLab Self-Managed, GitHub Enterprise).

Currently, the UI does an exact match on the domain (e.g., `domain === 'github.com'`), which fails for custom domains like `gitlab.internal.net`. This PR updates `getGitCommitURL` to handle these cases by checking if the hostname *includes* the provider keyword rather than requiring an exact match.

## Changes
- **Inference Logic:** The utility now detects provider keywords (e.g., `gitlab`, `github`, `bitbucket`) within custom domains to apply the correct URL formatting.
    - *Example:* `gitlab.internal.net` is detected as GitLab and gets the required `/-/commit/` path.
- **SSH Support:** Added logic to normalize SSH remote URLs (`git@...`) into clickable HTTPS links.
- **Refactor:** Switched to `URL` parsing for safer domain extraction.

## Verification
I verified this locally by spinning up a `tilt` environment and creating a mock Freight pointing to a self-hosted GitLab instance (`gitlab.internal.net`).

**1. Logic Verification:**
Console logs showing the utility correctly identifying providers from custom domains.
<img width="1519" height="270" alt="Screenshot from 2026-02-11 15-13-15" src="https://github.com/user-attachments/assets/c647a9fa-6557-4ad2-99db-b39a0c760e44" />

**2. End-to-End UI Verification:**
- Created a mock Freight pointing to `gitlab.internal.net`.
- Clicking the commit hash successfully navigated to `https://gitlab.internal.net/.../-/commit/...`, confirming the GitLab-specific `/-/` segment was applied.
<img width="1855" height="1010" alt="sa" src="https://github.com/user-attachments/assets/1d7aff94-4a23-4b4b-a388-f9940e73d077" />

## Related Issue
Closes #5480