### PR TITLE
fix: explicitly set init.defaultBranch in a cloned repo's home dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ test-unit: install-helm
 				-race \
 				-coverprofile=coverage.txt \
 				-covermode=atomic \
+				-count=1 \
 				./... $(GO_TEST_ARGS); \
 			cd - > /dev/null; \
 		done; \

--- a/pkg/controller/git/bare_repo.go
+++ b/pkg/controller/git/bare_repo.go
@@ -92,34 +92,26 @@ func CloneBare(
 	if cloneOpts == nil {
 		cloneOpts = &BareCloneOptions{}
 	}
-	homeDir, err := os.MkdirTemp(cloneOpts.BaseDir, "repo-")
-	if err != nil {
-		return nil,
-			fmt.Errorf("error creating home directory for repo %q: %w", repoURL, err)
-	}
-	if homeDir, err = filepath.EvalSymlinks(homeDir); err != nil {
-		return nil,
-			fmt.Errorf("error resolving symlinks in path %s: %w", homeDir, err)
-	}
 	b := &bareRepo{
 		baseRepo: &baseRepo{
 			creds:       clientOpts.Credentials,
-			dir:         filepath.Join(homeDir, "repo"),
-			homeDir:     homeDir,
 			originalURL: repoURL,
 			accessURL:   repoURL,
 		},
 	}
-	if err = b.setupClient(homeDir, clientOpts); err != nil {
+	if err := b.setupDirs(cloneOpts.BaseDir); err != nil {
 		return nil, err
 	}
-	if err = b.clone(cloneOpts); err != nil {
+	if err := b.setupClient(clientOpts); err != nil {
 		return nil, err
 	}
-	if err = b.saveDirs(); err != nil {
+	if err := b.clone(cloneOpts); err != nil {
 		return nil, err
 	}
-	if err = b.saveOriginalURL(); err != nil {
+	if err := b.saveDirs(); err != nil {
+		return nil, err
+	}
+	if err := b.saveOriginalURL(); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/pkg/controller/git/bare_repo_test.go
+++ b/pkg/controller/git/bare_repo_test.go
@@ -111,9 +111,7 @@ func TestBareRepo(t *testing.T) {
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
 	workTree, err := rep.AddWorkTree(
 		workingTreePath,
-		// "master" is still the default branch name for a new repository unless
-		// you configure it otherwise.
-		&AddWorkTreeOptions{Ref: "master"},
+		&AddWorkTreeOptions{Ref: "main"},
 	)
 
 	require.NoError(t, err)
@@ -397,7 +395,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 		workTree, err := rep.AddWorkTree(
 			workingTreePath,
 			&AddWorkTreeOptions{
-				Ref:    "master",
+				Ref:    "main",
 				Sparse: []string{"dir1", "dir2"},
 			},
 		)
@@ -421,9 +419,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "full-worktree")
 		workTree, err := rep.AddWorkTree(
 			workingTreePath,
-			&AddWorkTreeOptions{
-				Ref: "master",
-			},
+			&AddWorkTreeOptions{Ref: "main"},
 		)
 		require.NoError(t, err)
 		defer workTree.Close()
@@ -440,7 +436,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 		_, err := rep.AddWorkTree(
 			workingTreePath,
 			&AddWorkTreeOptions{
-				Ref:    "master",
+				Ref:    "main",
 				Sparse: []string{"/absolute/path"},
 			},
 		)
@@ -452,7 +448,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 		_, err := rep.AddWorkTree(
 			workingTreePath,
 			&AddWorkTreeOptions{
-				Ref:    "master",
+				Ref:    "main",
 				Sparse: []string{"../escape"},
 			},
 		)
@@ -464,7 +460,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 		_, err := rep.AddWorkTree(
 			workingTreePath,
 			&AddWorkTreeOptions{
-				Ref:    "master",
+				Ref:    "main",
 				Sparse: []string{"dir*"},
 			},
 		)
@@ -604,7 +600,7 @@ func TestBareRepo_WithFilter(t *testing.T) {
 	workingTreePath := filepath.Join(rep.HomeDir(), "worktree")
 	workTree, err := rep.AddWorkTree(
 		workingTreePath,
-		&AddWorkTreeOptions{Ref: "master"},
+		&AddWorkTreeOptions{Ref: "main"},
 	)
 	require.NoError(t, err)
 	defer workTree.Close()

--- a/pkg/controller/git/repo.go
+++ b/pkg/controller/git/repo.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	libExec "github.com/akuity/kargo/pkg/exec"
 )
@@ -77,19 +76,8 @@ func Clone(
 	if cloneOpts == nil {
 		cloneOpts = &CloneOptions{}
 	}
-	homeDir, err := os.MkdirTemp(cloneOpts.BaseDir, "repo-")
-	if err != nil {
-		return nil,
-			fmt.Errorf("error creating home directory for repo %q: %w", repoURL, err)
-	}
-	if homeDir, err = filepath.EvalSymlinks(homeDir); err != nil {
-		return nil,
-			fmt.Errorf("error resolving symlinks in path %s: %w", homeDir, err)
-	}
 	baseRepo := &baseRepo{
 		creds:       clientOpts.Credentials,
-		dir:         filepath.Join(homeDir, "repo"),
-		homeDir:     homeDir,
 		originalURL: repoURL,
 		accessURL:   repoURL,
 	}
@@ -99,16 +87,19 @@ func Clone(
 			baseRepo: baseRepo,
 		},
 	}
-	if err = r.setupClient(homeDir, clientOpts); err != nil {
+	if err := r.setupDirs(cloneOpts.BaseDir); err != nil {
 		return nil, err
 	}
-	if err = r.clone(cloneOpts); err != nil {
+	if err := r.setupClient(clientOpts); err != nil {
 		return nil, err
 	}
-	if err = r.saveDirs(); err != nil {
+	if err := r.clone(cloneOpts); err != nil {
 		return nil, err
 	}
-	if err = r.saveOriginalURL(); err != nil {
+	if err := r.saveDirs(); err != nil {
+		return nil, err
+	}
+	if err := r.saveOriginalURL(); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/pkg/controller/git/repo_test.go
+++ b/pkg/controller/git/repo_test.go
@@ -153,9 +153,7 @@ with a body
 
 	t.Run("can check if remote branch exists -- positive result", func(t *testing.T) {
 		var exists bool
-		// "master" is still the default branch name for a new repository unless
-		// you configure it otherwise.
-		exists, err = rep.RemoteBranchExists("master")
+		exists, err = rep.RemoteBranchExists("main")
 		require.NoError(t, err)
 		require.True(t, exists)
 	})

--- a/pkg/controller/git/work_tree_test.go
+++ b/pkg/controller/git/work_tree_test.go
@@ -93,9 +93,7 @@ func TestWorkTree(t *testing.T) {
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
 	workTree, err := rep.AddWorkTree(
 		workingTreePath,
-		// "master" is still the default branch name for a new repository unless
-		// you configure it otherwise.
-		&AddWorkTreeOptions{Ref: "master"},
+		&AddWorkTreeOptions{Ref: "main"},
 	)
 	require.NoError(t, err)
 	defer workTree.Close()

--- a/pkg/promotion/runner/builtin/git_cloner_test.go
+++ b/pkg/promotion/runner/builtin/git_cloner_test.go
@@ -369,8 +369,8 @@ func Test_gitCloner_run(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
 	require.DirExists(t, filepath.Join(stepCtx.WorkDir, "src"))
-	// The checked out master branch should have the content we know is in the
-	// test remote's master branch.
+	// The checked out main branch should have the content we know is in the
+	// test remote's main branch.
 	require.FileExists(t, filepath.Join(stepCtx.WorkDir, "src", "test.txt"))
 	require.DirExists(t, filepath.Join(stepCtx.WorkDir, "out"))
 	// The stage/dev branch is a new orphan branch with a single empty commit.
@@ -430,7 +430,7 @@ func Test_gitCloner_run_with_submodules(t *testing.T) {
 	})
 
 	// Use git submodule add to create proper submodule metadata
-	cmd := exec.Command("git", "submodule", "add", "-b", "master", subRepoURL, "sub")
+	cmd := exec.Command("git", "submodule", "add", "-b", "main", subRepoURL, "sub")
 	cmd.Dir = mainRepo.Dir()
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git submodule add failed: %s", string(out))


### PR DESCRIPTION
The root cause of the issue that was impetus for both #5767 and its reversal in #5795 has been identified.

The very abbreviated explanation is that some maintainers were using `git` from homebrew while others were using Apple's `git` binary, which has some small behavioral differences.

The well-intentioned change in #5767 did not account for the fact of all operations in our `git` package being carried out with `HOME` overridden to ensure git configuration that is completely isolated from a contributor's own git configuration.

The well-intentioned reversal restored things to good working order for those who were experiencing no issues to begin with, but re-broke others.

The right fix for the issue is some minor modifications in the `git` package to _explicitly_ set `init.defaultBranch` in the dummy home dir to compensate for behavioral differences in different implementations of `git`.



