### PR TITLE
feat: filter webhook-triggered warehouse refreshes by changed paths

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -707,6 +707,21 @@ Paths may _also_ be specified using glob patterns (by prefixing the string with
 
 :::
 
+:::info
+
+When using
+[webhook receivers](../60-reference-docs/80-webhook-receivers/index.md) with
+GitHub, GitLab, or Gitea, `includePaths` and `excludePaths` are also evaluated
+at webhook time. Push event payloads from these providers include per-commit
+file change lists, which Kargo uses to determine whether a `Warehouse` needs to
+be refreshed. If none of the changed files match the subscription's path
+filters, the `Warehouse` is not refreshed, avoiding unnecessary artifact
+discovery. This is particularly beneficial for monorepo setups where many
+`Warehouse` resources subscribe to the same repository but watch different
+paths.
+
+:::
+
 ### Helm Chart Repository Subscriptions
 
 Helm chart repository subscriptions can be defined using the following fields:
@@ -1112,7 +1127,15 @@ contains structured information (usually JSON) the sender wishes to share about
 some event. Invariably, among this information, is the URL of the repository
 from which the event originated.
 
-A webhook receiver's only job is to extract a repository URL from the webhook
-request's payload, query for all `Warehouse` resources within the Project having
-subscriptions to that repository, and request each to execute their discovery
-process.
+A webhook receiver extracts a repository URL from the webhook request's payload,
+queries for all `Warehouse` resources within the Project having subscriptions to
+that repository, and requests each to execute their discovery process.
+
+For Git push events from GitHub, GitLab, and Gitea, the receiver additionally
+extracts the list of changed files from the webhook payload. If a `Warehouse`
+has
+[`includePaths` or `excludePaths`](#git-subscription-path-filtering)
+configured on its Git subscription, the receiver evaluates the changed files
+against those filters. Only `Warehouse` resources whose path filters match at
+least one changed file are refreshed. This avoids unnecessary artifact discovery
+for `Warehouse` resources that would not produce new Freight from the push.

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitea/index.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitea/index.md
@@ -5,8 +5,11 @@ sidebar_label: Gitea
 # The Gitea Webhook Receiver
 
 The Gitea webhook receiver responds to `push` events originating from Gitea
-repositories by _refreshing_ all `Warehouse` resources subscribed to those
-repositories.
+repositories by _refreshing_ `Warehouse` resources subscribed to those
+repositories. If a `Warehouse` has `includePaths` or `excludePaths` configured
+on its Git subscription, the receiver evaluates the changed files from the push
+payload against those filters and only refreshes the `Warehouse` if at least one
+changed file matches.
 
 :::info
 

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/github/index.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/github/index.md
@@ -10,8 +10,12 @@ The GitHub webhook receiver responds to `ping`, `push`, `package`, and
 The receiver unconditionally responds to `ping` events with an HTTP `200` status
 code.
 
-The receiver responds to `push` events by _refreshing_ all `Warehouse` resources
-subscribed to the Git repositories from which those events originated.
+The receiver responds to `push` events by _refreshing_ `Warehouse` resources
+subscribed to the Git repositories from which those events originated. If a
+`Warehouse` has `includePaths` or `excludePaths` configured on its Git
+subscription, the receiver evaluates the changed files from the push payload
+against those filters and only refreshes the `Warehouse` if at least one changed
+file matches.
 
 The receiver responds to  `package` events by _refreshing_ all `Warehouse`
 resources subscribed to the GHCR repositories from which those events

--- a/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitlab/index.md
+++ b/docs/docs/50-user-guide/60-reference-docs/80-webhook-receivers/gitlab/index.md
@@ -5,8 +5,11 @@ sidebar_label: GitLab
 # GitLab Webhook Receiver
 
 The GitLab Webhook Receiver responds to `push` events originating from GitLab
-repositories by _refreshing_ all `Warehouse` resources subscribed to those
-repositories.
+repositories by _refreshing_ `Warehouse` resources subscribed to those
+repositories. If a `Warehouse` has `includePaths` or `excludePaths` configured
+on its Git subscription, the receiver evaluates the changed files from the push
+payload against those filters and only refreshes the `Warehouse` if at least one
+changed file matches.
 
 :::info
 

--- a/pkg/webhook/external/artifactory.go
+++ b/pkg/webhook/external/artifactory.go
@@ -221,7 +221,7 @@ func (a *artifactoryWebhookReceiver) getHandler(requestBody []byte) http.Handler
 		}
 		logger = logger.WithValues("repoURL", repoURL)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, a.client, a.project, []string{repoURL}, payload.Data.Tag)
