### PR TITLE
fix: Fix ambiguous `git log` command

### DIFF
--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -255,7 +255,15 @@ func (w *workTree) Commit(message string, opts *CommitOptions) error {
 
 func (w *workTree) CommitMessage(id string) (string, error) {
 	msgBytes, err := libExec.Exec(
-		w.buildGitCommand("log", "-n", "1", "--pretty=format:%B", id),
+		w.buildGitCommand(
+			"log",
+			"-n",
+			"1",
+			"--pretty=format:%B",
+			id,
+			// `--` clarifies that id is a branch name and not a file name
+			"--",
+		),
 	)
 	if err != nil {
 		return "", fmt.Errorf("error obtaining commit message for commit %q: %w", id, err)

--- a/pkg/promotion/runner/builtin/git_pr_opener_test.go
+++ b/pkg/promotion/runner/builtin/git_pr_opener_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
@@ -168,6 +170,14 @@ func Test_gitPROpener_run(t *testing.T) {
 	defer repo.Close()
 	err = repo.CreateOrphanedBranch(testSourceBranch)
 	require.NoError(t, err)
+
+	// Make a file with the same name as the branch
+	err = os.WriteFile(filepath.Join(repo.Dir(), testSourceBranch), []byte("foo"), 0600)
+	require.NoError(t, err)
+
+	err = repo.AddAll()
+	require.NoError(t, err)
+
 	err = repo.Commit("Initial commit", &git.CommitOptions{AllowEmpty: true})
 	require.NoError(t, err)
 	err = repo.Push(nil)


### PR DESCRIPTION
`git-open-pr` was failing when there was a file with the same name as the branch name.

Example error:
```
step "openpr" met error threshold of 1: error running step "openpr": error getting commit message from head of branch test: error obtaining commit message for commit "test": error executing cmd [/usr/bin/git log -n 1 --pretty=format:%B test]: fatal: ambiguous argument 'test': both revision and filename Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]'
```