### PR TITLE
fix(chart): allow mgmt controller to delete namespaces

### DIFF
--- a/charts/kargo/templates/management-controller/cluster-roles.yaml
+++ b/charts/kargo/templates/management-controller/cluster-roles.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   verbs:
   - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
Fixes a big in #5763, which was missing the permissions to delete namespaces, which the management controller now does explicitly.