### PR TITLE
fix: more thorough cleaning of .gpgnu state when loading an already-c…

### DIFF
--- a/pkg/controller/git/base_repo.go
+++ b/pkg/controller/git/base_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -324,20 +325,42 @@ func (b *baseRepo) loadHomeDir() error {
 	return nil
 }
 
-// reconcileGPGState removes any residual GnuPG lockfiles and stops any stale
-// gpg-agent associated with this repository's GNUPGHOME. Required because in
-// a container-per-step promotion model each step runs in its own container —
-// separate PID namespaces, shared UTS namespace, shared workspace volume.
-// GnuPG's stale-lock heuristic compares (hostname, PID) against /proc; across
-// sibling containers sharing a hostname but not a PID namespace, a lockfile's
-// recorded PID can collide with an unrelated live process in the new
-// container, causing new gpg invocations to wait indefinitely for a
-// non-existent holder and eventually fail with a "Connection timed out"
-// error.
+// reconcileGPGState removes any residual GnuPG state associated with this
+// repository's GNUPGHOME that may have been orphaned by a process in a
+// different container sharing the same underlying filesystem.
+//
+// Required because in a container-per-step promotion model each step runs
+// in its own container — separate PID namespaces, shared UTS namespace,
+// shared workspace volume. Several pieces of GnuPG's on-disk state are
+// process-bound and become hazardous when inherited by a new container:
+//
+//   - *.lock    — committed dotlock files. GnuPG's stale-lock heuristic
+//     compares (hostname, PID) against /proc; across sibling
+//     containers with a shared hostname but independent PID
+//     namespaces, the recorded PID can match an unrelated
+//     live process, causing indefinite waits that end in a
+//     "Connection timed out" signing failure.
+//   - .#lk*     — dotlock temp files created via O_CREAT|O_EXCL before
+//     being hard-linked to the committed .lock file. Their
+//     names embed an in-process memory address + hostname + PID;
+//     under weak ASLR and colliding container PIDs
+//     these names collide too, causing a "File exists"
+//     failure before gpg ever reaches the .lock file.
+//   - UNIX-domain sockets (gpg-agent, dirmngr, scdaemon, etc.). A stale
+//     socket left by a dead daemon in a prior container can
+//     race with a new daemon binding on the same path. After
+//     gpgconf --kill, any socket still present in GNUPGHOME
+//     is by definition stale, so we identify these by file
+//     mode rather than by name — new GnuPG daemons added
+//     upstream are covered automatically.
+//
+// The cleanup walks all of GNUPGHOME rather than enumerating specific
+// subdirectories so that GnuPG layout changes (e.g., the ongoing move
+// toward public-keys.d/pubring.db) are covered automatically.
 //
 // Safe to call when no GnuPG state exists (no-op) and in traditional
 // single-process deployments where no cross-container state sharing occurs
-// (effectively a no-op: there are no stale locks to clean).
+// (also effectively a no-op).
 func (b *baseRepo) reconcileGPGState() {
 	if b.homeDir == "" {
 		return
@@ -346,33 +369,38 @@ func (b *baseRepo) reconcileGPGState() {
 	if _, err := os.Stat(gnupgDir); err != nil {
 		return
 	}
-	// Best-effort: stop any gpg-agent bound to this GNUPGHOME. If no agent
-	// is running, gpgconf exits non-zero; ignore it.
+	// Must run before removing sockets: gpgconf finds the agent via its
+	// sockets and tells it to shut down cleanly.
 	_, _ = libExec.Exec(b.buildCommand("gpgconf", "--kill", "gpg-agent"))
-	// Remove any stale dotlock files. Dotlock records a (hostname, PID)
-	// pair which becomes ambiguous across containers sharing the workspace
-	// volume (see comment above).
-	patterns := []string{
-		filepath.Join(gnupgDir, "*.lock"),
-		filepath.Join(gnupgDir, "public-keys.d", "*.lock"),
-		filepath.Join(gnupgDir, "private-keys-v1.d", "*.lock"),
-	}
+
 	logger := logging.LoggerFromContext(context.TODO())
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			continue
+	remove := func(path string) {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			logger.Error(
+				err,
+				"error removing stale GnuPG state file",
+				"file", path,
+			)
 		}
-		for _, match := range matches {
-			if err := os.Remove(match); err != nil && !os.IsNotExist(err) {
-				logger.Error(
-					err,
-					"error removing stale GnuPG lockfile",
-					"file", match,
-				)
+	}
+	_ = filepath.WalkDir(gnupgDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		switch {
+		case strings.HasSuffix(name, ".lock"),
+			strings.HasPrefix(name, ".#lk"):
+			remove(path)
+		default:
+			// Any remaining UNIX-domain socket in GNUPGHOME belongs to a
+			// dead daemon (we killed the live agent above).
+			if info, statErr := d.Info(); statErr == nil && info.Mode()&os.ModeSocket != 0 {
+				remove(path)
 			}
 		}
-	}
+		return nil
+	})
 }
 
 // loadURLs restores the repository's original and access URLs from the


### PR DESCRIPTION
Follow-up to #6097.

## What #6097 left uncovered

#6097 cleaned committed dotlock files (`*.lock`) from a handful of enumerated subdirectories under `GNUPGHOME`. Testing on heavier workloads surfaced two additional failure modes that the original cleanup doesn't catch:

1. **Orphaned dotlock temp files (`.#lk*`).** GnuPG creates these via `O_CREAT|O_EXCL` before hard-linking them to the committed `.lock` file. Their names embed an in-process memory address + hostname + PID. Under weak ASLR and colliding container PIDs those names can repeat across processes, and a crashed writer's orphan causes the next `gpg` invocation to fail with `gpg: ... File exists` *before it ever reaches the `.lock` file*.

2. **Stale UNIX-domain sockets** left by dead `gpg-agent` / `dirmngr` / `scdaemon` processes. A new daemon binding on the same path can race with the stale socket.

Separately, the original cleanup enumerated specific subdirectories (`GNUPGHOME`, `public-keys.d/`, `private-keys-v1.d/`). That list is brittle — GnuPG's on-disk layout has changed before (the ongoing move toward `public-keys.d/pubring.db`, for instance) and may change again.

## Changes

- Extend `reconcileGPGState` to also remove `.#lk*` orphan temp files.
- Extend it to remove any file with `os.ModeSocket` set — covers `S.gpg-agent*`, `S.dirmngr`, `S.scdaemon`, and any future daemon without needing to know its name. The `gpgconf --kill gpg-agent` invocation still runs first, so anything remaining is by definition stale.
- Replace the enumerated-subdirectory glob loop with a single `filepath.WalkDir` over `GNUPGHOME`, matching files by predicate. Future layout changes are picked up automatically.

Single-file change to `pkg/controller/git/base_repo.go`. No call-site changes.

## Consequences

- Same as #6097: no-op in deployments that create fresh `homeDir`s per repo; fixes the newly-identified hazards in deployments that share a `GNUPGHOME` across process boundaries.
- Preserved files (`pubring.kbx`, `trustdb.gpg`, `random_seed`, `*.key`, `gpg.conf`, revocation certs, SQLite `-wal`/`-shm`/`-journal`, etc.) don't match any predicate and are never touched.
- Errors remain best-effort and logged.
- No public API or configuration changes.
