### PR TITLE
fix: bump grpc_health_probe to v0.4.46 (CVE-2025-68121)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ARG TARGETARCH
 
 WORKDIR /tools
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.41 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.46 && \
     curl -fL -o /tools/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
     chmod +x /tools/grpc_health_probe
 


### PR DESCRIPTION
Bumps `GRPC_HEALTH_PROBE_VERSION` in the Dockerfile from `v0.4.41` to `v0.4.46` (built with Go 1.25.8, which includes the `crypto/tls` fix).

### Trivy findings breakdown

| Component | Vulnerable? | Action |
|---|---|---|
| `grpc_health_probe` | **Yes** — built with Go < 1.24.13 | **Fixed in this MR** |
| `helm-3` (wolfi) | **Yes** — built with Go < 1.25.7 | Rebuild base image (no code change; `helm~3` already allows ≥ 3.20.0-r1) |
| `kargo` / `credential-helper` | **No** — false positive | Rebuild main image (see below) |

### Why not bump Helm in `hack/tools/go.mod`?

Kustomize `v0.20.1`/`v0.21.0` runs `helm version -c --short`, but Helm v3.20+ [removed the `-c` flag](https://github.com/helm/helm/pull/31301). The upstream fix ([kustomize #6016](https://github.com/kubernetes-sigs/kustomize/pull/6016)) is merged but unreleased. This dep only affects local dev tooling, not the production image.

### Why are `kargo`/`credential-helper` false positives?

Trivy reports stdlib `v1.25.5`, but per the [CVE advisory](https://cveawg.mitre.org/api/cve/CVE-2025-68121), Go 1.26.0 GA and later are `unaffected` (only `1.26.0-rc.1`–`rc.2` were). The Dockerfile already uses `golang:1.26.1-trixie`. The scanned image was likely built before this update. Rebuilding resolves it.

### Post-merge

- Rebuild the **base image** to pick up patched `helm-3` from Wolfi
- Rebuild the **main image** to clear the stale stdlib finding