+		refreshWarehouses(ctx, w, a.client, a.project, []string{repoURL}, nil, payload.Data.Tag)
 	})
 }
 

--- a/pkg/webhook/external/azure.go
+++ b/pkg/webhook/external/azure.go
@@ -134,7 +134,9 @@ func (a *azureWebhookReceiver) handleACREvent(
 			"tag", event.Target.Tag,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, a.client, a.project, repoURLs, event.Target.Tag)
+		refreshWarehouses(
+			ctx, w, a.client, a.project, repoURLs, nil, event.Target.Tag,
+		)
 	case acrPingEvent:
 		xhttp.WriteResponseJSON(
 			w,
@@ -190,7 +192,7 @@ func (a *azureWebhookReceiver) handleAzureDevOpsEvent(
 		"refs", refs,
 	)
 	ctx = logging.ContextWithLogger(ctx, logger)
-	refreshWarehouses(ctx, w, a.client, a.project, repoURLs, refs...)
+	refreshWarehouses(ctx, w, a.client, a.project, repoURLs, nil, refs...)
 }
 
 // acrEvent represents the payload for Azure Container Registry webhooks.

--- a/pkg/webhook/external/bitbucket.go
+++ b/pkg/webhook/external/bitbucket.go
@@ -157,7 +157,7 @@ func (b *bitbucketWebhookReceiver) getHandler(requestBody []byte) http.HandlerFu
 			"refs", refs,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, b.client, b.project, repoURLs, refs...)
+		refreshWarehouses(ctx, w, b.client, b.project, repoURLs, nil, refs...)
 	})
 }
 

--- a/pkg/webhook/external/dockerhub.go
+++ b/pkg/webhook/external/dockerhub.go
@@ -103,6 +103,6 @@ func (d *dockerhubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFu
 			"mediaType", payload.PushData.MediaType,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, d.client, d.project, repoURLs, payload.PushData.Tag)
+		refreshWarehouses(ctx, w, d.client, d.project, repoURLs, nil, payload.PushData.Tag)
 	})
 }

--- a/pkg/webhook/external/gitea.go
+++ b/pkg/webhook/external/gitea.go
@@ -130,6 +130,11 @@ func (g *giteaWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 			Repo struct {
 				URL string `json:"clone_url"`
 			} `json:"repository"`
+			Commits []struct {
+				Added    []string `json:"added"`
+				Modified []string `json:"modified"`
+				Removed  []string `json:"removed"`
+			} `json:"commits"`
 		}{}
 		if err := json.Unmarshal(requestBody, &payload); err != nil {
 			xhttp.WriteErrorJSON(
@@ -147,6 +152,18 @@ func (g *giteaWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 			"ref", payload.Ref,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, g.client, g.project, repoURLs, payload.Ref)
+		var changedFiles []string
+		seen := map[string]struct{}{}
+		for _, c := range payload.Commits {
+			for _, paths := range [][]string{c.Added, c.Modified, c.Removed} {
+				for _, p := range paths {
+					if _, ok := seen[p]; !ok {
+						seen[p] = struct{}{}
+						changedFiles = append(changedFiles, p)
+					}
+				}
+			}
+		}
+		refreshWarehouses(ctx, w, g.client, g.project, repoURLs, changedFiles, payload.Ref)
 	})
 }

--- a/pkg/webhook/external/github.go
+++ b/pkg/webhook/external/github.go
@@ -147,6 +147,7 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 
 		var qualifiers []string
 		var repoURLs []string
