### PR TITLE
fix: prevent stale cache from re-executing promotion steps

### DIFF
--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -62,6 +62,7 @@ func ReconcilerConfigFromEnv() ReconcilerConfig {
 type reconciler struct {
 	kargoClient    client.Client
 	promoEngine    promotion.Engine
+	fence          kubeclient.VersionWaiter
 	shardPredicate controller.ResponsibleFor[kargoapi.Promotion]
 
 	cfg ReconcilerConfig
@@ -117,8 +118,18 @@ func SetupReconcilerWithManager(
 		return fmt.Errorf("index running Promotions by Argo CD Applications: %w", err)
 	}
 
+	fence := kubeclient.NewVersionFence()
+	promoInformer, err := kargoMgr.GetCache().GetInformer(ctx, &kargoapi.Promotion{})
+	if err != nil {
+		return fmt.Errorf("error getting Promotion informer: %w", err)
+	}
+	if _, err = promoInformer.AddEventHandler(fence); err != nil {
+		return fmt.Errorf("error adding version fence event handler: %w", err)
+	}
+
 	reconciler := newReconciler(
 		kargoMgr.GetClient(),
+		fence,
 		k8sevent.NewEventSender(
 			libEvent.NewRecorder(ctx, kargoMgr.GetScheme(), kargoMgr.GetClient(), cfg.Name()),
 		),
@@ -198,12 +209,14 @@ func SetupReconcilerWithManager(
 
 func newReconciler(
 	kargoClient client.Client,
+	fence kubeclient.VersionWaiter,
 	sender event.Sender,
 	promoEngine promotion.Engine,
 	cfg ReconcilerConfig,
 ) *reconciler {
 	r := &reconciler{
 		kargoClient: kargoClient,
+		fence:       fence,
 		promoEngine: promoEngine,
 		sender:      sender,
 		cfg:         cfg,
@@ -289,7 +302,7 @@ func (r *reconciler) Reconcile(
 	// If the Promotion does not have a Phase, it must be new and (initially)
 	// pending. Mark it as such.
 	if promo.Status.Phase == "" {
-		if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+		if err = r.patchStatusAndWait(ctx, promo, func(status *kargoapi.PromotionStatus) {
 			status.Phase = kargoapi.PromotionPhasePending
 		}); err != nil {
 			return ctrl.Result{}, err
@@ -331,7 +344,7 @@ func (r *reconciler) Reconcile(
 	// Update promo status as Running to give visibility in UI. Also, a promo which
 	// has already entered Running status will be allowed to continue to reconcile.
 	if promo.Status.Phase != kargoapi.PromotionPhaseRunning {
-		if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+		if err = r.patchStatusAndWait(ctx, promo, func(status *kargoapi.PromotionStatus) {
 			status.Phase = kargoapi.PromotionPhaseRunning
 			status.StartedAt = &metav1.Time{Time: time.Now()}
 		}); err != nil {
@@ -394,7 +407,7 @@ func (r *reconciler) Reconcile(
 		newStatus.LastHandledRefresh = token
 	}
 
-	if err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+	if err = r.patchStatusAndWait(ctx, promo, func(status *kargoapi.PromotionStatus) {
 		*status = *newStatus
 	}); err != nil {
 		logger.Error(err, "error updating Promotion status")
@@ -406,7 +419,7 @@ func (r *reconciler) Reconcile(
 			// NB: This should be a rare occurrence, and is either due to the
 			// CustomResourceDefinition being out of sync with the controller
 			// version, or us inventing non-backwards-compatible changes.
-			err = kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+			err = r.patchStatusAndWait(ctx, promo, func(status *kargoapi.PromotionStatus) {
 				status.Phase = kargoapi.PromotionPhaseErrored
 				status.Message = fmt.Sprintf("error updating status: %v", err)
 			})
@@ -496,6 +509,28 @@ func (r *reconciler) Reconcile(
 		}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// patchStatusAndWait patches the Promotion status and then waits for the
+// informer cache to observe the update. This prevents the next reconciliation
+// from acting on stale cached data.
+func (r *reconciler) patchStatusAndWait(
+	ctx context.Context,
+	promo *kargoapi.Promotion,
+	update func(*kargoapi.PromotionStatus),
+) error {
+	if err := kubeclient.PatchStatus(ctx, r.kargoClient, promo, update); err != nil {
+		return err
+	}
+	if err := r.fence.WaitForVersion(
+		ctx, client.ObjectKeyFromObject(promo), promo.GetResourceVersion(), 5*time.Second,
+	); err != nil {
+		logging.LoggerFromContext(ctx).Debug(
+			"version fence: cache sync wait exceeded timeout",
+			"resourceVersion", promo.GetResourceVersion(),
+		)
+	}
+	return nil
 }
 
 func (r *reconciler) promote(
@@ -696,7 +731,7 @@ func (r *reconciler) terminatePromotion(
 	}
 	newStatus.FinishedAt = now
 
-	if err := kubeclient.PatchStatus(ctx, r.kargoClient, promo, func(status *kargoapi.PromotionStatus) {
+	if err := r.patchStatusAndWait(ctx, promo, func(status *kargoapi.PromotionStatus) {
 		*status = *newStatus
 	}); err != nil {
 		return err

--- a/pkg/controller/promotions/promotions_test.go
+++ b/pkg/controller/promotions/promotions_test.go
@@ -19,6 +19,7 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
+	fakekubeclient "github.com/akuity/kargo/pkg/kubeclient/fake"
 	fakeevent "github.com/akuity/kargo/pkg/kubernetes/event/fake"
 	"github.com/akuity/kargo/pkg/promotion"
 )
@@ -32,6 +33,7 @@ func TestNewPromotionReconciler(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
 	r := newReconciler(
 		kubeClient,
+		&fakekubeclient.VersionWaiter{},
 		k8sevent.NewEventSender(&fakeevent.EventRecorder{}),
 		&promotion.MockEngine{},
 		ReconcilerConfig{},
@@ -55,6 +57,7 @@ func newFakeReconciler(
 		WithObjects(objects...).WithStatusSubresource(objects...).Build()
 	return newReconciler(
 		kargoClient,
+		&fakekubeclient.VersionWaiter{},
 		k8sevent.NewEventSender(recorder),
 		&promotion.MockEngine{},
 		ReconcilerConfig{},
@@ -523,6 +526,7 @@ func Test_reconciler_terminatePromotion(t *testing.T) {
 
 			r := &reconciler{
 				kargoClient: c,
+				fence:       &fakekubeclient.VersionWaiter{},
 				sender:      k8sevent.NewEventSender(recorder),
 				cleanupWorkDirFn: func(context.Context, types.UID) {
 					// no-op for tests
@@ -657,6 +661,7 @@ func Test_reconciler_terminatePromotion_cleansUpWorkDir(t *testing.T) {
 	cleanupCalled := false
 	r := &reconciler{
 		kargoClient: c,
+		fence:       &fakekubeclient.VersionWaiter{},
 		sender:      k8sevent.NewEventSender(recorder),
 		cleanupWorkDirFn: func(context.Context, types.UID) {
 			cleanupCalled = true

--- a/pkg/kubeclient/fake/fake_version_waiter.go
+++ b/pkg/kubeclient/fake/fake_version_waiter.go
@@ -1,0 +1,49 @@
+package fake
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// VersionWait records a single call to WaitForVersion.
+type VersionWait struct {
+	Key             types.NamespacedName
+	ResourceVersion string
+	Timeout         time.Duration
+}
+
+// VersionWaiter is a test double for kubeclient.VersionWaiter that records
+// calls without blocking. Use Waits() to inspect what was awaited.
+type VersionWaiter struct {
+	mu    sync.Mutex
+	waits []VersionWait
+}
+
+// WaitForVersion records the call and returns nil immediately.
+func (f *VersionWaiter) WaitForVersion(
+	_ context.Context,
+	key types.NamespacedName,
+	rv string,
+	timeout time.Duration,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.waits = append(f.waits, VersionWait{
+		Key:             key,
+		ResourceVersion: rv,
+		Timeout:         timeout,
+	})
+	return nil
+}
+
+// Waits returns a copy of all recorded WaitForVersion calls.
+func (f *VersionWaiter) Waits() []VersionWait {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]VersionWait, len(f.waits))
+	copy(result, f.waits)
+	return result
+}

--- a/pkg/kubeclient/versionfence.go
+++ b/pkg/kubeclient/versionfence.go
@@ -1,0 +1,117 @@
+package kubeclient
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// VersionWaiter is the interface used by reconcilers to wait for the informer
+// cache to observe a specific resourceVersion after a status patch.
+type VersionWaiter interface {
+	WaitForVersion(ctx context.Context, key types.NamespacedName, rv string, timeout time.Duration) error
+}
+
+// VersionFence tracks resourceVersions observed by an informer cache and
+// allows callers to block until a specific version has been observed.
+// This prevents acting on stale cached data after a status patch.
+//
+// Attach it to an informer via cache.GetInformer() + AddEventHandler().
+type VersionFence struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	observed map[types.NamespacedName]int64
+}
+
+// NewVersionFence creates a new VersionFence.
+func NewVersionFence() *VersionFence {
+	f := &VersionFence{
+		observed: make(map[types.NamespacedName]int64),
+	}
+	f.cond = sync.NewCond(&f.mu)
+	return f
+}
+
+// OnAdd implements cache.ResourceEventHandler.
+func (f *VersionFence) OnAdd(obj any, _ bool) {
+	f.recordVersion(obj)
+}
+
+// OnUpdate implements cache.ResourceEventHandler.
+func (f *VersionFence) OnUpdate(_, newObj any) {
+	f.recordVersion(newObj)
+}
+
+// OnDelete implements cache.ResourceEventHandler.
+func (f *VersionFence) OnDelete(obj any) {
+	o, ok := obj.(client.Object)
+	if !ok {
+		return
+	}
+	key := types.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.observed, key)
+}
+
+func (f *VersionFence) recordVersion(obj any) {
+	o, ok := obj.(client.Object)
+	if !ok {
+		return
+	}
+	rv, err := strconv.ParseInt(o.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return
+	}
+	key := types.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if rv > f.observed[key] {
+		f.observed[key] = rv
+	}
+	f.cond.Broadcast()
+}
+
+// WaitForVersion blocks until the cache has observed at least the given
+// resourceVersion for the specified object, or until the timeout elapses
+// or ctx is canceled. Returns nil if the version was observed, or the
+// context error on timeout/cancellation.
+func (f *VersionFence) WaitForVersion(
+	ctx context.Context,
+	key types.NamespacedName,
+	rv string,
+	timeout time.Duration,
+) error {
+	target, err := strconv.ParseInt(rv, 10, 64)
+	if err != nil {
+		return nil // Non-integer RV, skip waiting
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Unblock cond.Wait() when the context is done.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			f.cond.Broadcast()
+		case <-done:
+		}
+	}()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for f.observed[key] < target {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		f.cond.Wait()
+	}
+	return nil
+}

--- a/pkg/kubeclient/versionfence_test.go
+++ b/pkg/kubeclient/versionfence_test.go
@@ -1,0 +1,162 @@
+package kubeclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestVersionFence_WaitForVersion_AlreadyObserved(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	f.OnAdd(&kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "10",
+		},
+	}, false)
+
+	err := f.WaitForVersion(t.Context(), key, "10", time.Second)
+	require.NoError(t, err)
+}
+
+func TestVersionFence_WaitForVersion_ObservedLater(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	f.OnAdd(&kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "5",
+		},
+	}, false)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- f.WaitForVersion(t.Context(), key, "10", 5*time.Second)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	f.OnUpdate(nil, &kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "10",
+		},
+	})
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForVersion did not return in time")
+	}
+}
+
+func TestVersionFence_WaitForVersion_Timeout(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	err := f.WaitForVersion(t.Context(), key, "10", 50*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestVersionFence_WaitForVersion_ContextCancelled(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := f.WaitForVersion(ctx, key, "10", 5*time.Second)
+	require.Error(t, err)
+}
+
+func TestVersionFence_WaitForVersion_NonIntegerRV(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	err := f.WaitForVersion(t.Context(), key, "not-a-number", time.Second)
+	require.NoError(t, err)
+	_ = key
+}
+
+func TestVersionFence_WaitForVersion_HigherVersionSatisfies(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	f.OnAdd(&kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "15",
+		},
+	}, false)
+
+	err := f.WaitForVersion(t.Context(), key, "10", time.Second)
+	require.NoError(t, err)
+}
+
+func TestVersionFence_OnDelete_CleansUp(t *testing.T) {
+	f := NewVersionFence()
+
+	f.OnAdd(&kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "10",
+		},
+	}, false)
+
+	f.OnDelete(&kargoapi.Promotion{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "obj",
+			ResourceVersion: "10",
+		},
+	})
+
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+	f.mu.Lock()
+	_, exists := f.observed[key]
+	f.mu.Unlock()
+	require.False(t, exists, "expected key to be removed after OnDelete")
+}
+
+func TestVersionFence_ConcurrentUpdates(t *testing.T) {
+	f := NewVersionFence()
+	key := types.NamespacedName{Namespace: "ns", Name: "obj"}
+
+	for i := range 20 {
+		rv := i + 1
+		go func() {
+			f.OnUpdate(nil, &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "ns",
+					Name:            "obj",
+					ResourceVersion: fmt.Sprintf("%d", rv),
+				},
+			})
+		}()
+	}
+
+	err := f.WaitForVersion(t.Context(), key, "20", 5*time.Second)
+	require.NoError(t, err)
+
+	f.mu.Lock()
+	require.GreaterOrEqual(t, f.observed[key], int64(20))
+	f.mu.Unlock()
+}


### PR DESCRIPTION
## Summary

Fixes #5282

### The race condition

Controller-runtime's informer cache is **eventually consistent**. When the promotion reconciler patches status (e.g. recording `StepExecutionMetadata` after completing steps), the API server accepts the write immediately, but the informer cache updates asynchronously via a watch event. If the controller processes the next reconciliation before that watch event arrives, it reads a **stale** Promotion object — one with no step metadata and `StartFromStep=0`.

```
Time ────────────────────────────────────────────────────────────────────────────────────────────────────►

                                 ◄──── critical section ────►
Reconciler  ── patch Running ──────── steps 0-5 ──────────────── patch + metadata ── unlock ─┬─ dequeue ── read cache ──
                  rv N                                               rv N+2                  │    (µs)     STALE ❌
                                                                                             │           sees rv N+1
                                          ▲                                                  │
Workqueue   ──────────────────────────── enqueue ──────────── blocked by key lock ───────────-┘
                                          │
UI/API      ─────────────────── user clicks refresh
                                       rv N+1

Cache       ─────────────────────────────────────────────────────────────────────────────────────── rv N+2 arrives ──
                                                                                                       (ms, too late)
```

### Why this matters for promotions

Promotion steps are **not idempotent by design**. Steps like `git-clone` create working directories, `git-open-pr` creates pull requests, and `git-push` pushes commits. When the reconciler re-reads a stale `StartFromStep=0` after already completing steps, it attempts to re-execute them, producing errors like:

```
application-repository already exists
```

Other steps may silently produce duplicate side effects (duplicate PRs, duplicate pushes). The correctness of the promotion engine depends on `StepExecutionMetadata` accurately reflecting what has already been done.

### The critical section

The promotion reconciler patches `Phase=Running` with **no step metadata** at the start of the first reconciliation, then executes steps in-process via `promoEngine.Promote()`. Step metadata is only written back to status when:

- A step **blocks** (e.g. `argocd-update` waiting for sync) — intermediate status is patched with metadata for all steps executed so far
- All steps **complete** — final status is patched with all metadata

The critical section is the wall-clock time from the initial `Phase=Running` patch until the first status patch that includes step metadata. For a typical promotion with `argocd-update` at step 6, that's the execution time of steps 0-5 (git-clone, kustomize, git-push, etc.) — usually a few seconds. For promotions with no blocking steps, it's the entire execution.

During this critical section, any re-enqueue that gets processed after the reconciler returns will read from the cache, which may still show the `Running, no metadata` state.

### Trigger: UI refresh during step execution

The most likely production trigger is the **UI refresh mechanism**. The Kargo UI can patch a refresh annotation on a Promotion while it is running. This creates a specific, nearly deterministic race:

1. Reconciler picks up Promotion, patches status to `Phase=Running` (no step metadata) — resourceVersion N
2. Steps 0-5 begin executing in-process (git-clone, kustomize, git-push)
3. **User clicks refresh in the UI**, which patches the refresh annotation. The API server applies this against resourceVersion N (the `Running, no metadata` state), producing resourceVersion N+1
4. The `RefreshRequested` predicate passes the watch event, and the workqueue enqueues a reconciliation — but the current reconciliation still holds the key lock, so it **waits**
5. Step 6 (`argocd-update`) blocks → reconciler patches intermediate status with metadata for steps 0-6 → resourceVersion N+2. Reconciler returns, releasing the lock
6. Workqueue immediately processes the enqueue from step 4 — this is in-process goroutine scheduling (microseconds)
7. The watch event for N+2 travels API server → watch stream → informer → cache (milliseconds at minimum)
8. **The in-process path wins**: cache still shows N+1 (no metadata) → reconciler re-executes from step 0 → `already exists`

This race is nearly deterministic once the refresh lands during the critical section — it doesn't require high API server load or unusual cache pressure. The in-process dequeue path is orders of magnitude faster than the network path for cache updates.

### The fix: VersionFence

The [recommended upstream pattern](https://github.com/kubernetes-sigs/controller-runtime/issues/1464) is to poll the cache after a write to ensure it has caught up before releasing the reconciliation lock. This PR implements an event-driven version of that pattern — a **VersionFence** — that avoids polling overhead:

1. A `VersionFence` is registered as an event handler on the Promotion informer
2. It records the latest `resourceVersion` observed for each object on every Add/Update event
3. After each `PatchStatus`, the reconciler calls `WaitForVersion(ctx, key, rv, timeout)` which blocks until the informer has delivered the watch event for (at least) that resourceVersion
4. A 5-second timeout prevents indefinite blocking — if the cache doesn't catch up in time, reconciliation proceeds anyway (best-effort)

This ensures that by the time the current reconciliation completes and releases its lock, the informer cache has already been updated with our latest write. The next reconciliation will see fresh data.

_This implementation takes the assumption that `resourceVersion` is an integer, as an optimization. If that's an unacceptable assumption, the code can be changed to perform an exact comparison only._

### Files changed

| File | Change |
|------|--------|
| `pkg/kubeclient/versionfence.go` | New `VersionWaiter` interface and `VersionFence` implementation |
| `pkg/kubeclient/versionfence_test.go` | Unit tests (already-observed, async delivery, timeout, cancellation, concurrent updates, delete cleanup) |
| `pkg/kubeclient/fake/fake_version_waiter.go` | Test fake that records waits without blocking |
| `pkg/controller/promotions/promotions.go` | Attach fence to informer, `patchStatusAndWait` helper, replace all `PatchStatus` call sites |
| `pkg/controller/promotions/promotions_test.go` | Supply fake fence to reconciler in all tests |

## Test plan

- [x] `go test ./pkg/kubeclient/...` — VersionFence unit tests pass
- [x] `go test ./pkg/controller/promotions/...` — all existing reconciler tests pass
- [x] `go vet` clean
- [x] Manual repro: with fence disabled and 10s Promotion watch delay, UI refresh during step execution reads stale cache and re-executes `git-clone` → `already exists` error (matches #5282 exactly)
- [x] Manual test with fence enabled: same conditions, no re-execution errors
- [x] Check controller logs for "version fence: cache sync wait exceeded timeout" (should be rare/absent under normal conditions)

## Follow-ups

- [ ] Open an enhancement issue to write a status update after each step