### PR TITLE
fix: restore credential resolution for deprecated globalCredentials.namespaces

### DIFF
--- a/charts/kargo/templates/controller/configmap.yaml
+++ b/charts/kargo/templates/controller/configmap.yaml
@@ -23,7 +23,11 @@ data:
   {{- if .Values.kubeconfigSecrets.kargo }}
   KUBECONFIG: /etc/kargo/kubeconfigs/kubeconfig.yaml
   {{- end }}
+  {{- if .Values.controller.globalCredentials.namespaces }}
+  SHARED_RESOURCES_NAMESPACE: {{ first .Values.controller.globalCredentials.namespaces | quote }}
+  {{- else }}
   SHARED_RESOURCES_NAMESPACE: {{ quote .Values.global.sharedResources.namespace }}
+  {{- end }}
   ALLOW_CREDENTIALS_OVER_HTTP: {{ quote .Values.controller.allowCredentialsOverHTTP }}
   GITCLIENT_NAME: {{ quote .Values.controller.gitClient.name }}
   GITCLIENT_EMAIL: {{ quote .Values.controller.gitClient.email }}

--- a/pkg/credentials/kubernetes/database.go
+++ b/pkg/credentials/kubernetes/database.go
@@ -19,6 +19,17 @@ import (
 	"github.com/akuity/kargo/pkg/urls"
 )
 
+// legacyConfig holds deprecated environment variables for backward compatibility.
+// These were renamed in v1.9.0 as part of the "Secret Shuffle" refactor.
+type legacyConfig struct {
+	// GlobalCredentialsNamespaces was renamed to SharedResourcesNamespace in
+	// v1.9.0. When SHARED_RESOURCES_NAMESPACE is unset, the first element of
+	// this slice is used as a fallback so that operators who have not yet
+	// migrated their Helm values (controller.globalCredentials.namespaces) do
+	// not silently lose credential resolution.
+	GlobalCredentialsNamespaces []string `envconfig:"GLOBAL_CREDENTIALS_NAMESPACES" default:""`
+}
+
 // database is an implementation of the credentials.Database interface that
 // utilizes a Kubernetes controller runtime client to retrieve credentials
 // stored in Kubernetes Secrets.
@@ -39,6 +50,18 @@ type DatabaseConfig struct {
 func DatabaseConfigFromEnv() DatabaseConfig {
 	cfg := DatabaseConfig{}
 	envconfig.MustProcess("", &cfg)
+	// Backward-compat: if SHARED_RESOURCES_NAMESPACE is not set, fall back to
+	// the first element of the deprecated GLOBAL_CREDENTIALS_NAMESPACES env var.
+	// This handles operators who upgraded to v1.9.x without migrating their Helm
+	// values from controller.globalCredentials.namespaces to
+	// global.sharedResources.namespace.
+	if cfg.SharedResourcesNamespace == "" {
+		legacy := legacyConfig{}
+		envconfig.MustProcess("", &legacy)
+		if len(legacy.GlobalCredentialsNamespaces) > 0 {
+			cfg.SharedResourcesNamespace = legacy.GlobalCredentialsNamespaces[0]
+		}
+	}
 	return cfg
 }
 

--- a/pkg/credentials/kubernetes/database_test.go
+++ b/pkg/credentials/kubernetes/database_test.go
@@ -17,6 +17,29 @@ import (
 	"github.com/akuity/kargo/pkg/credentials/basic"
 )
 
+func TestDatabaseConfigFromEnv(t *testing.T) {
+	t.Run("uses SHARED_RESOURCES_NAMESPACE when set", func(t *testing.T) {
+		t.Setenv("SHARED_RESOURCES_NAMESPACE", "my-shared-ns")
+		t.Setenv("GLOBAL_CREDENTIALS_NAMESPACES", "old-ns")
+		cfg := DatabaseConfigFromEnv()
+		require.Equal(t, "my-shared-ns", cfg.SharedResourcesNamespace)
+	})
+
+	t.Run("falls back to first GLOBAL_CREDENTIALS_NAMESPACES when SHARED_RESOURCES_NAMESPACE is unset", func(t *testing.T) {
+		t.Setenv("SHARED_RESOURCES_NAMESPACE", "")
+		t.Setenv("GLOBAL_CREDENTIALS_NAMESPACES", "kargo-cluster-secrets,other-ns")
+		cfg := DatabaseConfigFromEnv()
+		require.Equal(t, "kargo-cluster-secrets", cfg.SharedResourcesNamespace)
+	})
+
+	t.Run("empty config when neither env var is set", func(t *testing.T) {
+		t.Setenv("SHARED_RESOURCES_NAMESPACE", "")
+		t.Setenv("GLOBAL_CREDENTIALS_NAMESPACES", "")
+		cfg := DatabaseConfigFromEnv()
+		require.Equal(t, "", cfg.SharedResourcesNamespace)
+	})
+}
+
 func TestNewKubernetesDatabase(t *testing.T) {
 	testControlPlaneClient := fake.NewClientBuilder().Build()
 	testLocalClusterClient := fake.NewClientBuilder().Build()


### PR DESCRIPTION
Fixes #5838

## Problem

In v1.9.0 the "Secret Shuffle" renamed `controller.globalCredentials.namespaces` (`GLOBAL_CREDENTIALS_NAMESPACES`) to `global.sharedResources.namespace` (`SHARED_RESOURCES_NAMESPACE`). The management-controller ConfigMap template received a backward-compat shim for the old value, but the **controller ConfigMap template did not**.

Operators who had not yet migrated their Helm values silently got `SHARED_RESOURCES_NAMESPACE=kargo-shared-resources` (the new default) instead of their actual credentials namespace. This caused all warehouse git subscriptions to fail with dial-out errors because credentials could no longer be found.

We hit this three times in production upgrading from v1.8.9 to v1.9.0, v1.9.2, and v1.9.5 — each time requiring an emergency rollback.

## Fix

Two layers:

1. **Helm chart** (`charts/kargo/templates/controller/configmap.yaml`): When `controller.globalCredentials.namespaces` is set, use its first element as `SHARED_RESOURCES_NAMESPACE` — same shim already present in the management-controller template.

2. **Go code** (`pkg/credentials/kubernetes/database.go`): `DatabaseConfigFromEnv()` now falls back to the first element of the legacy `GLOBAL_CREDENTIALS_NAMESPACES` env var when `SHARED_RESOURCES_NAMESPACE` is empty, providing defense-in-depth for deployment paths that bypass the Helm chart.

## Tests

Added `TestDatabaseConfigFromEnv` covering:
- New env var takes precedence when set
- Falls back to first element of legacy env var
- Empty config when neither is set