### PR TITLE
fix(ui): fix invalid date in metric chart tooltip

### DIFF
--- a/ui/src/features/common/analysis-modal/metric-chart/metric-chart.tsx
+++ b/ui/src/features/common/analysis-modal/metric-chart/metric-chart.tsx
@@ -91,7 +91,7 @@ const TooltipContent = ({
   return (
     <div className={styles['metric-chart-tooltip']}>
       <Text className='ml-4' type='secondary' style={{ fontSize: 12 }}>
-        {moment(data.startedAt).format('LTS')}
+        {moment(timestampDate(data.startedAt)).format('LTS')}
       </Text>
       <div className={styles['metric-chart-tooltip-status']}>
         <StatusIndicator size='small' status={data.phase} />


### PR DESCRIPTION
## Summary
Fixes "Invalid date" appearing in metric chart tooltips when hovering over verification data points.

## Problem
When hovering over data points in the verification metric chart, the tooltip displays "Invalid date" instead of the actual timestamp. This occurs because the tooltip component passes a protobuf `Timestamp` object directly to moment.js, which doesn't recognize that format.

<img width="572" height="304" alt="Screenshot 2026-02-12 at 15 49 51" src="https://github.com/user-attachments/assets/d27d4369-eaf1-4d7e-8dab-e525dbf0a6fb" />


## Solution
Wrap the `data.startedAt` value with the existing `timestampDate()` utility function (already imported on line 20) before passing it to moment. This converts the protobuf Timestamp to a JavaScript Date object that moment can properly format.

This follows the same pattern already used elsewhere in the same file for the X-axis tick formatting (lines 129-130).

## Changes
- `ui/src/features/common/analysis-modal/metric-chart/metric-chart.tsx:93` - Changed `moment(data.startedAt)` to `moment(timestampDate(data.startedAt))`

## Test Plan
- [x] Reviewed the code change
- [ ] CI will verify linting passes
- [ ] Maintainers can verify tooltips display valid timestamps when testing

## Related Issues
Similar to the verification duration issue fixed in #3564, but this affects the metric chart tooltips specifically.