### PR TITLE
fix(argocd-wait): store health statuses as map[string]any to prevent DeepCopy panic

### DIFF
--- a/pkg/promotion/runner/builtin/argocd_waiter.go
+++ b/pkg/promotion/runner/builtin/argocd_waiter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"time"
 
@@ -128,8 +127,10 @@ func (w *argocdWaiter) run(
 	prevHealthStatuses := w.loadPreviousHealthStatuses(stepCtx)
 	// Seed with previous statuses so unchecked apps retain their last-known
 	// health if we bail early (e.g. on a TerminalError for another app).
-	newHealthStatuses := make(map[string]string, len(prevHealthStatuses))
-	maps.Copy(newHealthStatuses, prevHealthStatuses)
+	newHealthStatuses := make(map[string]any, len(prevHealthStatuses))
+	for k, v := range prevHealthStatuses {
+		newHealthStatuses[k] = v
+	}
 
 	allReady := true
 	for i := range stepCfg.Apps {

--- a/pkg/promotion/runner/builtin/argocd_waiter_test.go
+++ b/pkg/promotion/runner/builtin/argocd_waiter_test.go
@@ -215,7 +215,7 @@ func Test_argocdWaiter_run(t *testing.T) {
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
-				statuses, ok := res.Output[healthStatusKey].(map[string]string)
+				statuses, ok := res.Output[healthStatusKey].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "Progressing", statuses["argocd/my-app"])
 			},


### PR DESCRIPTION
## Summary

- `argocd-wait` stored per-app health statuses as `map[string]string` in the promotion `State`
- `State.DeepCopy` uses `runtime.DeepCopyJSON`, which only handles JSON-native map types (`map[string]interface{}`), causing a panic with "cannot deep copy map[string]string" when building the next step's context
- Fix: change `newHealthStatuses` to `map[string]any` and replace `maps.Copy` with a range loop (required because the source and destination map types differ)

Fixes #6138

## End-user impact

The bug only manifests when `argocd-wait` is not the final step in a promotion. The canonical case is using `argocd-update` followed by `argocd-wait` — `argocd-update` alone returns as soon as the sync operation completes without waiting for Argo Rollouts to finish a canary, so `argocd-wait` is the right tool to hold until the app is actually `Healthy`. If any step follows `argocd-wait` (a notification step, `compose-output`, `git-commit`, anything), the orchestrator panics when building that next step's context, and the promotion errors rather than continuing.

## Test plan

- [x] Existing `Test_argocdWaiter_run` tests updated and passing (type assertion updated from `map[string]string` to `map[string]any`)
- [x] `loadPreviousHealthStatuses` already reads from `map[string]any` — no change needed there