### PR TITLE
feat(ui): add tooltips to icon-only buttons on stage and warehouse nodes

### DIFF
--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -8,7 +8,7 @@ import {
   faTruckArrowRight
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Card, Dropdown, Flex, message, Space, Typography } from 'antd';
+import { Button, Card, Dropdown, Flex, message, Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { formatDistance } from 'date-fns';
 import { ReactNode, useMemo } from 'react';
@@ -155,31 +155,35 @@ export const StageNode = (props: { stage: Stage }) => {
                 icon: <img src='/argo-logo.svg' alt='ArgoCD' style={{ width: '18px' }} />
               }}
             />
-            <Dropdown
-              trigger={['click']}
-              overlayClassName='w-fit'
-              menu={{
-                items: dropdownItems
-              }}
-            >
+            <Tooltip title='Promote'>
+              <Dropdown
+                trigger={['click']}
+                overlayClassName='w-fit'
+                menu={{
+                  items: dropdownItems
+                }}
+              >
+                <Button
+                  size='small'
+                  loading={queryFreightMutation.isPending}
+                  icon={<FontAwesomeIcon icon={faTruckArrowRight} size='sm' />}
+                />
+              </Dropdown>
+            </Tooltip>
+            <Tooltip title='Stage Details'>
               <Button
+                icon={<FontAwesomeIcon icon={faBarsStaggered} className='mt-1' />}
                 size='small'
-                loading={queryFreightMutation.isPending}
-                icon={<FontAwesomeIcon icon={faTruckArrowRight} size='sm' />}
+                onClick={() =>
+                  navigate(
+                    generatePath(paths.stage, {
+                      name: props.stage?.metadata?.namespace,
+                      stageName: props.stage?.metadata?.name
+                    })
+                  )
+                }
               />
-            </Dropdown>
-            <Button
-              icon={<FontAwesomeIcon icon={faBarsStaggered} className='mt-1' />}
-              size='small'
-              onClick={() =>
-                navigate(
-                  generatePath(paths.stage, {
-                    name: props.stage?.metadata?.namespace,
-                    stageName: props.stage?.metadata?.name
-                  })
-                )
-              }
-            />
+            </Tooltip>
           </Space>
         }
         className={classNames(

--- a/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
@@ -71,18 +71,20 @@ export const WarehouseNode = (props: { warehouse: WarehouseExpanded }) => {
 
             {warehouseState.hasError && <Badge status='error' />}
           </Flex>
-          <Button
-            icon={<FontAwesomeIcon icon={faBarsStaggered} />}
-            size='small'
-            onClick={() =>
-              navigate(
-                generatePath(paths.warehouse, {
-                  name: props.warehouse?.metadata?.namespace,
-                  warehouseName: props.warehouse?.metadata?.name
-                })
-              )
-            }
-          />
+          <Tooltip title='Warehouse Details'>
+            <Button
+              icon={<FontAwesomeIcon icon={faBarsStaggered} />}
+              size='small'
+              onClick={() =>
+                navigate(
+                  generatePath(paths.warehouse, {
+                    name: props.warehouse?.metadata?.namespace,
+                    warehouseName: props.warehouse?.metadata?.name
+                  })
+                )
+              }
+            />
+          </Tooltip>
         </Flex>
       }
       className={styles['warehouse-node-size']}


### PR DESCRIPTION
The icon-only buttons in the stage and warehouse node headers (pipeline graph view) have no tooltips, which makes it unclear what they do - especially for new users. I found myself hesitant to click them when I first started using Kargo.

This wraps them with Ant Design's `<Tooltip>` to add labels:

- Truck icon on stage nodes: **Promote**
- Staggered-bars icon on stage nodes: **Stage Details**
- Staggered-bars icon on warehouse nodes: **Warehouse Details**

It's a small change so I skipped creating an issue first but I'm happy to open one retroactively if that's preferred.

### Screenshots

**"Promote" tooltip on the truck icon:**

<img width="2252" height="1642" alt="promote-tooltip" src="https://github.com/user-attachments/assets/116b6994-fb9d-4b81-9fd0-e8fe3c5cbc29" />


**"Stage Details" tooltip on the bars icon:**

<img width="2252" height="1642" alt="stage-details-tooltip" src="https://github.com/user-attachments/assets/3843eb3e-b1e7-4b7e-a17c-20272ceccdaf" />

