### PR TITLE
fix(ci): restore valid go-version input on Setup Go in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,12 @@ jobs:
         fi
         echo "Repository is set to: $REPO"
         echo "repo=$REPO" >> $GITHUB_OUTPUT
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: &golangImage golang:1.26.2-trixie
+        go-version-file: go.mod
     - name: Set version for unstable builds
       id: unstable-version
       run: |
@@ -71,8 +73,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -231,7 +231,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: *golangImage
+      image: &golangImage golang:1.26.2-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]


### PR DESCRIPTION
## Summary

The `Setup Go` step in `.github/workflows/release.yaml` is receiving a Docker image reference (`golang:1.26.2-trixie`) as its `go-version` input, causing scheduled unstable publishes to fail with:

> `Unable to find Go version 'golang:1.26.2-trixie' for platform linux and architecture x64.`

Switching to `go-version-file: go.mod` removes the duplication and keeps the Setup Go step tracking the repo's declared Go version (so unrelated base-image bumps can't break it again). This requires the repo to be checked out first, so the `Checkout` step is moved to right after `Harden the runner`, matching the pattern every other job in this file already uses. The `&golangImage` anchor is moved to the first `container: image:` site that actually uses it.

## Failing runs

- https://github.com/akuity/kargo/actions/runs/24755480519 (2026-04-22 scheduled)
- https://github.com/akuity/kargo/actions/runs/24699362485 (2026-04-21 scheduled)

When `publish-image` fails at Setup Go, `publish-charts` is skipped, so no new `1.x.0-unstable-*` chart tags are pushed to `ghcr.io/akuity/kargo-charts-unstable`.

## How it regressed

PR #6066 (routine golang base-image bump) inadvertently replaced the `go-version: '1.26.0'` scalar with the `&golangImage golang:1.26.2-trixie` anchor definition.

## Verification

The reordered sequence (harden → checkout → setup-go → set unstable version) was run end-to-end on a fork branch via a throwaway workflow that stops before any registry login or image push. All steps passed; `go-version-file: go.mod` correctly installed Go 1.26.0 and `go list -m -versions github.com/akuity/kargo` produced `v1.11.0-unstable-20260422` as expected.

Successful run: https://github.com/jacobboykin/kargo/actions/runs/24788405723
