### PR TITLE
chore: upgrade base image to openssh~10

### DIFF
--- a/kargo-base.apko.yaml
+++ b/kargo-base.apko.yaml
@@ -10,7 +10,7 @@ contents:
   - gpg~2
   - gpg-agent~2
   - helm~3 # Required for Kustomize Helm plugin
-  - openssh-client~9
+  - openssh-client~10
   - tini
 
 accounts:


### PR DESCRIPTION
apko no longer has openssh 9.x