### PR TITLE
chore: use test context where appropriate

### DIFF
--- a/hack/best-releases/fetch_test.go
+++ b/hack/best-releases/fetch_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -57,7 +56,7 @@ func TestFetchBestReleases(t *testing.T) {
 		defer srv.Close()
 
 		results, err := fetchBestReleases(
-			context.Background(), srv.URL,
+			t.Context(), srv.URL,
 		)
 		require.NoError(t, err)
 
@@ -77,7 +76,7 @@ func TestFetchBestReleases(t *testing.T) {
 		defer srv.Close()
 
 		results, err := fetchBestReleases(
-			context.Background(), srv.URL,
+			t.Context(), srv.URL,
 		)
 		require.Error(t, err)
 		assert.Nil(t, results)

--- a/pkg/api/cluster_config_test.go
+++ b/pkg/api/cluster_config_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,7 +44,7 @@ func TestGetClusterConfig(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			clusterCfg, err := GetClusterConfig(context.Background(), testCase.client)
+			clusterCfg, err := GetClusterConfig(t.Context(), testCase.client)
 			testCase.assertions(t, clusterCfg, err)
 		})
 	}

--- a/pkg/api/finalizers_test.go
+++ b/pkg/api/finalizers_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,7 +20,7 @@ func TestEnsureFinalizer(t *testing.T) {
 	const testNamespace = "fake-namespace"
 	const testStageName = "fake-stage"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stage := &kargoapi.Stage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,7 +56,7 @@ func TestRemoveFinalizer(t *testing.T) {
 	const testNamespace = "fake-namespace"
 	const testStageName = "fake-stage"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stage := &kargoapi.Stage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -93,7 +92,7 @@ func TestPatchOwnerReferences(t *testing.T) {
 	const testNamespace = "fake-namespace"
 	const testProjectName = "fake-project"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	initialNS := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -214,7 +213,7 @@ func Test_patchAnnotation(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := patchAnnotation(context.Background(), tc.client, tc.obj, tc.key, tc.value)
+			err := patchAnnotation(t.Context(), tc.client, tc.obj, tc.key, tc.value)
 			if tc.errExpected {
 				require.Error(t, err)
 				return
@@ -292,7 +291,7 @@ func Test_deleteAnnotation(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := deleteAnnotation(context.Background(), tc.client, tc.obj, tc.key)
+			err := deleteAnnotation(t.Context(), tc.client, tc.obj, tc.key)
 			if tc.errExpected {
 				require.Error(t, err)
 				return

--- a/pkg/api/freight_test.go
+++ b/pkg/api/freight_test.go
@@ -109,7 +109,7 @@ func TestGetFreight(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			freight, err := GetFreight(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",
@@ -163,7 +163,7 @@ func TestGetFreightByAlias(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			freight, err := GetFreightByAlias(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				"fake-namespace",
 				"fake-alias",
@@ -250,7 +250,7 @@ func TestListFreightByCurrentStage(t *testing.T) {
 			Build()
 
 		t.Run(testCase.name, func(t *testing.T) {
-			freight, err := ListFreightByCurrentStage(context.Background(), c, testStage)
+			freight, err := ListFreightByCurrentStage(t.Context(), c, testStage)
 			testCase.assertions(t, freight, err)
 		})
 	}

--- a/pkg/api/project_config_test.go
+++ b/pkg/api/project_config_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,7 +51,7 @@ func TestGetProjectConfig(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			projectCfg, err := GetProjectConfig(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				testProjectName,
 			)

--- a/pkg/api/project_test.go
+++ b/pkg/api/project_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,7 +49,7 @@ func TestGetProject(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			project, err := GetProject(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				"fake-project",
 			)

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -55,7 +54,7 @@ func TestGetPromotion(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			promo, err := GetPromotion(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",
@@ -74,7 +73,7 @@ func TestAbortPromotion(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := AbortPromotion(context.TODO(), c, types.NamespacedName{
+		err := AbortPromotion(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-promotion",
 		}, kargoapi.AbortActionTerminate)
@@ -94,13 +93,13 @@ func TestAbortPromotion(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortPromotion(context.TODO(), c, types.NamespacedName{
+		err := AbortPromotion(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-promotion",
 		}, kargoapi.AbortActionTerminate)
 		require.NoError(t, err)
 
-		promotion, err := GetPromotion(context.TODO(), c, types.NamespacedName{
+		promotion, err := GetPromotion(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-promotion",
 		})
@@ -119,13 +118,13 @@ func TestAbortPromotion(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortPromotion(context.TODO(), c, types.NamespacedName{
+		err := AbortPromotion(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-promotion",
 		}, kargoapi.AbortActionTerminate)
 		require.NoError(t, err)
 
-		stage, err := GetPromotion(context.TODO(), c, types.NamespacedName{
+		stage, err := GetPromotion(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-promotion",
 		})

--- a/pkg/api/stage_test.go
+++ b/pkg/api/stage_test.go
@@ -57,7 +57,7 @@ func TestGetStage(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			stage, err := GetStage(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",
@@ -261,7 +261,7 @@ func TestListFreightAvailableToStage(t *testing.T) {
 				},
 			}
 			freight, err := ListFreightAvailableToStage(
-				context.Background(), c, stage,
+				t.Context(), c, stage,
 			)
 			testCase.assertions(t, freight, err)
 		})
@@ -275,7 +275,7 @@ func TestReverifyStageFreight(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := ReverifyStageFreight(context.TODO(), c, types.NamespacedName{
+		err := ReverifyStageFreight(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -292,7 +292,7 @@ func TestReverifyStageFreight(t *testing.T) {
 			},
 		).Build()
 
-		err := ReverifyStageFreight(context.TODO(), c, types.NamespacedName{
+		err := ReverifyStageFreight(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -318,7 +318,7 @@ func TestReverifyStageFreight(t *testing.T) {
 			},
 		).Build()
 
-		err := ReverifyStageFreight(context.TODO(), c, types.NamespacedName{
+		err := ReverifyStageFreight(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -345,7 +345,7 @@ func TestReverifyStageFreight(t *testing.T) {
 			},
 		).Build()
 
-		err := ReverifyStageFreight(context.TODO(), c, types.NamespacedName{
+		err := ReverifyStageFreight(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -374,13 +374,13 @@ func TestReverifyStageFreight(t *testing.T) {
 			},
 		).Build()
 
-		err := ReverifyStageFreight(context.TODO(), c, types.NamespacedName{
+		err := ReverifyStageFreight(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
 		require.NoError(t, err)
 
-		stage, err := GetStage(context.TODO(), c, types.NamespacedName{
+		stage, err := GetStage(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -398,7 +398,7 @@ func TestAbortStageFreightVerification(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -415,7 +415,7 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -441,7 +441,7 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -468,7 +468,7 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -498,13 +498,13 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
 		require.NoError(t, err)
 
-		stage, err := GetStage(context.TODO(), c, types.NamespacedName{
+		stage, err := GetStage(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -535,13 +535,13 @@ func TestAbortStageFreightVerification(t *testing.T) {
 			},
 		).Build()
 
-		err := AbortStageFreightVerification(context.TODO(), c, types.NamespacedName{
+		err := AbortStageFreightVerification(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
 		require.NoError(t, err)
 
-		stage, err := GetStage(context.TODO(), c, types.NamespacedName{
+		stage, err := GetStage(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -559,7 +559,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := AnnotateStageWithArgoCDContext(context.TODO(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
+		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "fake-stage",
 				Namespace: "fake-namespace",
@@ -578,7 +578,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(context.TODO(), c, []kargoapi.HealthCheckStep{
+		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{
 			{
 				Uses: "argocd-update",
 				Config: &apiextensionsv1.JSON{
@@ -593,7 +593,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		stage, err := GetStage(context.TODO(), c, types.NamespacedName{
+		stage, err := GetStage(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})
@@ -616,7 +616,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(context.TODO(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
+		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "fake-stage",
 				Namespace: "fake-namespace",
@@ -624,7 +624,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		stage, err := GetStage(context.TODO(), c, types.NamespacedName{
+		stage, err := GetStage(t.Context(), c, types.NamespacedName{
 			Namespace: "fake-namespace",
 			Name:      "fake-stage",
 		})

--- a/pkg/api/stubs/rollouts/analysis_test.go
+++ b/pkg/api/stubs/rollouts/analysis_test.go
@@ -1,7 +1,6 @@
 package rollouts
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,7 +52,7 @@ func TestGetAnalysisTemplate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			template, err := GetAnalysisTemplate(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",
@@ -102,7 +101,7 @@ func TestGetClusterAnalysisTemplate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			template, err := GetClusterAnalysisTemplate(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				"fake-template",
 			)
@@ -150,7 +149,7 @@ func TestGetAnalysisRun(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			run, err := GetAnalysisRun(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",

--- a/pkg/api/warehouse_test.go
+++ b/pkg/api/warehouse_test.go
@@ -98,7 +98,7 @@ func TestGetWarehouse(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			warehouse, err := GetWarehouse(
-				context.Background(),
+				t.Context(),
 				testCase.client,
 				types.NamespacedName{
 					Namespace: "fake-namespace",
@@ -489,7 +489,7 @@ func TestListFreightFromWarehouse(t *testing.T) {
 				},
 			}
 			freight, err := ListFreightFromWarehouse(
-				context.Background(), c, warehouse, testCase.opts,
+				t.Context(), c, warehouse, testCase.opts,
 			)
 			testCase.assertions(t, freight, err)
 		})

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"context"
 	"testing"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -89,7 +88,7 @@ func TestInMemoryCache_Get(t *testing.T) {
 				testCase.setup(internalCache)
 			}
 			cache := &inMemoryCache[testStruct]{cache: internalCache}
-			value, found, err := cache.Get(context.Background(), testKey)
+			value, found, err := cache.Get(t.Context(), testKey)
 			require.NoError(t, err)
 			testCase.assertions(t, value, found, err)
 		})

--- a/pkg/cli/client/token_refresher_test.go
+++ b/pkg/cli/client/token_refresher_test.go
@@ -193,7 +193,7 @@ func TestRefreshToken(t *testing.T) {
 			}
 			cfg := testCase.setup()
 			newCfg, err :=
-				tf.refreshToken(context.Background(), testCase.setup(), false)
+				tf.refreshToken(t.Context(), testCase.setup(), false)
 			testCase.assertions(t, cfg, newCfg, err)
 		})
 	}

--- a/pkg/cli/cmd/login/login_test.go
+++ b/pkg/cli/cmd/login/login_test.go
@@ -1,7 +1,6 @@
 package login
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -20,7 +19,7 @@ func TestReceiveAuthCode(t *testing.T) {
 		testState = "fake-state"
 		testCode  = "fake-code"
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	codeCh := make(chan string)
 	errCh := make(chan error)
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/pkg/client/watch/watch_test.go
+++ b/pkg/client/watch/watch_test.go
@@ -92,7 +92,7 @@ func TestWatchStage(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchStage(ctx, "test-project", "test-stage")
@@ -133,7 +133,7 @@ func TestWatchStages(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchStages(ctx, "test-project")
@@ -174,7 +174,7 @@ func TestWatchWarehouse(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchWarehouse(ctx, "test-project", "test-warehouse")
@@ -215,7 +215,7 @@ func TestWatchWarehouses(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchWarehouses(ctx, "test-project")
@@ -256,7 +256,7 @@ func TestWatchPromotion(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchPromotion(ctx, "test-project", "test-promotion")
@@ -297,7 +297,7 @@ func TestWatchPromotions(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchPromotions(ctx, "test-project")
@@ -338,7 +338,7 @@ func TestWatchProjectConfig(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchProjectConfig(ctx, "test-project")
@@ -378,7 +378,7 @@ func TestWatchClusterConfig(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchClusterConfig(ctx)
@@ -402,7 +402,7 @@ func TestWatchResource_ErrorResponse(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "bad-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchStage(ctx, "test-project", "test-stage")
@@ -428,7 +428,7 @@ func TestWatchResource_ContextCancellation(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	eventCh, errCh := client.WatchStage(ctx, "test-project", "test-stage")
 
@@ -512,7 +512,7 @@ data: {"type":"ADDED","object":{"name":"test"}}
 			reader := strings.NewReader(tt.input)
 			eventCh := make(chan Event[*testObject], 1)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			err := readSSEStream(ctx, reader, eventCh)
 
 			if tt.expectError {
@@ -542,7 +542,7 @@ func TestReadSSEStream_ContextCancellation(t *testing.T) {
 
 	eventCh := make(chan Event[*testObject])
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -624,7 +624,7 @@ func TestStreamAnalysisRunLogs(t *testing.T) {
 			defer server.Close()
 
 			client := NewClient(server.URL, server.Client(), "test-token")
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 
 			logCh, errCh := client.StreamAnalysisRunLogs(ctx, "test-project", "test-run", tt.metricName, tt.containerName)
@@ -653,7 +653,7 @@ func TestStreamAnalysisRunLogs_Error(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	logCh, errCh := client.StreamAnalysisRunLogs(ctx, "test-project", "test-run", "", "")
@@ -724,7 +724,7 @@ data: line 2
 			reader := strings.NewReader(tt.input)
 			logCh := make(chan string, 10)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			err := readLogStream(ctx, reader, logCh)
 			close(logCh)
 
@@ -772,7 +772,7 @@ func TestMultipleEventsInStream(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, server.Client(), "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	eventCh, errCh := client.WatchStages(ctx, "test-project")

--- a/pkg/component/list_based_registry_test.go
+++ b/pkg/component/list_based_registry_test.go
@@ -213,11 +213,11 @@ func TestListBasedRegistry_WithFunctionValues(t *testing.T) {
 	}
 
 	// Test matching predicate
-	reg, err := registry.Get(context.Background(), "match")
+	reg, err := registry.Get(t.Context(), "match")
 	require.NoError(t, err)
 
 	// Verify the factory function works
-	result, err := reg.Value(context.Background(), "test")
+	result, err := reg.Value(t.Context(), "test")
 	require.NoError(t, err)
 	require.Equal(t, "output-test", result)
 }

--- a/pkg/component/map_based_registry_test.go
+++ b/pkg/component/map_based_registry_test.go
@@ -285,7 +285,7 @@ func TestMapBasedRegistry_WithFunctionValues(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the factory function works
-	result, err := reg.Value(context.Background(), "test")
+	result, err := reg.Value(t.Context(), "test")
 	require.NoError(t, err)
 	require.Equal(t, "output-test", result)
 }

--- a/pkg/controller/freight/finder_test.go
+++ b/pkg/controller/freight/finder_test.go
@@ -1,7 +1,6 @@
 package freight
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -239,7 +238,7 @@ func TestFindCommit(t *testing.T) {
 				cl = testCase.client()
 			}
 			commit, err := FindCommit(
-				context.Background(),
+				t.Context(),
 				cl,
 				testCase.stage.Namespace,
 				testCase.stage.Spec.RequestedFreight,
@@ -473,7 +472,7 @@ func TestFindImage(t *testing.T) {
 				cl = testCase.client()
 			}
 			image, err := FindImage(
-				context.Background(),
+				t.Context(),
 				cl,
 				testCase.stage.Namespace,
 				testCase.stage.Spec.RequestedFreight,
@@ -604,7 +603,7 @@ func TestHasAmbiguousImageRequest(t *testing.T) {
 				cl = testCase.client()
 			}
 			ok, err := HasAmbiguousImageRequest(
-				context.Background(),
+				t.Context(),
 				cl,
 				testNamespace,
 				testCase.freight,
@@ -841,7 +840,7 @@ func TestFindChart(t *testing.T) {
 				cl = testCase.client()
 			}
 			chart, err := FindChart(
-				context.Background(),
+				t.Context(),
 				cl,
 				testCase.stage.Namespace,
 				testCase.stage.Spec.RequestedFreight,
@@ -1096,7 +1095,7 @@ func TestFindArtifact(t *testing.T) {
 				cl = testCase.client()
 			}
 			commit, err := FindArtifact(
-				context.Background(),
+				t.Context(),
 				cl,
 				testCase.stage.Namespace,
 				testCase.stage.Spec.RequestedFreight,

--- a/pkg/controller/git/commit/lexical_selector_test.go
+++ b/pkg/controller/git/commit/lexical_selector_test.go
@@ -1,7 +1,6 @@
 package commit
 
 import (
-	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -361,7 +360,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			commits, err := testCase.selector.Select(context.Background())
+			commits, err := testCase.selector.Select(t.Context())
 			testCase.assertions(t, commits, err)
 		})
 	}

--- a/pkg/controller/git/commit/newest_from_branch_selector_test.go
+++ b/pkg/controller/git/commit/newest_from_branch_selector_test.go
@@ -1,7 +1,6 @@
 package commit
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -186,7 +185,7 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			commits, err := testCase.selector.Select(context.Background())
+			commits, err := testCase.selector.Select(t.Context())
 			testCase.assertions(t, commits, err)
 		})
 	}

--- a/pkg/controller/git/commit/newest_tag_selector_test.go
+++ b/pkg/controller/git/commit/newest_tag_selector_test.go
@@ -1,7 +1,6 @@
 package commit
 
 import (
-	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -310,7 +309,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			commits, err := testCase.selector.Select(context.Background())
+			commits, err := testCase.selector.Select(t.Context())
 			testCase.assertions(t, commits, err)
 		})
 	}

--- a/pkg/controller/git/commit/semver_selector_test.go
+++ b/pkg/controller/git/commit/semver_selector_test.go
@@ -1,7 +1,6 @@
 package commit
 
 import (
-	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -509,7 +508,7 @@ func Test_semverSelector_Select(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			commits, err := testCase.selector.Select(context.Background())
+			commits, err := testCase.selector.Select(t.Context())
 			testCase.assertions(t, commits, err)
 		})
 	}

--- a/pkg/controller/management/clusterconfigs/cluster_configs_test.go
+++ b/pkg/controller/management/clusterconfigs/cluster_configs_test.go
@@ -1,7 +1,6 @@
 package clusterconfigs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -163,7 +162,7 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			status, err := testCase.reconciler.syncWebhookReceivers(
-				context.Background(),
+				t.Context(),
 				testCase.clusterCfg,
 			)
 			testCase.assertions(t, status, err)

--- a/pkg/controller/management/projects/event_handlers_test.go
+++ b/pkg/controller/management/projects/event_handlers_test.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -86,7 +85,7 @@ func Test_projectWarehouseHealthEnqueuer_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*kargoapi.Warehouse]{
 					ObjectOld: tt.oldWarehouse,
 					ObjectNew: tt.newWarehouse,
@@ -176,7 +175,7 @@ func Test_projectStageHealthEnqueuer_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*kargoapi.Stage]{
 					ObjectOld: tt.oldStage,
 					ObjectNew: tt.newStage,

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -406,7 +406,7 @@ func TestReconciler_reconcile(t *testing.T) {
 				WithObjects(tt.project).
 				WithInterceptorFuncs(tt.interceptor).
 				Build()
-			status, err := tt.reconciler.reconcile(context.Background(), tt.project)
+			status, err := tt.reconciler.reconcile(t.Context(), tt.project)
 			tt.assertions(t, status, tt.reconciler.client, err)
 		})
 	}
@@ -1174,7 +1174,7 @@ func TestReconciler_syncProject(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			status, err := testCase.reconciler.syncProject(
-				context.Background(),
+				t.Context(),
 				testCase.project,
 			)
 			testCase.assertions(t, status, err)
@@ -1421,7 +1421,7 @@ func TestReconciler_ensureNamespace(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				t,
-				testCase.reconciler.ensureNamespace(context.Background(), testCase.project),
+				testCase.reconciler.ensureNamespace(t.Context(), testCase.project),
 			)
 		})
 	}
@@ -1521,7 +1521,7 @@ func TestReconciler_ensureSystemPermissions(t *testing.T) {
 			testCase.assertions(
 				t,
 				testCase.reconciler.ensureSystemPermissions(
-					context.Background(),
+					t.Context(),
 					&kargoapi.Project{},
 				),
 			)
@@ -1629,7 +1629,7 @@ func TestReconciler_ensureControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "fake-controller",
 						Namespace: cfg.KargoNamespace,
@@ -1670,7 +1670,7 @@ func TestReconciler_ensureControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSA.Name),
 						Namespace: testProject.Name,
@@ -1716,7 +1716,7 @@ func TestReconciler_ensureControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSA.Name),
 						Namespace: testProject.Name,
@@ -1777,7 +1777,7 @@ func TestReconciler_ensureControllerPermissions(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := newReconciler(testCase.client, cfg)
-			err = r.ensureControllerPermissions(context.Background(), testProject)
+			err = r.ensureControllerPermissions(t.Context(), testProject)
 			testCase.assertions(t, testCase.client, err)
 		})
 	}
@@ -2001,7 +2001,7 @@ func TestReconciler_ensureDefaultUserRoles(t *testing.T) {
 			}
 			testCase.assertions(
 				t,
-				testCase.reconciler.ensureDefaultUserRoles(context.Background(), p),
+				testCase.reconciler.ensureDefaultUserRoles(t.Context(), p),
 			)
 		})
 	}
@@ -2070,7 +2070,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify ServiceAccount still exists
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-control-plane",
 						Namespace: testProject.Name,
@@ -2095,7 +2095,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify ServiceAccount was created
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-control-plane",
 						Namespace: testProject.Name,
@@ -2108,7 +2108,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify RoleBinding was created
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-control-plane",
 						Namespace: testProject.Name,
@@ -2135,7 +2135,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify ArgoCD ServiceAccount was created
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "kargo-argocd-service-account",
 						Namespace: testProject.Name,
@@ -2162,7 +2162,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify ClusterRoleBinding was created
 				crb := &rbacv1.ClusterRoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name: kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-%s", testProject.Name)),
 					},
@@ -2193,7 +2193,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify ArgoCD RoleBinding was created
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-%s", testProject.Name)),
 						Namespace: "argocd",
@@ -2227,7 +2227,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify orchestrator ServiceAccount was created
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-orchestrator",
 						Namespace: testProject.Name,
@@ -2239,7 +2239,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify control plane ServiceAccount was created
 				sa = &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-control-plane",
 						Namespace: testProject.Name,
@@ -2259,7 +2259,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				for _, rbName := range roleBindings {
 					rb := &rbacv1.RoleBinding{}
 					err = cl.Get(
-						context.Background(),
+						t.Context(),
 						types.NamespacedName{
 							Name:      rbName,
 							Namespace: testProject.Name,
@@ -2286,7 +2286,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify orchestrator ServiceAccount was NOT created in project namespace
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "test-orchestrator",
 						Namespace: testProject.Name,
@@ -2313,7 +2313,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify manager RoleBinding was created
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "kargo-manager",
 						Namespace: testProject.Name,
@@ -2342,7 +2342,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify manager RoleBinding was NOT created
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      "kargo-manager",
 						Namespace: testProject.Name,
@@ -2424,7 +2424,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				// Verify it still exists
 				crb := &rbacv1.ClusterRoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name: kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-role-%s", testProject.Name)),
 					},
@@ -2438,7 +2438,7 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := newReconciler(testCase.client, testCase.cfg)
-			err := r.ensureExtendedPermissions(context.Background(), testProject)
+			err := r.ensureExtendedPermissions(t.Context(), testProject)
 			testCase.assertions(t, testCase.client, err)
 		})
 	}

--- a/pkg/controller/management/projects/stats_test.go
+++ b/pkg/controller/management/projects/stats_test.go
@@ -265,7 +265,7 @@ func Test_reconciler_collectStats(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &reconciler{client: tt.client}
-			status, err := r.collectStats(context.Background(), tt.project)
+			status, err := r.collectStats(t.Context(), tt.project)
 			tt.assertions(t, status, err)
 		})
 	}

--- a/pkg/controller/management/replication/replication_test.go
+++ b/pkg/controller/management/replication/replication_test.go
@@ -905,14 +905,14 @@ func TestReconcile_SkipsReconcileWhenAdapterRetursFalse(t *testing.T) {
 		Data: map[string][]byte{"key": []byte("value")},
 		Type: corev1.SecretTypeOpaque,
 	}
-	require.NoError(t, fc.Create(context.Background(), nonCredentialSecret))
+	require.NoError(t, fc.Create(t.Context(), nonCredentialSecret))
 
 	// Add the finalizer so it won't try to re-reconcile
 	controllerutil.AddFinalizer(nonCredentialSecret, kargoapi.FinalizerName)
-	require.NoError(t, fc.Update(context.Background(), nonCredentialSecret))
+	require.NoError(t, fc.Update(t.Context(), nonCredentialSecret))
 
 	// Create a test project
-	require.NoError(t, fc.Create(context.Background(), project("test-project")))
+	require.NoError(t, fc.Create(t.Context(), project("test-project")))
 
 	r := reconcilerForTest(fc, secretFixture())
 
@@ -923,7 +923,7 @@ func TestReconcile_SkipsReconcileWhenAdapterRetursFalse(t *testing.T) {
 
 	// Verify the Secret was not replicated to the project namespace
 	replicatedList := &corev1.SecretList{}
-	require.NoError(t, fc.List(context.Background(), replicatedList, client.InNamespace("test-project")))
+	require.NoError(t, fc.List(t.Context(), replicatedList, client.InNamespace("test-project")))
 	require.Empty(t, replicatedList.Items)
 }
 
@@ -946,14 +946,14 @@ func TestReconcile_ReplicatesWhenAdapterReturnsTrue(t *testing.T) {
 		Data: map[string][]byte{"key": []byte("value")},
 		Type: corev1.SecretTypeOpaque,
 	}
-	require.NoError(t, fc.Create(context.Background(), credentialSecret))
+	require.NoError(t, fc.Create(t.Context(), credentialSecret))
 
 	// Add the finalizer
 	controllerutil.AddFinalizer(credentialSecret, kargoapi.FinalizerName)
-	require.NoError(t, fc.Update(context.Background(), credentialSecret))
+	require.NoError(t, fc.Update(t.Context(), credentialSecret))
 
 	// Create a test project
-	require.NoError(t, fc.Create(context.Background(), project("test-project")))
+	require.NoError(t, fc.Create(t.Context(), project("test-project")))
 
 	r := reconcilerForTest(fc, secretFixture())
 
@@ -964,7 +964,7 @@ func TestReconcile_ReplicatesWhenAdapterReturnsTrue(t *testing.T) {
 
 	// Verify the Secret was replicated to the project namespace
 	replicatedList := &corev1.SecretList{}
-	require.NoError(t, fc.List(context.Background(), replicatedList, client.InNamespace("test-project")))
+	require.NoError(t, fc.List(t.Context(), replicatedList, client.InNamespace("test-project")))
 	require.Len(t, replicatedList.Items, 1)
 	require.Equal(t, testResourceName, replicatedList.Items[0].GetName())
 }

--- a/pkg/controller/management/serviceaccounts/serviceaccounts_test.go
+++ b/pkg/controller/management/serviceaccounts/serviceaccounts_test.go
@@ -120,7 +120,7 @@ func TestReconcile(t *testing.T) {
 				// RoleBinding should be deleted
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProjectName,
@@ -133,7 +133,7 @@ func TestReconcile(t *testing.T) {
 				// Finalizer should be removed
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      testControllerSARef.Name,
 						Namespace: testControllerSARef.Namespace,
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 				// RoleBinding should be deleted
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProjectName,
@@ -185,7 +185,7 @@ func TestReconcile(t *testing.T) {
 				// Finalizer should be removed
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      testControllerSARef.Name,
 						Namespace: testControllerSARef.Namespace,
@@ -282,7 +282,7 @@ func TestReconcile(t *testing.T) {
 				// Finalizer should be added
 				sa := &corev1.ServiceAccount{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					testControllerSARef,
 					sa,
 				)
@@ -292,7 +292,7 @@ func TestReconcile(t *testing.T) {
 				// RoleBinding should be created
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProjectName,
@@ -307,7 +307,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := newReconciler(testCase.client, cfg)
 			_, err := r.Reconcile(
-				context.Background(),
+				t.Context(),
 				ctrl.Request{
 					NamespacedName: testControllerSARef,
 				},
@@ -391,7 +391,7 @@ func TestEnsureControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProject.Name,
@@ -437,7 +437,7 @@ func TestEnsureControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProject.Name,
@@ -498,7 +498,7 @@ func TestEnsureControllerPermissions(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := newReconciler(testCase.client, cfg)
-			err = r.ensureControllerPermissions(context.Background(), testControllerSARef)
+			err = r.ensureControllerPermissions(t.Context(), testControllerSARef)
 			testCase.assertions(t, testCase.client, err)
 		})
 	}
@@ -586,7 +586,7 @@ func TestRemoveControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProject.Name,
@@ -607,7 +607,7 @@ func TestRemoveControllerPermissions(t *testing.T) {
 				require.NoError(t, err)
 				rb := &rbacv1.RoleBinding{}
 				err = cl.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      getRoleBindingName(testControllerSARef.Name),
 						Namespace: testProject.Name,
@@ -622,7 +622,7 @@ func TestRemoveControllerPermissions(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := newReconciler(testCase.client, cfg)
-			err = r.removeControllerPermissions(context.Background(), testControllerSARef)
+			err = r.removeControllerPermissions(t.Context(), testControllerSARef)
 			testCase.assertions(t, testCase.client, err)
 		})
 	}

--- a/pkg/controller/promotions/promotions_test.go
+++ b/pkg/controller/promotions/promotions_test.go
@@ -303,7 +303,7 @@ func TestReconcile(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			recorder := fakeevent.NewEventRecorder(1)
 			r := newFakeReconciler(t, recorder, tc.promos...)
 
@@ -530,7 +530,7 @@ func Test_reconciler_terminatePromotion(t *testing.T) {
 			}
 
 			req := tt.req
-			err := r.terminatePromotion(context.Background(), &req, tt.promo, tt.freight)
+			err := r.terminatePromotion(t.Context(), &req, tt.promo, tt.freight)
 			tt.assertions(t, recorder, tt.promo, err)
 		})
 	}
@@ -626,7 +626,7 @@ func Test_reconciler_handleDeletion(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			recorder := fakeevent.NewEventRecorder(1)
 			r := newFakeReconciler(t, recorder, tc.objects...)
 
@@ -664,13 +664,13 @@ func Test_reconciler_terminatePromotion_cleansUpWorkDir(t *testing.T) {
 	}
 
 	req := kargoapi.AbortPromotionRequest{Action: kargoapi.AbortActionTerminate}
-	err := r.terminatePromotion(context.Background(), &req, promo, nil)
+	err := r.terminatePromotion(t.Context(), &req, promo, nil)
 	require.NoError(t, err)
 
 	require.True(t, cleanupCalled)
 
 	var updated kargoapi.Promotion
-	require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+	require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 		Namespace: "fake-ns",
 		Name:      "fake-promo",
 	}, &updated))

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -238,7 +238,7 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 			}
 
 			wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
-			u.Update(context.TODO(), tt.e, wq)
+			u.Update(t.Context(), tt.e, wq)
 
 			tt.assertions(t, wq)
 		})
@@ -376,7 +376,7 @@ func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
 			wq := workqueue.NewTypedRateLimitingQueue(
 				workqueue.DefaultTypedControllerRateLimiter[reconcile.Request](),
 			)
-			p.Update(context.Background(), testCase.e, wq)
+			p.Update(t.Context(), testCase.e, wq)
 
 			testCase.assertions(t, wq)
 		})

--- a/pkg/controller/stages/control_flow_stages_test.go
+++ b/pkg/controller/stages/control_flow_stages_test.go
@@ -173,7 +173,7 @@ func TestControlFlowStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify finalizer was added
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), testStage, stage)
+				err = c.Get(t.Context(), testStage, stage)
 				require.NoError(t, err)
 				assert.Contains(t, stage.Finalizers, kargoapi.FinalizerName)
 			},
@@ -200,7 +200,7 @@ func TestControlFlowStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify annotation was removed
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), testStage, stage)
+				err = c.Get(t.Context(), testStage, stage)
 				require.NoError(t, err)
 				assert.NotContains(t, stage.Annotations, kargoapi.AnnotationKeyArgoCDContext)
 			},
@@ -230,7 +230,7 @@ func TestControlFlowStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify error is recorded in status
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), testStage, stage)
+				err = c.Get(t.Context(), testStage, stage)
 				require.NoError(t, err)
 			},
 		},
@@ -302,7 +302,7 @@ func TestControlFlowStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify status was updated
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), testStage, stage)
+				err = c.Get(t.Context(), testStage, stage)
 				require.NoError(t, err)
 			},
 		},
@@ -349,7 +349,7 @@ func TestControlFlowStageReconciler_Reconcile(t *testing.T) {
 				},
 			}
 
-			result, err := r.Reconcile(context.Background(), tt.req)
+			result, err := r.Reconcile(t.Context(), tt.req)
 			tt.assertions(t, c, result, err)
 		})
 	}
@@ -430,7 +430,7 @@ func TestControlFlowStageReconciler_reconcile(t *testing.T) {
 				require.NoError(t, err)
 				updatedFreight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Namespace: testProject,
 						Name:      "fake-freight",
@@ -675,7 +675,7 @@ func TestControlFlowStageReconciler_reconcile(t *testing.T) {
 				},
 			}
 
-			status, err := r.reconcile(context.Background(), tt.stage, time.Now())
+			status, err := r.reconcile(t.Context(), tt.stage, time.Now())
 			tt.assertions(t, status, c, err)
 		})
 	}
@@ -861,7 +861,7 @@ func TestControlFlowStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				assert.Len(t, recorder.Events, 2)
 
 				freight1 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-1",
 				}, freight1))
@@ -873,7 +873,7 @@ func TestControlFlowStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				)
 
 				freight2 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-2",
 				}, freight2))
@@ -990,28 +990,28 @@ func TestControlFlowStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				assert.Len(t, recorder.Events, 2)
 
 				freight1 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-1",
 				}, freight1))
 				assert.Contains(t, freight1.Status.VerifiedIn, "test-stage")
 
 				freight2 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-2",
 				}, freight2))
 				assert.NotContains(t, freight2.Status.VerifiedIn, "test-stage")
 
 				freight3 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-3",
 				}, freight3))
 				assert.Contains(t, freight3.Status.VerifiedIn, "test-stage")
 
 				freight4 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-4",
 				}, freight4))
@@ -1035,7 +1035,7 @@ func TestControlFlowStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				eventSender: k8sevent.NewEventSender(recorder),
 			}
 
-			_, err := r.markFreightVerifiedForStage(context.Background(), tt.stage, tt.freight, tt.startTime, tt.finishTime)
+			_, err := r.markFreightVerifiedForStage(t.Context(), tt.stage, tt.freight, tt.startTime, tt.finishTime)
 			tt.assertions(t, c, recorder, err)
 		})
 	}
@@ -1164,7 +1164,7 @@ func TestControlFlowStageReconciler_handleDelete(t *testing.T) {
 				client: c,
 			}
 
-			err := r.handleDelete(context.Background(), tt.stage)
+			err := r.handleDelete(t.Context(), tt.stage)
 			tt.assertions(t, tt.stage, err)
 		})
 	}
@@ -1230,7 +1230,7 @@ func TestControlFlowStageReconciler_clearVerifications(t *testing.T) {
 				require.NoError(t, err)
 
 				freight1 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-1",
 				}, freight1))
