### PR TITLE
feat: Allow port numbers in image refs for OCI downloads

### DIFF
--- a/pkg/promotion/runner/builtin/oci_downloader_test.go
+++ b/pkg/promotion/runner/builtin/oci_downloader_test.go
@@ -56,6 +56,20 @@ func Test_ociDownloader_validate(t *testing.T) {
 			},
 		},
 		{
+			name: "valid config with non-standard port",
+			config: promotion.Config{
+				"imageRef": "an.internal.registry.com:5050/myrepo/myimage:latest",
+				"outPath":  "output/file.tar",
+			},
+		},
+		{
+			name: "valid config with OCI protocol and non-standard port",
+			config: promotion.Config{
+				"imageRef": "oci://registry.example.com:5050/image:tag",
+				"outPath":  "output/file.tar",
+			},
+		},
+		{
 			name: "valid config with optional fields",
 			config: promotion.Config{
 				"imageRef":              "registry.example.com/image:tag",
@@ -116,6 +130,16 @@ func Test_ociDownloader_parseImageReference(t *testing.T) {
 				require.NotNil(t, ref)
 				assert.Equal(t, credentials.TypeHelm, credType)
 				assert.Equal(t, "localhost:5000/chart:latest", ref.String())
+			},
+		},
+		{
+			name:     "standard registry reference with port",
+			imageRef: "an.internal.registry.com:5050/myrepo/myimage:latest",
+			assertions: func(t *testing.T, ref name.Reference, credType credentials.Type, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, ref)
+				assert.Equal(t, credentials.TypeImage, credType)
+				assert.Equal(t, "an.internal.registry.com:5050/myrepo/myimage:latest", ref.String())
 			},
 		},
 	}
@@ -493,6 +517,52 @@ func Test_ociDownloader_getAuthOption(t *testing.T) {
 				},
 			},
 			imageRef: "oci://registry.example.com/chart:1.0.0",
+			assertions: func(t *testing.T, opt remote.Option, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, opt)
+			},
+		},
+		{
+			name: "valid image credentials with port",
+			credsDB: &credentials.FakeDB{
+				GetFn: func(
+					_ context.Context,
+					_ string,
+					credType credentials.Type,
+					repoURL string,
+				) (*credentials.Credentials, error) {
+					assert.Equal(t, credentials.TypeImage, credType)
+					assert.Equal(t, "an.internal.registry.com:5050/myrepo/myimage", repoURL)
+					return &credentials.Credentials{
+						Username: "user",
+						Password: "pass",
+					}, nil
+				},
+			},
+			imageRef: "an.internal.registry.com:5050/myrepo/myimage:latest",
+			assertions: func(t *testing.T, opt remote.Option, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, opt)
+			},
+		},
+		{
+			name: "valid Helm credentials with OCI prefix and port",
+			credsDB: &credentials.FakeDB{
+				GetFn: func(
+					_ context.Context,
+					_ string,
+					credType credentials.Type,
+					repoURL string,
+				) (*credentials.Credentials, error) {
+					assert.Equal(t, credentials.TypeHelm, credType)
+					assert.Equal(t, "oci://registry.example.com:5050/chart", repoURL)
+					return &credentials.Credentials{
+						Username: "helm-user",
+						Password: "helm-pass",
+					}, nil
+				},
+			},
+			imageRef: "oci://registry.example.com:5050/chart:1.0.0",
 			assertions: func(t *testing.T, opt remote.Option, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, opt)

--- a/pkg/promotion/runner/builtin/schemas/oci-download-config.json
+++ b/pkg/promotion/runner/builtin/schemas/oci-download-config.json
@@ -9,7 +9,7 @@
       "type": "string",
       "description": "ImageRef is the reference to the OCI artifact to pull. Supports both tag format 'registry/repository:tag' and digest format 'registry/repository@sha256:digest'.",
       "minLength": 1,
-      "pattern": "^(oci://)?[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
+      "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
     },
     "outPath": {
       "type": "string",

--- a/ui/src/gen/directives/oci-download-config.json
+++ b/ui/src/gen/directives/oci-download-config.json
@@ -8,7 +8,7 @@
    "type": "string",
    "description": "ImageRef is the reference to the OCI artifact to pull. Supports both tag format 'registry/repository:tag' and digest format 'registry/repository@sha256:digest'.",
    "minLength": 1,
-   "pattern": "^(oci://)?[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
+   "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
   },
   "outPath": {
    "type": "string",


### PR DESCRIPTION
Sometimes internal registries or tools might be running on non-standard ports so this should allow a little more flexibility