### PR TITLE
fix(ui): preserve full git tag in pipeline view

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-artifact.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-artifact.tsx
@@ -46,14 +46,16 @@ export const FreightArtifact = (props: FreightArtifactProps) => {
   if (artifactType === 'github.com.akuity.kargo.api.v1alpha1.GitCommit') {
     const url = getGitCommitURL(props.artifact.repoURL, props.artifact.id);
 
-    // prioritize semver
-    const id = props.artifact.tag || props.artifact.id;
+    // prioritize semver; use shortVersion for tags, 7-char slice for raw commit hashes
+    const displayId = props.artifact.tag
+      ? shortVersion(props.artifact.tag)
+      : props.artifact.id.slice(0, 7);
 
     const TagComponent = (
       <Tag title={props.artifact.repoURL} bordered={false} color='geekblue' key={props.artifact.id}>
         <ArtifactIcon artifactType={artifactType} className='mr-1' />
 
-        {id.slice(0, 7)}
+        {displayId}
 
         {Expand}
       </Tag>


### PR DESCRIPTION
## What

In the pipeline stage view, `GitCommit` artifacts with a semver tag were being displayed with the last character cut off. For example, a tag `1.0.1220` would appear as `1.0.122`.

## Why

The display logic always applied `.slice(0, 7)` — a convention for abbreviating commit hashes — regardless of whether the value was a raw commit ID or a human-readable tag:

```ts
// prioritize semver
const id = props.artifact.tag || props.artifact.id;
// ...
{id.slice(0, 7)}
```

The comment acknowledges the intent to prefer semver tags, but the 7-char truncation was still applied to them.

## Fix

Apply the truncation conditionally: use `shortVersion()` for tags (consistent with how `Chart` and `Image` artifacts are handled elsewhere in the same file), and keep `.slice(0, 7)` for raw commit IDs.

```ts
const displayId = props.artifact.tag
  ? shortVersion(props.artifact.tag)
  : props.artifact.id.slice(0, 7);
```