+		var changedFiles []string
 
 		switch e := event.(type) {
 		case *gh.PackageEvent:
@@ -216,6 +217,7 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			}
 			ref := e.GetRef()
 			qualifiers = []string{ref}
+			changedFiles = collectGitHubChangedFiles(e)
 			logger = logger.WithValues("ref", ref)
 
 		case *gh.RegistryPackageEvent:
@@ -270,6 +272,26 @@ func (g *githubWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 		logger = logger.WithValues("repoURLs", repoURLs)
 		ctx = logging.ContextWithLogger(ctx, logger)
 
-		refreshWarehouses(ctx, w, g.client, g.project, repoURLs, qualifiers...)
+		refreshWarehouses(ctx, w, g.client, g.project, repoURLs, changedFiles, qualifiers...)
 	})
+}
+
+func collectGitHubChangedFiles(e *gh.PushEvent) []string {
+	seen := map[string]struct{}{}
+	var files []string
+	add := func(paths []string) {
+		for _, p := range paths {
+			if _, ok := seen[p]; !ok {
+				seen[p] = struct{}{}
+				files = append(files, p)
+			}
+		}
+	}
+	// nolint: staticcheck // Commits deprecation applies to Events API, not webhooks
+	for _, c := range e.Commits {
+		add(c.Added)
+		add(c.Modified)
+		add(c.Removed)
+	}
+	return files
 }

--- a/pkg/webhook/external/gitlab.go
+++ b/pkg/webhook/external/gitlab.go
@@ -125,12 +125,13 @@ func (g *gitlabWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 					urls.NormalizeGit(e.Repository.GitSSHURL),
 				}
 			}
+			changedFiles := collectGitLabChangedFiles(e.Commits)
 			logger = logger.WithValues(
 				"repoURLs", repoURLs,
 				"ref", e.Ref,
 			)
 			ctx = logging.ContextWithLogger(ctx, logger)
-			refreshWarehouses(ctx, w, g.client, g.project, repoURLs, e.Ref)
+			refreshWarehouses(ctx, w, g.client, g.project, repoURLs, changedFiles, e.Ref)
 		case *gl.TagEvent:
 			var repoURLs []string
 			if e.Repository != nil {
@@ -144,7 +145,26 @@ func (g *gitlabWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 				"tag", e.Ref,
 			)
 			ctx = logging.ContextWithLogger(ctx, logger)
-			refreshWarehouses(ctx, w, g.client, g.project, repoURLs, e.Ref)
+			refreshWarehouses(ctx, w, g.client, g.project, repoURLs, nil, e.Ref)
 		}
 	})
+}
+
+func collectGitLabChangedFiles(commits []*gl.PushEventCommit) []string {
+	seen := map[string]struct{}{}
+	var files []string
+	add := func(paths []string) {
+		for _, p := range paths {
+			if _, ok := seen[p]; !ok {
+				seen[p] = struct{}{}
+				files = append(files, p)
+			}
+		}
+	}
+	for _, c := range commits {
+		add(c.Added)
+		add(c.Modified)
+		add(c.Removed)
+	}
+	return files
 }

--- a/pkg/webhook/external/harbor.go
+++ b/pkg/webhook/external/harbor.go
@@ -168,6 +168,6 @@ func (h *harborWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc 
 			"tags", tags,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, h.client, h.project, repoURLs, tags...)
+		refreshWarehouses(ctx, w, h.client, h.project, repoURLs, nil, tags...)
 	})
 }

--- a/pkg/webhook/external/quay.go
+++ b/pkg/webhook/external/quay.go
@@ -107,6 +107,6 @@ func (q *quayWebhookReceiver) getHandler(requestBody []byte) http.HandlerFunc {
 			"tags", payload.UpdatedTags,
 		)
 		ctx = logging.ContextWithLogger(ctx, logger)
-		refreshWarehouses(ctx, w, q.client, q.project, repoURLs, payload.UpdatedTags...)
+		refreshWarehouses(ctx, w, q.client, q.project, repoURLs, nil, payload.UpdatedTags...)
 	})
 }

