### PR TITLE
chore: follow up on #5995 with removing 30s suggested retry workaround

### DIFF
--- a/pkg/promotion/runner/builtin/argocd_updater.go
+++ b/pkg/promotion/runner/builtin/argocd_updater.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -235,17 +234,6 @@ func (a *argocdUpdater) run(
 		"status", aggregatedStatus,
 	)
 
-	// TODO(krancour): This enables more aggressive polling while waiting to
-	// observe the Application has successfully synced. This is a workaround for
-	// an as-yet-unexplained, but rare phenomenon where Application status change
-	// events do not seem to be promptly triggering re-reconciliation of the
-	// Promotion resources.
-	var retryAfter *time.Duration
-	if aggregatedStatus == kargoapi.PromotionStepStatusRunning {
-		retryAfter = ptr.To(30 * time.Second)
-		logger.Info("step to be retried", "interval", retryAfter)
-	}
-
 	return promotion.StepResult{
 		Status: aggregatedStatus,
 		HealthCheck: &health.Criteria{
@@ -254,7 +242,6 @@ func (a *argocdUpdater) run(
 				"apps": appHealthChecks,
 			},
 		},
-		RetryAfter: retryAfter,
 	}, nil
 }
 

--- a/pkg/promotion/runner/builtin/argocd_updater_test.go
+++ b/pkg/promotion/runner/builtin/argocd_updater_test.go
@@ -616,7 +616,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
-				assert.NotNil(t, res.RetryAfter)
+				assert.Nil(t, res.RetryAfter)
 				require.NoError(t, err)
 			},
 		},
@@ -652,7 +652,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
-				assert.NotNil(t, res.RetryAfter)
+				assert.Nil(t, res.RetryAfter)
 				require.NoError(t, err)
 			},
 		},
@@ -688,7 +688,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
-				assert.NotNil(t, res.RetryAfter)
+				assert.Nil(t, res.RetryAfter)
 				require.NoError(t, err)
 			},
 		},
@@ -1080,7 +1080,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
-				assert.NotNil(t, res.RetryAfter)
+				assert.Nil(t, res.RetryAfter)
 				require.NoError(t, err)
 				// Verify health checks include all 3 apps
 				require.NotNil(t, res.HealthCheck)


### PR DESCRIPTION
This removes a workaround that should no longer be required after #5995 and which should have been removed then.