### PR TITLE
fix(events): Ensure events don't get stuck due to cancelled context

### DIFF
--- a/cmd/controlplane/api.go
+++ b/cmd/controlplane/api.go
@@ -130,6 +130,17 @@ func (o *apiOptions) run(ctx context.Context) error {
 		)
 	}
 
+	recorder, shutdown := event.NewRecorderWithShutdown(
+		ctx,
+		kubeClient.InternalClient().Scheme(),
+		kubeClient.InternalClient(),
+		"api",
+	)
+	sender := k8sevent.NewEventSenderWithShutdown(
+		recorder, shutdown,
+	)
+	defer sender.Shutdown()
+
 	srv := server.NewServer(
 		serverCfg,
 		kubeClient,
@@ -137,14 +148,7 @@ func (o *apiOptions) run(ctx context.Context) error {
 			kubeClient,
 			rbac.RolesDatabaseConfigFromEnv(),
 		),
-		k8sevent.NewEventSender(
-			event.NewRecorder(
-				ctx,
-				kubeClient.InternalClient().Scheme(),
-				kubeClient.InternalClient(),
-				"api",
-			),
-		),
+		sender,
 	)
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%s", o.BindAddress, o.Port))
 	if err != nil {

--- a/pkg/event/kubernetes/sender.go
+++ b/pkg/event/kubernetes/sender.go
@@ -16,13 +16,38 @@ import (
 )
 
 type EventSender struct {
-	recorder record.EventRecorder
+	recorder   record.EventRecorder
+	shutdownFn func()
 }
 
-// NewEventSender creates a new EventSender that uses the provided EventRecorder
+// NewEventSender creates a new EventSender that uses the provided
+// EventRecorder. The returned sender's Shutdown method is a no-op; use
+// NewEventSenderWithShutdown when graceful drain is required.
 func NewEventSender(recorder record.EventRecorder) *EventSender {
 	return &EventSender{
 		recorder: recorder,
+	}
+}
+
+// NewEventSenderWithShutdown creates a new EventSender whose Shutdown method
+// calls the provided function to drain the underlying event broadcaster. Use
+// this variant for any processes that must flush events before exiting.
+func NewEventSenderWithShutdown(
+	recorder record.EventRecorder,
+	shutdown func(),
+) *EventSender {
+	return &EventSender{
+		recorder:   recorder,
+		shutdownFn: shutdown,
+	}
+}
+
+// Shutdown drains buffered events. It blocks until all queued events
+// have been processed or the underlying transport gives up. It is a
+// no-op when the sender was created with NewEventSender.
+func (s *EventSender) Shutdown() {
+	if s.shutdownFn != nil {
+		s.shutdownFn()
 	}
 }
 

--- a/pkg/event/sender.go
+++ b/pkg/event/sender.go
@@ -7,4 +7,14 @@ import (
 type Sender interface {
 	// Send sends the event to the configured destination, returning an error if the send fails.
 	Send(ctx context.Context, evt Meta) error
+
+	// NOTE(thomastaylor312): We've never done any handling of event sending shutdown before,
+	// and it was out of scope when I added this in. But now it is available if we want to be
+	// more graceful about draining events when the controller shuts down
+
+	// Shutdown drains any buffered events, blocking until they have been
+	// delivered or the underlying transport gives up. Callers should
+	// invoke Shutdown during graceful termination to avoid losing queued
+	// events.
+	Shutdown()
 }

--- a/pkg/kubernetes/event/event.go
+++ b/pkg/kubernetes/event/event.go
@@ -49,6 +49,35 @@ func NewRecorder(
 	)
 }
 
+// NewRecorderWithShutdown is like NewRecorder but returns a shutdown function
+// that drains the internal event broadcaster queue. The caller can use the
+// returned function during graceful termination to ensure queued events are
+// delivered before the process exits.
+func NewRecorderWithShutdown(
+	ctx context.Context,
+	scheme *runtime.Scheme,
+	client libClient.Client,
+	name string,
+) (record.EventRecorder, func()) {
+	logger := logging.LoggerFromContext(ctx)
+	// NOTE(thomastaylor312): We use a non-cancelable context for the internal recorder to ensure that
+	// the recorder can continue to process events until the shutdown function is called, even if the
+	// original context is canceled (e.g. due to controller shutdown). Otherwise the context we end up
+	// using for our sink would be canceled before events were sent. Based on my investigation of the
+	// underlying k8s libraries, this should be fine because those libraries already don't use context
+	// for the underlying event creation, and there are other retry and timeouts in place by default
+	// on the underlying clients
+	internalRecorder := newRecorder(context.WithoutCancel(ctx), client, logger)
+	b := record.NewBroadcaster()
+	b.StartEventWatcher(internalRecorder.handleEvent)
+	return b.NewRecorder(
+		scheme,
+		corev1.EventSource{
+			Component: name,
+		},
+	), b.Shutdown
+}
+
 func newRecorder(
 	ctx context.Context,
 	client libClient.Client,
@@ -90,8 +119,7 @@ func (r *recorder) newRetryDecider(event *corev1.Event) func(error) bool {
 	return func(err error) bool {
 		logger := r.logger.WithValues("event", event)
 
-		var statusErr *apierrors.StatusError
-		if errors.As(err, &statusErr) {
+		if _, ok := errors.AsType[*apierrors.StatusError](err); ok {
 			if apierrors.IsAlreadyExists(err) ||
 				apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
 				logger.Info(


### PR DESCRIPTION
This removes the direct pass through of the context used when creating a new event sender. It solves an issue where if a context was cancelled, even if things hadn't finished shutting down, it would prevent the internal sink we use for events from actually publishing them to the k8s API.

As part of this, I also added a new `Shutdown` method to the `Sender` interface to allow for more graceful cleanup. I used it in the one place where it was easy to plumb through, but we don't really have a cleanup/shutdown hook in place on our controllers where I could easily put it in. However, they are still in a better state than they were before because while the manager shuts down all the caches and reconcile queues, it will still have time to send events. We can plumb through some shutdown logic later, but that felt like something that should be done in a separate follow up