@@ -1238,7 +1238,7 @@ func TestControlFlowStageReconciler_clearVerifications(t *testing.T) {
 				assert.Contains(t, freight1.Status.VerifiedIn, "another-stage")
 
 				freight2 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-2",
 				}, freight2))
@@ -1359,7 +1359,7 @@ func TestControlFlowStageReconciler_clearVerifications(t *testing.T) {
 				client: c,
 			}
 
-			tt.assertions(t, c, r.clearVerifications(context.Background(), tt.stage))
+			tt.assertions(t, c, r.clearVerifications(t.Context(), tt.stage))
 		})
 	}
 }
@@ -1424,7 +1424,7 @@ func TestControlFlowStageReconciler_clearApprovals(t *testing.T) {
 				require.NoError(t, err)
 
 				freight1 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-1",
 				}, freight1))
@@ -1432,7 +1432,7 @@ func TestControlFlowStageReconciler_clearApprovals(t *testing.T) {
 				assert.Contains(t, freight1.Status.ApprovedFor, "another-stage")
 
 				freight2 := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "freight-2",
 				}, freight2))
@@ -1553,7 +1553,7 @@ func TestControlFlowStageReconciler_clearApprovals(t *testing.T) {
 				client: c,
 			}
 
-			tt.assertions(t, c, r.clearApprovals(context.Background(), tt.stage))
+			tt.assertions(t, c, r.clearApprovals(t.Context(), tt.stage))
 		})
 	}
 }
