### PR TITLE
refactor: speed up image build with mounted caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN npm install --global pnpm@${PNPM_VERSION}
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
 
-RUN pnpm install
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install
 COPY ["ui/", "."]
 
 ARG VERSION
-RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production' VERSION=${VERSION} pnpm run build
 
 ####################################################################################################
 # back-end-builder
@@ -32,7 +32,7 @@ ARG CGO_ENABLED=0
 WORKDIR /kargo
 COPY ["api/go.mod", "api/go.sum", "api/"]
 COPY ["go.mod", "go.sum", "./"]
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
 COPY api/ api/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
@@ -42,13 +42,15 @@ ARG VERSION
 ARG GIT_COMMIT
 ARG GIT_TREE_STATE
 
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -trimpath \
       -ldflags "-w -s" \
       -o bin/credential-helper \
       ./cmd/credential-helper
 
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -trimpath \
       -ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PACKAGE}.gitCommit=${GIT_COMMIT} -X ${VERSION_PACKAGE}.gitTreeState=${GIT_TREE_STATE}" \
       -o bin/kargo \
@@ -107,7 +109,7 @@ RUN npm install --global pnpm@${PNPM_VERSION}
 WORKDIR /ui
 COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
 
-RUN pnpm install
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install
 
 COPY ["ui/", "."]
 


### PR DESCRIPTION
EE has been doing this for some time. We should do it here. On my own device, 7.2x faster when the cache is warm.

Note: Needs a small tweak if #6000 is merged first.