### PR TITLE
feat(ui): git commit deep links for self-hosted providers

### DIFF
--- a/ui/src/features/freight-timeline/open-container-initiative-utils.test.ts
+++ b/ui/src/features/freight-timeline/open-container-initiative-utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGitCommitURL } from './open-container-initiative-utils';
+
+describe('getGitCommitURL', () => {
+  const revision = 'abc1234';
+
+  const cases: { name: string; url: string; expected: string }[] = [
+    // GitHub — hosted
+    {
+      name: 'github HTTPS',
+      url: 'https://github.com/akuity/kargo.git',
+      expected: 'https://github.com/akuity/kargo/commit/abc1234'
+    },
+    {
+      name: 'github SSH',
+      url: 'git@github.com:akuity/kargo.git',
+      expected: 'https://github.com/akuity/kargo/commit/abc1234'
+    },
+    // GitHub Enterprise — self-hosted
+    {
+      name: 'github enterprise custom domain',
+      url: 'https://github.internal.net/akuity/kargo.git',
+      expected: 'https://github.internal.net/akuity/kargo/commit/abc1234'
+    },
+    // GitLab — hosted
+    {
+      name: 'gitlab HTTPS',
+      url: 'https://gitlab.com/akuity/kargo.git',
+      expected: 'https://gitlab.com/akuity/kargo/-/commit/abc1234'
+    },
+    {
+      name: 'gitlab SSH',
+      url: 'git@gitlab.com:akuity/kargo.git',
+      expected: 'https://gitlab.com/akuity/kargo/-/commit/abc1234'
+    },
+    // GitLab — self-hosted
+    {
+      name: 'gitlab self-managed custom domain',
+      url: 'https://gitlab.internal.net/akuity/kargo.git',
+      expected: 'https://gitlab.internal.net/akuity/kargo/-/commit/abc1234'
+    },
+    {
+      name: 'gitlab self-managed SSH',
+      url: 'git@gitlab.internal.net:akuity/kargo.git',
+      expected: 'https://gitlab.internal.net/akuity/kargo/-/commit/abc1234'
+    },
+    // Bitbucket — hosted
+    {
+      name: 'bitbucket HTTPS',
+      url: 'https://bitbucket.org/akuity/kargo.git',
+      expected: 'https://bitbucket.org/akuity/kargo/commits/abc1234'
+    },
+    {
+      name: 'bitbucket SSH',
+      url: 'git@bitbucket.org:akuity/kargo.git',
+      expected: 'https://bitbucket.org/akuity/kargo/commits/abc1234'
+    },
+    // Bitbucket Data Center — self-hosted
+    {
+      name: 'bitbucket data center custom domain',
+      url: 'https://bitbucket.internal.net/akuity/kargo.git',
+      expected: 'https://bitbucket.internal.net/akuity/kargo/commits/abc1234'
+    },
+    {
+      name: 'bitbucket data center SSH',
+      url: 'git@bitbucket.internal.net:akuity/kargo.git',
+      expected: 'https://bitbucket.internal.net/akuity/kargo/commits/abc1234'
+    },
+    // Unknown provider — fall back to original url
+    {
+      name: 'unknown provider returns original url',
+      url: 'https://git.example.com/akuity/kargo.git',
+      expected: 'https://git.example.com/akuity/kargo.git'
+    }
+  ];
+
+  for (const tc of cases) {
+    it(tc.name, () => {
+      expect(getGitCommitURL(tc.url, revision)).toBe(tc.expected);
+    });
+  }
+});

--- a/ui/src/features/freight-timeline/open-container-initiative-utils.ts
+++ b/ui/src/features/freight-timeline/open-container-initiative-utils.ts
@@ -1,4 +1,5 @@
 import { formatDistance } from 'date-fns';
+import gitUrlParse from 'git-url-parse';
 
 const ociPrefix = 'org.opencontainers.image';
 
@@ -29,26 +30,19 @@ export const getImageSource = (annotation: Annotation) => {
 };
 
 export const getGitCommitURL = (url: string, revision: string) => {
-  let baseUrl;
+  try {
+    const { resource, owner, name } = gitUrlParse(url);
+    const baseUrl = `https://${resource}/${owner}/${name}`;
 
-  if (url.includes('github.com')) {
-    baseUrl = url
-      .replace(/^git@github.com:/, 'https://github.com/')
-      .replace(/^https?:\/\/github.com\//, 'https://github.com/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/commit/${revision}`;
-  } else if (url.includes('gitlab.com')) {
-    baseUrl = url
-      .replace(/^git@gitlab.com:/, 'https://gitlab.com/')
-      .replace(/^https?:\/\/gitlab.com\//, 'https://gitlab.com/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/-/commit/${revision}`;
-  } else if (url.includes('bitbucket.org')) {
-    baseUrl = url
-      .replace(/^git@bitbucket.org:/, 'https://bitbucket.org/')
-      .replace(/^https?:\/\/bitbucket.org\//, 'https://bitbucket.org/')
-      .replace(/\.git$/, '');
-    return `${baseUrl}/commits/${revision}`;
+    if (resource.includes('github')) {
+      return `${baseUrl}/commit/${revision}`;
+    } else if (resource.includes('gitlab')) {
+      return `${baseUrl}/-/commit/${revision}`;
+    } else if (resource.includes('bitbucket')) {
+      return `${baseUrl}/commits/${revision}`;
+    }
+  } catch {
+    // fall through to return original url
   }
 
   return url;


### PR DESCRIPTION
Replace manual regex-based URL normalization in `getGitCommitURL` with `git-url-parse` (already a project dependency, previously unused).

The old implementation used exact domain matching (`url.includes('github.com')`), which broke deep links for self-hosted instances. The new implementation uses the `resource` field from `git-url-parse`, which contains the full hostname (`gitlab.internal.net`, `github.internal.net`, etc.), so provider detection works regardless of the domain.

SSH URLs (`git@...`) are handled automatically by the library — no more manual regex substitutions.

Added unit tests covering:
- GitHub / GitLab / Bitbucket hosted (HTTPS + SSH)
- GitHub Enterprise and GitLab Self-Managed custom domains (HTTPS + SSH)
- Unknown provider fallback

Fixes #5480

Related to https://github.com/akuity/kargo/pull/5726