### PR TITLE
fix(controller): fix broken branch locks in git-push step

### DIFF
--- a/pkg/promotion/runner/builtin/git_pusher.go
+++ b/pkg/promotion/runner/builtin/git_pusher.go
@@ -33,6 +33,8 @@ const (
 )
 
 func init() {
+	var once sync.Once
+	var pusher promotion.StepRunner
 	promotion.DefaultStepRunnerRegistry.MustRegister(
 		promotion.StepRunnerRegistration{
 			Name: stepKindGitPush,
@@ -41,7 +43,15 @@ func init() {
 					promotion.StepCapabilityAccessCredentials,
 				},
 			},
-			Value: newGitPusher,
+			// This factory function closes over a single instance of gitPushPusher
+			// so that that its mutexes are shared across all executions of this step
+			// runner, which is necessary to ensure proper locking behavior.
+			Value: func(caps promotion.StepRunnerCapabilities) promotion.StepRunner {
+				once.Do(func() {
+					pusher = newGitPusher(caps)
+				})
+				return pusher
+			},
 		},
 	)
 }


### PR DESCRIPTION
Refactoring in #5079 (further refactored in #5378) broke an optimization from #3119.

Besides introducing a pull + rebase + retry loop, #3119 sought to minimize the _need_ for that by using mutexes to to reduce incidence (within a single controller, at least) of multiple `git-push` step runners competing with one another to push different (non-conflicting) changes to the same branch.

The behavior described above relied on a single instance of the step runner to handle all pushes, else the mutexes would be ineffective. #5079 caused us to resume using a new runner for every push. Whoops.

This PR restores the optimization and leaves a comment to avert the possibility of future refactoring re-introducing the same mistake.