@@ -1631,7 +1631,7 @@ func TestControlFlowStageReconciler_clearAnalysisRuns(t *testing.T) {
 
 				// Verify analysis runs for test-stage are deleted
 				var runs rollouts.AnalysisRunList
-				err = c.List(context.Background(), &runs,
+				err = c.List(t.Context(), &runs,
 					client.InNamespace("default"),
 					client.MatchingLabels{kargoapi.LabelKeyStage: "test-stage"},
 				)
@@ -1639,7 +1639,7 @@ func TestControlFlowStageReconciler_clearAnalysisRuns(t *testing.T) {
 				assert.Empty(t, runs.Items)
 
 				// Verify other analysis runs still exist
-				err = c.List(context.Background(), &runs,
+				err = c.List(t.Context(), &runs,
 					client.InNamespace("default"),
 					client.MatchingLabels{kargoapi.LabelKeyStage: "other-stage"},
 				)
@@ -1694,7 +1694,7 @@ func TestControlFlowStageReconciler_clearAnalysisRuns(t *testing.T) {
 				require.NoError(t, err)
 
 				var runs rollouts.AnalysisRunList
-				err = c.List(context.Background(), &runs, client.InNamespace("default"))
+				err = c.List(t.Context(), &runs, client.InNamespace("default"))
 				require.NoError(t, err)
 				assert.Empty(t, runs.Items)
 			},
@@ -1714,7 +1714,7 @@ func TestControlFlowStageReconciler_clearAnalysisRuns(t *testing.T) {
 				cfg:    tt.cfg,
 			}
 
-			tt.assertions(t, c, r.clearAnalysisRuns(context.Background(), tt.stage))
+			tt.assertions(t, c, r.clearAnalysisRuns(t.Context(), tt.stage))
 		})
 	}
 }

--- a/pkg/controller/stages/event_handlers_test.go
+++ b/pkg/controller/stages/event_handlers_test.go
@@ -306,7 +306,7 @@ func Test_downstreamStageEnqueuer_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*kargoapi.Freight]{
 					ObjectOld: tt.oldFreight,
 					ObjectNew: tt.newFreight,
@@ -412,7 +412,7 @@ func Test_stageEnqueuerForApprovedFreight_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*kargoapi.Freight]{
 					ObjectOld: tt.oldFreight,
 					ObjectNew: tt.newFreight,
@@ -678,7 +678,7 @@ func Test_warehouseStageEnqueuer_Create(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Create(
-				context.Background(),
+				t.Context(),
 				event.TypedCreateEvent[*kargoapi.Freight]{
 					Object: tt.freight,
 				},
@@ -1053,7 +1053,7 @@ func Test_stageEnqueuerForArgoCDChanges_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*argocd.Application]{
 					ObjectOld: tt.oldApp,
 					ObjectNew: tt.newApp,
@@ -1350,7 +1350,7 @@ func Test_stageEnqueuerForAnalysisRuns_Update(t *testing.T) {
 			queue := &controllertest.Queue{TypedInterface: workqueue.NewTyped[reconcile.Request]()}
 
 			enqueuer.Update(
-				context.Background(),
+				t.Context(),
 				event.TypedUpdateEvent[*rollouts.AnalysisRun]{
 					ObjectOld: tt.oldAnalysisRun,
 					ObjectNew: tt.newAnalysisRun,
@@ -1495,7 +1495,7 @@ func Test_appHealthOrSyncStatusChanged(t *testing.T) {
 			require.Equal(
 				t,
 				testCase.updated,
-				appHealthOrSyncStatusChanged(context.Background(), e),
+				appHealthOrSyncStatusChanged(t.Context(), e),
 			)
 		})
 	}
@@ -1546,7 +1546,7 @@ func Test_analysisRunPhaseChanged(t *testing.T) {
 			require.Equal(
 				t,
 				testCase.updated,
-				analysisRunPhaseChanged(context.Background(), e),
+				analysisRunPhaseChanged(t.Context(), e),
 			)
 		})
 	}

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -195,7 +195,7 @@ func TestRegularStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify finalizer was added
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "test-stage",
 				}, stage)
@@ -238,7 +238,7 @@ func TestRegularStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify error is recorded in status
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "test-stage",
 				}, stage)
@@ -361,7 +361,7 @@ func TestRegularStageReconciler_Reconcile(t *testing.T) {
 
 				// Verify status was updated
 				stage := &kargoapi.Stage{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "test-stage",
 				}, stage)
@@ -423,7 +423,7 @@ func TestRegularStageReconciler_Reconcile(t *testing.T) {
 				eventSender: k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
 			}
 
-			result, err := r.Reconcile(context.Background(), tt.req)
+			result, err := r.Reconcile(t.Context(), tt.req)
 			tt.assertions(t, c, result, err)
 		})
 	}
@@ -563,7 +563,7 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 				healthChecker: &health.MockAggregatingChecker{},
 			}
 
-			status, requeue, err := r.reconcile(context.Background(), tt.stage, now)
+			status, requeue, err := r.reconcile(t.Context(), tt.stage, now)
 			tt.assertions(t, status, requeue, err)
 		})
 	}
@@ -1325,7 +1325,7 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 				client: c,
 			}
 
-			status, requeue, err := r.syncPromotions(context.Background(), tt.stage)
+			status, requeue, err := r.syncPromotions(t.Context(), tt.stage)
 			tt.assertions(t, status, requeue, err)
 		})
 	}
@@ -1419,28 +1419,28 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				require.NoError(t, err)
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-1"},
 					freight,
 				)
 				require.NoError(t, err)
 				require.Contains(t, freight.Status.CurrentlyIn, testStage.Name)
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-2"},
 					freight,
 				)
 				require.NoError(t, err)
 				require.Contains(t, freight.Status.CurrentlyIn, testStage.Name)
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-3"},
 					freight,
 				)
 				require.NoError(t, err)
 				require.NotContains(t, freight.Status.CurrentlyIn, testStage.Name)
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-4"},
 					freight,
 				)
@@ -1494,7 +1494,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				// Check that expected freight remain in CurrentlyIn (they're in the stage's FreightHistory)
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-1"},
 					freight,
 				)
@@ -1502,7 +1502,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				require.Contains(t, freight.Status.CurrentlyIn, testStage.Name)
 
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-2"},
 					freight,
 				)
@@ -1511,7 +1511,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 
 				// Check verified freight - should be removed from CurrentlyIn and soak time updated
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "verified-freight"},
 					freight,
 				)
@@ -1564,7 +1564,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				// Check unverified freight - should just be removed from CurrentlyIn
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "unverified-freight"},
 					freight,
 				)
@@ -1619,7 +1619,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				// Check longer soak freight - should be removed but soak time should not be updated
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "longer-soak-freight"},
 					freight,
 				)
@@ -1684,7 +1684,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				// Check that expected freight remains in CurrentlyIn (they're in the stage's FreightHistory)
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-1"},
 					freight,
 				)
@@ -1692,7 +1692,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				require.Contains(t, freight.Status.CurrentlyIn, testStage.Name)
 
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-2"},
 					freight,
 				)
@@ -1701,7 +1701,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 
 				// Should handle nil Since field gracefully without panic
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "nil-since-freight"},
 					freight,
 				)
@@ -1766,7 +1766,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				// Check that expected freight remains in CurrentlyIn (they're in the stage's FreightHistory)
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-1"},
 					freight,
 				)
@@ -1774,7 +1774,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 				require.Contains(t, freight.Status.CurrentlyIn, testStage.Name)
 
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "fake-freight-2"},
 					freight,
 				)
@@ -1783,7 +1783,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 
 				// Should handle nil LongestCompletedSoak gracefully
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{Namespace: testProject, Name: "nil-soak-freight"},
 					freight,
 				)
@@ -1816,7 +1816,7 @@ func TestRegularStageReconciler_syncFreight(t *testing.T) {
 
 			r := &RegularStageReconciler{client: c}
 
-			err := r.syncFreight(context.Background(), testStage)
+			err := r.syncFreight(t.Context(), testStage)
 			testCase.assertions(t, c, err)
 		})
 	}
@@ -2062,7 +2062,7 @@ func TestRegularStageReconciler_assessHealth(t *testing.T) {
 				},
 			}
 
-			status := r.assessHealth(context.Background(), tt.stage)
+			status := r.assessHealth(t.Context(), tt.stage)
 			tt.assertions(t, status)
 		})
 	}
@@ -2428,7 +2428,7 @@ func TestRegularStageReconciler_verifyStageFreight(t *testing.T) {
 
 				// Verify AnalysisRun was patched to terminate
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Name:      "test-analysis-run",
 					Namespace: "fake-project",
 				}, ar))
@@ -2508,7 +2508,7 @@ func TestRegularStageReconciler_verifyStageFreight(t *testing.T) {
 
 				// Verify new AnalysisRun was created
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Name:      lastVerification.AnalysisRun.Name,
 					Namespace: lastVerification.AnalysisRun.Namespace,
 				}, ar))
@@ -2914,7 +2914,7 @@ func TestRegularStageReconciler_verifyStageFreight(t *testing.T) {
 				},
 			}
 
-			status, err := r.verifyStageFreight(context.Background(), tt.stage, startTime, fixedEndTime)
+			status, err := r.verifyStageFreight(t.Context(), tt.stage, startTime, fixedEndTime)
 			tt.assertions(t, c, recorder, status, err)
 		})
 	}
