### PR TITLE
fix(git): remove pre-existing worktree dir on retry to prevent AddWorkTree failure

### DIFF
--- a/pkg/controller/git/bare_repo.go
+++ b/pkg/controller/git/bare_repo.go
@@ -192,6 +192,18 @@ func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree,
 	if slices.Contains(workTreePaths, path) {
 		return nil, fmt.Errorf("working tree already exists at %q", path)
 	}
+	// If the target directory already exists on disk but is not registered
+	// as a git worktree (e.g. left over from a previous failed promotion
+	// attempt), remove it before calling git worktree add, which would
+	// otherwise fail with "fatal: '<path>' already exists".
+	if _, statErr := os.Stat(path); statErr == nil {
+		if removeErr := os.RemoveAll(path); removeErr != nil {
+			return nil, fmt.Errorf(
+				"error removing pre-existing directory at %q: %w",
+				path, removeErr,
+			)
+		}
+	}
 	args := []string{"worktree", "add", path}
 	if opts.Orphan {
 		args = append(args, "--orphan")


### PR DESCRIPTION
## Problem

When a Kargo promotion is retried after a failure mid-run, the `git-clone` step can fail with:

```
fatal: '<path>' already exists
```

This is tracked in issue #5282.

## Root Cause

In `pkg/controller/git/bare_repo.go`, `AddWorkTree()` checks for duplicate worktrees using:

```go
if slices.Contains(workTreePaths, path) { ... }
```

This only checks worktrees **registered** in the bare repo. On a retry, the bare repo is freshly cloned (no registered worktrees), but the target directory on disk may still exist from the previous failed promotion run — because `Close()` / `RemoveWorkTree()` was never called when the first attempt failed mid-flight.

`git worktree add` then fails because the directory already exists on disk, even though it isn't a registered git worktree.

## Fix

Before calling `git worktree add`, check whether the target directory exists on disk and, if so, remove it (since it is not a registered worktree and is therefore stale):

```go
if _, statErr := os.Stat(path); statErr == nil {
    if removeErr := os.RemoveAll(path); removeErr != nil {
        return nil, fmt.Errorf(
            "error removing pre-existing directory at %q: %w",
            path, removeErr,
        )
    }
}
```

## Testing

Reproduced locally by:
1. Running a promotion that fails mid-run after `git-clone` has created the worktree directory.
2. Retrying the promotion — without this fix the `git worktree add` fails; with this fix the stale directory is cleaned up and the clone succeeds.

Fixes #5282