### PR TITLE
feat: add functionality to helm-update-chart to match on an alias

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-update-chart.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/helm-update-chart.md
@@ -19,6 +19,7 @@ referenced by the Freight being promoted. This step is commonly followed by a
 | `charts` | `[]object` | N | The details of dependency (subchart) updates to be applied to the chart's `Chart.yaml` file. When left unspecified, charts will be updated according to the SemVer ranges declared in the `Chart.yaml` file. |
 | `charts[].repository` | `string` | Y | The URL of the Helm chart repository in the `dependencies` entry whose `version` field is to be updated. Must _exactly_ match the `repository` field of that entry. |
 | `charts[].name` | `string` | Y | The name of the chart in in the `dependencies` entry whose `version` field is to be updated. Must exactly match the `name` field of that entry. |
+| `charts[].alias` | `string` | N | Optional. The `alias` of the dependency in `Chart.yaml`. When specified, only the dependency with this alias is matched (e.g. when the same chart is listed multiple times with different aliases). When omitted, matching is by repository and name only. |
 | `charts[].version` | `string` | Y | The version to which the dependency should be updated. |
 
 ## Output

--- a/pkg/helm/dependency.go
+++ b/pkg/helm/dependency.go
@@ -15,6 +15,7 @@ type ChartDependency struct {
 	Repository string `json:"repository,omitempty"`
 	Name       string `json:"name,omitempty"`
 	Version    string `json:"version,omitempty"`
+	Alias      string `json:"alias,omitempty"`
 }
 
 // chartMetadata is a minimal representation of a Helm chart's metadata

--- a/pkg/helm/dependency_manager.go
+++ b/pkg/helm/dependency_manager.go
@@ -349,7 +349,13 @@ func (em *EphemeralDependencyManager) processDependencyUpdates(
 	for _, update := range updates {
 		var found bool
 		for i, dep := range dependencies {
-			if dep.Name == update.Name && dep.Repository == update.Repository {
+			var matched bool
+			if update.Alias != "" {
+				matched = dep.Alias == update.Alias
+			} else {
+				matched = dep.Name == update.Name
+			}
+			if matched && dep.Repository == update.Repository {
 				found = true
 				// If the version is different, add the updated dependency
 				if dep.Version != update.Version {
@@ -363,8 +369,8 @@ func (em *EphemeralDependencyManager) processDependencyUpdates(
 		}
 		if !found {
 			return fmt.Errorf(
-				"no dependency in Chart.yaml matches update with repository %q and name %q",
-				update.Repository, update.Name,
+				"no dependency in Chart.yaml matches update with repository %q and name %q or alias %q",
+				update.Repository, update.Name, update.Alias,
 			)
 		}
 	}

--- a/pkg/helm/dependency_manager_test.go
+++ b/pkg/helm/dependency_manager_test.go
@@ -632,6 +632,40 @@ version: 1.0.0
 				assert.ErrorContains(t, err, `no dependency in Chart.yaml matches update`)
 			},
 		},
+		{
+			name: "match by alias when present",
+			chartFile: `name: test-chart
+version: 1.0.0
+dependencies:
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.0.0
+    alias: redis-session
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 17.0.0
+    alias: redis-cache
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.0.0
+    alias: redis-sentinel
+`,
+			updates: []ChartDependency{
+				{Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "18.0.0", Alias: "redis-cache"},
+				{Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "13.0.0", Alias: "redis-sentinel"},
+			},
+			assertions: func(t *testing.T, chartPath string, err error) {
+				assert.NoError(t, err)
+
+				dependencies, err := GetChartDependencies(chartPath)
+				assert.NoError(t, err)
+				assert.Equal(t, []ChartDependency{
+					{Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "16.0.0", Alias: "redis-session"},
+					{Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "18.0.0", Alias: "redis-cache"},
+					{Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "13.0.0", Alias: "redis-sentinel"},
+				}, dependencies)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #5891 

Implements a new `alias` option to the `helm-update-chart` step that allows matching on a chart dependency's `alias` field.