@@ -3111,7 +3111,7 @@ func TestRegularStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 
 				// Check if freight was properly marked as verified
 				freight := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), client.ObjectKey{
+				require.NoError(t, c.Get(t.Context(), client.ObjectKey{
 					Namespace: "fake-project",
 					Name:      "test-freight",
 				}, freight))
@@ -3165,7 +3165,7 @@ func TestRegularStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 
 				// Verify no changes were made to the freight
 				freight := &kargoapi.Freight{}
-				require.NoError(t, c.Get(context.Background(), client.ObjectKey{
+				require.NoError(t, c.Get(t.Context(), client.ObjectKey{
 					Namespace: "fake-project",
 					Name:      "test-freight",
 				}, freight))
@@ -3222,7 +3222,7 @@ func TestRegularStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				// Check both freight objects were marked as verified
 				for _, name := range []string{"freight-1", "freight-2"} {
 					freight := &kargoapi.Freight{}
-					require.NoError(t, c.Get(context.Background(), client.ObjectKey{
+					require.NoError(t, c.Get(t.Context(), client.ObjectKey{
 						Namespace: "fake-project",
 						Name:      name,
 					}, freight))
@@ -3342,7 +3342,7 @@ func TestRegularStageReconciler_markFreightVerifiedForStage(t *testing.T) {
 				healthChecker: &health.MockAggregatingChecker{},
 			}
 
-			status, err := r.markFreightVerifiedForStage(context.Background(), tt.stage)
+			status, err := r.markFreightVerifiedForStage(t.Context(), tt.stage)
 			tt.assertions(t, c, status, err)
 		})
 	}
@@ -3774,7 +3774,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify analysis run was created
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
@@ -3822,7 +3822,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify analysis run was created
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
@@ -3893,7 +3893,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify promotion annotation was added
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
@@ -3953,7 +3953,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 
 				// Verify analysis run was created
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: vi.AnalysisRun.Namespace,
 					Name:      vi.AnalysisRun.Name,
 				}, ar))
@@ -4021,7 +4021,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				},
 			}
 
-			vi, err := r.startVerification(context.Background(), tt.stage, tt.freightCol, tt.req, now)
+			vi, err := r.startVerification(t.Context(), tt.stage, tt.freightCol, tt.req, now)
 			tt.assertions(t, c, vi, err)
 		})
 	}
@@ -4352,7 +4352,7 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				},
 			}
 
-			vi, err := r.getVerificationResult(context.Background(), tt.freight)
+			vi, err := r.getVerificationResult(t.Context(), tt.freight)
 			tt.assertions(t, vi, err)
 		})
 	}
@@ -4552,7 +4552,7 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 
 				// Verify analysis run was patched with terminate = true
 				ar := &rolloutsapi.AnalysisRun{}
-				require.NoError(t, c.Get(context.Background(), types.NamespacedName{
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{
 					Namespace: "fake-project",
 					Name:      "test-analysis",
 				}, ar))
@@ -4696,7 +4696,7 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 				},
 			}
 
-			vi, err := r.abortVerification(context.Background(), tt.freightCol, tt.req)
+			vi, err := r.abortVerification(t.Context(), tt.freightCol, tt.req)
 			tt.assertions(t, c, vi, err)
 		})
 	}
@@ -4958,7 +4958,7 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 				client: c,
 			}
 
-			ar, err := r.findExistingAnalysisRun(context.Background(), tt.stage, tt.freightColID)
+			ar, err := r.findExistingAnalysisRun(t.Context(), tt.stage, tt.freightColID)
 			tt.assertions(t, ar, err)
 		})
 	}
@@ -5000,7 +5000,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Empty(t, promoList.Items)
 			},
 		},
@@ -5051,7 +5051,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Empty(t, promoList.Items)
 			},
 		},
@@ -5086,7 +5086,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Empty(t, promoList.Items)
 			},
 		},
@@ -5177,7 +5177,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify promotion was created for newest freight
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				require.Len(t, promoList.Items, 1)
 				assert.Equal(t, "test-freight-1", promoList.Items[0].Spec.Freight)
 			},
@@ -5258,7 +5258,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Empty(t, promoList.Items)
 			},
 		},
@@ -5342,7 +5342,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no new promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Len(t, promoList.Items, 1)
 				assert.Equal(t, "existing-promotion", promoList.Items[0].Name)
 			},
@@ -5430,7 +5430,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify no new promotions were created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Len(t, promoList.Items, 1)
 				assert.Equal(t, "existing-promotion", promoList.Items[0].Name)
 			},
@@ -5516,7 +5516,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify promotion was created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				require.Len(t, promoList.Items, 1)
 				assert.Equal(t, "test-freight-1", promoList.Items[0].Spec.Freight)
 			},
@@ -5636,7 +5636,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify promotion was created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				require.Len(t, promoList.Items, 1)
 				assert.Equal(t, "test-freight-2", promoList.Items[0].Spec.Freight)
 			},
@@ -5717,7 +5717,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify promotion was created
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				require.Len(t, promoList.Items, 1)
 				assert.Equal(t, "test-freight-1", promoList.Items[0].Spec.Freight)
 			},
@@ -5824,7 +5824,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify promotions were created for both freight items
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				require.Len(t, promoList.Items, 2)
 
 				// Verify they're for different freight
@@ -6000,7 +6000,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 
 				// Verify only one promotion was created despite multiple sources
 				promoList := &kargoapi.PromotionList{}
-				require.NoError(t, c.List(context.Background(), promoList, client.InNamespace("fake-project")))
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
 				assert.Len(t, promoList.Items, 1)
 			},
 		},
@@ -6193,7 +6193,7 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 				eventSender: k8sevent.NewEventSender(recorder),
 			}
 
-			status, err := r.autoPromoteFreight(context.Background(), tt.stage)
+			status, err := r.autoPromoteFreight(t.Context(), tt.stage)
 			tt.assertions(t, recorder, c, status, err)
 		})
 	}
@@ -6474,7 +6474,7 @@ func TestRegularStageReconciler_autoPromotionAllowed(t *testing.T) {
 				client: c,
 			}
 
-			allowed, err := r.autoPromotionAllowed(context.Background(), tt.stage)
+			allowed, err := r.autoPromotionAllowed(t.Context(), tt.stage)
 			tt.assertions(t, allowed, err)
 		})
 	}

--- a/pkg/controller/warehouses/warehouses_test.go
+++ b/pkg/controller/warehouses/warehouses_test.go
@@ -636,7 +636,7 @@ func TestSyncWarehouse(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			status, err := testCase.reconciler.syncWarehouse(context.TODO(), testCase.warehouse)
+			status, err := testCase.reconciler.syncWarehouse(t.Context(), testCase.warehouse)
 			testCase.assertions(t, status, err)
 		})
 	}
@@ -837,7 +837,7 @@ func TestDiscoverArtifacts(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			discoveredArtifacts, err := testCase.reconciler.discoverArtifacts(
-				context.TODO(),
+				t.Context(),
 				"fake-project",
 				[]kargoapi.RepoSubscription{{}},
 			)

--- a/pkg/event/kubernetes/kubernetes_test.go
+++ b/pkg/event/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -345,7 +344,7 @@ func TestEventSender_Send(t *testing.T) {
 			recorder := &mockEventRecorder{}
 			sender := NewEventSender(recorder)
 
-			err := sender.Send(context.Background(), tc.event)
+			err := sender.Send(t.Context(), tc.event)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/expressions/function/functions_test.go
+++ b/pkg/expressions/function/functions_test.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -214,7 +213,7 @@ func Test_getCommitFromFreight(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -448,7 +447,7 @@ func Test_getImageFromFreight(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -775,7 +774,7 @@ func Test_getChartFromFreight(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1031,7 +1030,7 @@ func Test_getArtifactFromFreight(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(testCase.objects...).
@@ -1255,7 +1254,7 @@ func Test_getConfigMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1445,7 +1444,7 @@ func Test_getSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1513,7 +1512,7 @@ func Test_getConfigMap_getSecret_no_cache_key_collision(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1765,7 +1764,7 @@ func Test_freightMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1889,7 +1888,7 @@ func Test_stageMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).

--- a/pkg/garbage/collector_test.go
+++ b/pkg/garbage/collector_test.go
@@ -142,7 +142,7 @@ func TestRun(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 			defer cancel()
 			c := &collector{
 				cfg: CollectorConfig{

--- a/pkg/garbage/freight_test.go
+++ b/pkg/garbage/freight_test.go
@@ -85,7 +85,7 @@ func TestCleanProjectFreight(t *testing.T) {
 			testCase.assertions(
 				t,
 				testCase.collector.cleanProjectFreight(
-					context.Background(),
+					t.Context(),
 					"fake-project",
 				),
 			)
@@ -271,7 +271,7 @@ func TestCleanWarehouseFreight(t *testing.T) {
 			testCase.assertions(
 				t,
 				testCase.collector.cleanWarehouseFreight(
-					context.Background(),
+					t.Context(),
 					"fake-project",
 					"fake-warehouse",
 				),

--- a/pkg/garbage/projects_test.go
+++ b/pkg/garbage/projects_test.go
@@ -64,7 +64,7 @@ func TestCleanProjects(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 			defer cancel()
 
 			projectCh := make(chan string)
@@ -125,7 +125,7 @@ func TestCleanProject(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				t,
-				testCase.collector.cleanProject(context.Background(), "fake-project"),
+				testCase.collector.cleanProject(t.Context(), "fake-project"),
 			)
 		})
 	}

--- a/pkg/garbage/promotions_test.go
+++ b/pkg/garbage/promotions_test.go
@@ -86,7 +86,7 @@ func TestCleanProjectPromotions(t *testing.T) {
 			testCase.assertions(
 				t,
 				testCase.collector.cleanProjectPromotions(
-					context.Background(),
+					t.Context(),
 					"fake-project",
 				),
 			)
@@ -237,7 +237,7 @@ func TestCleanStagePromotions(t *testing.T) {
 			testCase.assertions(
 				t,
 				testCase.collector.cleanStagePromotions(
-					context.Background(),
+					t.Context(),
 					"fake-project",
 					"fake-stage",
 				),

--- a/pkg/gitprovider/bitbucket/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket/bitbucket_test.go
@@ -1,7 +1,6 @@
 package bitbucket
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -107,7 +106,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		opts := &gitprovider.CreatePullRequestOpts{
 			Title:       "Test PR",
 			Description: "PR description",
@@ -139,7 +138,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.CreatePullRequest(ctx, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, pr)
@@ -169,7 +168,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.CreatePullRequest(ctx, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, pr)
@@ -188,7 +187,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.CreatePullRequest(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, pr)
@@ -207,7 +206,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.CreatePullRequest(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, pr)
@@ -234,7 +233,7 @@ func TestCreatePullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.CreatePullRequest(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, pr)
@@ -277,7 +276,7 @@ func TestGetPullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.GetPullRequest(ctx, 1)
 		assert.NoError(t, err)
 		assert.NotNil(t, pr)
@@ -312,7 +311,7 @@ func TestGetPullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.GetPullRequest(ctx, 1)
 		assert.NoError(t, err)
 		assert.NotNil(t, pr)
@@ -333,7 +332,7 @@ func TestGetPullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.GetPullRequest(ctx, 1)
 		assert.Error(t, err)
 		assert.Nil(t, pr)
@@ -352,7 +351,7 @@ func TestGetPullRequest(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		pr, err := provider.GetPullRequest(ctx, 1)
 		assert.Error(t, err)
 		assert.Nil(t, pr)
@@ -376,7 +375,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.NoError(t, err)
 		assert.Len(t, prs, 2)
@@ -403,7 +402,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			State: gitprovider.PullRequestStateAny,
 		})
@@ -431,7 +430,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			State: gitprovider.PullRequestStateClosed,
 		})
@@ -486,7 +485,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			HeadBranch: "feature-1",
 		})
@@ -542,7 +541,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			BaseBranch: "dev",
 		})
@@ -588,7 +587,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			HeadCommit: "specific-hash",
 		})
@@ -622,7 +621,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.NoError(t, err)
 		assert.Len(t, prs, 1)
@@ -641,7 +640,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, prs)
@@ -659,7 +658,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, prs)
@@ -677,7 +676,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, prs)
@@ -695,7 +694,7 @@ func TestListPullRequests(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, nil)
 		assert.Error(t, err)
 		assert.Nil(t, prs)
@@ -707,7 +706,7 @@ func TestListPullRequests(t *testing.T) {
 			repoSlug: "repo",
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		prs, err := provider.ListPullRequests(ctx, &gitprovider.ListPullRequestOptions{
 			State: "invalid-state",
 		})
@@ -732,7 +731,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "short123")
 		assert.NoError(t, err)
 		assert.Equal(t, "full1234567890abcdef", sha)
@@ -744,7 +743,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			repoSlug: "repo",
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "")
 		assert.NoError(t, err)
 		assert.Equal(t, "", sha)
@@ -762,7 +761,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "short123")
 		assert.Error(t, err)
 		assert.Equal(t, "", sha)
@@ -780,7 +779,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "short123")
 		assert.Error(t, err)
 		assert.Equal(t, "", sha)
@@ -798,7 +797,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "short123")
 		assert.Error(t, err)
 		assert.Equal(t, "", sha)
