### PR TITLE
test: add unit tests for project webhook validation

### DIFF
--- a/pkg/webhook/kubernetes/project_test.go
+++ b/pkg/webhook/kubernetes/project_test.go
@@ -1,0 +1,99 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateProject(t *testing.T) {
+	const testPodName = "test-pod"
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	testCases := []struct {
+		name        string
+		objects     []client.Object
+		targetObj   client.Object
+		expectedErr func(error) bool
+	}{
+		{
+			name: "success: project exists",
+			objects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ns",
+						Labels: map[string]string{
+							"kargo.akuity.io/project": "true",
+						},
+					},
+				},
+			},
+			targetObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      testPodName,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:    "error: project not found (namespace missing)",
+			objects: []client.Object{},
+			targetObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "missing-ns",
+					Name:      testPodName,
+				},
+			},
+			expectedErr: apierrors.IsNotFound,
+		},
+		{
+			name: "error: namespace exists but is not a project (label missing)",
+			objects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "other-ns",
+					},
+				},
+			},
+			targetObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "other-ns",
+					Name:      testPodName,
+				},
+			},
+			expectedErr: func(err error) bool {
+				var fieldErr *field.Error
+				return errors.As(err, &fieldErr)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.objects...).
+				Build()
+
+			err := ValidateProject(context.Background(), k8sClient, tc.targetObj)
+
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.True(t, tc.expectedErr(err), "unexpected error type: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation
This PR introduces unit tests for the `pkg/webhook/kubernetes/project.go file`. The goal is to ensure the `ValidateProject` function correctly handles validation outcomes and maps internal errors (such as `ErrProjectNotFound`) to the appropriate Kubernetes API errors (like `404 NotFound`).

## Proposed Changes
1. Added `pkg/webhook/kubernetes/project_test.go`.
2. Implemented `TestValidateProject` using the controller-runtime `fake` client to simulate:
    - Success Scenario: Validating an object in an existing, labeled Project namespace.
    - Failure Scenario: Validating an object in a non-existent or invalid namespace, ensuring it returns a proper `apierrors.IsNotFound` result.

## Test Results
```
=== RUN   TestValidateProject
=== RUN   TestValidateProject/success:_project_exists
=== RUN   TestValidateProject/error:_project_not_found_(namespace_missing)
=== RUN   TestValidateProject/error:_namespace_exists_but_is_not_a_project_(label_missing)
--- PASS: TestValidateProject (0.05s)
    --- PASS: TestValidateProject/success:_project_exists (0.05s)
    --- PASS: TestValidateProject/error:_project_not_found_(namespace_missing) (0.00s)
    --- PASS: TestValidateProject/error:_namespace_exists_but_is_not_a_project_(label_missing) (0.00s)
PASS
ok      github.com/akuity/kargo/pkg/webhook/kubernetes  (cached)
```