### PR TITLE
fix: dangling webhook receivers after delete from spec

### DIFF
--- a/pkg/controller/management/clusterconfigs/cluster_configs.go
+++ b/pkg/controller/management/clusterconfigs/cluster_configs.go
@@ -200,6 +200,7 @@ func (r *reconciler) syncWebhookReceivers(
 
 	if len(clusterCfg.Spec.WebhookReceivers) == 0 {
 		logger.Debug("ClusterConfig does not define any webhook receiver configurations")
+		status.WebhookReceivers = nil
 		conditions.Delete(status, kargoapi.ConditionTypeReconciling)
 		conditions.Set(status, &metav1.Condition{
 			Type:               kargoapi.ConditionTypeReady,

--- a/pkg/controller/management/clusterconfigs/cluster_configs_test.go
+++ b/pkg/controller/management/clusterconfigs/cluster_configs_test.go
@@ -48,6 +48,26 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 			},
 		},
 		{
+			name:       "stale webhook receivers are cleared when spec is empty",
+			reconciler: &reconciler{},
+			clusterCfg: &kargoapi.ClusterConfig{
+				Status: kargoapi.ClusterConfigStatus{
+					WebhookReceivers: []kargoapi.WebhookReceiverDetails{{
+						Name: "stale-receiver",
+						Path: "/webhook/github/abc123",
+					}},
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.ClusterConfigStatus, err error) {
+				require.NoError(t, err)
+				require.Empty(t, status.WebhookReceivers)
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+				require.Equal(t, "Synced", readyCondition.Reason)
+			},
+		},
+		{
 			name: "error building receiver",
 			reconciler: &reconciler{
 				cfg: ReconcilerConfig{

--- a/pkg/controller/management/projectconfigs/project_configs.go
+++ b/pkg/controller/management/projectconfigs/project_configs.go
@@ -209,6 +209,7 @@ func (r *reconciler) syncWebhookReceivers(
 
 	if len(projectCfg.Spec.WebhookReceivers) == 0 {
 		logger.Debug("ProjectConfig does not define any webhook receiver configurations")
+		status.WebhookReceivers = nil
 		conditions.Delete(status, kargoapi.ConditionTypeReconciling)
 		conditions.Set(status, &metav1.Condition{
 			Type:               kargoapi.ConditionTypeReady,

--- a/pkg/controller/management/projectconfigs/project_configs_test.go
+++ b/pkg/controller/management/projectconfigs/project_configs_test.go
@@ -51,6 +51,26 @@ func TestReconciler_syncWebhookReceivers(t *testing.T) {
 			},
 		},
 		{
+			name:       "stale webhook receivers are cleared when spec is empty",
+			reconciler: &reconciler{},
+			projectCfg: &kargoapi.ProjectConfig{
+				Status: kargoapi.ProjectConfigStatus{
+					WebhookReceivers: []kargoapi.WebhookReceiverDetails{{
+						Name: "stale-receiver",
+						Path: "/webhook/github/abc123",
+					}},
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.ProjectConfigStatus, err error) {
+				require.NoError(t, err)
+				require.Empty(t, status.WebhookReceivers)
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+				require.Equal(t, "Synced", readyCondition.Reason)
+			},
+		},
+		{
 			name: "error building receiver",
 			reconciler: &reconciler{
 				client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(


### PR DESCRIPTION
Closes: https://github.com/akuityio/kargo-enterprise/issues/675

I found the same bug on the `ClusterConfig` side so applied the same fix there as well.