### PR TITLE
feat: clean up existing locks on gpg keyring when loading an already-clone repo from fs

### DIFF
--- a/pkg/controller/git/base_repo.go
+++ b/pkg/controller/git/base_repo.go
@@ -307,7 +307,10 @@ func (b *baseRepo) saveOriginalURL() error {
 
 // loadHomeDir restores the repository's home directory from the repository's
 // configuration. This is useful for reliably determining this information when
-// an existing repository or working tree is loaded from the file system.
+// an existing repository or working tree is loaded from the file system. It
+// also reconciles any residual GnuPG state in that home directory that may
+// have been left behind by a process in a different container sharing the
+// same underlying filesystem.
 func (b *baseRepo) loadHomeDir() error {
 	res, err := libExec.Exec(b.buildGitCommand(
 		"config",
@@ -317,7 +320,59 @@ func (b *baseRepo) loadHomeDir() error {
 		return fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
 	b.homeDir = strings.TrimSpace(string(res))
+	b.reconcileGPGState()
 	return nil
+}
+
+// reconcileGPGState removes any residual GnuPG lockfiles and stops any stale
+// gpg-agent associated with this repository's GNUPGHOME. Required because in
+// a container-per-step promotion model each step runs in its own container —
+// separate PID namespaces, shared UTS namespace, shared workspace volume.
+// GnuPG's stale-lock heuristic compares (hostname, PID) against /proc; across
+// sibling containers sharing a hostname but not a PID namespace, a lockfile's
+// recorded PID can collide with an unrelated live process in the new
+// container, causing new gpg invocations to wait indefinitely for a
+// non-existent holder and eventually fail with a "Connection timed out"
+// error.
+//
+// Safe to call when no GnuPG state exists (no-op) and in traditional
+// single-process deployments where no cross-container state sharing occurs
+// (effectively a no-op: there are no stale locks to clean).
+func (b *baseRepo) reconcileGPGState() {
+	if b.homeDir == "" {
+		return
+	}
+	gnupgDir := filepath.Join(b.homeDir, ".gnupg")
+	if _, err := os.Stat(gnupgDir); err != nil {
+		return
+	}
+	// Best-effort: stop any gpg-agent bound to this GNUPGHOME. If no agent
+	// is running, gpgconf exits non-zero; ignore it.
+	_, _ = libExec.Exec(b.buildCommand("gpgconf", "--kill", "gpg-agent"))
+	// Remove any stale dotlock files. Dotlock records a (hostname, PID)
+	// pair which becomes ambiguous across containers sharing the workspace
+	// volume (see comment above).
+	patterns := []string{
+		filepath.Join(gnupgDir, "*.lock"),
+		filepath.Join(gnupgDir, "public-keys.d", "*.lock"),
+		filepath.Join(gnupgDir, "private-keys-v1.d", "*.lock"),
+	}
+	logger := logging.LoggerFromContext(context.TODO())
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			if err := os.Remove(match); err != nil && !os.IsNotExist(err) {
+				logger.Error(
+					err,
+					"error removing stale GnuPG lockfile",
+					"file", match,
+				)
+			}
+		}
+	}
 }
 
 // loadURLs restores the repository's original and access URLs from the


### PR DESCRIPTION
## Problem

When git operations happen across multiple containers sharing a single workspace volume (e.g., step containers in a pod that share `.gnupg/` via an emptyDir), GnuPG's dotlock cleanup gets confused. Those containers share a UTS namespace (same hostname) but have separate PID namespaces by default. GnuPG decides whether a dotlock's holder is still live by checking `(hostname, pid)` in `/proc` — a check that's only meaningful within one PID namespace. A lockfile written by a dead process in container A can collide with a live-but-unrelated PID in container B, and `gpg` waits indefinitely for a non-existent holder. The symptom is:

```
gpg: signing failed: Connection timed out
fatal: failed to write commit object
```

Reproduces reliably with many signed commits against one shared `.gnupg/`.

## Solution

Add `reconcileGPGState()` on `baseRepo` — stops any residual `gpg-agent` and removes stale dotlock files (`*.lock`, `public-keys.d/*.lock`, `private-keys-v1.d/*.lock`). Call it from `loadHomeDir()` so every caller that rehydrates an existing repo (`LoadBareRepo`, `LoadWorkTree`, `LoadRepo`) benefits with no changes to call sites or gpg invocation sites.

Single-file change in `pkg/controller/git/base_repo.go`.

## Consequences

- **Typical deployments:** effectively a no-op — fresh repos are created via `MkdirTemp`, so there's nothing to clean.
- **Shared-volume deployments:** fixes the contention at its root; the cleanup runs once per load of a pre-existing repo.
- Errors are best-effort: `gpgconf --kill` failures are swallowed (expected when no agent is running); stale-lock removal failures are logged but don't abort.
- Cost is one `stat`, one short `gpgconf` exec, and a handful of globs/unlinks per repo load.
- No public API or configuration changes.
