### PR TITLE
feat: add startupProbe to account for indeterminate cache sync

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -103,6 +103,20 @@ spec:
               containerPort: 8080
               protocol: TCP
 {{- if .Values.api.probes.enabled }}
+          startupProbe:
+            {{- if .Values.api.tls.enabled }}
+            exec:
+              command:
+                - /usr/local/bin/grpc_health_probe
+                - -addr=:8080
+                - -tls
+                - -tls-no-verify
+            {{- else }}
+            grpc:
+              port: 8080
+            {{- end }}
+            failureThreshold: 30
+            initialDelaySeconds: 10
           livenessProbe:
             {{- if .Values.api.tls.enabled }}
             exec:
@@ -115,7 +129,6 @@ spec:
             grpc:
               port: 8080
             {{- end }}
-            initialDelaySeconds: 10
           readinessProbe:
             {{- if .Values.api.tls.enabled }}
             exec:


### PR DESCRIPTION
Resolves https://github.com/akuity/kargo/issues/3149

The Kargo API server will not start serving/listening HTTP/gRPC until its caches are synced. This includes the health endpoint used by liveness/readiness. This has been shown to take time if there are many objects in the system (Freight/Events/Stages/etc.).  The current initialDelaySeconds of 10s used for our liveness probe has been insufficient in large instances, causing the kargo-api server to be killed before it had time to sync its caches, preventing the kargo-api Pod from ever coming up.

The change introduces a startupProbe with a failureThreshold of 30 and periodSeconds of 10s, giving up to 300s (5min) for initial caches to sync. After which, it will switch to our usual livenessProbe.