### PR TITLE
chore(devx): upgrade dev/quickstart dependency versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ include $(CURDIR)/hack/tools.mk
 SHELL	      ?= /bin/bash
 EXTENDED_PATH ?= $(CURDIR)/hack/bin:$(PATH)
 
-ARGO_CD_CHART_VERSION		:= 8.1.4
-ARGO_ROLLOUTS_CHART_VERSION := 2.40.1
-CERT_MANAGER_CHART_VERSION 	:= 1.18.2
+ARGO_CD_CHART_VERSION		:= 9.4.3
+ARGO_ROLLOUTS_CHART_VERSION := 2.40.6
+CERT_MANAGER_CHART_VERSION 	:= 1.19.3
 
 BUF_LINT_ERROR_FORMAT	?= text
 GO_LINT_EXTRA_FLAGS 	?= --output.text.print-issued-lines --output.text.colors
@@ -429,8 +429,9 @@ hack-install-argocd: install-helm
 		--set server.service.type=NodePort \
 		--set server.service.nodePortHttp=30080 \
 		--set server.extensions.enabled=true \
-		--set server.extensions.contents[0].name=argo-rollouts \
-		--set server.extensions.contents[0].url=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar \
+		--set server.extensions.extensionList[0].name=argo-rollouts \
+		--set server.extensions.extensionList[0].env[0].name=EXTENSION_URL \
+		--set server.extensions.extensionList[0].env[0].value=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar \
 		--wait
 
 .PHONY: hack-install-argo-rollouts

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-argo_cd_chart_version=8.1.4
-argo_rollouts_chart_version=2.40.1
-cert_manager_chart_version=1.18.2
+argo_cd_chart_version=9.4.3
+argo_rollouts_chart_version=2.40.6
+cert_manager_chart_version=1.19.3
 
 helm install cert-manager cert-manager \
   --repo https://charts.jetstack.io \
@@ -25,8 +25,9 @@ helm install argocd argo-cd \
   --set server.service.type=NodePort \
   --set server.service.nodePortHttp=31443 \
   --set server.extensions.enabled=true \
-  --set 'server.extensions.contents[0].name=argo-rollouts' \
-  --set 'server.extensions.contents[0].url=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar' \
+  --set 'server.extensions.extensionList[0].name=argo-rollouts' \
+  --set 'server.extensions.extensionList[0].env[0].name=EXTENSION_URL' \
+  --set 'server.extensions.extensionList[0].env[0].value=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar' \
   --wait
 
 helm install argo-rollouts argo-rollouts \

--- a/hack/quickstart/k3d.sh
+++ b/hack/quickstart/k3d.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-argo_cd_chart_version=8.1.4
-argo_rollouts_chart_version=2.40.1
-cert_manager_chart_version=1.18.2
+argo_cd_chart_version=9.4.3
+argo_rollouts_chart_version=2.40.6
+cert_manager_chart_version=1.19.3
 
 k3d cluster create kargo-quickstart \
   --no-lb \
@@ -32,8 +32,9 @@ helm install argocd argo-cd \
   --set server.service.type=NodePort \
   --set server.service.nodePortHttp=31443 \
   --set server.extensions.enabled=true \
-  --set 'server.extensions.contents[0].name=argo-rollouts' \
-  --set 'server.extensions.contents[0].url=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar' \
+  --set 'server.extensions.extensionList[0].name=argo-rollouts' \
+  --set 'server.extensions.extensionList[0].env[0].name=EXTENSION_URL' \
+  --set 'server.extensions.extensionList[0].env[0].value=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar' \
   --wait
 
 helm install argo-rollouts argo-rollouts \

--- a/hack/quickstart/kind.sh
+++ b/hack/quickstart/kind.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-argo_cd_chart_version=8.1.4
-argo_rollouts_chart_version=2.40.1
-cert_manager_chart_version=1.18.2
+argo_cd_chart_version=9.4.3
+argo_rollouts_chart_version=2.40.6
+cert_manager_chart_version=1.19.3
 
 kind create cluster \
   --wait 120s \
@@ -48,8 +48,9 @@ helm install argocd argo-cd \
   --set server.service.type=NodePort \
   --set server.service.nodePortHttp=31443 \
   --set server.extensions.enabled=true \
-  --set 'server.extensions.contents[0].name=argo-rollouts' \
-  --set 'server.extensions.contents[0].url=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar' \
+  --set 'server.extensions.extensionList[0].name=argo-rollouts' \
+  --set 'server.extensions.extensionList[0].env[0].name=EXTENSION_URL' \
+  --set 'server.extensions.extensionList[0].env[0].value=https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar' \
   --wait
 
 helm install argo-rollouts argo-rollouts \


### PR DESCRIPTION
Upgrades for various dependencies pinned in odd places that Dependabot doesn't find.

- argo-cd chart: 8.1.4 → 9.4.3 (Argo CD v3.0.11 → v3.3.1)
- argo-rollouts chart: 2.40.1 → 2.40.6
- cert-manager chart: 1.18.2 → 1.19.3
- rollout-extension: v0.3.3 → v0.3.7