### PR TITLE
fix(ui): add smooth scrolling to freight list

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -199,7 +199,10 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
             }
           }}
         >
-          <div className='flex gap-1 relative right-0' ref={freightListStyleRef}>
+          <div
+            className='flex gap-1 relative right-0 transition-[right] duration-300 ease-out'
+            ref={freightListStyleRef}
+          >
             {filteredFreights.map((freight) => {
               const freightSoakTime = soakTime?.[freight?.metadata?.name || ''];
 


### PR DESCRIPTION
We're finding scrolling the freight list somewhat disorienting in my team. As each item within is so visually similar to its neighbours, the instantaneous scroll means your eyes kind of lose context of the relationship between where you were before the scroll and where you've landed after it. It produces an optical illusion where the list appears to scroll in the opposite direction than it really is.

Adding a slight transition to smooth it seems to address the issue and improves the usability of this part of the UI quite nicely.

## Before

![2026-03-13 10 25 32](https://github.com/user-attachments/assets/332e27c1-5c0b-4e51-b604-5cc18fde806b)

## After

![2026-03-13 10 24 46](https://github.com/user-attachments/assets/8a0660e0-7acb-4e66-a6c3-b5a266016d71)
