### PR TITLE
feat: Gitea pull request label support

### DIFF
--- a/pkg/gitprovider/gitea/gitea.go
+++ b/pkg/gitprovider/gitea/gitea.go
@@ -169,7 +169,7 @@ func (p *provider) resolveLabelIDs(labelNames []string) ([]int64, error) {
 		return nil, nil
 	}
 
-	repoLabels := make([]*gitea.Label, 0, len(labelNames))
+	labelIDsByName := make(map[string]int64, len(labelNames))
 	for page := 1; ; {
 		pageLabels, resp, err := p.client.ListRepoLabels(
 			p.owner,
@@ -181,19 +181,16 @@ func (p *provider) resolveLabelIDs(labelNames []string) ([]int64, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error listing repository labels: %w", err)
 		}
-		repoLabels = append(repoLabels, pageLabels...)
+		for _, repoLabel := range pageLabels {
+			if repoLabel == nil {
+				continue
+			}
+			labelIDsByName[repoLabel.Name] = repoLabel.ID
+		}
 		if resp == nil || resp.NextPage == 0 {
 			break
 		}
 		page = resp.NextPage
-	}
-
-	labelIDsByName := make(map[string]int64, len(repoLabels))
-	for _, repoLabel := range repoLabels {
-		if repoLabel == nil {
-			continue
-		}
-		labelIDsByName[repoLabel.Name] = repoLabel.ID
 	}
 
 	labelIDs := make([]int64, 0, len(labelNames))

--- a/pkg/gitprovider/gitea/gitea.go
+++ b/pkg/gitprovider/gitea/gitea.go
@@ -74,13 +74,6 @@ type giteaClient interface {
 		number int64,
 	) (*gitea.PullRequest, *gitea.Response, error)
 
-	AddIssueLabels(
-		owner string,
-		repo string,
-		number int64,
-		opts gitea.IssueLabelsOption,
-	) ([]*gitea.Label, *gitea.Response, error)
-
 	MergePullRequest(
 		owner string,
 		repo string,
@@ -154,10 +147,11 @@ func (p *provider) CreatePullRequest(
 		p.owner,
 		p.repo,
 		gitea.CreatePullRequestOption{
-			Title: opts.Title,
-			Head:  opts.Head,
-			Base:  opts.Base,
-			Body:  opts.Description,
+			Title:  opts.Title,
+			Head:   opts.Head,
+			Base:   opts.Base,
+			Body:   opts.Description,
+			Labels: labelIDs,
 		},
 	)
 	if err != nil {
@@ -165,20 +159,6 @@ func (p *provider) CreatePullRequest(
 	}
 	if giteaPR == nil {
 		return nil, fmt.Errorf("unexpected nil pull request")
-	}
-	if len(labelIDs) > 0 {
-		if _, _, err := p.client.AddIssueLabels(
-			p.owner,
-			p.repo,
-			giteaPR.Index,
-			gitea.IssueLabelsOption{Labels: labelIDs},
-		); err != nil {
-			return nil, fmt.Errorf(
-				"error adding labels to pull request %d: %w",
-				giteaPR.Index,
-				err,
-			)
-		}
 	}
 	pr := convertGiteaPR(*giteaPR)
 	return &pr, nil
@@ -189,13 +169,23 @@ func (p *provider) resolveLabelIDs(labelNames []string) ([]int64, error) {
 		return nil, nil
 	}
 
-	repoLabels, _, err := p.client.ListRepoLabels(
-		p.owner,
-		p.repo,
-		gitea.ListLabelsOptions{},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error listing repository labels: %w", err)
+	repoLabels := make([]*gitea.Label, 0, len(labelNames))
+	for page := 1; ; {
+		pageLabels, resp, err := p.client.ListRepoLabels(
+			p.owner,
+			p.repo,
+			gitea.ListLabelsOptions{
+				ListOptions: gitea.ListOptions{Page: page},
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error listing repository labels: %w", err)
+		}
+		repoLabels = append(repoLabels, pageLabels...)
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		page = resp.NextPage
 	}
 
 	labelIDsByName := make(map[string]int64, len(repoLabels))

--- a/pkg/gitprovider/gitea/gitea.go
+++ b/pkg/gitprovider/gitea/gitea.go
@@ -62,11 +62,24 @@ type giteaClient interface {
 		opts gitea.ListPullRequestsOptions,
 	) ([]*gitea.PullRequest, *gitea.Response, error)
 
+	ListRepoLabels(
+		owner string,
+		repo string,
+		opts gitea.ListLabelsOptions,
+	) ([]*gitea.Label, *gitea.Response, error)
+
 	GetPullRequest(
 		owner string,
 		repo string,
 		number int64,
 	) (*gitea.PullRequest, *gitea.Response, error)
+
+	AddIssueLabels(
+		owner string,
+		repo string,
+		number int64,
+		opts gitea.IssueLabelsOption,
+	) ([]*gitea.Label, *gitea.Response, error)
 
 	MergePullRequest(
 		owner string,
@@ -133,6 +146,10 @@ func (p *provider) CreatePullRequest(
 	if opts == nil {
 		opts = &gitprovider.CreatePullRequestOpts{}
 	}
+	labelIDs, err := p.resolveLabelIDs(opts.Labels)
+	if err != nil {
+		return nil, err
+	}
 	giteaPR, _, err := p.client.CreatePullRequest(
 		p.owner,
 		p.repo,
@@ -149,13 +166,71 @@ func (p *provider) CreatePullRequest(
 	if giteaPR == nil {
 		return nil, fmt.Errorf("unexpected nil pull request")
 	}
-	// TODO(krancour): Add label support. The Gitea SDK's AddIssueLabels expects
-	// label IDs ([]int64), but Kargo's CreatePullRequestOpts.Labels are names
-	// ([]string). A previous implementation attempted this but silently discarded
-	// the labels entirely. To fix properly: list repo labels, match by name to
-	// get IDs, then call AddIssueLabels.
+	if len(labelIDs) > 0 {
+		if _, _, err := p.client.AddIssueLabels(
+			p.owner,
+			p.repo,
+			giteaPR.Index,
+			gitea.IssueLabelsOption{Labels: labelIDs},
+		); err != nil {
+			return nil, fmt.Errorf(
+				"error adding labels to pull request %d: %w",
+				giteaPR.Index,
+				err,
+			)
+		}
+	}
 	pr := convertGiteaPR(*giteaPR)
 	return &pr, nil
+}
+
+func (p *provider) resolveLabelIDs(labelNames []string) ([]int64, error) {
+	if len(labelNames) == 0 {
+		return nil, nil
+	}
+
+	repoLabels, _, err := p.client.ListRepoLabels(
+		p.owner,
+		p.repo,
+		gitea.ListLabelsOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing repository labels: %w", err)
+	}
+
+	labelIDsByName := make(map[string]int64, len(repoLabels))
+	for _, repoLabel := range repoLabels {
+		if repoLabel == nil {
+			continue
+		}
+		labelIDsByName[repoLabel.Name] = repoLabel.ID
+	}
+
+	labelIDs := make([]int64, 0, len(labelNames))
+	seen := make(map[int64]struct{}, len(labelNames))
+	missing := make([]string, 0)
+	for _, labelName := range labelNames {
+		labelID, ok := labelIDsByName[labelName]
+		if !ok {
+			missing = append(missing, labelName)
+			continue
+		}
+		if _, ok := seen[labelID]; ok {
+			continue
+		}
+		seen[labelID] = struct{}{}
+		labelIDs = append(labelIDs, labelID)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf(
+			"labels not found in repository %s/%s: %s",
+			p.owner,
+			p.repo,
+			strings.Join(missing, ", "),
+		)
+	}
+
+	return labelIDs, nil
 }
 
 // GetPullRequest implements gitprovider.Interface.

--- a/pkg/gitprovider/gitea/gitea_test.go
+++ b/pkg/gitprovider/gitea/gitea_test.go
@@ -85,6 +85,7 @@ type mockGiteaClient struct {
 	owner              string
 	repo               string
 	issueLabelsOptions gitea.IssueLabelsOption
+	repoLabelsOpts     gitea.ListLabelsOptions
 	listOpts           gitea.ListPullRequestsOptions
 }
 
@@ -125,6 +126,26 @@ func (m *mockGiteaClient) GetPullRequest(
 		return pr, nil, args.Error(2)
 	}
 	return pr, resp, args.Error(2)
+}
+
+func (m *mockGiteaClient) ListRepoLabels(
+	owner string,
+	repo string,
+	opts gitea.ListLabelsOptions,
+) ([]*gitea.Label, *gitea.Response, error) {
+	args := m.Called(owner, repo, opts)
+	m.owner = owner
+	m.repo = repo
+	m.repoLabelsOpts = opts
+	labels, ok := args.Get(0).([]*gitea.Label)
+	if !ok {
+		return nil, nil, args.Error(2)
+	}
+	resp, ok := args.Get(1).(*gitea.Response)
+	if !ok {
+		return labels, nil, args.Error(2)
+	}
+	return labels, resp, args.Error(2)
 }
 
 func (m *mockGiteaClient) AddIssueLabels(
@@ -250,6 +271,128 @@ func TestCreatePullRequest(t *testing.T) {
 	require.Equal(t, mockClient.pr.Base.Sha, pr.MergeCommitSHA)
 	require.Equal(t, mockClient.pr.URL, pr.URL)
 	require.True(t, pr.Open)
+}
+
+func TestCreatePullRequestWithLabels(t *testing.T) {
+	opts := gitprovider.CreatePullRequestOpts{
+		Head:        "feature-branch",
+		Base:        "main",
+		Title:       "title",
+		Description: "desc",
+		Labels:      []string{"label1", "label2"},
+	}
+
+	mockClient := &mockGiteaClient{
+		pr: &gitea.PullRequest{
+			Index: int64(42),
+			State: gitea.StateOpen,
+			Head: &gitea.PRBranchInfo{
+				Sha: "HeadSha",
+			},
+			Base: &gitea.PRBranchInfo{
+				Sha: "BaseSha",
+			},
+			URL:            "http://localhost:8080",
+			MergedCommitID: ptr.To("2994fd93"),
+			HasMerged:      false,
+		},
+	}
+	mockClient.
+		On("ListRepoLabels", testRepoOwner, testRepoName, gitea.ListLabelsOptions{}).
+		Return(
+			[]*gitea.Label{
+				{ID: 101, Name: "label1"},
+				{ID: 202, Name: "label2"},
+			},
+			&gitea.Response{},
+			nil,
+		)
+	mockClient.
+		On("CreatePullRequest", testRepoOwner, testRepoName, mock.Anything).
+		Return(
+			&gitea.PullRequest{
+				Index: int64(42),
+				State: gitea.StateOpen,
+				Head: &gitea.PRBranchInfo{
+					Sha: "HeadSha",
+				},
+				Base: &gitea.PRBranchInfo{
+					Sha: "BaseSha",
+				},
+				URL:            "http://localhost:8080",
+				MergedCommitID: ptr.To("BaseSha"),
+				HasMerged:      false,
+				Created:        &time.Time{},
+			},
+			&gitea.Response{},
+			nil,
+		)
+	mockClient.
+		On(
+			"AddIssueLabels",
+			testRepoOwner,
+			testRepoName,
+			int64(42),
+			gitea.IssueLabelsOption{Labels: []int64{101, 202}},
+		).
+		Return([]*gitea.Label{}, &gitea.Response{}, nil)
+
+	g := provider{
+		owner:  testRepoOwner,
+		repo:   testRepoName,
+		client: mockClient,
+	}
+	pr, err := g.CreatePullRequest(t.Context(), &opts)
+
+	mockClient.AssertExpectations(t)
+
+	require.NoError(t, err)
+	require.Equal(t, testRepoOwner, mockClient.owner)
+	require.Equal(t, testRepoName, mockClient.repo)
+	require.Equal(t, opts.Head, mockClient.newPr.Head)
+	require.Equal(t, opts.Base, mockClient.newPr.Base)
+	require.Equal(t, opts.Title, mockClient.newPr.Title)
+	require.Equal(t, opts.Description, mockClient.newPr.Body)
+	require.Equal(t, []int64{101, 202}, mockClient.issueLabelsOptions.Labels)
+	require.Equal(t, mockClient.pr.Index, pr.Number)
+	require.Equal(t, mockClient.pr.Base.Sha, pr.MergeCommitSHA)
+	require.Equal(t, mockClient.pr.URL, pr.URL)
+	require.True(t, pr.Open)
+}
+
+func TestCreatePullRequestWithMissingLabels(t *testing.T) {
+	opts := gitprovider.CreatePullRequestOpts{
+		Head:        "feature-branch",
+		Base:        "main",
+		Title:       "title",
+		Description: "desc",
+		Labels:      []string{"label1", "missing"},
+	}
+
+	mockClient := &mockGiteaClient{}
+	mockClient.
+		On("ListRepoLabels", testRepoOwner, testRepoName, gitea.ListLabelsOptions{}).
+		Return(
+			[]*gitea.Label{
+				{ID: 101, Name: "label1"},
+			},
+			&gitea.Response{},
+			nil,
+		)
+
+	g := provider{
+		owner:  testRepoOwner,
+		repo:   testRepoName,
+		client: mockClient,
+	}
+	pr, err := g.CreatePullRequest(t.Context(), &opts)
+
+	mockClient.AssertExpectations(t)
+
+	require.Nil(t, pr)
+	require.ErrorContains(t, err, "labels not found")
+	mockClient.AssertNotCalled(t, "CreatePullRequest", mock.Anything, mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "AddIssueLabels", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestGetPullRequest(t *testing.T) {

--- a/pkg/gitprovider/gitea/gitea_test.go
+++ b/pkg/gitprovider/gitea/gitea_test.go
@@ -298,7 +298,14 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 		},
 	}
 	mockClient.
-		On("ListRepoLabels", testRepoOwner, testRepoName, gitea.ListLabelsOptions{}).
+		On(
+			"ListRepoLabels",
+			testRepoOwner,
+			testRepoName,
+			gitea.ListLabelsOptions{
+				ListOptions: gitea.ListOptions{Page: 1},
+			},
+		).
 		Return(
 			[]*gitea.Label{
 				{ID: 101, Name: "label1"},
@@ -327,16 +334,6 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 			&gitea.Response{},
 			nil,
 		)
-	mockClient.
-		On(
-			"AddIssueLabels",
-			testRepoOwner,
-			testRepoName,
-			int64(42),
-			gitea.IssueLabelsOption{Labels: []int64{101, 202}},
-		).
-		Return([]*gitea.Label{}, &gitea.Response{}, nil)
-
 	g := provider{
 		owner:  testRepoOwner,
 		repo:   testRepoName,
@@ -353,11 +350,19 @@ func TestCreatePullRequestWithLabels(t *testing.T) {
 	require.Equal(t, opts.Base, mockClient.newPr.Base)
 	require.Equal(t, opts.Title, mockClient.newPr.Title)
 	require.Equal(t, opts.Description, mockClient.newPr.Body)
-	require.Equal(t, []int64{101, 202}, mockClient.issueLabelsOptions.Labels)
+	require.Equal(t, []int64{101, 202}, mockClient.newPr.Labels)
 	require.Equal(t, mockClient.pr.Index, pr.Number)
 	require.Equal(t, mockClient.pr.Base.Sha, pr.MergeCommitSHA)
 	require.Equal(t, mockClient.pr.URL, pr.URL)
 	require.True(t, pr.Open)
+	mockClient.AssertNotCalled(
+		t,
+		"AddIssueLabels",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	)
 }
 
 func TestCreatePullRequestWithMissingLabels(t *testing.T) {
@@ -371,7 +376,14 @@ func TestCreatePullRequestWithMissingLabels(t *testing.T) {
 
 	mockClient := &mockGiteaClient{}
 	mockClient.
-		On("ListRepoLabels", testRepoOwner, testRepoName, gitea.ListLabelsOptions{}).
+		On(
+			"ListRepoLabels",
+			testRepoOwner,
+			testRepoName,
+			gitea.ListLabelsOptions{
+				ListOptions: gitea.ListOptions{Page: 1},
+			},
+		).
 		Return(
 			[]*gitea.Label{
 				{ID: 101, Name: "label1"},
@@ -393,6 +405,57 @@ func TestCreatePullRequestWithMissingLabels(t *testing.T) {
 	require.ErrorContains(t, err, "labels not found")
 	mockClient.AssertNotCalled(t, "CreatePullRequest", mock.Anything, mock.Anything, mock.Anything)
 	mockClient.AssertNotCalled(t, "AddIssueLabels", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestResolveLabelIDsPagesThroughAllRepositoryLabels(t *testing.T) {
+	mockClient := &mockGiteaClient{}
+	mockClient.
+		On(
+			"ListRepoLabels",
+			testRepoOwner,
+			testRepoName,
+			gitea.ListLabelsOptions{
+				ListOptions: gitea.ListOptions{Page: 1},
+			},
+		).
+		Return(
+			[]*gitea.Label{
+				{ID: 101, Name: "label1"},
+			},
+			&gitea.Response{NextPage: 2},
+			nil,
+		).
+		Once()
+	mockClient.
+		On(
+			"ListRepoLabels",
+			testRepoOwner,
+			testRepoName,
+			gitea.ListLabelsOptions{
+				ListOptions: gitea.ListOptions{Page: 2},
+			},
+		).
+		Return(
+			[]*gitea.Label{
+				{ID: 202, Name: "label2"},
+			},
+			&gitea.Response{},
+			nil,
+		).
+		Once()
+
+	g := provider{
+		owner:  testRepoOwner,
+		repo:   testRepoName,
+		client: mockClient,
+	}
+
+	labelIDs, err := g.resolveLabelIDs([]string{"label1", "label2"})
+
+	mockClient.AssertExpectations(t)
+
+	require.NoError(t, err)
+	require.Equal(t, []int64{101, 202}, labelIDs)
 }
 
 func TestGetPullRequest(t *testing.T) {


### PR DESCRIPTION
Fixes #6021

## Summary
- resolve configured Gitea label names to repository label IDs ( with pagination support ) before creating the PR
- add regression coverage for both the successful label pagination path and missing-label validation

## Testing
- `go test ./pkg/gitprovider/gitea`
- `./hack/bin/golangci-lint run --config .golangci.yaml ./pkg/gitprovider/gitea/...`