@@ -818,7 +817,7 @@ func TestGetFullCommitSHA(t *testing.T) {
 			client:   mockClient,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		sha, err := provider.getFullCommitSHA(ctx, "short123")
 		assert.Error(t, err)
 		assert.Equal(t, "", sha)

--- a/pkg/gitprovider/gitea/gitea_test.go
+++ b/pkg/gitprovider/gitea/gitea_test.go
@@ -213,7 +213,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("CreatePullRequest", context.Background(), testRepoOwner, testRepoName, mock.Anything).
+		On("CreatePullRequest", t.Context(), testRepoOwner, testRepoName, mock.Anything).
 		Return(
 			&gitea.PullRequest{
 				Index: int64(42),
@@ -233,7 +233,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 			nil,
 		)
 	mockClient.
-		On("AddLabelsToIssue", context.Background(), testRepoOwner, testRepoName, int(mockClient.pr.Index), mock.Anything).
+		On("AddLabelsToIssue", t.Context(), testRepoOwner, testRepoName, int(mockClient.pr.Index), mock.Anything).
 		Return(
 			[]*gitea.Label{},
 			&gitea.Response{},
@@ -246,7 +246,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 		repo:   testRepoName,
 		client: mockClient,
 	}
-	pr, err := g.CreatePullRequest(context.Background(), &opts)
+	pr, err := g.CreatePullRequest(t.Context(), &opts)
 
 	// assert that the expectations were met
 	mockClient.AssertExpectations(t)
@@ -291,7 +291,7 @@ func TestGetPullRequest(t *testing.T) {
 	}
 
 	mockClient.
-		On("GetPullRequests", context.Background(), testRepoOwner, testRepoName, int(mockClient.pr.Index)).
+		On("GetPullRequests", t.Context(), testRepoOwner, testRepoName, int(mockClient.pr.Index)).
 		Return(
 			&gitea.PullRequest{
 				Index: int64(42),
@@ -316,7 +316,7 @@ func TestGetPullRequest(t *testing.T) {
 		repo:   testRepoName,
 		client: mockClient,
 	}
-	pr, err := g.GetPullRequest(context.Background(), 42)
+	pr, err := g.GetPullRequest(t.Context(), 42)
 
 	// assert that the expectations were met
 	mockClient.AssertExpectations(t)
@@ -356,7 +356,7 @@ func TestListPullRequests(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("ListPullRequests", context.Background(), testRepoOwner, testRepoName, &gitea.ListPullRequestsOptions{
+		On("ListPullRequests", t.Context(), testRepoOwner, testRepoName, &gitea.ListPullRequestsOptions{
 			State: "all",
 			ListOptions: gitea.ListOptions{
 				Page: 0,
@@ -388,7 +388,7 @@ func TestListPullRequests(t *testing.T) {
 		client: mockClient,
 	}
 
-	prs, err := g.ListPullRequests(context.Background(), &opts)
+	prs, err := g.ListPullRequests(t.Context(), &opts)
 	require.NoError(t, err)
 
 	require.Equal(t, testRepoOwner, mockClient.owner)
@@ -571,7 +571,7 @@ func TestMergePullRequest(t *testing.T) {
 
 			tt.setupMock(mockClient)
 
-			pr, merged, err := p.MergePullRequest(context.Background(), tt.prNumber)
+			pr, merged, err := p.MergePullRequest(t.Context(), tt.prNumber)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/gitprovider/github/github_test.go
+++ b/pkg/gitprovider/github/github_test.go
@@ -258,7 +258,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("CreatePullRequest", context.Background(), testRepoOwner, testRepoName, mock.Anything).
+		On("CreatePullRequest", t.Context(), testRepoOwner, testRepoName, mock.Anything).
 		Return(
 			&github.PullRequest{
 				Number: mockClient.pr.Number,
@@ -278,7 +278,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 			nil,
 		)
 	mockClient.
-		On("AddLabelsToIssue", context.Background(), testRepoOwner, testRepoName, *mockClient.pr.Number, mock.Anything).
+		On("AddLabelsToIssue", t.Context(), testRepoOwner, testRepoName, *mockClient.pr.Number, mock.Anything).
 		Return(
 			[]*github.Label{},
 			&github.Response{},
@@ -291,7 +291,7 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 		repo:   testRepoName,
 		client: mockClient,
 	}
-	pr, err := g.CreatePullRequest(context.Background(), &opts)
+	pr, err := g.CreatePullRequest(t.Context(), &opts)
 
 	// assert that the expectations were met
 	mockClient.AssertExpectations(t)
@@ -327,7 +327,7 @@ func TestGetPullRequest(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("GetPullRequests", context.Background(), testRepoOwner, testRepoName, *mockClient.pr.Number).
+		On("GetPullRequests", t.Context(), testRepoOwner, testRepoName, *mockClient.pr.Number).
 		Return(
 			&github.PullRequest{
 				Number: mockClient.pr.Number,
@@ -348,7 +348,7 @@ func TestGetPullRequest(t *testing.T) {
 		repo:   testRepoName,
 		client: mockClient,
 	}
-	pr, err := g.GetPullRequest(context.Background(), 42)
+	pr, err := g.GetPullRequest(t.Context(), 42)
 
 	// assert that the expectations were met
 	mockClient.AssertExpectations(t)
@@ -381,7 +381,7 @@ func TestListPullRequests(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("ListPullRequests", context.Background(), testRepoOwner, testRepoName, &github.PullRequestListOptions{
+		On("ListPullRequests", t.Context(), testRepoOwner, testRepoName, &github.PullRequestListOptions{
 			State:     "all",
 			Head:      opts.HeadBranch,
 			Base:      opts.BaseBranch,
@@ -413,7 +413,7 @@ func TestListPullRequests(t *testing.T) {
 		client: mockClient,
 	}
 
-	prs, err := g.ListPullRequests(context.Background(), &opts)
+	prs, err := g.ListPullRequests(t.Context(), &opts)
 	require.NoError(t, err)
 
 	require.Equal(t, testRepoOwner, mockClient.owner)
@@ -681,7 +681,7 @@ func TestMergePullRequest(t *testing.T) {
 
 			tt.setupMock(mockClient)
 
-			pr, merged, err := p.MergePullRequest(context.Background(), tt.prNumber)
+			pr, merged, err := p.MergePullRequest(t.Context(), tt.prNumber)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/gitprovider/gitlab/gitlab_test.go
+++ b/pkg/gitprovider/gitlab/gitlab_test.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -95,7 +94,7 @@ func TestCreatePullRequest(t *testing.T) {
 		Title:       "title",
 		Description: "desc",
 	}
-	pr, err := g.CreatePullRequest(context.Background(), &opts)
+	pr, err := g.CreatePullRequest(t.Context(), &opts)
 
 	require.NoError(t, err)
 	require.Equal(t, testProjectName, mockClient.pid)
@@ -126,7 +125,7 @@ func TestGetPullRequest(t *testing.T) {
 		client:      mockClient,
 	}
 
-	pr, err := g.GetPullRequest(context.Background(), 1)
+	pr, err := g.GetPullRequest(t.Context(), 1)
 
 	require.NoError(t, err)
 	require.Equal(t, testProjectName, mockClient.pid)
@@ -157,7 +156,7 @@ func TestListPullRequests(t *testing.T) {
 		HeadBranch: "head",
 		BaseBranch: "base",
 	}
-	prs, err := g.ListPullRequests(context.Background(), &opts)
+	prs, err := g.ListPullRequests(t.Context(), &opts)
 	require.NoError(t, err)
 
 	require.Equal(t, testProjectName, mockClient.pid)
@@ -359,7 +358,7 @@ func TestMergePullRequest(t *testing.T) {
 				client:      tc.mockClient,
 			}
 
-			pr, merged, err := g.MergePullRequest(context.Background(), tc.id)
+			pr, merged, err := g.MergePullRequest(t.Context(), tc.id)
 
 			if tc.expectErr {
 				require.Error(t, err)

--- a/pkg/health/aggregating_checker_test.go
+++ b/pkg/health/aggregating_checker_test.go
@@ -66,7 +66,7 @@ func TestAggregatingChecker_Check(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			testRegistry := checkerRegistry{}
@@ -162,7 +162,7 @@ func TestAggregatingChecker_executeHealthChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			testRegistry := checkerRegistry{}
@@ -256,7 +256,7 @@ func TestAggregatingChecker_executeHealthCheck(t *testing.T) {
 			}
 
 			result := checker.executeHealthCheck(
-				context.Background(),
+				t.Context(),
 				"fake-project",
 				"fake-stage",
 				tt.criteria,

--- a/pkg/health/checker/builtin/argocd_test.go
+++ b/pkg/health/checker/builtin/argocd_test.go
@@ -172,7 +172,7 @@ func Test_argocdUpdater_check(t *testing.T) {
 			testCase.assertions(
 				t,
 				runner.check(
-					context.Background(),
+					t.Context(),
 					ArgoCDHealthInput{
 						Apps: []ArgoCDAppHealthCheck{
 							{
@@ -516,7 +516,7 @@ func Test_argocdUpdater_getApplicationHealth(t *testing.T) {
 					Build(),
 			}
 			stageHealth, appStatus, err := runner.getApplicationHealth(
-				context.Background(),
+				t.Context(),
 				client.ObjectKey{
 					Namespace: app.Namespace,
 					Name:      app.Name,

--- a/pkg/health/mock_aggregating_checker_test.go
+++ b/pkg/health/mock_aggregating_checker_test.go
@@ -12,12 +12,12 @@ import (
 func TestMockAggregatingChecker_Check(t *testing.T) {
 	t.Run("without function injection", func(t *testing.T) {
 		checker := &MockAggregatingChecker{}
-		res := checker.Check(context.Background(), "fake-project", "fake-stage", nil)
+		res := checker.Check(t.Context(), "fake-project", "fake-stage", nil)
 		assert.Equal(t, kargoapi.HealthStateHealthy, res.Status)
 	})
 
 	t.Run("with function injection", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		const testProject = "fake-project"
 		const testStage = "fake-stage"
 		criteria := []Criteria{{Kind: "mock"}}

--- a/pkg/helm/chart/http_selector_test.go
+++ b/pkg/helm/chart/http_selector_test.go
@@ -1,7 +1,6 @@
 package chart
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -201,7 +200,7 @@ func Test_httpSelector_Select(t *testing.T) {
 				),
 				chartName: testCase.chart,
 			}
-			versions, err := s.Select(context.Background())
+			versions, err := s.Select(t.Context())
 			testCase.assertions(t, versions, err)
 		})
 	}

--- a/pkg/helm/chart/oci_selector_test.go
+++ b/pkg/helm/chart/oci_selector_test.go
@@ -1,7 +1,6 @@
 package chart
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,7 +78,7 @@ func Test_ociSelector_Select(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	versions, err := s.Select(context.Background())
+	versions, err := s.Select(t.Context())
 	require.NoError(t, err)
 	require.NotEmpty(t, versions)
 }

--- a/pkg/helm/dependency_manager_test.go
+++ b/pkg/helm/dependency_manager_test.go
@@ -292,7 +292,7 @@ generated: "2023-01-01T00:00:00Z"
 						Version:    dep.Version,
 					}
 				}
-				require.NoError(t, em.setupRepositories(context.Background(), dependencies))
+				require.NoError(t, em.setupRepositories(t.Context(), dependencies))
 			}
 
 			updates, err := em.update(chartDir)
@@ -728,7 +728,7 @@ func TestEphemeralDependencyManager_setupRepositories(t *testing.T) {
 
 				// Verify an entry exists for the OCI host
 				ociHost := hostForRepositoryURL(ociServer)
-				entry, err := em.authorizer.Get(context.Background(), ociHost)
+				entry, err := em.authorizer.Get(t.Context(), ociHost)
 				assert.NoError(t, err)
 				assert.NotNil(t, entry)
 			},
@@ -819,7 +819,7 @@ func TestEphemeralDependencyManager_setupRepositories(t *testing.T) {
 
 				// Verify an entry exists for the OCI host
 				ociHost := hostForRepositoryURL(ociServer)
-				entry, err := em.authorizer.Get(context.Background(), ociHost)
+				entry, err := em.authorizer.Get(t.Context(), ociHost)
 				assert.NoError(t, err)
 				assert.NotNil(t, entry)
 			},
@@ -852,7 +852,7 @@ func TestEphemeralDependencyManager_setupRepositories(t *testing.T) {
 				}
 			}
 
-			err := em.setupRepositories(context.Background(), dependencies)
+			err := em.setupRepositories(t.Context(), dependencies)
 			tt.assertions(t, registryURL, em, err)
 		})
 	}

--- a/pkg/image/repository_client_docker_hub_test.go
+++ b/pkg/image/repository_client_docker_hub_test.go
@@ -3,7 +3,6 @@
 package image
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestGetTags(t *testing.T) {
 	client, err := newRepositoryClient("debian", false, getDockerHubCreds(), true)
 	require.NoError(t, err)
 	require.NotNil(t, client)
-	tags, err := client.getTags(context.Background())
+	tags, err := client.getTags(t.Context())
 	require.NoError(t, err)
 	require.NotEmpty(t, tags)
 }

--- a/pkg/image/repository_client_test.go
+++ b/pkg/image/repository_client_test.go
@@ -230,7 +230,7 @@ func Test_repositoryClient_getImageByTag(t *testing.T) {
 				testCase.setupCache(t, testCase.client.imageCache)
 			}
 			img, err := testCase.client.getImageByTag(
-				context.Background(),
+				t.Context(),
 				testTag,
 				testCase.platformConstraint,
 			)
@@ -336,7 +336,7 @@ func Test_repositoryClient_getImageByDigest(t *testing.T) {
 				require.NoError(t, err)
 			}
 			img, err := testCase.client.getImageByDigest(
-				context.Background(),
+				t.Context(),
 				testDigest,
 			)
 			testCase.assertions(t, img, err)
@@ -370,7 +370,7 @@ func Test_repositoryClient_getImageFromRemoteDesc(t *testing.T) {
 	for _, mediaType := range mediaTypes {
 		t.Run(string(mediaType), func(t *testing.T) {
 			img, err := testClient.getImageFromRemoteDesc(
-				context.Background(),
+				t.Context(),
 				&remote.Descriptor{
 					Descriptor: v1.Descriptor{
 						MediaType: mediaType,
@@ -413,7 +413,7 @@ func Test_repositoryClient_getImageFromRemoteDesc(t *testing.T) {
 		}
 
 		img, err := testClientWithAnnotations.getImageFromRemoteDesc(
-			context.Background(),
+			t.Context(),
 			remoteDesc,
 		)
 		require.NoError(t, err)
@@ -535,7 +535,7 @@ func Test_repositoryClient_getImageFromV1ImageIndex(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			image, err := testCase.client.getImageFromV1ImageIndex(
-				context.Background(),
+				t.Context(),
 				testDigest,
 				testCase.idx,
 			)

--- a/pkg/image/selector_docker_hub_test.go
+++ b/pkg/image/selector_docker_hub_test.go
@@ -3,7 +3,6 @@
 package image
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -28,7 +27,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 	logger, err := logging.NewLogger(logging.TraceLevel, logging.DefaultFormat)
 	require.NoError(t, err)
 
-	ctx := logging.ContextWithLogger(context.Background(), logger)
+	ctx := logging.ContextWithLogger(t.Context(), logger)
 
 	t.Run("digest strategy", func(t *testing.T) {
 

--- a/pkg/image/selector_ghcr_test.go
+++ b/pkg/image/selector_ghcr_test.go
@@ -3,7 +3,6 @@
 package image
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -21,7 +20,7 @@ func TestSelectImageGHCR(t *testing.T) {
 	const platform = "linux/amd64"
 
 	ctx := logging.ContextWithLogger(
-		context.Background(),
+		t.Context(),
 		logging.NewLoggerOrDie(logging.TraceLevel, logging.DefaultFormat),
 	)
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -1,7 +1,6 @@
 package indexer
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"testing"
@@ -528,7 +527,7 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 				t,
 				testCase.expected,
 				RunningPromotionsByArgoCDApplications(
-					context.TODO(),
+					t.Context(),
 					c,
 					testCase.shardName,
 					false,

--- a/pkg/indexer/shared_field_indexer_test.go
+++ b/pkg/indexer/shared_field_indexer_test.go
@@ -101,7 +101,7 @@ func TestIndexField(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			index := NewSharedFieldIndexer(tt.internalIndex)
-			err := index.IndexField(context.Background(), &mockObject{}, "metadata.name", nil)
+			err := index.IndexField(t.Context(), &mockObject{}, "metadata.name", nil)
 			tt.assertions(t, index, tt.key, err)
 		})
 	}

--- a/pkg/kargo/promotion_builder_test.go
+++ b/pkg/kargo/promotion_builder_test.go
@@ -173,7 +173,7 @@ func TestPromotionBuilder_Build(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := user.ContextWithInfo(context.Background(), tt.userInfo)
+			ctx := user.ContextWithInfo(t.Context(), tt.userInfo)
 
 			c := fake.NewClientBuilder().
 				WithScheme(s).
@@ -395,7 +395,7 @@ func TestPromotionBuilder_InflateSteps(t *testing.T) {
 
 			b := NewPromotionBuilder(c)
 			p := tt.promo.DeepCopy()
-			err := b.InflateSteps(context.Background(), p)
+			err := b.InflateSteps(t.Context(), p)
 			tt.assertions(t, p.Spec.Steps, err)
 		})
 	}
@@ -611,7 +611,7 @@ func TestPromotionBuilder_inflateTaskSteps(t *testing.T) {
 				Build()
 
 			b := NewPromotionBuilder(c)
-			steps, err := b.inflateTaskSteps(context.Background(), tt.project, tt.taskAlias, tt.promoVars, tt.taskStep)
+			steps, err := b.inflateTaskSteps(t.Context(), tt.project, tt.taskAlias, tt.promoVars, tt.taskStep)
 			tt.assertions(t, steps, err)
 		})
 	}
@@ -793,7 +793,7 @@ func TestPromotionBuilder_getTaskSpec(t *testing.T) {
 				Build()
 
 			b := NewPromotionBuilder(c)
-			result, err := b.getTaskSpec(context.Background(), tt.project, tt.ref)
+			result, err := b.getTaskSpec(t.Context(), tt.project, tt.ref)
 			tt.assertions(t, result, err)
 		})
 	}

--- a/pkg/kubeclient/transport_test.go
+++ b/pkg/kubeclient/transport_test.go
@@ -1,7 +1,6 @@
 package kubeclient
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -39,7 +38,7 @@ func Test_credentialHook(t *testing.T) {
 			if ts.credential != "" {
 				req.Header.Set("Authorization", ts.credential)
 			}
-			res, err := hc.Do(req.WithContext(context.Background()))
+			res, err := hc.Do(req.WithContext(t.Context()))
 			defer func() {
 				_ = res.Body.Close()
 			}()

--- a/pkg/kubernetes/event/event_test.go
+++ b/pkg/kubernetes/event/event_test.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -17,7 +16,7 @@ import (
 )
 
 func Test_newRecorder(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	client := fake.NewClientBuilder().Build()
 	logger := logging.LoggerFromContext(ctx)
 	r := newRecorder(ctx, client, logger)
@@ -74,7 +73,7 @@ func Test_retryDecider(t *testing.T) {
 
 func Test_newSink(t *testing.T) {
 	s := newSink(
-		context.TODO(),
+		t.Context(),
 		fake.NewClientBuilder().Build(),
 	)
 	require.NotNil(t, s.client)

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -1,7 +1,6 @@
 package promotion
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -791,7 +790,7 @@ func TestStepEvaluator_Vars(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewStepEvaluator(testClient, nil)
 			vars, err := evaluator.Vars(
-				context.Background(),
+				t.Context(),
 				tt.promoCtx,
 				tt.step,
 			)
@@ -955,7 +954,7 @@ func TestStepEvaluator_ShouldSkip(t *testing.T) {
 				nil,
 			)
 			got, err := evaluator.ShouldSkip(
-				context.Background(),
+				t.Context(),
 				tt.promoCtx,
 				tt.step,
 			)
@@ -1421,7 +1420,7 @@ func TestStepEvaluator_Config(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewStepEvaluator(testClient, nil)
 			stepCfg, err := evaluator.Config(
-				context.Background(),
+				t.Context(),
 				tt.promoCtx,
 				tt.step,
 			)
@@ -1554,7 +1553,7 @@ func TestStepEvaluator_BuildStepContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewStepEvaluator(testClient, nil)
 			stepCtx, err := evaluator.BuildStepContext(
-				context.Background(),
+				t.Context(),
 				tt.promoCtx,
 				tt.step,
 			)

--- a/pkg/promotion/local_engine_test.go
+++ b/pkg/promotion/local_engine_test.go
@@ -89,7 +89,7 @@ func TestSimpleEngine_Promote(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			testRegistry := MustNewStepRunnerRegistry(

--- a/pkg/promotion/local_executor_test.go
+++ b/pkg/promotion/local_executor_test.go
@@ -190,7 +190,7 @@ func TestLocalStepExecutor_ExecuteStep(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executor := NewLocalStepExecutor(tt.registry, nil, nil, nil)
-			result, err := executor.ExecuteStep(context.Background(), tt.request)
+			result, err := executor.ExecuteStep(t.Context(), tt.request)
 			tt.assertions(t, result, err)
 		})
 	}

--- a/pkg/promotion/local_orchestrator_test.go
+++ b/pkg/promotion/local_orchestrator_test.go
@@ -612,7 +612,7 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			t.Cleanup(cancel)
 
 			registry := MustNewStepRunnerRegistry(

--- a/pkg/promotion/mock_engine_test.go
+++ b/pkg/promotion/mock_engine_test.go
@@ -13,13 +13,13 @@ import (
 func TestMockEngine_Promote(t *testing.T) {
 	t.Run("without function injection", func(t *testing.T) {
 		engine := &MockEngine{}
-		res, err := engine.Promote(context.Background(), Context{}, nil)
+		res, err := engine.Promote(t.Context(), Context{}, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, kargoapi.PromotionPhaseSucceeded, res.Status)
 	})
 
 	t.Run("with function injection", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		promoCtx := Context{
 			Stage: "foo",
 		}

--- a/pkg/promotion/runner/builtin/argocd_updater_test.go
+++ b/pkg/promotion/runner/builtin/argocd_updater_test.go
@@ -1271,7 +1271,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			res, err := testCase.runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{},
 				testCase.stepCfg,
 			)
@@ -1796,7 +1796,7 @@ func Test_argoCDUpdater_syncApplication(t *testing.T) {
 				},
 			}
 			err := testCase.runner.syncApplication(
-				context.Background(),
+				t.Context(),
 				stepCtx,
 				testCase.app,
 				testCase.desiredSources,
@@ -1892,7 +1892,7 @@ func Test_argoCDUpdater_logAppEvent(t *testing.T) {
 			eventMessage: "fake-message",
 			assertions: func(t *testing.T, c client.Client, app *argocd.Application) {
 				events := &corev1.EventList{}
-				require.NoError(t, c.List(context.Background(), events))
+				require.NoError(t, c.List(t.Context(), events))
 				assert.Len(t, events.Items, 1)
 
 				event := events.Items[0]
@@ -1929,7 +1929,7 @@ func Test_argoCDUpdater_logAppEvent(t *testing.T) {
 			eventMessage: "fake-message",
 			assertions: func(t *testing.T, c client.Client, _ *argocd.Application) {
 				events := &corev1.EventList{}
-				require.NoError(t, c.List(context.Background(), events))
+				require.NoError(t, c.List(t.Context(), events))
 				assert.Len(t, events.Items, 1)
 
 				event := events.Items[0]
@@ -1945,7 +1945,7 @@ func Test_argoCDUpdater_logAppEvent(t *testing.T) {
 				argocdClient: c,
 			}
 			runner.logAppEvent(
-				context.Background(),
+				t.Context(),
 				testCase.app,
 				testCase.user,
 				testCase.eventReason,
@@ -2812,7 +2812,7 @@ func Test_argoCDUpdater_getAuthorizedApplications(t *testing.T) {
 			runner.buildLabelSelectorFn = runner.buildLabelSelector
 
 			apps, err := runner.getAuthorizedApplications(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{
 					Project: "fake-project",
 					Stage:   "fake-stage",
@@ -3060,7 +3060,7 @@ func Test_argoCDUpdater_processApplication(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			phase, err := testCase.runner.processApplication(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{},
 				testCase.update,
 				testCase.app,

--- a/pkg/promotion/runner/builtin/file_copier_test.go
+++ b/pkg/promotion/runner/builtin/file_copier_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -359,7 +358,7 @@ func Test_fileCopier_run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			workDir := tt.setupFiles(t)
 			result, err := runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{WorkDir: workDir},
 				tt.cfg,
 			)

--- a/pkg/promotion/runner/builtin/file_deleter_test.go
+++ b/pkg/promotion/runner/builtin/file_deleter_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -224,7 +223,7 @@ func Test_fileDeleter_run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			workDir := tt.setupFiles(t)
 			result, err := runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{WorkDir: workDir},
 				tt.cfg,
 			)

--- a/pkg/promotion/runner/builtin/git_cloner_test.go
+++ b/pkg/promotion/runner/builtin/git_cloner_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -349,7 +348,7 @@ func Test_gitCloner_run(t *testing.T) {
 	}
 
 	res, err := runner.run(
-		context.Background(),
+		t.Context(),
 		stepCtx,
 		builtin.GitCloneConfig{
 			RepoURL: fmt.Sprintf("%s/test.git", server.URL),

--- a/pkg/promotion/runner/builtin/git_commiter_test.go
+++ b/pkg/promotion/runner/builtin/git_commiter_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -222,7 +221,7 @@ func Test_gitCommitter_run(t *testing.T) {
 	}
 
 	res, err := runner.run(
-		context.Background(),
+		t.Context(),
 		stepCtx,
 		builtin.GitCommitConfig{
 			Path:    "master",
@@ -243,7 +242,7 @@ func Test_gitCommitter_run(t *testing.T) {
 	// Run the step again to confirm a Skipped status is returned when no new
 	// commit is actually made.
 	res, err = runner.run(
-		context.Background(),
+		t.Context(),
 		stepCtx,
 		builtin.GitCommitConfig{
 			Path:    "master",

--- a/pkg/promotion/runner/builtin/git_pr_merger_test.go
+++ b/pkg/promotion/runner/builtin/git_pr_merger_test.go
@@ -258,7 +258,7 @@ func Test_gitPRMerger_run(t *testing.T) {
 			cfg.RepoURL = "https://github.com/example/repo.git"
 
 			res, err := runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{},
 				cfg,
 			)

--- a/pkg/promotion/runner/builtin/git_pr_waiter_test.go
+++ b/pkg/promotion/runner/builtin/git_pr_waiter_test.go
@@ -225,7 +225,7 @@ func Test_gitPRWaiter_run(t *testing.T) {
 			)
 
 			res, err := runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{},
 				builtin.GitWaitForPRConfig{
 					Provider: ptr.To(builtin.Provider(testGitProviderName)),

--- a/pkg/promotion/runner/builtin/git_tagger_test.go
+++ b/pkg/promotion/runner/builtin/git_tagger_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -163,7 +162,7 @@ func Test_gitTagger_run(t *testing.T) {
 
 	// Test creating a tag
 	res, err := runner.run(
-		context.Background(),
+		t.Context(),
 		&promotion.StepContext{WorkDir: workDir},
 		builtin.GitTagConfig{
 			Path: "master",

--- a/pkg/promotion/runner/builtin/git_tree_clearer_test.go
+++ b/pkg/promotion/runner/builtin/git_tree_clearer_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -94,7 +93,7 @@ func Test_gitTreeOverwriter_run(t *testing.T) {
 	require.True(t, ok)
 
 	res, err := runner.run(
-		context.Background(),
+		t.Context(),
 		&promotion.StepContext{
 			Project: "fake-project",
 			Stage:   "fake-stage",

--- a/pkg/promotion/runner/builtin/helm_chart_updater_test.go
+++ b/pkg/promotion/runner/builtin/helm_chart_updater_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -328,7 +327,7 @@ func Test_helmChartUpdater_run(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), b, 0o600))
 			}
 
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, stepCtx.WorkDir, result, err)
 
 			// Assert that the Helm cache directory was not used

--- a/pkg/promotion/runner/builtin/helm_template_runner_test.go
+++ b/pkg/promotion/runner/builtin/helm_template_runner_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -750,7 +749,7 @@ metadata:
 				WorkDir: workDir,
 				Project: "test-project",
 			}
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, workDir, result, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/http_downloader_test.go
+++ b/pkg/promotion/runner/builtin/http_downloader_test.go
@@ -373,7 +373,7 @@ func Test_httpDownloader_run(t *testing.T) {
 
 			// Run the downloader
 			d := &httpDownloader{}
-			res, err := d.run(context.Background(), stepCtx, tt.cfg)
+			res, err := d.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, res, err, workDir)
 		})
 	}
@@ -524,7 +524,7 @@ func Test_httpDownloader_downloadToFile(t *testing.T) {
 
 			// Download the file
 			d := &httpDownloader{}
-			err := d.downloadToFile(context.Background(), resp, outPath)
+			err := d.downloadToFile(t.Context(), resp, outPath)
 			tt.assertions(t, err, outPath)
 		})
 	}
@@ -553,7 +553,7 @@ func Test_httpDownloader_downloadToFile_contextCancellation(t *testing.T) {
 	outPath := filepath.Join(tempDir, "interrupted-file.txt")
 
 	// Create context that will be canceled
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Cancel context after a short delay
 	go func() {
@@ -591,7 +591,7 @@ func Test_httpDownloader_downloadToFile_sizeExceeded(t *testing.T) {
 	outPath := filepath.Join(tempDir, "large-file.txt")
 
 	d := &httpDownloader{}
-	err := d.downloadToFile(context.Background(), resp, outPath)
+	err := d.downloadToFile(t.Context(), resp, outPath)
 
 	require.ErrorContains(t, err, "download exceeds limit")
 

--- a/pkg/promotion/runner/builtin/http_requester_test.go
+++ b/pkg/promotion/runner/builtin/http_requester_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -567,7 +566,7 @@ func Test_httpRequester_run(t *testing.T) {
 			srv := httptest.NewServer(testCase.handler)
 			t.Cleanup(srv.Close)
 			testCase.cfg.URL = srv.URL
-			res, err := h.run(context.Background(), nil, testCase.cfg)
+			res, err := h.run(t.Context(), nil, testCase.cfg)
 			testCase.assertions(t, res, err)
 		})
 	}
@@ -1060,7 +1059,7 @@ func Test_httpRequester_buildExprEnv(t *testing.T) {
 	h := &httpRequester{}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			env, err := h.buildExprEnv(context.Background(), testCase.resp, testCase.responseContentType)
+			env, err := h.buildExprEnv(t.Context(), testCase.resp, testCase.responseContentType)
 			testCase.assertions(t, env, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/json_parser_test.go
+++ b/pkg/promotion/runner/builtin/json_parser_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -308,7 +307,7 @@ func Test_jsonParser_run(t *testing.T) {
 				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
 			}
 
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, stepCtx.WorkDir, result, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/json_updater_test.go
+++ b/pkg/promotion/runner/builtin/json_updater_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path"
@@ -467,7 +466,7 @@ func Test_jsonUpdater_run(t *testing.T) {
 				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
 			}
 
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, stepCtx.WorkDir, result, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/kustomize_image_setter_test.go
+++ b/pkg/promotion/runner/builtin/kustomize_image_setter_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,7 +263,7 @@ kind: Kustomization
 			if tt.setupFiles != nil {
 				tt.setupFiles(t, tt.stepCtx.WorkDir)
 			}
-			result, err := runner.run(context.Background(), tt.stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), tt.stepCtx, tt.cfg)
 			tt.assertions(t, tt.stepCtx.WorkDir, result, err)
 		})
 	}
@@ -420,7 +419,7 @@ func Test_kustomizeImageSetter_buildTargetImagesAutomatically(t *testing.T) {
 				},
 			}
 
-			result, err := runner.buildTargetImagesAutomatically(context.Background(), stepCtx)
+			result, err := runner.buildTargetImagesAutomatically(t.Context(), stepCtx)
 			tt.assertions(t, result, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/metadata_setter_test.go
+++ b/pkg/promotion/runner/builtin/metadata_setter_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -263,7 +262,7 @@ func Test_metadataSetter_run(t *testing.T) {
 
 				stage := &kargoapi.Stage{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      testObjName,
 						Namespace: testProject,
@@ -378,7 +377,7 @@ func Test_metadataSetter_run(t *testing.T) {
 
 				freight := &kargoapi.Freight{}
 				err = c.Get(
-					context.Background(),
+					t.Context(),
 					types.NamespacedName{
 						Name:      testObjName,
 						Namespace: testProject,
@@ -423,7 +422,7 @@ func Test_metadataSetter_run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setter := &metadataSetter{kargoClient: tt.client}
 			stepCtx := &promotion.StepContext{Project: testProject}
-			result, err := setter.run(context.Background(), stepCtx, tt.cfg)
+			result, err := setter.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, result, tt.client, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/oci_downloader_test.go
+++ b/pkg/promotion/runner/builtin/oci_downloader_test.go
@@ -220,7 +220,7 @@ func Test_ociDownloader_resolveImage(t *testing.T) {
 				Project: "fake-project",
 			}
 
-			img, err := runner.resolveImage(context.Background(), stepCtx, tt.cfg)
+			img, err := runner.resolveImage(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, img, err)
 		})
 	}
@@ -404,7 +404,7 @@ func Test_ociDownloader_buildRemoteOptions(t *testing.T) {
 				Project: "fake-project",
 			}
 
-			opts, err := runner.buildRemoteOptions(context.Background(), stepCtx, tt.cfg, ref, credType)
+			opts, err := runner.buildRemoteOptions(t.Context(), stepCtx, tt.cfg, ref, credType)
 			tt.assertions(t, opts, err)
 		})
 	}
@@ -611,7 +611,7 @@ func Test_ociDownloader_getAuthOption(t *testing.T) {
 				Project: "fake-project",
 			}
 
-			opt, err := runner.getAuthOption(context.Background(), stepCtx, ref, credType)
+			opt, err := runner.getAuthOption(t.Context(), stepCtx, ref, credType)
 			tt.assertions(t, opt, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/tar_extractor_test.go
+++ b/pkg/promotion/runner/builtin/tar_extractor_test.go
@@ -3,7 +3,6 @@ package builtin
 import (
 	"archive/tar"
 	"compress/gzip"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -420,7 +419,7 @@ func Test_tarExtractor_run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			workDir := tt.setupFiles(t)
 			result, err := runner.run(
-				context.Background(),
+				t.Context(),
 				&promotion.StepContext{WorkDir: workDir},
 				tt.cfg,
 			)
@@ -1011,7 +1010,7 @@ func Test_tarExtractor_extractToDir(t *testing.T) {
 			extractDir := filepath.Join(workDir, "temp_extract")
 
 			result, err := runner.extractToDir(
-				context.Background(),
+				t.Context(),
 				tt.cfg,
 				tarPath,
 				extractDir,

--- a/pkg/promotion/runner/builtin/yaml_parser_test.go
+++ b/pkg/promotion/runner/builtin/yaml_parser_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -309,7 +308,7 @@ config:
 				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
 			}
 
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, stepCtx.WorkDir, result, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/yaml_updater_test.go
+++ b/pkg/promotion/runner/builtin/yaml_updater_test.go
@@ -1,7 +1,6 @@
 package builtin
 
 import (
-	"context"
 	"os"
 	"path"
 	"testing"
@@ -186,7 +185,7 @@ image:
 				require.NoError(t, os.WriteFile(path.Join(stepCtx.WorkDir, p), []byte(c), 0o600))
 			}
 
-			result, err := runner.run(context.Background(), stepCtx, tt.cfg)
+			result, err := runner.run(t.Context(), stepCtx, tt.cfg)
 			tt.assertions(t, stepCtx.WorkDir, result, err)
 		})
 	}

--- a/pkg/rollouts/analysis_run_builder_test.go
+++ b/pkg/rollouts/analysis_run_builder_test.go
@@ -1,7 +1,6 @@
 package rollouts
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -290,7 +289,7 @@ func TestAnalysisRunBuilder_Build(t *testing.T) {
 				Build()
 
 			builder := NewAnalysisRunBuilder(c, tt.cfg)
-			ar, err := builder.Build(context.Background(), tt.namespace, tt.verification, tt.options...)
+			ar, err := builder.Build(t.Context(), tt.namespace, tt.verification, tt.options...)
 			tt.assertions(t, ar, err)
 		})
 	}
@@ -894,7 +893,7 @@ func TestAnalysisRunBuilder_buildOwnerReferences(t *testing.T) {
 				Build()
 
 			builder := &AnalysisRunBuilder{client: c}
-			refs, err := builder.buildOwnerReferences(context.Background(), tt.owners)
+			refs, err := builder.buildOwnerReferences(t.Context(), tt.owners)
 			tt.assertions(t, refs, err)
 		})
 	}
@@ -1018,7 +1017,7 @@ func TestAnalysisRunBuilder_getAnalysisTemplates(t *testing.T) {
 
 			builder := &AnalysisRunBuilder{client: c}
 			analysisTemplates, clusterAnalysisTemplates, err := builder.getAnalysisTemplates(
-				context.Background(),
+				t.Context(),
 				tt.namespace,
 				tt.references,
 			)

--- a/pkg/server/approve_freight_v1alpha1_test.go
+++ b/pkg/server/approve_freight_v1alpha1_test.go
@@ -384,7 +384,7 @@ func TestApproveFreight(t *testing.T) {
 			recorder := fakeevent.NewEventRecorder(1)
 			testCase.server.sender = k8sevent.NewEventSender(recorder)
 			resp, err := testCase.server.ApproveFreight(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(testCase.req),
 			)
 			testCase.assertions(t, recorder, resp, err)

--- a/pkg/server/auth_middleware_test.go
+++ b/pkg/server/auth_middleware_test.go
@@ -50,7 +50,7 @@ c1e3
 
 func TestNewAuthMiddleware(t *testing.T) {
 	a := &authMiddleware{}
-	middleware := newAuthMiddleware(context.Background(), config.ServerConfig{}, nil)
+	middleware := newAuthMiddleware(t.Context(), config.ServerConfig{}, nil)
 	require.NotNil(t, middleware)
 	// Call the middleware to get the initialized authMiddleware
 	// We can't directly inspect it, but we can verify it doesn't panic
@@ -151,7 +151,7 @@ func TestGetKeySet(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			svr, cfg := testCase.setup()
 			t.Cleanup(svr.Close)
-			keyset, err := getKeySet(context.Background(), cfg)
+			keyset, err := getKeySet(t.Context(), cfg)
 			require.NoError(t, err)
 			require.NotNil(t, keyset)
 		})
@@ -412,7 +412,7 @@ func TestAuthenticate(t *testing.T) {
 				ts.authMiddleware = &authMiddleware{}
 			}
 			ctx, err := ts.authMiddleware.authenticate(
-				context.Background(),
+				t.Context(),
 				ts.path,
 				ts.token,
 			)
@@ -507,7 +507,7 @@ func TestVerifyIDPIssuedTokenFn(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			c, err := testCase.authMiddleware.verifyIDPIssuedToken(
-				context.Background(),
+				t.Context(),
 				// With the way these tests are constructed, this doesn't have to
 				// be valid.
 				"some-token",

--- a/pkg/server/create_config_map_v1alpha1_test.go
+++ b/pkg/server/create_config_map_v1alpha1_test.go
@@ -174,7 +174,7 @@ func TestCreateConfigMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			client, err := kubernetes.NewClient(
 				ctx,

--- a/pkg/server/create_generic_credentials_v1alpha1_test.go
+++ b/pkg/server/create_generic_credentials_v1alpha1_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestCreateGenericCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cl, err := kubernetes.NewClient(
 		ctx,

--- a/pkg/server/create_repo_credentials_v1alpha1_test.go
+++ b/pkg/server/create_repo_credentials_v1alpha1_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestCreateRepoCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cl, err := kubernetes.NewClient(
 		ctx,

--- a/pkg/server/delete_config_map_v1alpha1_test.go
+++ b/pkg/server/delete_config_map_v1alpha1_test.go
@@ -119,7 +119,7 @@ func TestDeleteConfigMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			client, err := kubernetes.NewClient(
 				ctx,

--- a/pkg/server/delete_generic_credentials_v1alpha1_test.go
+++ b/pkg/server/delete_generic_credentials_v1alpha1_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDeleteGenericCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cl, err := kubernetes.NewClient(
 		ctx,

--- a/pkg/server/get_repo_credentials_v1alpha1_test.go
+++ b/pkg/server/get_repo_credentials_v1alpha1_test.go
@@ -282,7 +282,7 @@ func TestGetRepoCredentials(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			client, err := kubernetes.NewClient(
 				ctx,

--- a/pkg/server/kubernetes/client_test.go
+++ b/pkg/server/kubernetes/client_test.go
@@ -29,7 +29,7 @@ func TestSetOptionsDefaults(t *testing.T) {
 func TestNewClient(t *testing.T) {
 	testInternalClient := fake.NewClientBuilder().Build()
 	c, err := NewClient(
-		context.Background(),
+		t.Context(),
 		&rest.Config{},
 		ClientOptions{
 			// Override this because the default behavior will fail without real REST
@@ -54,7 +54,7 @@ func TestNewClient(t *testing.T) {
 func TestAllClientOperations(t *testing.T) {
 	getOp := func(client *client) error {
 		return client.Get(
-			context.Background(),
+			t.Context(),
 			types.NamespacedName{
 				Namespace: "test-namespace",
 				Name:      "test-name",
@@ -65,7 +65,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	listOp := func(client *client) error {
 		return client.List(
-			context.Background(),
+			t.Context(),
 			&corev1.PodList{},
 			libClient.InNamespace("test-namespace"),
 		)
@@ -73,7 +73,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	createOp := func(client *client) error {
 		return client.Create(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -85,7 +85,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	deleteOp := func(client *client) error {
 		return client.Delete(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -97,7 +97,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	updateOp := func(client *client) error {
 		return client.Update(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -109,7 +109,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	patchOp := func(client *client) error {
 		return client.Patch(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -122,7 +122,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	deleteAllOp := func(client *client) error {
 		return client.DeleteAllOf(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{},
 			libClient.InNamespace("test-namespace"),
 		)
@@ -130,7 +130,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	updateStatusOp := func(client *client) error {
 		return client.Status().Update(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -142,7 +142,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	patchStatusOp := func(client *client) error {
 		return client.Status().Patch(
-			context.Background(),
+			t.Context(),
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
@@ -155,7 +155,7 @@ func TestAllClientOperations(t *testing.T) {
 
 	watchOp := func(client *client) error {
 		_, err := client.Watch(
-			context.Background(),
+			t.Context(),
 			&corev1.PodList{},
 			libClient.InNamespace("test-namespace"),
 		)
@@ -351,7 +351,7 @@ func TestAllClientOperations(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			c, err := NewClient(
-				context.Background(),
+				t.Context(),
 				nil,
 				ClientOptions{
 					NewInternalClient: func(
@@ -431,7 +431,7 @@ func TestGetAuthorizedClient(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.userInfo != nil {
-				ctx := user.ContextWithInfo(context.Background(), *testCase.userInfo)
+				ctx := user.ContextWithInfo(t.Context(), *testCase.userInfo)
 				client, err := getAuthorizedClient(nil)(
 					ctx,
 					testInternalClient,

--- a/pkg/server/list_generic_credentials_v1alpha1_test.go
+++ b/pkg/server/list_generic_credentials_v1alpha1_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestListGenericCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testData := map[string][]byte{
 		"PROJECT_SECRET": []byte("Soylent Green is people!"),

--- a/pkg/server/option/auth_test.go
+++ b/pkg/server/option/auth_test.go
@@ -48,7 +48,7 @@ c1e3
 -----END CERTIFICATE-----`)
 
 func TestNewAuthInterceptor(t *testing.T) {
-	a := newAuthInterceptor(context.Background(), config.ServerConfig{}, nil)
+	a := newAuthInterceptor(t.Context(), config.ServerConfig{}, nil)
 	require.NotNil(t, a)
 	require.NotNil(t, a.parseUnverifiedJWTFn)
 	require.NotNil(t, a.verifyKargoIssuedTokenFn)
@@ -147,7 +147,7 @@ func TestGetKeySet(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			svr, cfg := testCase.setup()
 			t.Cleanup(svr.Close)
-			keyset, err := getKeySet(context.Background(), cfg)
+			keyset, err := getKeySet(t.Context(), cfg)
 			require.NoError(t, err)
 			require.NotNil(t, keyset)
 		})
@@ -408,7 +408,7 @@ func TestAuthenticate(t *testing.T) {
 				header.Set("Authorization", ts.token)
 			}
 			ctx, err := ts.authInterceptor.authenticate(
-				context.Background(),
+				t.Context(),
 				ts.procedure,
 				header,
 			)
@@ -503,7 +503,7 @@ func TestVerifyIDPIssuedTokenFn(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			c, err := testCase.authInterceptor.verifyIDPIssuedToken(
-				context.Background(),
+				t.Context(),
 				// With the way these tests are constructed, this doesn't have to
 				// be valid.
 				"some-token",

--- a/pkg/server/option/error_test.go
+++ b/pkg/server/option/error_test.go
@@ -105,7 +105,7 @@ func TestErrorInterceptor(t *testing.T) {
 
 			cli := svcv1alpha1connect.NewKargoServiceClient(srv.Client(), srv.URL, connect.WithGRPC())
 			_, err := cli.GetVersionInfo(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(&svcv1alpha1.GetVersionInfoRequest{}),
 			)
 			if tc.errExpected {

--- a/pkg/server/option/log_test.go
+++ b/pkg/server/option/log_test.go
@@ -1,7 +1,6 @@
 package option
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,7 +54,7 @@ func TestUnaryServerLogging(t *testing.T) {
 				srv.URL+"/grpc.health.v1.Health/Check",
 				connect.WithGRPC(),
 			)
-			_, err := client.CallUnary(context.Background(),
+			_, err := client.CallUnary(t.Context(),
 				connect.NewRequest[grpc_health_v1.HealthCheckRequest](
 					&grpc_health_v1.HealthCheckRequest{}))
 			require.NoError(t, err)

--- a/pkg/server/promote_downstream_v1alpha1_test.go
+++ b/pkg/server/promote_downstream_v1alpha1_test.go
@@ -664,7 +664,7 @@ func TestPromoteDownstream(t *testing.T) {
 			recorder := fakeevent.NewEventRecorder(1)
 			testCase.server.sender = k8sevent.NewEventSender(recorder)
 			resp, err := testCase.server.PromoteDownstream(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(testCase.req),
 			)
 			testCase.assertions(t, recorder, resp, err)

--- a/pkg/server/promote_to_stage_v1alpha1_test.go
+++ b/pkg/server/promote_to_stage_v1alpha1_test.go
@@ -529,7 +529,7 @@ func TestPromoteToStage(t *testing.T) {
 			recorder := fakeevent.NewEventRecorder(1)
 			testCase.server.sender = k8sevent.NewEventSender(recorder)
 			res, err := testCase.server.PromoteToStage(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(testCase.req),
 			)
 			testCase.assertions(t, recorder, res, err)

--- a/pkg/server/query_freights_v1alpha1_test.go
+++ b/pkg/server/query_freights_v1alpha1_test.go
@@ -354,7 +354,7 @@ func TestQueryFreight(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			res, err := testCase.server.QueryFreight(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(testCase.req),
 			)
 			testCase.assertions(t, res, err)
@@ -418,7 +418,7 @@ func TestGetFreightFromWarehouse(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			freight, err := testCase.server.getFreightFromWarehouses(
-				context.Background(),
+				t.Context(),
 				"fake-project",
 				[]string{"fake-warehouse"},
 			)
@@ -484,7 +484,7 @@ func TestGetVerifiedFreight(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			freight, err := testCase.server.getVerifiedFreight(
-				context.Background(),
+				t.Context(),
 				"fake-project",
 				[]string{
 					"fake-stage",

--- a/pkg/server/rbac/roles_test.go
+++ b/pkg/server/rbac/roles_test.go
@@ -2257,7 +2257,7 @@ func Test_rolesDatabase_waitForTokenData(t *testing.T) {
 				internalClient: testCase.client,
 			}
 			secret, err := s.waitForTokenData(
-				context.Background(),
+				t.Context(),
 				testProject,
 				testTokenName,
 				2, // Only two attempts so that backoffs are minimal during tests

--- a/pkg/server/refresh_v1alpha1_test.go
+++ b/pkg/server/refresh_v1alpha1_test.go
@@ -301,7 +301,7 @@ func TestRefreshResource(t *testing.T) {
 	}
 	for name, ts := range testSets {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			client, err := kubernetes.NewClient(
 				ctx,
 				&rest.Config{},

--- a/pkg/server/rest_test.go
+++ b/pkg/server/rest_test.go
@@ -205,7 +205,7 @@ func testRESTWatchEndpoint(
 			internalClient := testCase.clientBuilder.WithScheme(testScheme).Build()
 			var err error
 			s.client, err = kubernetes.NewClient(
-				context.Background(),
+				t.Context(),
 				&rest.Config{},
 				kubernetes.ClientOptions{
 					SkipAuthorization: true,
@@ -236,7 +236,7 @@ func testRESTWatchEndpoint(
 			}
 
 			// Create a context with timeout to prevent hanging on watch endpoints
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
 			req = req.WithContext(ctx)
 
@@ -249,7 +249,7 @@ func testRESTWatchEndpoint(
 				}()
 			}
 
-			router := s.setupRESTRouter(context.Background())
+			router := s.setupRESTRouter(t.Context())
 			router.ServeHTTP(w, req)
 
 			testCase.assertions(t, w, internalClient)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -20,7 +20,7 @@ import (
 func TestNewServer(t *testing.T) {
 	testServerConfig := config.ServerConfig{}
 	testClient, err := kubernetes.NewClient(
-		context.Background(),
+		t.Context(),
 		&rest.Config{},
 		kubernetes.ClientOptions{
 			NewInternalClient: func(

--- a/pkg/server/update_config_map_v1alpha1_test.go
+++ b/pkg/server/update_config_map_v1alpha1_test.go
@@ -226,7 +226,7 @@ func TestUpdateConfigMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			client, err := kubernetes.NewClient(
 				ctx,

--- a/pkg/server/update_freight_alias_v1alpha1_test.go
+++ b/pkg/server/update_freight_alias_v1alpha1_test.go
@@ -298,7 +298,7 @@ func TestUpdateFreightAlias(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := testCase.server.UpdateFreightAlias(
-				context.Background(),
+				t.Context(),
 				connect.NewRequest(testCase.req),
 			)
 			testCase.assertions(t, err)

--- a/pkg/server/update_generic_credentials_v1alpha1_test.go
+++ b/pkg/server/update_generic_credentials_v1alpha1_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestUpdateGenericCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cl, err := kubernetes.NewClient(
 		ctx,

--- a/pkg/server/update_repo_credentials_v1alpha1_test.go
+++ b/pkg/server/update_repo_credentials_v1alpha1_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestUpdateRepoCredentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cl, err := kubernetes.NewClient(
 		ctx,

--- a/pkg/server/user/user_test.go
+++ b/pkg/server/user/user_test.go
@@ -11,17 +11,17 @@ func TestContextWithUserInfo(t *testing.T) {
 	testUserInfo := Info{
 		Claims: map[string]any{"sub": "hansolo"},
 	}
-	ctx := ContextWithInfo(context.Background(), testUserInfo)
+	ctx := ContextWithInfo(t.Context(), testUserInfo)
 	require.Equal(t, testUserInfo, ctx.Value(userInfoKey{}))
 }
 
 func TestUserInfoFromContext(t *testing.T) {
-	_, ok := InfoFromContext(context.Background())
+	_, ok := InfoFromContext(t.Context())
 	require.False(t, ok)
 	testUserInfo := Info{
 		Claims: map[string]any{"sub": "hansolo"},
 	}
-	ctx := context.WithValue(context.Background(), userInfoKey{}, testUserInfo)
+	ctx := context.WithValue(t.Context(), userInfoKey{}, testUserInfo)
 	u, ok := InfoFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, testUserInfo, u)

--- a/pkg/server/validators_test.go
+++ b/pkg/server/validators_test.go
@@ -187,7 +187,7 @@ func TestValidateProjectExists(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.assertions(
 				t,
-				testCase.server.validateProjectExists(context.Background(), "fake-project"),
+				testCase.server.validateProjectExists(t.Context(), "fake-project"),
 			)
 		})
 	}

--- a/pkg/webhook/external/server_test.go
+++ b/pkg/webhook/external/server_test.go
@@ -30,7 +30,7 @@ func TestServer_Healthz(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go func() {

--- a/pkg/webhook/kubernetes/clusterconfig/webhook_test.go
+++ b/pkg/webhook/kubernetes/clusterconfig/webhook_test.go
@@ -1,7 +1,6 @@
 package clusterconfig
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -106,7 +105,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			w := &webhook{}
-			warnings, err := w.ValidateCreate(context.Background(), testCase.cfg)
+			warnings, err := w.ValidateCreate(t.Context(), testCase.cfg)
 			testCase.assertions(t, warnings, err)
 		})
 	}
@@ -181,7 +180,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			w := &webhook{}
-			warnings, err := w.ValidateUpdate(context.Background(), nil, testCase.cfg)
+			warnings, err := w.ValidateUpdate(t.Context(), nil, testCase.cfg)
 			testCase.assertions(t, warnings, err)
 		})
 	}

--- a/pkg/webhook/kubernetes/freight/webhook_test.go
+++ b/pkg/webhook/kubernetes/freight/webhook_test.go
@@ -138,7 +138,7 @@ func Test_webhook_Default(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		ctx := context.Background()
+		ctx := t.Context()
 		if testCase.op != "" {
 			ctx = admission.NewContextWithRequest(
 				ctx,
@@ -481,7 +481,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase // Avoid implicit memory aliasing
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := tc.webhook.ValidateCreate(context.Background(), &tc.freight)
+			_, err := tc.webhook.ValidateCreate(t.Context(), &tc.freight)
 			tc.assertions(t, err)
 		})
 	}
@@ -797,7 +797,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 			if testCase.userInfo != nil {
 				req.UserInfo = *testCase.userInfo
 			}
-			ctx := admission.NewContextWithRequest(context.Background(), req)
+			ctx := admission.NewContextWithRequest(t.Context(), req)
 
 			_, err := testCase.webhook.ValidateUpdate(
 				ctx,
@@ -870,7 +870,7 @@ func Test_webhook_ValidateDelete(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			_, err := tc.webhook.ValidateDelete(context.Background(), tc.input)
+			_, err := tc.webhook.ValidateDelete(t.Context(), tc.input)
 			if tc.shouldErr {
 				require.Error(t, err)
 				require.True(t, apierrors.IsForbidden(err))

--- a/pkg/webhook/kubernetes/project/webhook_test.go
+++ b/pkg/webhook/kubernetes/project/webhook_test.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -120,7 +119,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 				cfg:    libWebhook.Config{KargoNamespace: "kargo-system"},
 			}
 
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					DryRun: &tt.isDryRun,
 				},
@@ -141,7 +140,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 		},
 	}
 
-	warnings, err := w.ValidateUpdate(context.Background(), project, project)
+	warnings, err := w.ValidateUpdate(t.Context(), project, project)
 	assert.Empty(t, warnings)
 	assert.NoError(t, err)
 }
@@ -155,7 +154,7 @@ func Test_webhook_ValidateDelete(t *testing.T) {
 		},
 	}
 
-	warnings, err := w.ValidateDelete(context.Background(), project)
+	warnings, err := w.ValidateDelete(t.Context(), project)
 	assert.Empty(t, warnings)
 	assert.NoError(t, err)
 }
@@ -239,7 +238,7 @@ func Test_webhook_ensureNamespace(t *testing.T) {
 				client: c,
 			}
 
-			err := w.ensureNamespace(context.Background(), tt.project)
+			err := w.ensureNamespace(t.Context(), tt.project)
 			tt.assertions(t, err)
 		})
 	}
@@ -297,7 +296,7 @@ func Test_webhook_ensureProjectAdminPermissions(t *testing.T) {
 
 				// Check role binding creation
 				rb := &rbacv1.RoleBinding{}
-				err = c.Get(context.Background(), client.ObjectKey{
+				err = c.Get(t.Context(), client.ObjectKey{
 					Name:      roleBindingName,
 					Namespace: testProjectName,
 				}, rb)
@@ -334,7 +333,7 @@ func Test_webhook_ensureProjectAdminPermissions(t *testing.T) {
 				cfg:    libWebhook.Config{KargoNamespace: kargoNamespace},
 			}
 
-			err := w.ensureProjectAdminPermissions(context.Background(), tt.project)
+			err := w.ensureProjectAdminPermissions(t.Context(), tt.project)
 			tt.assertions(t, err, c)
 		})
 	}

--- a/pkg/webhook/kubernetes/projectconfig/webhook_test.go
+++ b/pkg/webhook/kubernetes/projectconfig/webhook_test.go
@@ -1,7 +1,6 @@
 package projectconfig
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -651,7 +650,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 				client: c,
 			}
 
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					DryRun: &tt.isDryRun,
 				},
@@ -858,7 +857,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &webhook{}
-			warnings, err := w.ValidateUpdate(context.Background(), nil, tt.projectCfg)
+			warnings, err := w.ValidateUpdate(t.Context(), nil, tt.projectCfg)
 			tt.assertions(t, warnings, err)
 		})
 	}

--- a/pkg/webhook/kubernetes/promotion/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotion/webhook_test.go
@@ -623,7 +623,7 @@ func Test_webhook_Default(t *testing.T) {
 			}
 
 			ctx := admission.NewContextWithRequest(
-				context.Background(),
+				t.Context(),
 				testCase.req,
 			)
 			testCase.assertions(
@@ -926,7 +926,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 			if testCase.userInfo != nil {
 				req.UserInfo = *testCase.userInfo
 			}
-			ctx := admission.NewContextWithRequest(context.Background(), req)
+			ctx := admission.NewContextWithRequest(t.Context(), req)
 
 			_, err := testCase.webhook.ValidateCreate(
 				ctx,
@@ -1030,7 +1030,7 @@ func Tes_webhook_tValidateUpdate(t *testing.T) {
 				authorizeFn: testCase.authorizeFn,
 			}
 			oldPromo, newPromo := testCase.setup()
-			_, err := w.ValidateUpdate(context.Background(), oldPromo, newPromo)
+			_, err := w.ValidateUpdate(t.Context(), oldPromo, newPromo)
 			testCase.assertions(t, err)
 		})
 	}
@@ -1068,7 +1068,7 @@ func Test_webhook_ValidateDelete(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := testCase.webhook.ValidateDelete(
-				context.Background(),
+				t.Context(),
 				&kargoapi.Promotion{},
 			)
 			testCase.assertions(t, err)
@@ -1168,7 +1168,7 @@ func Test_webhook_Authorize(t *testing.T) {
 			testCase.assertions(
 				t,
 				w.authorize(
-					context.Background(),
+					t.Context(),
 					&kargoapi.Promotion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "fake-promotion",

--- a/pkg/webhook/kubernetes/promotiontask/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotiontask/webhook_test.go
@@ -1,7 +1,6 @@
 package promotiontask
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +87,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 				client: c,
 			}
 
-			got, err := w.ValidateCreate(context.Background(), tt.task)
+			got, err := w.ValidateCreate(t.Context(), tt.task)
 			tt.assertions(t, got, err)
 		})
 	}

--- a/pkg/webhook/kubernetes/stage/webhook_test.go
+++ b/pkg/webhook/kubernetes/stage/webhook_test.go
@@ -822,7 +822,7 @@ func Test_webhook_Default(t *testing.T) {
 			}
 
 			ctx := admission.NewContextWithRequest(
-				context.Background(),
+				t.Context(),
 				tc.req,
 			)
 			tc.assertions(
@@ -909,7 +909,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := testCase.webhook.ValidateCreate(
-				context.Background(),
+				t.Context(),
 				&kargoapi.Stage{},
 			)
 			testCase.assertions(t, err)
@@ -955,7 +955,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := testCase.webhook.ValidateUpdate(
-				context.Background(),
+				t.Context(),
 				nil,
 				&kargoapi.Stage{},
 			)
@@ -966,7 +966,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 
 func Test_webhook_ValidateDelete(t *testing.T) {
 	w := &webhook{}
-	_, err := w.ValidateDelete(context.Background(), nil)
+	_, err := w.ValidateDelete(t.Context(), nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/webhook/kubernetes/warehouse/webhook_test.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook_test.go
@@ -87,7 +87,7 @@ func Test_webhook_Default(t *testing.T) {
 
 	t.Run("shard stays default when not specified at all", func(t *testing.T) {
 		warehouse := &kargoapi.Warehouse{}
-		err := w.Default(context.Background(), warehouse)
+		err := w.Default(t.Context(), warehouse)
 		require.NoError(t, err)
 		require.Empty(t, warehouse.Labels)
 		require.Empty(t, warehouse.Spec.Shard)
@@ -99,7 +99,7 @@ func Test_webhook_Default(t *testing.T) {
 				Shard: testShardName,
 			},
 		}
-		err := w.Default(context.Background(), warehouse)
+		err := w.Default(t.Context(), warehouse)
 		require.NoError(t, err)
 		require.Equal(t, testShardName, warehouse.Spec.Shard)
 		require.Equal(t, testShardName, warehouse.Labels[kargoapi.LabelKeyShard])
@@ -113,7 +113,7 @@ func Test_webhook_Default(t *testing.T) {
 				},
 			},
 		}
-		err := w.Default(context.Background(), warehouse)
+		err := w.Default(t.Context(), warehouse)
 		require.NoError(t, err)
 		require.Empty(t, warehouse.Spec.Shard)
 		_, ok := warehouse.Labels[kargoapi.LabelKeyShard]
@@ -133,7 +133,7 @@ func Test_webhook_Default(t *testing.T) {
 				},
 			},
 		}
-		err := w.Default(context.Background(), warehouse)
+		err := w.Default(t.Context(), warehouse)
 		require.NoError(t, err)
 		const testDiscoveryLimit int64 = 42
 		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[0].Git.DiscoveryLimit)
@@ -150,7 +150,7 @@ func Test_webhook_Default(t *testing.T) {
 				},
 			},
 		}
-		err := w.Default(context.Background(), warehouse)
+		err := w.Default(t.Context(), warehouse)
 		require.NoError(t, err)
 		require.Equal(
 			t,
@@ -251,7 +251,7 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.webhook.subscriberRegistry = subscription.DefaultSubscriberRegistry
 			_, err := testCase.webhook.ValidateCreate(
-				context.Background(),
+				t.Context(),
 				testCase.warehouse,
 			)
 			testCase.assertions(t, err)
@@ -333,7 +333,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.webhook.subscriberRegistry = subscription.DefaultSubscriberRegistry
 			_, err := testCase.webhook.ValidateUpdate(
-				context.Background(),
+				t.Context(),
 				nil,
 				testCase.warehouse,
 			)
@@ -344,7 +344,7 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 
 func Test_webhook_ValidateDelete(t *testing.T) {
 	w := &webhook{}
-	_, err := w.ValidateDelete(context.Background(), nil)
+	_, err := w.ValidateDelete(t.Context(), nil)
 	require.NoError(t, err, nil)
 }
 


### PR DESCRIPTION
I had claude rip through the codebase and replace non-test-context context implementations like `context.Background()` and `context.TODO` with `t.Context` where we should be using it.