### PR TITLE
feat(ui): filter freight/stages by current warehouse filters

### DIFF
--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -83,56 +83,60 @@ export const Graph = (props: GraphProps) => {
     setNodes(graph.nodes);
   }, [graph.nodes]);
 
-  useEventsWatcher(props.project, {
-    onStage(stage) {
-      const index = stageIndexer.index(stage);
-      setNodes((nodes) =>
-        nodes.map((node) => {
-          if (node.id === index && node.type === reactFlowNodeConstants.CUSTOM_NODE) {
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                value: stage
-              }
-            };
-          }
+  useEventsWatcher(
+    props.project,
+    {
+      onStage(stage) {
+        const index = stageIndexer.index(stage);
+        setNodes((nodes) =>
+          nodes.map((node) => {
+            if (node.id === index && node.type === reactFlowNodeConstants.CUSTOM_NODE) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  value: stage
+                }
+              };
+            }
 
-          return node;
-        })
-      );
+            return node;
+          })
+        );
 
-      if (!nodes.find((n) => n.id === index)) {
-        setRedraw((prev) => !prev);
+        if (!nodes.find((n) => n.id === index)) {
+          setRedraw((prev) => !prev);
+        }
+
+        queryCache.imageStageMatrix.update(stage);
+      },
+      onWarehouse(warehouse) {
+        const index = warehouseIndexer.index(warehouse);
+        setNodes((nodes) =>
+          nodes.map((node) => {
+            if (node.id === index && node.type === reactFlowNodeConstants.CUSTOM_NODE) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  value: warehouse
+                }
+              };
+            }
+
+            return node;
+          })
+        );
+
+        if (!nodes.find((n) => n.id === index)) {
+          setRedraw((prev) => !prev);
+        }
+
+        queryCache.freight.refetch();
       }
-
-      queryCache.imageStageMatrix.update(stage);
     },
