### PR TITLE
fix(ui): preserve filters when switching tabs in promote drawer

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
@@ -1,7 +1,7 @@
 import { faDocker, faGitAlt } from '@fortawesome/free-brands-svg-icons';
 import { faAnchor, faFilter, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Checkbox, Select, SelectProps } from 'antd';
+import { Badge, Button, Checkbox, Select, SelectProps } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 
@@ -24,6 +24,11 @@ type FreightTimelineFiltersProps = {
 };
 
 export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
+  const isFilterActive =
+    (props.preferredFilter?.sources?.length ?? 0) > 0 ||
+    props.preferredFilter?.timerange !== 'all-time' ||
+    props.preferredFilter?.hideUnusedFreights === true;
+
   const sourcesDropdownOptions: SelectProps['options'] = useMemo(() => {
     const freightSourcesCatalogue = catalogueFreights(props.freights);
 
@@ -63,9 +68,11 @@ export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
           </div>
         )}
 
-        <Button size='small' className='ml-auto' onClick={props.onCollapseToggle}>
-          <FontAwesomeIcon icon={props.collapsed ? faFilter : faTimes} />
-        </Button>
+        <Badge dot={props.collapsed && isFilterActive} offset={[-2, 2]} className='ml-auto'>
+          <Button size='small' onClick={props.onCollapseToggle}>
+            <FontAwesomeIcon icon={props.collapsed ? faFilter : faTimes} />
+          </Button>
+        </Badge>
       </span>
 
       <div

--- a/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
+++ b/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
@@ -24,7 +24,9 @@ export const useFreightTimelineControllerStore = (project: string) => {
       showMinimap: true
     };
 
-    if (searchParams.size === 0) {
+    const hasFilterParams = Object.keys(filters).some((name) => searchParams.has(name));
+
+    if (!hasFilterParams) {
       return { ...filters, ...getFreightTimelineFiltersLocalStorage(project) };
     }
 


### PR DESCRIPTION
fixes https://github.com/akuity/kargo/issues/6106

Switching tabs in the promote slideout added a `?tab=` param to the URL, causing the filter store to skip its localStorage fallback and reset all filters to defaults.

Replace the `searchParams.size === 0` guard with a check against the known filter param keys (`Object.keys(filters)`) so that non-filter params like `tab` no longer bypass localStorage.

Also add a badge dot to the freight timeline filter button to indicate when filters are active while the panel is collapsed.