--- a/pkg/webhook/external/refresh.go
+++ b/pkg/webhook/external/refresh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/akuity/kargo/pkg/image"
 	"github.com/akuity/kargo/pkg/indexer"
 	"github.com/akuity/kargo/pkg/logging"
+	"github.com/akuity/kargo/pkg/pattern"
 	"github.com/akuity/kargo/pkg/urls"
 )
 
@@ -80,6 +81,7 @@ func refreshWarehouses(
 	c client.Client,
 	project string,
 	repoURLs []string,
+	changedFiles []string,
 	qualifiers ...string,
 ) {
 	logger := logging.LoggerFromContext(ctx)
@@ -129,7 +131,7 @@ func refreshWarehouses(
 			}
 
 			if len(qualifiers) > 0 {
-				shouldRefresh, err := shouldRefresh(ctx, wh, repoURL, qualifiers...)
+				shouldRefresh, err := shouldRefresh(ctx, wh, repoURL, changedFiles, qualifiers...)
 				if err != nil {
 					logger.Error(
 						err,
@@ -190,6 +192,7 @@ func shouldRefresh(
 	ctx context.Context,
 	wh kargoapi.Warehouse,
 	repoURL string,
+	changedFiles []string,
 	qualifiers ...string,
 ) (bool, error) {
 	var shouldRefresh bool
@@ -202,7 +205,13 @@ func shouldRefresh(
 					s.Git.RepoURL, err,
 				)
 			}
-			shouldRefresh = slices.ContainsFunc(qualifiers, selector.MatchesRef)
+			if !slices.ContainsFunc(qualifiers, selector.MatchesRef) {
+				continue
+			}
+			if !matchesChangedFiles(s.Git.IncludePaths, s.Git.ExcludePaths, changedFiles) {
+				continue
+			}
+			shouldRefresh = true
 		case s.Image != nil && urls.NormalizeImage(s.Image.RepoURL) == repoURL:
 			selector, err := image.NewSelector(ctx, *s.Image, nil)
 			if err != nil {
@@ -225,4 +234,57 @@ func shouldRefresh(
 		}
 	}
 	return false, nil
+}
+
+// parsePathMatchers parses a list of path selector strings into a single
+// Matcher. Returns nil if paths is empty. Returns an error if any pattern
+// is invalid.
+func parsePathMatchers(paths []string) (pattern.Matcher, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	matchers := make(pattern.Matchers, 0, len(paths))
+	for _, p := range paths {
+		m, err := pattern.ParsePathPattern(p)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, m)
+	}
+	return matchers, nil
+}
+
+// matchesChangedFiles checks whether the given changedFiles match the
+// subscription's includePaths/excludePaths filters. Returns true (allow
+// refresh) when changedFiles is empty (provider didn't supply file data) or
+// when the subscription has no path filters configured.
+func matchesChangedFiles(
+	includePaths []string,
+	excludePaths []string,
+	changedFiles []string,
+) bool {
+	if len(changedFiles) == 0 ||
+		(len(includePaths) == 0 && len(excludePaths) == 0) {
+		return true
+	}
+	include, err := parsePathMatchers(includePaths)
+	if err != nil {
+		// If a pattern is invalid, fall back to allowing refresh
+		// so the controller can report the error during reconciliation.
+		return true
+	}
+	exclude, err := parsePathMatchers(excludePaths)
+	if err != nil {
+		return true
+	}
+	for _, path := range changedFiles {
+		if include != nil && !include.Matches(path) {
+			continue
+		}
+		if exclude != nil && exclude.Matches(path) {
+			continue
+		}
+		return true
+	}
+	return false
 }

--- a/pkg/webhook/external/refresh_test.go
+++ b/pkg/webhook/external/refresh_test.go
@@ -211,6 +211,7 @@ func TestRefreshWarehouses(t *testing.T) {
 				tt.client,
 				tt.project,
 				testRepoURLs,
+				nil,
 			)
 			tt.assertions(t, w)
 		})
