### PR TITLE
fix(ci): make apko base image build work with nonroot container user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ CONTAINER_RUNTIME ?= docker
 IMAGE_REPO 			?= kargo
 LOCAL_REG_PORT			?= 5001
 BASE_IMAGE 			?= localhost:$(LOCAL_REG_PORT)/$(IMAGE_REPO)-base
+APKO_IMAGE 			?= cgr.dev/chainguard/apko
 IMAGE_TAG 			?= dev
 IMAGE_PUSH 			?= false
 IMAGE_PLATFORMS 	?=
@@ -168,12 +169,13 @@ clean:
 .PHONY: build-base-image
 build-base-image:
 	mkdir -p build
+	chmod 0777 build
 	cp kargo-base.apko.yaml build
 	$(CONTAINER_RUNTIME) run \
 		--rm \
 		-v $(dir $(realpath $(firstword $(MAKEFILE_LIST))))build:/build \
 		-w /build \
-		cgr.dev/chainguard/apko \
+		$(APKO_IMAGE) \
 		build kargo-base.apko.yaml $(BASE_IMAGE) kargo-base.tar.gz
 	$(CONTAINER_RUNTIME) image load -i build/kargo-base.tar.gz
 


### PR DESCRIPTION
## Summary

Kargo CI started failing at the `build-image` job earlier today with:

```
2026/04/23 22:59:05 INFO error during command execution: bundling image: failed to open outfile kargo-base.tar.gz: open kargo-base.tar.gz: permission denied
make: *** [Makefile:172: build-base-image] Error 1
```

## Root cause

Chainguard flipped the public apko image from running as root to a nonroot user in [chainguard-images/images@572348d](https://github.com/chainguard-images/images/commit/572348dad4e7211dc7fa1c468e051a4c8d3f4e9d); `run-as` went from `"0"` to `"65532"`, and `/work` ownership went from `0:0` to `65532:65532`. Our `build-base-image` Makefile target bind-mounts a host-owned `build/` dir into the container; the new nonroot UID can't write the output tarball into it.

## Fix

`chmod 0777 build` after creating it so the container's nonroot UID can write the output tarball. Also factors the image reference into a new `APKO_IMAGE` variable.