### PR TITLE
fix(conditions): truncate condition messages exceeding Kubernetes 32768-byte limit

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -2,9 +2,14 @@ package conditions
 
 import (
 	"time"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// maxConditionMessageLength is the Kubernetes-enforced maximum byte length for
+// a condition message field.
+const maxConditionMessageLength = 32768
 
 // Getter is an interface that allows getting conditions from a (sub)resource.
 type Getter interface {
@@ -60,6 +65,11 @@ func Set(on Setter, conditions ...*metav1.Condition) {
 		if condition == nil {
 			continue
 		}
+
+		// Kubernetes enforces a 32768-byte limit on condition messages. Truncate
+		// to prevent status patch failures when upstream sources (e.g. ArgoCD)
+		// embed large payloads in error messages.
+		condition.Message = truncateMessage(condition.Message)
 
 		// Set ObservedGeneration if applicable
 		if objGeneration != 0 && condition.ObservedGeneration == 0 {
@@ -121,4 +131,20 @@ func Delete(on Setter, conditionType string) {
 // generation.
 func Equal(a, b metav1.Condition) bool {
 	return a.Type == b.Type && a.Status == b.Status && a.Reason == b.Reason && a.Message == b.Message
+}
+
+// truncateMessage truncates msg to maxConditionMessageLength bytes, appending a
+// suffix to indicate truncation. The truncation point is adjusted to avoid
+// splitting a multi-byte UTF-8 character.
+func truncateMessage(msg string) string {
+	if len(msg) <= maxConditionMessageLength {
+		return msg
+	}
+	const suffix = " ... (truncated)"
+	end := maxConditionMessageLength - len(suffix)
+	// Walk back to a valid UTF-8 rune boundary.
+	for end > 0 && !utf8.RuneStart(msg[end]) {
+		end--
+	}
+	return msg[:end] + suffix
 }

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -498,6 +498,23 @@ func TestSet(t *testing.T) {
 	}
 }
 
+func TestSet_TruncatesLongMessage(t *testing.T) {
+	t.Parallel()
+
+	longMsg := string(make([]byte, maxConditionMessageLength+100))
+	setter := &mockSetter{}
+	Set(setter, &metav1.Condition{
+		Type:    "Test",
+		Status:  metav1.ConditionTrue,
+		Reason:  "Reason",
+		Message: longMsg,
+	})
+
+	conds := setter.GetConditions()
+	require.Len(t, conds, 1)
+	require.LessOrEqual(t, len(conds[0].Message), maxConditionMessageLength)
+}
+
 func TestDelete(t *testing.T) {
 	const (
 		mockType1 = "MockType1"
@@ -729,6 +746,53 @@ func TestEqual(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Equal(tt.a, tt.b)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTruncateMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		input  string
+		assert func(*testing.T, string)
+	}{
+		{
+			name:  "short message unchanged",
+			input: "short",
+			assert: func(t *testing.T, got string) {
+				require.Equal(t, "short", got)
+			},
+		},
+		{
+			name:  "exactly at limit unchanged",
+			input: string(make([]byte, maxConditionMessageLength)),
+			assert: func(t *testing.T, got string) {
+				require.Equal(t, maxConditionMessageLength, len(got))
+			},
+		},
+		{
+			name:  "over limit gets truncated",
+			input: string(make([]byte, maxConditionMessageLength+1)),
+			assert: func(t *testing.T, got string) {
+				require.LessOrEqual(t, len(got), maxConditionMessageLength)
+				require.Contains(t, got, "(truncated)")
+			},
+		},
+		{
+			name:  "multi-byte UTF-8 not split",
+			input: string(make([]byte, maxConditionMessageLength-1)) + "é", // 2-byte rune crosses boundary
+			assert: func(t *testing.T, got string) {
+				require.LessOrEqual(t, len(got), maxConditionMessageLength)
+				require.Contains(t, got, "(truncated)")
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assert(t, truncateMessage(tc.input))
 		})
 	}
 }

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -1,8 +1,10 @@
 package conditions
 
 import (
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -781,11 +783,17 @@ func TestTruncateMessage(t *testing.T) {
 			},
 		},
 		{
-			name:  "multi-byte UTF-8 not split",
-			input: string(make([]byte, maxConditionMessageLength-1)) + "é", // 2-byte rune crosses boundary
+			name: "multi-byte UTF-8 not split",
+			// The suffix " ... (truncated)" is 16 bytes, so the cut index is
+			// maxConditionMessageLength-16 = 32752. Place é (UTF-8: 0xC3 0xA9)
+			// starting at index 32751 so its continuation byte (0xA9) lands
+			// exactly at the cut point, forcing the walk-back to trigger.
+			input: string(make([]byte, maxConditionMessageLength-len(" ... (truncated)")-1)) +
+				strings.Repeat("é", 20),
 			assert: func(t *testing.T, got string) {
 				require.LessOrEqual(t, len(got), maxConditionMessageLength)
 				require.Contains(t, got, "(truncated)")
+				require.True(t, utf8.ValidString(got))
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #6147

When an upstream source such as ArgoCD embeds a large payload (e.g. an entire pod spec JSON) in a sync error, that text flows through the promotion engine into a Stage condition. Kubernetes enforces a hard 32768-byte limit on `status.conditions[*].message`, so every subsequent `PatchStatus` call fails, leaving the Stage permanently stuck in "pending".

- Truncate condition messages to the 32768-byte limit inside `conditions.Set`, the single choke point for all condition writes across all resource types
- Truncation is UTF-8-safe (walks back to a valid rune boundary) and appends `" ... (truncated)"` so operators know the message was cut

## Test plan

- [x] `go test ./pkg/conditions/...` passes — new `TestTruncateMessage` and `TestSet_TruncatesLongMessage` cases cover the boundary, the over-limit, and the multi-byte UTF-8 split case