@@ -219,11 +220,12 @@ func TestRefreshWarehouses(t *testing.T) {
 
 func TestShouldRefresh(t *testing.T) {
 	testCases := []struct {
-		name       string
-		wh         kargoapi.Warehouse
-		qualifiers []string
-		repoURL    string
-		expect     bool
+		name         string
+		wh           kargoapi.Warehouse
+		qualifiers   []string
+		repoURL      string
+		changedFiles []string
+		expect       bool
 	}{
 		{
 			name: "Git subscription with matching qualifier",
@@ -258,6 +260,118 @@ func TestShouldRefresh(t *testing.T) {
 			repoURL:    "https://github.com/username/repo",
 			qualifiers: []string{"release"},
 			expect:     false,
+		},
+		{
+			name: "Git subscription with matching ref and matching includePaths",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+							IncludePaths:            []string{"src/"},
+						},
+					}},
+				},
+			},
+			repoURL:      "https://github.com/username/repo",
+			qualifiers:   []string{"refs/heads/main"},
+			changedFiles: []string{"src/main.go", "docs/readme.md"},
+			expect:       true,
+		},
+		{
+			name: "Git subscription with matching ref but non-matching includePaths",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+							IncludePaths:            []string{"src/"},
+						},
+					}},
+				},
+			},
+			repoURL:      "https://github.com/username/repo",
+			qualifiers:   []string{"refs/heads/main"},
+			changedFiles: []string{"docs/readme.md"},
+			expect:       false,
+		},
+		{
+			name: "Git subscription with matching ref and excluded paths",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+							ExcludePaths:            []string{"docs/"},
+						},
+					}},
+				},
+			},
+			repoURL:      "https://github.com/username/repo",
+			qualifiers:   []string{"refs/heads/main"},
+			changedFiles: []string{"docs/readme.md"},
+			expect:       false,
+		},
+		{
+			name: "Git subscription with matching ref and no path filters",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+						},
+					}},
+				},
+			},
+			repoURL:      "https://github.com/username/repo",
+			qualifiers:   []string{"refs/heads/main"},
+			changedFiles: []string{"anything/file.txt"},
+			expect:       true,
+		},
+		{
+			name: "Git subscription with matching ref and path filters but no changedFiles",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+							IncludePaths:            []string{"src/"},
+						},
+					}},
+				},
+			},
+			repoURL:    "https://github.com/username/repo",
+			qualifiers: []string{"refs/heads/main"},
+			expect:     true,
+		},
+		{
+			name: "Git subscription with glob includePaths",
+			wh: kargoapi.Warehouse{
+				Spec: kargoapi.WarehouseSpec{
+					InternalSubscriptions: []kargoapi.RepoSubscription{{
+						Git: &kargoapi.GitSubscription{
+							CommitSelectionStrategy: kargoapi.CommitSelectionStrategyNewestFromBranch,
+							RepoURL:                 "https://github.com/username/repo",
+							Branch:                  "main",
+							IncludePaths:            []string{"glob:charts/**"},
+						},
+					}},
+				},
+			},
+			repoURL:      "https://github.com/username/repo",
+			qualifiers:   []string{"refs/heads/main"},
+			changedFiles: []string{"charts/my-app/values.yaml"},
+			expect:       true,
 		},
 		{
 			name: "Image subscription with matching qualifier",
@@ -340,9 +454,89 @@ func TestShouldRefresh(t *testing.T) {
 				t.Context(),
 				tc.wh,
 				tc.repoURL,
+				tc.changedFiles,
 				tc.qualifiers...,
 			)
 			require.NoError(t, err)
+			require.Equal(t, tc.expect, result)
+		})
+	}
+}
+
+func TestMatchesChangedFiles(t *testing.T) {
+	testCases := []struct {
+		name         string
+		includePaths []string
+		excludePaths []string
+		changedFiles []string
+		expect       bool
+	}{
+		{
+			name:         "no changedFiles returns true",
+			includePaths: []string{"src/"},
+			expect:       true,
+		},
+		{
+			name:         "no path filters returns true",
+			changedFiles: []string{"anything.txt"},
+			expect:       true,
+		},
+		{
+			name:         "includePaths match",
+			includePaths: []string{"src/"},
+			changedFiles: []string{"src/main.go"},
+			expect:       true,
+		},
+		{
+			name:         "includePaths no match",
+			includePaths: []string{"src/"},
+			changedFiles: []string{"docs/readme.md"},
+			expect:       false,
+		},
+		{
+			name:         "excludePaths excludes all files",
+			excludePaths: []string{"docs/"},
+			changedFiles: []string{"docs/readme.md"},
+			expect:       false,
+		},
+		{
+			name:         "excludePaths allows non-excluded files",
+			excludePaths: []string{"docs/"},
+			changedFiles: []string{"docs/readme.md", "src/main.go"},
+			expect:       true,
+		},
+		{
+			name:         "include and exclude combined",
+			includePaths: []string{"src/"},
+			excludePaths: []string{"src/generated/"},
+			changedFiles: []string{"src/generated/types.go"},
+			expect:       false,
+		},
+		{
+			name:         "include and exclude with match",
+			includePaths: []string{"src/"},
+			excludePaths: []string{"src/generated/"},
+			changedFiles: []string{"src/generated/types.go", "src/main.go"},
+			expect:       true,
+		},
+		{
+			name:         "glob pattern",
+			includePaths: []string{"glob:charts/**/*.yaml"},
+			changedFiles: []string{"charts/app/values.yaml"},
+			expect:       true,
+		},
+		{
+			name:         "regex pattern",
+			includePaths: []string{"regexp:^src/.*\\.go$"},
+			changedFiles: []string{"src/main.go"},
+			expect:       true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := matchesChangedFiles(
+				tc.includePaths, tc.excludePaths, tc.changedFiles,
+			)
 			require.Equal(t, tc.expect, result)
 		})
 	}


