### PR TITLE
docs: updating IRSA managing secrets hyperlink to ambient credentials

### DIFF
--- a/docs/docs/50-user-guide/50-security/30-managing-secrets.md
+++ b/docs/docs/50-user-guide/50-security/30-managing-secrets.md
@@ -600,7 +600,7 @@ in a `Secret` resource.
 Both of these options rely upon extensive external configuration that likely
 requires the assistance of Kargo's operator and an AWS account administrator,
 and as such, further details are covered in the
-[Managing Secrets](../../40-operator-guide/40-security/40-managing-secrets.md)
+[Ambient Credentials](../../40-operator-guide/40-security/50-ambient-credentials.md)
 section of the Operator Guide.
 
 :::


### PR DESCRIPTION
The current hyperlink in for [using Pod Identity or IRSA in the User Guide](https://docs.kargo.io/user-guide/security/managing-secrets/#eks-pod-identity-or-iam-roles-for-service-accounts-irsa) is stale. It should be pointing to [Ambient Credentials](https://docs.kargo.io/operator-guide/security/ambient-credentials/) in the Operator's Guide instead of the [Managing Secrets page](https://docs.kargo.io/operator-guide/security/managing-secrets/) in the Operator's Guide. 

