### PR TITLE
fix(rbac): add missing release namespace to Role and RoleBinding resources

### DIFF
--- a/charts/kargo/templates/api/role-bindings.yaml
+++ b/charts/kargo/templates/api/role-bindings.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
 roleRef:

--- a/charts/kargo/templates/api/roles.yaml
+++ b/charts/kargo/templates/api/roles.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kargo-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
 rules:

--- a/charts/kargo/templates/users/role-bindings.yaml
+++ b/charts/kargo/templates/users/role-bindings.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kargo-admin
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
 roleRef:

--- a/charts/kargo/templates/users/roles.yaml
+++ b/charts/kargo/templates/users/roles.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kargo-admin
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
When rendering the chart with kustomize I noticed the following namespaced-scoped resources are missing the `namespace` on their spec.