### PR DESCRIPTION
## Summary

When a Git push webhook is received, Kargo currently refreshes **all** warehouses
subscribed to the matching repo URL and branch — even if the warehouse's
`includePaths`/`excludePaths` filters would exclude the changed files. This causes
unnecessary git fetches, particularly impactful for monorepo setups where many
warehouses subscribe to the same repository but watch different paths.

This change extracts the per-commit changed file lists (`added`, `modified`, `removed`)
from Git push webhook payloads and evaluates them against each warehouse's path filters
**before** triggering a refresh. Warehouses whose path filters don't match any changed
files are skipped entirely.

- **GitHub, GitLab, Gitea**: Changed files are extracted from the push event payload
  and used for path filter evaluation
- **Bitbucket, Azure DevOps, and image/chart providers**: These payloads don't include
  per-commit file lists, so existing behavior is preserved (refresh on ref match alone)
- **Backwards-compatible**: Warehouses with no `includePaths`/`excludePaths` configured,
  or webhooks without changed file data, behave exactly as before

### Flow

```mermaid
flowchart TD
    A[Webhook Received] --> B[Parse push event payload]
    B --> C[Extract repo URLs, ref, and changed files]
    C --> D[Find warehouses subscribed to repo URL]
    D --> E{Ref matches subscription branch?}
    E -- No --> F[Skip warehouse]
    E -- Yes --> G{Subscription has includePaths or excludePaths?}
    G -- No --> I[Refresh warehouse]
    G -- Yes --> H{Changed files provided by webhook?}
    H -- No --> I
    H -- Yes --> J{Any changed file matches path filters?}
    J -- Yes --> I
    J -- No --> F
```

## Test plan

- [ ] New unit tests in `TestShouldRefresh` cover: matching/non-matching include paths,
  exclude paths, glob patterns, no path filters, and empty changed files (backwards compat)
- [ ] New `TestMatchesChangedFiles` covers: include-only, exclude-only, combined
  include+exclude, glob patterns, regex patterns, and edge cases
- [ ] All existing tests pass unchanged
- [ ] `make lint-go` passes with zero issues
