### PR TITLE
refactor: consolidate git identity and signing config into git-clone

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -17,10 +17,17 @@ step](git-push.md).
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing changes to be committed. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `message` | `string` | Y | The commit message. |
-| `author` | `[]object` | N | Optional authorship information for the commit. If provided, this takes precedence over both system-level defaults and any default authorship information configured in the [`git-clone`](./git-clone.md) step. |
-| `author.name` | `string` | Y | The committer's name. |
-| `author.email` | `string` | Y | The committer's email address. |
-| `author.signingKey` | `string` | N | The GPG signing key for the author. This field is optional. |
+| `author` | `[]object` | N | **Deprecated (v1.10.0, removal in v1.13.0).** Optional authorship information for the commit. Configure authorship in the [`git-clone`](./git-clone.md) step instead. |
+| `author.name` | `string` | Y | **Deprecated.** The committer's name. |
+| `author.email` | `string` | Y | **Deprecated.** The committer's email address. |
+| `author.signingKey` | `string` | N | **Deprecated.** The GPG signing key for the author. Configure signing keys in the [`git-clone`](./git-clone.md) step or via `ClusterConfig` instead. |
+
+:::warning
+
+The `author` field is deprecated as of v1.10.0 and will be removed in v1.13.0.
+If authorship differing from any system-level default is required, configure it in the [`git-clone`](./git-clone.md) step instead.
+
+:::
 
 ## Output
 
@@ -95,57 +102,3 @@ steps:
     message: |
       ${{ ctx.stage }}: ${{ outputs['update-image'].commitMessage }}
 ```
-
-### Commit with Custom Author
-
-The `author` field can be used to specify the committer's name and email address
-for the commit. This can be useful when the committer's identity should be
-different from Kargo's default identity.
-
-```yaml
-steps:
-# Update Kustomize manifests, etc...
-- uses: git-commit
-  config:
-    path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
-    author:
-      name: Kargo
-      email: kargo@example.com
-```
-
-### Create A Signed Commit
-
-In this example, the `git-commit` step creates a signed commit using the
-provided `author.signingKey` by sourcing it from an existing secret in the same 
-namespace using the [`secret()`](../40-expressions.md#secretname) expression 
-function.
-
-:::note
-
-Author signing information may have been configured at the system level by a 
-Kargo admin. If system-level configuration exists, the example shown below 
-would override it.
-
-:::
-
-
-```yaml
-steps:
-# Update Kustomize manifests, etc...
-- uses: git-commit
-  config:
-    path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
-    author:
-      name: Me
-      email: me@example.com
-      signingKey: ${{ secret('my-gpg-secret').privateKey }}
-```
-
-:::note
-
-If `author.signingKey` is provided, but `author.name` and `author.email` do not
-match the key's UID, the commit will fail.
-
-:::

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -17,7 +17,7 @@ step](git-push.md).
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to a Git working tree containing changes to be committed. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `message` | `string` | Y | The commit message. |
-| `author` | `[]object` | N | **Deprecated (v1.10.0, removal in v1.13.0).** Optional authorship information for the commit. Configure authorship in the [`git-clone`](./git-clone.md) step instead. |
+| `author` | `object` | N | **Deprecated (v1.10.0, removal in v1.13.0).** Optional authorship information for the commit. Configure authorship in the [`git-clone`](./git-clone.md) step instead. |
 | `author.name` | `string` | Y | **Deprecated.** The committer's name. |
 | `author.email` | `string` | Y | **Deprecated.** The committer's email address. |
 | `author.signingKey` | `string` | N | **Deprecated.** The GPG signing key for the author. Configure signing keys in the [`git-clone`](./git-clone.md) step or via `ClusterConfig` instead. |

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-push.md
@@ -44,21 +44,20 @@ When the policy evaluates rebase safety (`RebaseOrMerge` and `RebaseOrFail`),
 the decision is based on the GPG signature status of the local commits that
 would be replayed:
 
-- If all local commits are __signed by a trusted key__ and signing is configured
-  for the committer, a __rebase__ is performed. The replacement commits are
-  re-signed by the committer.
+- If all local commits are __signed by a trusted key__ and signing was enabled
+  at the time the repository was cloned, a __rebase__ is performed. The
+  replacement commits are re-signed by Kargo.
 
-- If all local commits are __unsigned__ and signing is _not_ configured, a
-  __rebase__ is performed. The replacement commits remain unsigned.
+- If all local commits are __unsigned__ and signing was _not_ enabled at the
+  time the repository was cloned, a __rebase__ is performed. The replacement
+  commits remain unsigned.
 
 - In all other cases, the policy's fallback behavior applies (merge or fail).
 
-A "trusted key" is one that has been imported into the committer's GPG keyring
-with ultimate trust. When a `committer` with a `signingKey` is specified in this
-step's configuration, that key is the only trusted key. When `committer` is not
-specified, the trusted key (if any) is the one configured during the
-[`git-clone`](git-clone.md) step -- either from the `author` field or from
-system-level defaults set by a Kargo admin.
+A "trusted key" is one that was imported with ultimate trust when the repository
+was cloned, either through explicit configuration of the
+[`git-clone`](git-clone.md) step or via fallback on a system-level signing key
+configured by a Kargo admin.
 
 :::info
 
@@ -98,10 +97,6 @@ system to access the git repos.
 | `targetBranch` | `string` | N | The branch to push to in the remote repository. Mutually exclusive with `generateTargetBranch=true` and `tag`. If none of these are provided, the target branch will be the same as the branch currently checked out in the working tree. |
 | `maxAttempts` | `int32` | N | The maximum number of attempts to make when pushing to the remote repository. Default is 50. |
 | `generateTargetBranch` | `boolean` | N | Whether to push to a remote branch named like `kargo/promotion/<promotionName>`. If such a branch does not already exist, it will be created. A value of `true` is mutually exclusive with `targetBranch` and `tag`. If none of these are provided, the target branch will be the currently checked out branch. This option is useful when a subsequent promotion step will open a pull request against a Stage-specific branch. In such a case, the generated target branch pushed to by the `git-push` step can later be utilized as the source branch of the pull request. |
-| `committer` | `object` | N | Optional committer information for merge commits or replacement commits created when integrating remote changes before pushing. If provided, this takes precedence over both system-level defaults and any default authorship information configured in the [`git-clone`](./git-clone.md) step. |
-| `committer.name` | `string` | Y | The committer's name. |
-| `committer.email` | `string` | Y | The committer's email address. |
-| `committer.signingKey` | `string` | N | A GPG signing key for the committer. This field is optional. |
 | `tag` | `string` | N | An tag to push to the remote repository. Mutually exclusive with `generateTargetBranch` and `targetBranch`. |
 | `force` | `boolean` | N | Whether to force push to the target branch, overwriting any existing history. This is useful for scenarios where you want to completely replace the branch content (e.g., pushing rendered manifests that don't depend on previous state). **Use with caution** as this will overwrite any commits that exist on the remote branch but not in your local branch. Default is `false`. A value of `true` is mutually exclusive with `tag`. |
 | `provider` | `string` | N | The name of the Git provider to use. Currently 'azure', 'bitbucket', 'gitea', 'github', and 'gitlab' are supported. Kargo will try to infer the provider if it is not explicitly specified. This setting does not affect the push operation but helps generate the correct [`commitURL` output](#output) when working with repositories where the provider cannot be automatically determined, such as self-hosted instances. |
@@ -164,65 +159,6 @@ steps:
     generateTargetBranch: true
 # Open a PR and wait for it to be merged or closed...
 ```
