### PR TITLE
fix: cli and server to match openapi spec

### DIFF
--- a/pkg/cli/cmd/promote/promote.go
+++ b/pkg/cli/cmd/promote/promote.go
@@ -212,14 +212,10 @@ func (o *promotionOptions) run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("marshal promotion: %w", err)
 		}
-		// The response is {"promotion": {...}}
-		var result struct {
-			Promotion *kargoapi.Promotion `json:"promotion"`
-		}
-		if err = json.Unmarshal(promoJSON, &result); err != nil {
+		promo := &kargoapi.Promotion{}
+		if err = json.Unmarshal(promoJSON, promo); err != nil {
 			return fmt.Errorf("unmarshal promotion: %w", err)
 		}
-		promo := result.Promotion
 		if o.Wait {
 			if err = o.waitForPromotion(ctx, nil, promo); err != nil {
 				return fmt.Errorf("wait for promotion: %w", err)

--- a/pkg/server/promote_to_stage_v1alpha1.go
+++ b/pkg/server/promote_to_stage_v1alpha1.go
@@ -284,5 +284,5 @@ func (s *server) promoteToStage(c *gin.Context) {
 		s.recordPromotionCreatedEvent(ctx, promotion, freight)
 	}
 
-	c.JSON(http.StatusCreated, gin.H{"promotion": promotion})
+	c.JSON(http.StatusCreated, promotion)
 }


### PR DESCRIPTION
Fixes #6134 

#5903 improved our OpenAPI spec significantly, but included a breaking change we failed to notice. It changed the shape of the response from the "promote to stage endpoint" (for the better, but breaking nonetheless).

We'll keep that change. This PR gets the endpoint and the CLI caught up to it.