### PR TITLE
fix(controller): Fix flapping owner reference write

### DIFF
--- a/pkg/controller/management/namespaces/namespaces.go
+++ b/pkg/controller/management/namespaces/namespaces.go
@@ -131,6 +131,10 @@ func (r *reconciler) Reconcile(
 	// and that we don't end up with namespaces that can't be deleted
 	// because they have a non-existent project owner reference.
 	// For more information see: https://github.com/akuity/kargo/issues/4627#issuecomment-3821967156
+	//
+	// The Project reconciler no longer sets this owner reference, so for newly
+	// reconciled namespaces this is a no-op. It is retained to clean up
+	// namespaces that were created by older Kargo versions.
 	project := &kargoapi.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: ns.Name},
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -13,7 +13,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -118,12 +117,6 @@ type reconciler struct {
 		context.Context,
 		client.Object,
 		...client.DeleteOption,
-	) error
-
-	patchOwnerReferencesFn func(
-		context.Context,
-		client.Client,
-		client.Object,
 	) error
 
 	ensureFinalizerFn func(
@@ -254,7 +247,6 @@ func newReconciler(kubeClient client.Client, cfg ReconcilerConfig) *reconciler {
 	r.getNamespaceFn = r.client.Get
 	r.createNamespaceFn = r.client.Create
 	r.deleteNamespaceFn = r.client.Delete
-	r.patchOwnerReferencesFn = api.PatchOwnerReferences
 	r.ensureFinalizerFn = api.EnsureFinalizer
 	r.removeFinalizerFn = api.RemoveFinalizer
 	r.ensureSystemPermissionsFn = r.ensureSystemPermissions
@@ -577,12 +569,14 @@ func (r *reconciler) syncProject(
 func (r *reconciler) ensureNamespace(ctx context.Context, project *kargoapi.Project) error {
 	logger := logging.LoggerFromContext(ctx).WithValues("project", project.Name)
 
-	ownerRef := metav1.NewControllerRef(
-		project,
-		kargoapi.GroupVersion.WithKind("Project"),
-	)
-	ownerRef.BlockOwnerDeletion = ptr.To(false)
-	ownerRef.Controller = nil
+	// Note: We intentionally do not set an owner reference from the Namespace to the Project.
+	// Two-way deletion semantics between a Project and its Namespace are instead implemented via
+	// finalizers: this controller adds a finalizer to the Namespace, and the Namespace reconciler
+	// uses it to delete the Project when the Namespace is deleted. Owner references are avoided
+	// because they break foreground cascade deletion of the Project (the Namespace would block on
+	// garbage collection) and can leave the Namespace pointing at a non-existent Project. See
+	// https://github.com/akuity/kargo/issues/4627. The Namespace reconciler strips any Project
+	// owner reference it finds.
 
 	ns := &corev1.Namespace{}
 	if err := r.getNamespaceFn(
@@ -609,47 +603,6 @@ func (r *reconciler) ensureNamespace(ctx context.Context, project *kargoapi.Proj
 		if updated {
 			logger.Debug("added finalizer to namespace")
 		}
-
-		for i, ownerRef := range ns.OwnerReferences {
-			if ownerRef.UID == project.UID {
-				logger.Debug("namespace exists and is already owned by this Project")
-				if ownerRef.Controller != nil {
-					logger.Debug("owner reference requires update")
-					ns.OwnerReferences[i].Controller = nil // Update in place
-					if err = r.patchOwnerReferencesFn(ctx, r.client, ns); err != nil {
-						return fmt.Errorf(
-							"error patching namespace %q owner references: %w",
-							project.Name, err,
-						)
-					}
-					logger.Debug("updated owner reference")
-				}
-				return nil
-			}
-		}
-
-		// If we get to here, the Project is not already an owner of the existing
-		// namespace.
-		logger.Debug(
-			"namespace exists, is not owned by this Project, but has the " +
-				"project label; Project will adopt it",
-		)
-
-		// Note: We allow multiple owners of a namespace due to the not entirely
-		// uncommon scenario where an organization has its own controller that
-		// creates and initializes namespaces to ensure compliance with
-		// internal policies. Such a controller might already own the namespace.
-		ns.OwnerReferences = append(ns.OwnerReferences, *ownerRef)
-		if err = r.patchOwnerReferencesFn(ctx, r.client, ns); err != nil {
-			return fmt.Errorf(
-				"error patching namespace %q with project %q as owner: %w",
-				project.Name,
-				project.Name,
-				err,
-			)
-		}
-		logger.Debug("patched namespace with Project as owner")
-
 		return nil
 	}
 
@@ -664,14 +617,8 @@ func (r *reconciler) ensureNamespace(ctx context.Context, project *kargoapi.Proj
 			Labels: map[string]string{
 				kargoapi.LabelKeyProject: kargoapi.LabelValueTrue,
 			},
-			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 	}
-	// Project namespaces are owned by a Project. Deleting a Project automatically
-	// deletes the namespace. But we also want this to work in the other
-	// direction, where that behavior is not automatic. We add a finalizer to the
-	// namespace and use our own namespace reconciler to clear it after deleting
-	// the Project.
 	controllerutil.AddFinalizer(ns, kargoapi.FinalizerName)
 	if err := r.createNamespaceFn(ctx, ns); err != nil {
 		return fmt.Errorf("error creating namespace %q: %w", project.Name, err)

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -37,7 +37,6 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, r.getNamespaceFn)
 	require.NotNil(t, r.createNamespaceFn)
 	require.NotNil(t, r.deleteNamespaceFn)
-	require.NotNil(t, r.patchOwnerReferencesFn)
 	require.NotNil(t, r.ensureFinalizerFn)
 	require.NotNil(t, r.removeFinalizerFn)
 	require.NotNil(t, r.ensureSystemPermissionsFn)
@@ -719,17 +718,6 @@ func TestReconciler_cleanupProject(t *testing.T) {
 					ns, ok := obj.(*corev1.Namespace)
 					require.True(t, ok)
 					ns.Name = "test-project"
-					ns.OwnerReferences = []metav1.OwnerReference{
-						{UID: "project-uid"},
-						{UID: "other-uid"},
-					}
-					return nil
-				},
-				patchOwnerReferencesFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
-				) error {
 					return nil
 				},
 				removeFinalizerFn: func(
@@ -1225,45 +1213,8 @@ func TestReconciler_ensureNamespace(t *testing.T) {
 			},
 		},
 		{
-			name: "namespace exists, is labeled as a project namespace, and is " +
-				"already owned by the project",
-			project: &kargoapi.Project{
-				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("fake-uid"),
-				},
-			},
-			reconciler: &reconciler{
-				ensureFinalizerFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
-				) (bool, error) {
-					return false, nil
-				},
-				getNamespaceFn: func(
-					_ context.Context,
-					_ types.NamespacedName,
-					obj client.Object,
-					_ ...client.GetOption,
-				) error {
-					ns, ok := obj.(*corev1.Namespace)
-					require.True(t, ok)
-					ns.Labels = map[string]string{
-						kargoapi.LabelKeyProject: kargoapi.LabelValueTrue,
-					}
-					ns.OwnerReferences = []metav1.OwnerReference{{
-						UID: "fake-uid",
-					}}
-					return nil
-				},
-			},
-			assertions: func(t *testing.T, err error) {
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "namespace exists, is labeled as a project namespace, and is " +
-				"NOT already owned by the project; error ensuring finalizer",
+			name: "namespace exists, is labeled as a project namespace; " +
+				"error ensuring finalizer",
 			project: &kargoapi.Project{},
 			reconciler: &reconciler{
 				getNamespaceFn: func(
@@ -1293,8 +1244,7 @@ func TestReconciler_ensureNamespace(t *testing.T) {
 			},
 		},
 		{
-			name: "namespace exists, is labeled as a project namespace, and is " +
-				"NOT already owned by the project; error patching it",
+			name:    "namespace exists, is labeled as a project namespace; success",
 			project: &kargoapi.Project{},
 			reconciler: &reconciler{
 				getNamespaceFn: func(
@@ -1311,56 +1261,13 @@ func TestReconciler_ensureNamespace(t *testing.T) {
 					return nil
 				},
 				ensureFinalizerFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
-				) (bool, error) {
-					return false, nil
-				},
-				patchOwnerReferencesFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
-				) error {
-					return errors.New("something went wrong")
-				},
-			},
-			assertions: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "error patching namespace")
-				require.ErrorContains(t, err, "something went wrong")
-			},
-		},
-		{
-			name: "namespace exists, is labeled as a project namespace, and is " +
-				"NOT already owned by the project; success",
-			project: &kargoapi.Project{},
-			reconciler: &reconciler{
-				getNamespaceFn: func(
 					_ context.Context,
-					_ types.NamespacedName,
+					_ client.Client,
 					obj client.Object,
-					_ ...client.GetOption,
-				) error {
-					ns, ok := obj.(*corev1.Namespace)
-					require.True(t, ok)
-					ns.Labels = map[string]string{
-						kargoapi.LabelKeyProject: kargoapi.LabelValueTrue,
-					}
-					return nil
-				},
-				ensureFinalizerFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
 				) (bool, error) {
+					// Smoke/sanity test to ensure we are not adding an owner reference anymore
+					require.Len(t, obj.GetOwnerReferences(), 0)
 					return false, nil
-				},
-				patchOwnerReferencesFn: func(
-					context.Context,
-					client.Client,
-					client.Object,
-				) error {
-					return nil
 				},
 			},
 			assertions: func(t *testing.T, err error) {


### PR DESCRIPTION
As part of the work done in #5763 (and as referenced in #4627), we said we weren't going to use owner references anymore. In fact, because we still have them, we have some thrashing going on because the project controller still writes a reference, and the new code in #5763 added code to the namespace controller that deletes it. This removes the code that adds an owner reference