### PR TITLE
fix(ui): avoid mutating freights prop in the freight timeline

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -53,7 +53,7 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
   const filteredFreights: (Freight & {
     count?: number;
   })[] = useMemo(() => {
-    let filtered = props.freights?.sort((a, b) => {
+    let filtered = [...(props.freights || [])].sort((a, b) => {
       const t1 = timestampDate(a?.metadata?.creationTimestamp);
 
       const t2 = timestampDate(b?.metadata?.creationTimestamp);


### PR DESCRIPTION
Mutating props causes the behavior where the promotion flow UI spins forever and the browser spams the backend with QueryFreight API calls.