-    onWarehouse(warehouse) {
-      const index = warehouseIndexer.index(warehouse);
-      setNodes((nodes) =>
-        nodes.map((node) => {
-          if (node.id === index && node.type === reactFlowNodeConstants.CUSTOM_NODE) {
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                value: warehouse
-              }
-            };
-          }
-
-          return node;
-        })
-      );
-
-      if (!nodes.find((n) => n.id === index)) {
-        setRedraw((prev) => !prev);
-      }
-
-      queryCache.freight.refetch();
-    }
-  });
+    filterContext?.preferredFilter?.warehouses || []
+  );
 
   const warehouseByName = useMemo(() => {
     const warehouseByName: Record<string, WarehouseExpanded> = {};

--- a/ui/src/features/project/pipelines/graph/use-events-watcher.ts
+++ b/ui/src/features/project/pipelines/graph/use-events-watcher.ts
@@ -12,7 +12,8 @@ export const useEventsWatcher = (
   act?: {
     onStage: (stage: Stage) => void;
     onWarehouse: (warehouse: WarehouseExpanded) => void;
-  }
+  },
+  warehouses?: string[]
 ) => {
   const client = useQueryClient();
   const isWindowVisible = useDocumentEvent(
@@ -27,7 +28,7 @@ export const useEventsWatcher = (
 
     const watcher = new Watcher(project, client);
 
-    watcher.watchStages(act?.onStage);
+    watcher.watchStages(act?.onStage, warehouses);
     watcher.watchWarehouses({
       onWarehouseEvent: act?.onWarehouse,
       refreshHook: queryCache.freight.refetchQueryFreight
@@ -36,5 +37,5 @@ export const useEventsWatcher = (
     return () => {
       watcher.cancelWatch();
     };
-  }, [isWindowVisible, project]);
+  }, [isWindowVisible, project, (warehouses || []).join(',')]);
 };

--- a/ui/src/features/project/pipelines/list/list-view.tsx
+++ b/ui/src/features/project/pipelines/list/list-view.tsx
@@ -30,7 +30,11 @@ export const PipelineListView = (props: PipelineListViewProps) => {
   const actionContext = useActionContext();
   const freightTimelineControllerContext = useFreightTimelineControllerContext();
 
-  useEventsWatcher(props.project);
+  useEventsWatcher(
+    props.project,
+    undefined,
+    freightTimelineControllerContext?.preferredFilter?.warehouses || []
+  );
 
   const [filters, setFilters] = useState<Filter>({
     stage: ''

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -70,8 +70,6 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
 
   const listImagesQuery = useQuery(listImages, { project: name });
 
-  const getFreightQuery = useQuery(queryFreight, { project: projectName });
-
   const listWarehousesQuery = useQuery(
     listWarehouses,
     {
@@ -91,7 +89,19 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
     }
   );
 
-  const listStagesQuery = useQuery(listStages, { project: projectName });
+  const [preferredFilter, setPreferredFilter] = useFreightTimelineControllerStore(
+    projectName || ''
+  );
+
+  const getFreightQuery = useQuery(queryFreight, {
+    project: projectName,
+    origins: preferredFilter.warehouses
+  });
+
+  const listStagesQuery = useQuery(listStages, {
+    project: projectName,
+    freightOrigins: preferredFilter.warehouses
+  });
 
   const loading =
     projectQuery.isLoading ||
@@ -121,10 +131,6 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
   const stageColorMap = useMemo(
     () => getColors(project?.metadata?.name || '', listStagesQuery.data?.stages || []),
     [project, listStagesQuery.data?.stages]
-  );
-
-  const [preferredFilter, setPreferredFilter] = useFreightTimelineControllerStore(
-    projectName || ''
   );
 
   const pipelineView = preferredFilter.view;

--- a/ui/src/features/project/pipelines/use-watch-freight.ts
+++ b/ui/src/features/project/pipelines/use-watch-freight.ts
@@ -79,21 +79,31 @@ export const useWatchFreight = (project: string) => {
           }
         }
 
-        const updatedFreight =
-          e.type === 'DELETED'
-            ? deleteFreight(currentFreight, freight)
-            : upsertFreight(currentFreight, freight);
-
-        const queryFreightKey = createConnectQueryKey({
-          cardinality: 'finite',
-          schema: queryFreight,
-          input: {
-            project
-          },
-          transport: transportWithAuth
-        });
-
-        client.setQueryData(queryFreightKey, updatedFreight);
+        if (e.type === 'DELETED') {
+          // Remove from all queryFreight caches for this project, including
+          // warehouse-filtered variants, which use a different cache key.
+          client.setQueriesData<QueryFreightResponse>(
+            {
+              queryKey: createConnectQueryKey({
+                cardinality: 'finite',
+                schema: queryFreight,
+                input: { project },
+                transport: transportWithAuth
+              }),
+              exact: false
+            },
+            (current) => deleteFreight(current, freight)
+          );
+        } else {
+          const updatedFreight = upsertFreight(currentFreight, freight);
+          const queryFreightKey = createConnectQueryKey({
+            cardinality: 'finite',
+            schema: queryFreight,
+            input: { project },
+            transport: transportWithAuth
+          });
+          client.setQueryData(queryFreightKey, updatedFreight);
+        }
       }
     };
 

--- a/ui/src/features/project/pipelines/watcher.ts
+++ b/ui/src/features/project/pipelines/watcher.ts
@@ -71,12 +71,18 @@ export class Watcher {
   async watchStages(
     // utilise the fact that something changed in this stage
     // avoid as much as re-construction of data as possible by using this parameter
-    onStageEvent?: (stage: Stage) => void
+    onStageEvent?: (stage: Stage) => void,
+    warehouses?: string[]
   ) {
     const stream = this.promiseClient.watchStages(
-      { project: this.project },
+      { project: this.project, freightOrigins: warehouses || [] },
       { signal: this.cancel.signal }
     );
+
+    const stagesInput = create(ListStagesRequestSchema, {
+      project: this.project,
+      freightOrigins: warehouses || []
+    });
 
     ProcessEvents(
       stream,
@@ -84,7 +90,7 @@ export class Watcher {
         const data = this.client.getQueryData(
           createConnectQueryKey({
             schema: listStages,
-            input: create(ListStagesRequestSchema, { project: this.project }),
+            input: stagesInput,
             cardinality: 'finite',
             transport: transportWithAuth
           })
@@ -97,7 +103,7 @@ export class Watcher {
         // update Stages list
         const listStagesQueryKey = createConnectQueryKey({
           schema: listStages,
-          input: create(ListStagesRequestSchema, { project: this.project }),
+          input: stagesInput,
           cardinality: 'finite',
           transport: transportWithAuth
         });


### PR DESCRIPTION
Companion PR to https://github.com/akuity/kargo/pull/6153

This improves UI performance by sending the currently selected warehouse filters to the backend, reducing the response payload so the UI does not have to handle as many objects.

@rpelczar, please feel free to discard this or take it over; it was entirely vibecoded, and I just created it to prove that https://github.com/akuity/kargo/pull/6153 would help with the UI performance.

##  What changed:

The UI's queryFreight and listStages calls now pass the active warehouse filter (origins / freightOrigins) as query parameters, so the server-side filter applies to the initial data fetch — not just the display.

The stage/freight watchers are also updated to respect the active filter:

  - Watcher.watchStages now accepts an optional warehouses array and passes it as freightOrigins to the watch stream, so live stage updates are scoped to the filtered warehouses. The ListStagesRequest input used for cache key lookups is constructed once with the filter and reused.
  - useEventsWatcher (used by both graph and list views) accepts and forwards the warehouses filter to watchStages, and includes the warehouse list in its useEffect dependency array so the watcher restarts when the filter changes.
  - useWatchFreight fixes a bug where deleting Freight while a warehouse filter was active didn't update the UI: DELETED events now use setQueriesData with exact: false to remove the freight from all queryFreight cache entries (both unfiltered and warehouse-filtered), rather than only the unfiltered one.
  - In pipelines.tsx, the preferredFilter store is read before the queries are declared so the filter values are available to pass into both queryFreight and listStages.