### PR TITLE
fix: pass git user config to git-open-pr for commit signing

### DIFF
--- a/pkg/promotion/runner/builtin/git_pr_opener.go
+++ b/pkg/promotion/runner/builtin/git_pr_opener.go
@@ -42,6 +42,7 @@ func init() {
 // gitPROpener is an implementation of the promotion.StepRunner interface that
 // opens a pull request.
 type gitPROpener struct {
+	gitUser      git.User
 	schemaLoader gojsonschema.JSONLoader
 	credsDB      credentials.Database
 }
@@ -50,6 +51,7 @@ type gitPROpener struct {
 // that opens a pull request.
 func newGitPROpener(caps promotion.StepRunnerCapabilities) promotion.StepRunner {
 	return &gitPROpener{
+		gitUser:      gitUserFromEnv(),
 		credsDB:      caps.CredsDB,
 		schemaLoader: getConfigSchemaLoader(stepKindGitOpenPR),
 	}
@@ -123,6 +125,7 @@ func (g *gitPROpener) run(
 	repo, err := git.Clone(
 		cfg.RepoURL,
 		&git.ClientOptions{
+			User:                  &g.gitUser,
 			Credentials:           repoCreds,
 			InsecureSkipTLSVerify: cfg.InsecureSkipTLSVerify,
 		},


### PR DESCRIPTION
## Summary
- Pass `User` (with signing key config) to `git.Clone()` in `git-open-pr`, matching the pattern used by `git-clone` and other git steps
- Without this, any clone performed by `git-open-pr` lacks signing configuration, which could affect operations that create commits

Fixes #4851

## Test plan
- [x] Existing `Test_gitPROpener` unit tests pass
- [x] Manually tested with a promotion using `git-clone` (`create: true`) + `git-open-pr` — the initial commit on the new branch is GPG-signed