-
-### Push with Custom Committer
-
-The `committer` field can be used to specify the identity used for merge commits
-or replacement commits created when integrating remote changes before pushing.
-
-```yaml
-steps:
-# Clone, prepare the contents of ./out, etc...
-- uses: git-commit
-  config:
-    path: ./out
-    message: rendered updated manifests
-- uses: git-push
-  config:
-    path: ./out
-    committer:
-      name: Kargo
-      email: kargo@example.com
-```
-
-### Push with Signed Commits
-
-In this example, the `git-push` step uses a GPG signing key for the committer,
-sourced from an existing secret in the same namespace using the
-[`secret()`](../40-expressions.md#secretname) expression function. This ensures
-that any merge commits or replacement commits created when integrating remote
-changes bear a valid GPG signature.
-
-:::note
-
-Committer information may have been configured at the system level by a Kargo
-admin. If system-level configuration exists, the example shown below would
-override it.
-
-:::
-
-```yaml
-steps:
-# Clone, prepare the contents of ./out, etc...
-- uses: git-commit
-  config:
-    path: ./out
-    message: rendered updated manifests
-- uses: git-push
-  config:
-    path: ./out
-    committer:
-      name: Me
-      email: me@example.com
-      signingKey: ${{ secret('my-gpg-secret').privateKey }}
-```
-
-:::note
-
-If `committer.signingKey` is provided, but `committer.name` and
-`committer.email` do not match the key's UID, the push will fail.
-
-:::
 
 ### Pushing Tags
 

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
@@ -15,9 +15,6 @@ referencing the current `HEAD` of a checked-out branch.
 | `path` | `string` | Y        | Path to a working directory of a local repository. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `tag`  | `string` | Y        | The tag to create. |
 | `message` | `string` | Y | The message with which to annotate the tag. |
-| `tagger.name` | `string` | N | The tagger's name. If unspecified, defaults to the repo-level configuration specified when the repo was cloned. Can also be configured at the system level. |
-| `tagger.email` | `string` | N | The tagger's email address. If unspecified, defaults to the repo-level configuration specified when the repo was cloned. Can also be configured at the system level. |
-| `tagger.signingKey` | `string` | N | The GPG signing key for the tagger. If provided `tagger.name` and `tagger.email` must also be provided and must match the email and name in the uid of the associated GPG key. |
 
 ## Output
 
@@ -70,37 +67,3 @@ steps:
     path: ./out
     tag: v1.0.0
 ```
-
-### Creating A Signed Tag
-
-In this example, the `git-tag` step creates a signed tag using the provided 
-`tagger.signingKey` by sourcing it from an existing secret in the same namespace
-using the [`secret()`](../40-expressions.md#secretname) expression function.
-
-:::note
-
-Tagger signing information may have been configured at the system level by a 
-Kargo admin. If system-level configuration exists, the example shown below 
-would override it.
-
-:::
-
-```yaml
-steps:
-- uses: git-tag
-  config:
-    path: ./out
-    tag: v1.0.0
-    message: My example tag
-    tagger:
-      name: Me
-      email: me@example.com
-      signingKey: ${{ secret('my-gpg-secret').privateKey }}
-```
-
-:::note
-
-If `tagger.signingKey` is provided, but `tagger.name` and `tagger.email` do not
-match the key's UID, tagging will fail.
-
-:::

--- a/pkg/controller/git/mock_repo.go
+++ b/pkg/controller/git/mock_repo.go
@@ -13,7 +13,7 @@ type MockRepo struct {
 	CommitFn                  func(message string, opts *CommitOptions) error
 	CreateChildBranchFn       func(branch string) error
 	CreateOrphanedBranchFn    func(branch string) error
-	CreateTagFn               func(tag, msg string, opts *TagOptions) error
+	CreateTagFn               func(tag, msg string) error
 	CurrentBranchFn           func() (string, error)
 	DeleteBranchFn            func(branch string) error
 	DirFn                     func() string
@@ -77,8 +77,8 @@ func (m *MockRepo) CreateOrphanedBranch(branch string) error {
 	return m.CreateOrphanedBranchFn(branch)
 }
 
-func (m *MockRepo) CreateTag(tag, msg string, opts *TagOptions) error {
-	return m.CreateTagFn(tag, msg, opts)
+func (m *MockRepo) CreateTag(tag, msg string) error {
+	return m.CreateTagFn(tag, msg)
 }
 
 func (m *MockRepo) CurrentBranch() (string, error) {

--- a/pkg/controller/git/remote_commit_integration.go
+++ b/pkg/controller/git/remote_commit_integration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	libExec "github.com/akuity/kargo/pkg/exec"
@@ -27,7 +26,6 @@ const (
 // integrateBeforePush integrates remote changes before pushing.
 func (w *workTree) integrateBeforePush(
 	targetBranch string,
-	committer *User,
 	integrationPolicy PushIntegrationPolicy,
 ) error {
 	if integrationPolicy == "" {
@@ -35,33 +33,6 @@ func (w *workTree) integrateBeforePush(
 	}
 	if integrationPolicy == PushIntegrationPolicyNone {
 		return nil
-	}
-
-	var homeDir string
-	if committer != nil {
-		// This committer is specific to any commits made during rebasing or
-		// merging, so we will override repository-level user information by
-		// creating a temporary home directory, configuring the user information
-		// "globally" within it, and then ensuring git commits use that home
-		// directory.
-		var err error
-		if homeDir, err = os.MkdirTemp(w.homeDir, ""); err != nil {
-			return fmt.Errorf(
-				"error creating virtual home directory %q for rebase/merge commands: %w",
-				homeDir, err,
-			)
-		}
-		defer func() {
-			if cleanErr := os.RemoveAll(homeDir); cleanErr != nil {
-				logging.LoggerFromContext(context.TODO()).
-					Error(cleanErr, "error removing virtual home directory", "path", homeDir)
-			}
-		}()
-		if err = w.setupUser(homeDir, committer); err != nil {
-			return fmt.Errorf(
-				"error setting up committer information for rebase/merge commands: %w", err,
-			)
-		}
 	}
 
 	logger := logging.LoggerFromContext(context.TODO()).WithValues(
@@ -72,18 +43,18 @@ func (w *workTree) integrateBeforePush(
 	switch integrationPolicy {
 	case PushIntegrationPolicyAlwaysRebase:
 		logger.Trace("integrating remote changes via rebase (always)")
-		return w.pullRebase(targetBranch, homeDir)
+		return w.pullRebase(targetBranch)
 	case PushIntegrationPolicyAlwaysMerge:
 		logger.Trace("integrating remote changes via merge (always)")
-		return w.pullMerge(targetBranch, homeDir)
+		return w.pullMerge(targetBranch)
 	case PushIntegrationPolicyRebaseOrMerge, PushIntegrationPolicyRebaseOrFail:
-		safe, err := w.canSafelyRebase(targetBranch, homeDir)
+		safe, err := w.canSafelyRebase(targetBranch)
 		if err != nil {
 			return fmt.Errorf("error checking rebase safety: %w", err)
 		}
 		if safe {
 			logger.Trace("integrating remote changes via rebase")
-			return w.pullRebase(targetBranch, homeDir)
+			return w.pullRebase(targetBranch)
 		}
 		if integrationPolicy == PushIntegrationPolicyRebaseOrFail {
 			logger.Trace(
@@ -92,27 +63,15 @@ func (w *workTree) integrateBeforePush(
 			return ErrRebaseUnsafe
 		}
 		logger.Trace("integrating remote changes via merge (rebase unsafe)")
-		return w.pullMerge(targetBranch, homeDir)
+		return w.pullMerge(targetBranch)
 	default:
 		return fmt.Errorf("unknown push integration policy: %q", integrationPolicy)
 	}
 }
 
 // pullRebase performs a git pull --rebase against the specified remote branch.
-// If homeDir is non-empty, it overrides the home directory used by the git
-// command, allowing a custom committer's identity and signing key to be used
-// for the replacement commits created by the rebase.
-func (w *workTree) pullRebase(
-	targetBranch string,
-	homeDir string,
-) error {
-	cmd := w.buildGitCommand(
-		"pull", "--rebase", "origin", targetBranch,
-	)
-	if homeDir != "" {
-		// Override the home directory set by w.buildGitCommand().
-		w.setCmdHome(cmd, homeDir)
-	}
+func (w *workTree) pullRebase(targetBranch string) error {
+	cmd := w.buildGitCommand("pull", "--rebase", "origin", targetBranch)
 	if _, err := libExec.Exec(cmd); err != nil {
 		if isRebasing, rbErr := w.IsRebasing(); rbErr == nil && isRebasing {
 			return ErrMergeConflict
@@ -123,20 +82,8 @@ func (w *workTree) pullRebase(
 }
 
 // pullMerge performs a git pull (merge) against the specified remote branch.
-// If homeDir is non-empty, it overrides the home directory used by the git
-// command, allowing a custom committer's identity and signing key to be used
-// for the merge commit.
-func (w *workTree) pullMerge(
-	targetBranch string,
-	homeDir string,
-) error {
-	cmd := w.buildGitCommand(
-		"pull", "--no-rebase", "origin", targetBranch,
-	)
-	if homeDir != "" {
-		// Override the home directory set by w.buildGitCommand().
-		w.setCmdHome(cmd, homeDir)
-	}
+func (w *workTree) pullMerge(targetBranch string) error {
+	cmd := w.buildGitCommand("pull", "--no-rebase", "origin", targetBranch)
 	if _, err := libExec.Exec(cmd); err != nil {
 		// Check for merge conflicts — MERGE_HEAD exists when a merge is
 		// in progress and waiting for conflict resolution.
@@ -152,9 +99,7 @@ func (w *workTree) pullMerge(
 
 // canSafelyRebase determines whether it is safe to rebase the local commits
 // on top of the specified remote branch without misrepresenting commit
-// signature trust. If homeDir is non-empty, it overrides the home directory
-// used by git commands so that a custom committer's GPG trust database and
-// signing configuration are consulted. The decision matrix:
+// signature trust. The decision matrix:
 //
 //   - Signed with trusted key + signing configured: safe (Kargo can re-sign)
 //   - Signed with trusted key + signing not configured: unsafe (would strip
@@ -162,10 +107,7 @@ func (w *workTree) pullMerge(
 //   - Signed with untrusted key: always unsafe (Kargo can't vouch for it)
 //   - Unsigned + signing configured: unsafe (would fabricate a signature)
 //   - Unsigned + signing not configured: safe (stays unsigned)
-func (w *workTree) canSafelyRebase(
-	targetBranch string,
-	homeDir string,
-) (bool, error) {
+func (w *workTree) canSafelyRebase(targetBranch string) (bool, error) {
 	commits, err := w.commitsToReplay(targetBranch)
 	if err != nil {
 		return false, fmt.Errorf(
@@ -175,14 +117,14 @@ func (w *workTree) canSafelyRebase(
 	if len(commits) == 0 {
 		return true, nil
 	}
-	signing, err := w.isSigningConfigured(homeDir)
+	signing, err := w.isSigningConfigured()
 	if err != nil {
 		return false, fmt.Errorf(
 			"error checking signing configuration: %w", err,
 		)
 	}
 	for _, commitID := range commits {
-		status, err := w.verifyCommitSignature(commitID, homeDir)
+		status, err := w.verifyCommitSignature(commitID)
 		if err != nil {
 			return false, fmt.Errorf(
 				"error verifying signature of commit %s: %w",
@@ -227,15 +169,9 @@ func (w *workTree) commitsToReplay(
 }
 
 // isSigningConfigured returns true if GPG commit signing is enabled in the
-// git configuration for this repository. If homeDir is non-empty, it overrides
-// the home directory used by the git command so that a custom committer's
-// configuration is consulted.
-func (w *workTree) isSigningConfigured(homeDir string) (bool, error) {
+// git configuration for this repository.
+func (w *workTree) isSigningConfigured() (bool, error) {
 	cmd := w.buildGitCommand("config", "--get", "commit.gpgSign")
-	if homeDir != "" {
-		// Override the home directory set by w.buildGitCommand().
-		w.setCmdHome(cmd, homeDir)
-	}
 	res, err := libExec.Exec(cmd)
 	if err != nil {
 		var exitErr *libExec.ExitError
@@ -262,20 +198,10 @@ func (w *workTree) isSigningConfigured(homeDir string) (bool, error) {
 //   - R: good signature made by a revoked key
 //   - E: signature cannot be checked (missing key)
 //   - N: no signature
-//
-// If homeDir is non-empty, it overrides the home directory used by the git
-// command so that a custom committer's GPG trust database is consulted.
 func (w *workTree) verifyCommitSignature(
 	commitID string,
-	homeDir string,
 ) (signatureStatus, error) {
-	cmd := w.buildGitCommand(
-		"log", "-1", "--format=%G?", commitID, "--",
-	)
-	if homeDir != "" {
-		// Override the home directory set by w.buildGitCommand().
-		w.setCmdHome(cmd, homeDir)
-	}
+	cmd := w.buildGitCommand("log", "-1", "--format=%G?", commitID, "--")
 	res, err := libExec.Exec(cmd)
 	if err != nil {
 		return signatureUnsigned, fmt.Errorf(

--- a/pkg/controller/git/remote_commit_integration_test.go
+++ b/pkg/controller/git/remote_commit_integration_test.go
@@ -34,9 +34,7 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyAlwaysRebase,
-		)
+		err = wt.integrateBeforePush("ahead", PushIntegrationPolicyAlwaysRebase)
 		require.NoError(t, err)
 
 		// A rebase produces no merge commits:
@@ -57,7 +55,8 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		require.NoError(t, err)
 
 		err = internalWorkTree(t, repo).integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyRebaseOrMerge,
+			"ahead",
+			PushIntegrationPolicyRebaseOrMerge,
 		)
 		require.NoError(t, err)
 
@@ -82,9 +81,7 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyRebaseOrMerge,
-		)
+		err = wt.integrateBeforePush("ahead", PushIntegrationPolicyRebaseOrMerge)
 		require.NoError(t, err)
 
 		// Should have fallen back to merge.
@@ -104,7 +101,8 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		require.NoError(t, err)
 
 		err = internalWorkTree(t, repo).integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyRebaseOrFail,
+			"ahead",
+			PushIntegrationPolicyRebaseOrFail,
 		)
 		require.NoError(t, err)
 
@@ -127,9 +125,7 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyRebaseOrFail,
-		)
+		err = wt.integrateBeforePush("ahead", PushIntegrationPolicyRebaseOrFail)
 		require.ErrorIs(t, err, ErrRebaseUnsafe)
 	})
 
@@ -144,7 +140,8 @@ func Test_workTree_integrateBeforePush(t *testing.T) {
 		require.NoError(t, err)
 
 		err = internalWorkTree(t, repo).integrateBeforePush(
-			"ahead", nil, PushIntegrationPolicyAlwaysMerge,
+			"ahead",
+			PushIntegrationPolicyAlwaysMerge,
 		)
 		require.NoError(t, err)
 
@@ -181,7 +178,7 @@ func Test_workTree_pullRebase(t *testing.T) {
 		require.NoError(t, err)
 
 		// With a conflict, the rebase should have failed.
-		err = internalWorkTree(t, repo).pullRebase("ahead", "")
+		err = internalWorkTree(t, repo).pullRebase("ahead")
 		require.ErrorIs(t, err, ErrMergeConflict)
 	})
 
@@ -201,7 +198,7 @@ func Test_workTree_pullRebase(t *testing.T) {
 		require.NoError(t, err)
 
 		// With no conflicts, the rebase should have succeeded.
-		err = internalWorkTree(t, repo).pullRebase("ahead", "")
+		err = internalWorkTree(t, repo).pullRebase("ahead")
 		require.NoError(t, err)
 
 		// The rebase should not have created any merge commits, so the commit count
@@ -237,7 +234,7 @@ func Test_workTree_pullMerge(t *testing.T) {
 		require.NoError(t, err)
 
 		// With a conflict, the merge should have failed.
-		err = internalWorkTree(t, repo).pullMerge("ahead", "")
+		err = internalWorkTree(t, repo).pullMerge("ahead")
 		require.ErrorIs(t, err, ErrMergeConflict)
 	})
 
@@ -257,7 +254,7 @@ func Test_workTree_pullMerge(t *testing.T) {
 		require.NoError(t, err)
 
 		// With no conflicts, the merge should have succeeded.
-		require.NoError(t, internalWorkTree(t, repo).pullMerge("ahead", ""))
+		require.NoError(t, internalWorkTree(t, repo).pullMerge("ahead"))
 
 		// After a merge, the head of the local branch should be a merge commit.
 		msg, err := repo.CommitMessage("HEAD")
@@ -275,7 +272,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 		require.NoError(t, err)
 		defer repo.Close()
 
-		safe, err := internalWorkTree(t, repo).canSafelyRebase("main", "")
+		safe, err := internalWorkTree(t, repo).canSafelyRebase("main")
 		require.NoError(t, err)
 		require.True(t, safe)
 	})
@@ -295,7 +292,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 		err = repo.AddAllAndCommit("local commit", nil)
 		require.NoError(t, err)
 
-		safe, err := internalWorkTree(t, repo).canSafelyRebase("main", "")
+		safe, err := internalWorkTree(t, repo).canSafelyRebase("main")
 		require.NoError(t, err)
 		// This should be safe because rebasing won't lend Kargo's signature to
 		// commits that were previously unsigned.
@@ -322,7 +319,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		safe, err := wt.canSafelyRebase("main", "")
+		safe, err := wt.canSafelyRebase("main")
 		require.NoError(t, err)
 		// This should be unsafe because rebasing would lend Kargo's signature to
 		// commits that were previously unsigned.
@@ -346,7 +343,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 		err = repo.AddAllAndCommit("signed commit", nil)
 		require.NoError(t, err)
 
-		safe, err := wt.canSafelyRebase("main", "")
+		safe, err := wt.canSafelyRebase("main")
 		require.NoError(t, err)
 		// This should be safe because Kargo trusted the signature on commits it
 		// will re-sign during the rebase.
@@ -372,7 +369,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 
 		disableFakeCommitSigning(t, wt)
 
-		safe, err := wt.canSafelyRebase("main", "")
+		safe, err := wt.canSafelyRebase("main")
 		require.NoError(t, err)
 		// This should be unsafe because rebasing would strip trusted signatures
 		// from existing commits.
@@ -397,7 +394,7 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 		require.NoError(t, err)
 
 		// Unsafe regardless — Kargo can't vouch for this commit.
-		safe, err := wt.canSafelyRebase("main", "")
+		safe, err := wt.canSafelyRebase("main")
 		require.NoError(t, err)
 		// This should be unsafe, no matter what. If signing were not configured,
 		// rebasing would strip signatures from existing commits. Something
@@ -503,7 +500,7 @@ func Test_workTree_isSigningConfigured(t *testing.T) {
 		require.NoError(t, err)
 		defer repo.Close()
 
-		configured, err := internalWorkTree(t, repo).isSigningConfigured("")
+		configured, err := internalWorkTree(t, repo).isSigningConfigured()
 		require.NoError(t, err)
 		require.False(t, configured)
 	})
@@ -520,7 +517,7 @@ func Test_workTree_isSigningConfigured(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		configured, err := wt.isSigningConfigured("")
+		configured, err := wt.isSigningConfigured()
 		require.NoError(t, err)
 		require.True(t, configured)
 	})
@@ -539,7 +536,7 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 		require.NoError(t, err)
 
 		wt := internalWorkTree(t, repo)
-		status, err := wt.verifyCommitSignature(commitID, "")
+		status, err := wt.verifyCommitSignature(commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureUnsigned, status)
 	})
@@ -564,7 +561,7 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 		commitID, err := repo.LastCommitID()
 		require.NoError(t, err)
 
-		status, err := wt.verifyCommitSignature(commitID, "")
+		status, err := wt.verifyCommitSignature(commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureTrusted, status)
 	})
@@ -589,7 +586,7 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 		commitID, err := repo.LastCommitID()
 		require.NoError(t, err)
 
-		status, err := wt.verifyCommitSignature(commitID, "")
+		status, err := wt.verifyCommitSignature(commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureUntrusted, status)
 	})

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -43,7 +43,7 @@ type WorkTree interface {
 	// with any other branch.
 	CreateOrphanedBranch(branch string) error
 	// CreateTag creates a new tag with the specified name.
-	CreateTag(name, msg string, opts *TagOptions) error
+	CreateTag(name, msg string) error
 	// CurrentBranch returns the current branch
 	CurrentBranch() (string, error)
 	// DeleteBranch deletes the specified branch
@@ -318,51 +318,10 @@ func (w *workTree) CreateOrphanedBranch(branch string) error {
 	return w.Clean()
 }
 
-// TagOptions represents options for creating a new git tag.
-type TagOptions struct {
-	// Tagger is the tagger of the tag. If nil, the default tagger already
-	// configured in the git repository will be used.
-	Tagger *User
-}
-
-func (w *workTree) CreateTag(tag, msg string, opts *TagOptions) error {
-	if opts == nil {
-		opts = &TagOptions{}
-	}
-
-	var homeDir string
-	// This tagger is specific to this tag, so we will override repository-level
-	// user information by creating a temporary home directory, configuring the
-	// user information "globally" within it, and then ensuring the git tag
-	// command uses that home directory.
-	if opts.Tagger != nil {
-		var err error
-		if homeDir, err = os.MkdirTemp(w.homeDir, ""); err != nil {
-			return fmt.Errorf(
-				"error creating virtual home directory %q for tag command: %w",
-				homeDir, err,
-			)
-		}
-		defer func() {
-			if cleanErr := os.RemoveAll(homeDir); cleanErr != nil {
-				logging.LoggerFromContext(context.TODO()).
-					Error(cleanErr, "error removing virtual home directory", "path", homeDir)
-			}
-		}()
-		if err = w.setupUser(homeDir, opts.Tagger); err != nil {
-			return fmt.Errorf(
-				"error setting up author information for tag command: %w", err,
-			)
-		}
-	}
-
+func (w *workTree) CreateTag(tag, msg string) error {
 	cmd := w.buildGitCommand("tag", "-a", tag, "-m", msg)
-	if homeDir != "" {
-		// Override the home directory set by w.buildGitCommand().
-		w.setCmdHome(cmd, homeDir)
-	}
 	if _, err := libExec.Exec(cmd); err != nil {
-		return fmt.Errorf("error creating signed tag %q", err)
+		return fmt.Errorf("error creating annotated tag %q: %w", tag, err)
 	}
 	return nil
 }
@@ -702,11 +661,6 @@ type PushOptions struct {
 	// pushing. If empty or set to PushIntegrationPolicyNone, no integration
 	// is performed.
 	IntegrationPolicy PushIntegrationPolicy
-	// Committer is the identity used as the committer for merge commits or
-	// replacement commits created when integrating remote changes before
-	// pushing. If nil, the default author already configured in the git
-	// repository will be used.
-	Committer *User
 	// Tag specifies a tag to push to the remote repository. If this field and
 	// TargetBranch are both non-empty, this field takes precedence and the tag
 	// will be pushed -- the branch will not.
@@ -753,7 +707,7 @@ func (w *workTree) Push(opts *PushOptions) error {
 		if exists {
 			if err = w.integrateBeforePush(
 				targetBranch,
-				opts.Committer, opts.IntegrationPolicy,
+				opts.IntegrationPolicy,
 			); err != nil {
 				return err
 			}

--- a/pkg/promotion/runner/builtin/git_pusher.go
+++ b/pkg/promotion/runner/builtin/git_pusher.go
@@ -157,13 +157,6 @@ func (g *gitPushPusher) run(
 		IntegrationPolicy: g.integrationPolicy,
 		Force:             cfg.Force,
 	}
-	if cfg.Committer != nil {
-		pushOpts.Committer = &git.User{
-			Name:       cfg.Committer.Name,
-			Email:      cfg.Committer.Email,
-			SigningKey: cfg.Committer.SigningKey,
-		}
-	}
 	// If we're supposed to generate a target branch name, do so.
 	if cfg.GenerateTargetBranch {
 		// TargetBranch and GenerateTargetBranch are mutually exclusive, so we're

--- a/pkg/promotion/runner/builtin/git_pusher_test.go
+++ b/pkg/promotion/runner/builtin/git_pusher_test.go
@@ -224,7 +224,7 @@ func Test_gitPusher_run(t *testing.T) {
 	require.NoError(t, err)
 
 	// Tag the commit so we can also test pushing tags later.
-	require.NoError(t, workTree.CreateTag("v1.0.0", "hello", nil))
+	require.NoError(t, workTree.CreateTag("v1.0.0", "hello"))
 
 	// Set up a fake git provider
 	// Cannot register multiple providers with the same name, so this takes

--- a/pkg/promotion/runner/builtin/git_tagger.go
+++ b/pkg/promotion/runner/builtin/git_tagger.go
@@ -73,17 +73,7 @@ func (g *gitTagTagger) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
-	var tagOpts *git.TagOptions
-	if cfg.Tagger != nil {
-		tagOpts = &git.TagOptions{
-			Tagger: &git.User{
-				Name:       cfg.Tagger.Name,
-				Email:      cfg.Tagger.Email,
-				SigningKey: cfg.Tagger.SigningKey,
-			},
-		}
-	}
-	if err = workTree.CreateTag(cfg.Tag, cfg.Message, tagOpts); err != nil {
+	if err = workTree.CreateTag(cfg.Tag, cfg.Message); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error creating tag %s: %w", cfg.Tag, err)
 	}

--- a/pkg/promotion/runner/builtin/schemas/git-commit-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-commit-config.json
@@ -7,22 +7,26 @@
   "properties": {
     "author": {
       "type": "object",
-      "description": "Optional authorship information for the commit. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
+      "description": "Optional authorship information for the commit. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0. Configure authorship in the `git-clone` step instead.",
+      "deprecated": true,
       "additionalProperties": false,
       "properties": {
         "email": {
           "type": "string",
-          "description": "The email of the author.",
+          "description": "The email of the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0.",
+          "deprecated": true,
           "format": "email"
         },
         "name": {
           "type": "string",
-          "description": "The name of the author.",
+          "description": "The name of the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0.",
+          "deprecated": true,
           "minLength": 1
         },
         "signingKey": {
           "type": "string",
-          "description": "The GPG signing key for the author. If provided, 'email' and 'name' must match the key's UID." 
+          "description": "The GPG signing key for the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0. Configure signing keys in the `git-clone` step or via ClusterConfig instead.",
+          "deprecated": true
         }
       },
       "required": ["name", "email"]

--- a/pkg/promotion/runner/builtin/schemas/git-push-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-push-config.json
@@ -20,28 +20,6 @@
       "description": "The path to a working directory of a local repository.",
       "minLength": 1
     },
-    "committer": {
-      "type": "object",
-      "description": "Optional committer information for merge commits or replacement commits created when integrating remote changes before pushing. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
-      "additionalProperties": false,
-      "properties": {
-        "email": {
-          "type": "string",
-          "description": "The email of the committer.",
-          "format": "email"
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the committer.",
-          "minLength": 1
-        },
-        "signingKey": {
-          "type": "string",
-          "description": "A GPG signing key for the committer. If provided, 'email' and 'name' must match the key's UID."
-        }
-      },
-      "required": ["name", "email"]
-    },
     "targetBranch": {
       "type": "string",
       "description": "The target branch to push to. Mutually exclusive with 'generateTargetBranch=true' and 'tag'. If none of these are provided, the target branch will be the currently checked out branch."

--- a/pkg/promotion/runner/builtin/schemas/git-tag-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-tag-config.json
@@ -3,28 +3,6 @@
   "title": "GitTagConfig",
   "type": "object",
   "properties": {
-    "tagger": {
-      "type": "object",
-      "description": "Optional tagger information for the tag. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
-      "additionalProperties": false,
-      "properties": {
-        "email": {
-          "type": "string",
-          "description": "The email of the tagger.",
-          "format": "email"
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the tagger.",
-          "minLength": 1
-        },
-        "signingKey": {
-          "type": "string",
-          "description": "The GPG signing key for the tagger. If provided, 'email' and 'name' must match the key's UID." 
-        }
-      },
-      "required": ["name", "email"]
-    },
     "message": {
       "type": "string",
       "description": "The annotation message for the tag.",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -295,11 +295,6 @@ type GitOpenPRConfig struct {
 }
 
 type GitPushConfig struct {
-	// Optional committer information for merge commits or replacement commits created when
-	// integrating remote changes before pushing. If provided, this takes precedence over both
-	// system-level defaults and any optional, default authorship information configured in the
-	// `git-clone` step.
-	Committer *Committer `json:"committer,omitempty"`
 	// Whether to force push to the target branch, overwriting any existing history. This is
 	// useful for scenarios where you want to completely replace the branch content (e.g.,
 	// pushing rendered manifests that don't depend on previous state). Use with caution as this
@@ -333,20 +328,6 @@ type GitPushConfig struct {
 	TargetBranch string `json:"targetBranch,omitempty"`
 }
 
-// Optional committer information for merge commits or replacement commits created when
-// integrating remote changes before pushing. If provided, this takes precedence over both
-// system-level defaults and any optional, default authorship information configured in the
-// `git-clone` step.
-type Committer struct {
-	// The email of the committer.
-	Email string `json:"email"`
-	// The name of the committer.
-	Name string `json:"name"`
-	// A GPG signing key for the committer. If provided, 'email' and 'name' must match the key's
-	// UID.
-	SigningKey string `json:"signingKey,omitempty"`
-}
-
 type GitTagConfig struct {
 	// The annotation message for the tag.
 	Message string `json:"message"`
@@ -354,23 +335,6 @@ type GitTagConfig struct {
 	Path string `json:"path"`
 	// The tag to create in the repository.
 	Tag string `json:"tag"`
-	// Optional tagger information for the tag. If provided, this takes precedence over both
-	// system-level defaults and any optional, default authorship information configured in the
-	// `git-clone` step.
-	Tagger *Tagger `json:"tagger,omitempty"`
-}
-
-// Optional tagger information for the tag. If provided, this takes precedence over both
-// system-level defaults and any optional, default authorship information configured in the
-// `git-clone` step.
-type Tagger struct {
-	// The email of the tagger.
-	Email string `json:"email"`
-	// The name of the tagger.
-	Name string `json:"name"`
-	// The GPG signing key for the tagger. If provided, 'email' and 'name' must match the key's
-	// UID.
-	SigningKey string `json:"signingKey,omitempty"`
 }
 
 type GitWaitForPRConfig struct {

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -223,7 +223,8 @@ type Checkout struct {
 type GitCommitConfig struct {
 	// Optional authorship information for the commit. If provided, this takes precedence over
 	// both system-level defaults and any optional, default authorship information configured in
-	// the `git-clone` step.
+	// the `git-clone` step. Deprecated: This field is deprecated as of v1.10.0 and will be
+	// removed in v1.13.0. Configure authorship in the `git-clone` step instead.
 	Author *GitCommitConfigAuthor `json:"author,omitempty"`
 	// The commit message.
 	Message string `json:"message"`
@@ -233,14 +234,18 @@ type GitCommitConfig struct {
 
 // Optional authorship information for the commit. If provided, this takes precedence over
 // both system-level defaults and any optional, default authorship information configured in
-// the `git-clone` step.
+// the `git-clone` step. Deprecated: This field is deprecated as of v1.10.0 and will be
+// removed in v1.13.0. Configure authorship in the `git-clone` step instead.
 type GitCommitConfigAuthor struct {
-	// The email of the author.
+	// The email of the author. Deprecated: This field is deprecated as of v1.10.0 and will be
+	// removed in v1.13.0.
 	Email string `json:"email"`
-	// The name of the author.
+	// The name of the author. Deprecated: This field is deprecated as of v1.10.0 and will be
+	// removed in v1.13.0.
 	Name string `json:"name"`
-	// The GPG signing key for the author. If provided, 'email' and 'name' must match the key's
-	// UID.
+	// The GPG signing key for the author. Deprecated: This field is deprecated as of v1.10.0
+	// and will be removed in v1.13.0. Configure signing keys in the `git-clone` step or via
+	// ClusterConfig instead.
 	SigningKey string `json:"signingKey,omitempty"`
 }
 

--- a/ui/src/gen/directives/git-commit-config.json
+++ b/ui/src/gen/directives/git-commit-config.json
@@ -6,22 +6,26 @@
  "properties": {
   "author": {
    "type": "object",
-   "description": "Optional authorship information for the commit. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
+   "description": "Optional authorship information for the commit. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0. Configure authorship in the `git-clone` step instead.",
+   "deprecated": true,
    "additionalProperties": false,
    "properties": {
     "email": {
      "type": "string",
-     "description": "The email of the author.",
+     "description": "The email of the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0.",
+     "deprecated": true,
      "format": "email"
     },
     "name": {
      "type": "string",
-     "description": "The name of the author.",
+     "description": "The name of the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0.",
+     "deprecated": true,
      "minLength": 1
     },
     "signingKey": {
      "type": "string",
-     "description": "The GPG signing key for the author. If provided, 'email' and 'name' must match the key's UID."
+     "description": "The GPG signing key for the author. Deprecated: This field is deprecated as of v1.10.0 and will be removed in v1.13.0. Configure signing keys in the `git-clone` step or via ClusterConfig instead.",
+     "deprecated": true
     }
    }
   },

--- a/ui/src/gen/directives/git-push-config.json
+++ b/ui/src/gen/directives/git-push-config.json
@@ -19,27 +19,6 @@
    "description": "The path to a working directory of a local repository.",
    "minLength": 1
   },
-  "committer": {
-   "type": "object",
-   "description": "Optional committer information for merge commits or replacement commits created when integrating remote changes before pushing. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
-   "additionalProperties": false,
-   "properties": {
-    "email": {
-     "type": "string",
-     "description": "The email of the committer.",
-     "format": "email"
-    },
-    "name": {
-     "type": "string",
-     "description": "The name of the committer.",
-     "minLength": 1
-    },
-    "signingKey": {
-     "type": "string",
-     "description": "A GPG signing key for the committer. If provided, 'email' and 'name' must match the key's UID."
-    }
-   }
-  },
   "targetBranch": {
    "type": "string",
    "description": "The target branch to push to. Mutually exclusive with 'generateTargetBranch=true' and 'tag'. If none of these are provided, the target branch will be the currently checked out branch."

--- a/ui/src/gen/directives/git-tag-config.json
+++ b/ui/src/gen/directives/git-tag-config.json
@@ -3,27 +3,6 @@
  "title": "GitTagConfig",
  "type": "object",
  "properties": {
-  "tagger": {
-   "type": "object",
-   "description": "Optional tagger information for the tag. If provided, this takes precedence over both system-level defaults and any optional, default authorship information configured in the `git-clone` step.",
-   "additionalProperties": false,
-   "properties": {
-    "email": {
-     "type": "string",
-     "description": "The email of the tagger.",
-     "format": "email"
-    },
-    "name": {
-     "type": "string",
-     "description": "The name of the tagger.",
-     "minLength": 1
-    },
-    "signingKey": {
-     "type": "string",
-     "description": "The GPG signing key for the tagger. If provided, 'email' and 'name' must match the key's UID."
-    }
-   }
-  },
   "message": {
    "type": "string",
    "description": "The annotation message for the tag.",


### PR DESCRIPTION
Remove step-level git user and signing key overrides from `git-push`, `git-tag`, and the git library's remote change integration code. These options were added in this release cycle but are unnecessary — `git-clone` is the single authority for configuring the work tree's identity and signing key, and all downstream steps inherit that configuration.

The `committer` and `tagger` options on `git-push` and `git-tag` have not yet appeared in any release, so they can be removed cleanly without deprecation. The `author` field on `git-commit` shipped in v1.9, so it is deprecated here with removal targeted for v1.13.0.

- Remove `committer` (name/email/signingKey) from `git-push` schema, step runner, and docs
- Remove `tagger` (name/email/signingKey) from `git-tag` schema, step runner, and docs
- Remove `Committer` from `PushOptions` and `TagOptions` from the git library; simplify `CreateTag`, `integrateBeforePush`, and all internal functions that accepted a `homeDir` override for per-step identity switching
- Deprecate `author` (name/email/signingKey) on `git-commit` (shipped in v1.9, removal in v1.13.0) with schema and doc notices pointing to `git-clone` and `ClusterConfig` as replacements
