### PR TITLE
feat(projects): support contributor registry for project setup and cleanup

### DIFF
--- a/pkg/controller/management/projects/project_setup_contributor.go
+++ b/pkg/controller/management/projects/project_setup_contributor.go
@@ -1,0 +1,74 @@
+package projects
+
+import (
+	"context"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/component"
+)
+
+type (
+	// projectSetupContributorPredicate returns true if the contributor has
+	// setup work to perform for the given Project.
+	projectSetupContributorPredicate = func(context.Context, *kargoapi.Project) (bool, error)
+
+	// projectSetupContributorFunc performs additional setup for a Project
+	// during reconciliation.
+	projectSetupContributorFunc = func(ctx context.Context, project *kargoapi.Project) error
+
+	// ProjectSetupContributorRegistration associates a predicate with a
+	// contributor function for project setup.
+	ProjectSetupContributorRegistration = component.PredicateBasedRegistration[
+		*kargoapi.Project,
+		projectSetupContributorPredicate,
+		projectSetupContributorFunc,
+		struct{},
+	]
+
+	// projectCleanupContributorPredicate returns true if the contributor has
+	// cleanup work to perform for the given Project.
+	projectCleanupContributorPredicate = func(context.Context, *kargoapi.Project) (bool, error)
+
+	// projectCleanupContributorFunc performs cleanup for a Project when it is
+	// deleted.
+	projectCleanupContributorFunc = func(ctx context.Context, project *kargoapi.Project) error
+
+	// ProjectCleanupContributorRegistration associates a predicate with a
+	// contributor function for project cleanup.
+	ProjectCleanupContributorRegistration = component.PredicateBasedRegistration[
+		*kargoapi.Project,
+		projectCleanupContributorPredicate,
+		projectCleanupContributorFunc,
+		struct{},
+	]
+)
+
+var defaultProjectSetupContributorRegistry = component.MustNewPredicateBasedRegistry[
+	*kargoapi.Project,
+	projectSetupContributorPredicate,
+	projectSetupContributorFunc,
+	struct{},
+]()
+
+var defaultProjectCleanupContributorRegistry = component.MustNewPredicateBasedRegistry[
+	*kargoapi.Project,
+	projectCleanupContributorPredicate,
+	projectCleanupContributorFunc,
+	struct{},
+]()
+
+// RegisterProjectSetupContributor adds a contributor to the global registry
+// used by the project reconciler to perform additional setup during project
+// reconciliation. It should be called before SetupReconcilerWithManager (e.g.
+// at program startup).
+func RegisterProjectSetupContributor(reg ProjectSetupContributorRegistration) {
+	defaultProjectSetupContributorRegistry.MustRegister(reg)
+}
+
+// RegisterProjectCleanupContributor adds a contributor to the global registry
+// used by the project reconciler to perform cleanup when a project is deleted.
+// It should be called before SetupReconcilerWithManager (e.g. at program
+// startup).
+func RegisterProjectCleanupContributor(reg ProjectCleanupContributorRegistration) {
+	defaultProjectCleanupContributorRegistry.MustRegister(reg)
+}

--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -44,26 +44,6 @@ type ReconcilerConfig struct {
 	ManageControllerRoleBindings bool   `envconfig:"MANAGE_CONTROLLER_ROLE_BINDINGS" default:"true"`
 	KargoNamespace               string `envconfig:"KARGO_NAMESPACE" default:"kargo"`
 	MaxConcurrentReconciles      int    `envconfig:"MAX_CONCURRENT_PROJECT_RECONCILES" default:"4"`
-
-	ManageExtendedPermissions bool `envconfig:"MANAGE_EXTENDED_PERMISSIONS" default:"false"`
-
-	ManageOrchestrator             bool   `envconfig:"MANAGE_ORCHESTRATOR" default:"false"`
-	OrchestratorServiceAccountName string `envconfig:"ORCHESTRATOR_SERVICE_ACCOUNT_NAME" default:""`
-	OrchestratorClusterRoleName    string `envconfig:"ORCHESTRATOR_CLUSTER_ROLE_NAME" default:""`
-	TokenManagerClusterRoleName    string `envconfig:"TOKEN_MANAGER_CLUSTER_ROLE_NAME" default:""`
-
-	ControlPlaneServiceAccountName string `envconfig:"CONTROL_PLANE_SERVICE_ACCOUNT_NAME" default:""`
-	ControlPlaneClusterRoleName    string `envconfig:"CONTROL_PLANE_CLUSTER_ROLE_NAME" default:""`
-
-	ManagerServiceAccountName string `envconfig:"MANAGER_SERVICE_ACCOUNT_NAME" default:""`
-	ManagerClusterRoleName    string `envconfig:"MANAGER_CLUSTER_ROLE_NAME" default:""`
-	ManagedResourceNamespace  string `envconfig:"MANAGED_RESOURCE_NAMESPACE" default:""`
-
-	ArgoCDServiceAccountName string `envconfig:"ARGOCD_SERVICE_ACCOUNT_NAME" default:""`
-	ArgoCDRoleName           string `envconfig:"ARGOCD_ROLE_NAME" default:""`
-	ArgoCDClusterRoleName    string `envconfig:"ARGOCD_CLUSTER_ROLE_NAME" default:""`
-	ArgoCDNamespace          string `envconfig:"ARGOCD_NAMESPACE" default:"argocd"`
-	ArgoCDWatchNamespaceOnly bool   `envconfig:"ARGOCD_WATCH_ARGOCD_NAMESPACE_ONLY" default:"false"`
 }
 
 func ReconcilerConfigFromEnv() ReconcilerConfig {
@@ -136,8 +116,6 @@ type reconciler struct {
 	ensureControllerPermissionsFn func(context.Context, *kargoapi.Project) error
 
 	ensureDefaultUserRolesFn func(context.Context, *kargoapi.Project) error
-
-	ensureExtendedPermissionsFn func(context.Context, *kargoapi.Project) error
 
 	createServiceAccountFn func(
 		context.Context,
@@ -252,7 +230,6 @@ func newReconciler(kubeClient client.Client, cfg ReconcilerConfig) *reconciler {
 	r.ensureSystemPermissionsFn = r.ensureSystemPermissions
 	r.ensureControllerPermissionsFn = r.ensureControllerPermissions
 	r.ensureDefaultUserRolesFn = r.ensureDefaultUserRoles
-	r.ensureExtendedPermissionsFn = r.ensureExtendedPermissions
 	r.createServiceAccountFn = r.client.Create
 	r.createRoleFn = r.client.Create
 	r.createRoleBindingFn = r.client.Create
@@ -386,33 +363,31 @@ func (r *reconciler) reconcile(
 func (r *reconciler) cleanupProject(ctx context.Context, project *kargoapi.Project) error {
 	logger := logging.LoggerFromContext(ctx)
 
-	// Delete cluster-scoped resources that are specific to the Project
-	crbs := map[string]bool{
-		kubernetes.ShortenResourceName(fmt.Sprintf("kargo-project-admin-%s", project.Name)): true,
+	// Run EE cleanup contributors before removing OSS base resources, so that
+	// any EE resources that reference OSS resources are removed first.
+	cleanupContribs, contribsErr := defaultProjectCleanupContributorRegistry.GetAll(ctx, project)
+	if contribsErr != nil {
+		return fmt.Errorf("error getting project cleanup contributors: %w", contribsErr)
 	}
-	if r.cfg.ManageExtendedPermissions && r.cfg.ArgoCDClusterRoleName != "" {
-		crbs[kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.ArgoCDClusterRoleName, project.Name))] = false
+	for _, contrib := range cleanupContribs {
+		if contribErr := contrib.Value(ctx, project); contribErr != nil {
+			return contribErr
+		}
 	}
-	for crbName, hasCR := range crbs {
-		if err := r.deleteClusterRoleBindingFn(
-			ctx,
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: crbName}},
-		); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting ClusterRoleBinding %q: %w", crbName, err)
-		}
 
-		if !hasCR {
-			// No ClusterRole to delete for this ClusterRoleBinding.
-			continue
-		}
-
-		crName := crbName
-		if err := r.deleteClusterRoleFn(
-			ctx,
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: crName}},
-		); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting ClusterRole %q: %w", crName, err)
-		}
+	// Delete the project-admin ClusterRoleBinding and ClusterRole.
+	crbName := kubernetes.ShortenResourceName(fmt.Sprintf("kargo-project-admin-%s", project.Name))
+	if err := r.deleteClusterRoleBindingFn(
+		ctx,
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: crbName}},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting ClusterRoleBinding %q: %w", crbName, err)
+	}
+	if err := r.deleteClusterRoleFn(
+		ctx,
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: crbName}},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting ClusterRole %q: %w", crbName, err)
 	}
 
 	// Get namespace for the Project
@@ -542,8 +517,12 @@ func (r *reconciler) syncProject(
 		return *status, fmt.Errorf("error ensuring default project roles: %w", err)
 	}
 
-	if r.cfg.ManageExtendedPermissions {
-		if err := r.ensureExtendedPermissionsFn(ctx, project); err != nil {
+	setupContribs, err := defaultProjectSetupContributorRegistry.GetAll(ctx, project)
+	if err != nil {
+		return *status, fmt.Errorf("error getting project setup contributors: %w", err)
+	}
+	for _, contrib := range setupContribs {
+		if err := contrib.Value(ctx, project); err != nil {
 			conditions.Set(status, &metav1.Condition{
 				Type:               kargoapi.ConditionTypeReady,
 				Status:             metav1.ConditionFalse,
@@ -1094,290 +1073,6 @@ func (r *reconciler) ensureDefaultUserRoles(
 		crbLogger.Debug("ClusterRoleBinding already exists")
 	}
 	crbLogger.Debug("created ClusterRoleBinding")
-
-	return nil
-}
-
-func (r *reconciler) ensureExtendedPermissions(
-	ctx context.Context,
-	project *kargoapi.Project,
-) error {
-	logger := logging.LoggerFromContext(ctx).WithValues("project", project.Name)
-
-	var serviceAccounts []string
-
-	// If a control plane ServiceAccount is configured, then add it to the list
-	// of ServiceAccounts to create and bind extended permissions to.
-	if r.cfg.ControlPlaneServiceAccountName != "" {
-		serviceAccounts = append(serviceAccounts, r.cfg.ControlPlaneServiceAccountName)
-	}
-
-	// If a dedicated namespace for managed resources is configured, then we do
-	// not have to create the orchestrator ServiceAccount in every Project
-	// namespace.
-	if r.cfg.ManageOrchestrator && r.cfg.ManagedResourceNamespace == "" && r.cfg.OrchestratorServiceAccountName != "" {
-		serviceAccounts = append([]string{
-			r.cfg.OrchestratorServiceAccountName,
-		}, serviceAccounts...)
-	}
-
-	// If an Argo CD ServiceAccount is configured, then add it to the list of
-	// ServiceAccounts to create and bind extended permissions to.
-	//
-	// Note: We only do this if Argo CD is not restricted to watch its own
-	// namespace only. If it is, then the Argo CD ServiceAccount does not need
-	// to exist in every Project namespace, and we do not need to create a
-	// ClusterRoleBinding for it.
-	if r.cfg.ArgoCDServiceAccountName != "" {
-		serviceAccounts = append(serviceAccounts, r.cfg.ArgoCDServiceAccountName)
-	}
-
-	saAnnotations := map[string]string{
-		rbacapi.AnnotationKeyManaged: rbacapi.AnnotationValueTrue,
-	}
-
-	for _, saName := range serviceAccounts {
-		saLogger := logger.WithValues(
-			"name", saName,
-			"namespace", project.Name,
-		)
-
-		if err := r.createServiceAccountFn(
-			ctx,
-			&corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        saName,
-					Namespace:   project.Name,
-					Annotations: saAnnotations,
-				},
-			},
-		); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				saLogger.Debug("ServiceAccount already exists in project namespace")
-				continue
-			}
-			return fmt.Errorf(
-				"error creating ServiceAccount %q in project namespace %q: %w",
-				saName,
-				project.Name,
-				err,
-			)
-		}
-	}
-
-	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
-
-	if r.cfg.ArgoCDServiceAccountName != "" && !r.cfg.ArgoCDWatchNamespaceOnly {
-		// ClusterRoleBinding for the Argo CD ServiceAccount to access and
-		// operate on Argo CD Application resources in any namespace.
-		clusterRoleBindings = append(clusterRoleBindings, &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.ArgoCDClusterRoleName, project.Name)),
-				Annotations: map[string]string{
-					rbacapi.AnnotationKeyManaged: rbacapi.AnnotationValueTrue,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     r.cfg.ArgoCDClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.ArgoCDServiceAccountName,
-					Namespace: project.Name,
-				},
-			},
-		})
-	}
-
-	for _, crb := range clusterRoleBindings {
-		crbLogger := logger.WithValues("name", crb.Name, "project", project.Name)
-		if err := r.createClusterRoleBindingFn(ctx, crb); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				crbLogger.Debug("ClusterRoleBinding already exists for Project")
-				continue
-			}
-
-			return fmt.Errorf(
-				"error creating ClusterRoleBinding %q for Project %q: %w",
-				crb.Name, project.Name, err,
-			)
-		}
-	}
-
-	rbAnnotations := map[string]string{
-		rbacapi.AnnotationKeyManaged: rbacapi.AnnotationValueTrue,
-	}
-
-	var roleBindings []*rbacv1.RoleBinding
-
-	if r.cfg.ControlPlaneServiceAccountName != "" && r.cfg.ControlPlaneClusterRoleName != "" {
-		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-			// RoleBinding for the control plane ServiceAccount to access and
-			// operate on a minimal set of Kargo resources in the Project
-			// namespace.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        r.cfg.ControlPlaneServiceAccountName,
-				Namespace:   project.Name,
-				Annotations: rbAnnotations,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     r.cfg.ControlPlaneClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.ControlPlaneClusterRoleName,
-					Namespace: project.Name,
-				},
-			},
-		})
-	}
-
-	if r.cfg.ManagerServiceAccountName != "" && r.cfg.ManagedResourceNamespace == "" {
-		// RoleBinding for the manager ServiceAccount to manage resources in
-		// the Project namespace, if no dedicated managed resources namespace
-		// is configured.
-		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        r.cfg.ManagerClusterRoleName,
-				Namespace:   project.Name,
-				Annotations: rbAnnotations,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     r.cfg.ManagerClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.ManagerServiceAccountName,
-					Namespace: r.cfg.KargoNamespace,
-				},
-			},
-		})
-	}
-
-	if r.cfg.OrchestratorServiceAccountName != "" {
-		// RoleBinding for the orchestrator ServiceAccount to access and operate
-		// on resources in the Project namespace.
-		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        r.cfg.OrchestratorServiceAccountName,
-				Namespace:   project.Name,
-				Annotations: rbAnnotations,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     r.cfg.OrchestratorClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.OrchestratorServiceAccountName,
-					Namespace: project.Name,
-				},
-			},
-		})
-
-		if r.cfg.TokenManagerClusterRoleName != "" {
-			// RoleBinding for the orchestrator ServiceAccount to create and
-			// manage ServiceAccount tokens in the Project namespace.
-			roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        r.cfg.TokenManagerClusterRoleName,
-					Namespace:   project.Name,
-					Annotations: rbAnnotations,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: rbacv1.GroupName,
-					Kind:     "ClusterRole",
-					Name:     r.cfg.TokenManagerClusterRoleName,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      r.cfg.OrchestratorClusterRoleName,
-						Namespace: project.Name,
-					},
-				},
-			})
-		}
-
-		// RoleBinding for the orchestrator ServiceAccount to access Secrets
-		// in the Project namespace.
-		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubernetes.ShortenResourceName(
-					fmt.Sprintf("%s-secrets-reader", r.cfg.OrchestratorServiceAccountName),
-				),
-				Namespace:   project.Name,
-				Annotations: rbAnnotations,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     projectSecretsReaderClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.OrchestratorServiceAccountName,
-					Namespace: project.Name,
-				},
-			},
-		})
-	}
-
-	if r.cfg.ArgoCDServiceAccountName != "" && r.cfg.ArgoCDNamespace != "" && r.cfg.ArgoCDWatchNamespaceOnly {
-		// RoleBinding for the Argo CD ServiceAccount to access and operate
-		// on Applications in the Argo CD namespace.
-		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubernetes.ShortenResourceName(
-					fmt.Sprintf("%s-%s", r.cfg.ArgoCDRoleName, project.Name),
-				),
-				Namespace:   r.cfg.ArgoCDNamespace,
-				Annotations: rbAnnotations,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "Role",
-				Name:     r.cfg.ArgoCDRoleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      r.cfg.ArgoCDServiceAccountName,
-					Namespace: project.Name,
-				},
-			},
-		})
-	}
-
-	for _, rb := range roleBindings {
-		rbLogger := logger.WithValues(
-			"name", rb.Name,
-			"namespace", project.Name,
-		)
-
-		if err := r.createRoleBindingFn(ctx, rb); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				rbLogger.Debug("RoleBinding already exists in project namespace")
-				continue
-			}
-			return fmt.Errorf(
-				"error creating RoleBinding %q in project namespace %q: %w",
-				rb.Name, project.Name, err,
-			)
-		}
-	}
 
 	return nil
 }

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -43,7 +43,6 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, r.ensureSystemPermissionsFn)
 	require.NotNil(t, r.ensureControllerPermissionsFn)
 	require.NotNil(t, r.ensureDefaultUserRolesFn)
-	require.NotNil(t, r.ensureExtendedPermissionsFn)
 	require.NotNil(t, r.createServiceAccountFn)
 	require.NotNil(t, r.createRoleFn)
 	require.NotNil(t, r.createRoleBindingFn)
@@ -511,7 +510,7 @@ func TestReconciler_cleanupProject(t *testing.T) {
 			},
 		},
 		{
-			name: "deletes promotion ArgoCD cluster role binding",
+			name: "deletes project admin cluster role and binding",
 			project: &kargoapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-project",
@@ -523,10 +522,8 @@ func TestReconciler_cleanupProject(t *testing.T) {
 					obj client.Object,
 					_ ...client.DeleteOption,
 				) error {
-					// Verify both ClusterRoleBindings are deleted
 					name := obj.GetName()
-					if name != kubernetes.ShortenResourceName("kargo-project-admin-test-project") &&
-						name != kubernetes.ShortenResourceName("kargo-argocd-test-project") {
+					if name != kubernetes.ShortenResourceName("kargo-project-admin-test-project") {
 						return fmt.Errorf("unexpected ClusterRoleBinding name: %s", name)
 					}
 					return nil
@@ -536,7 +533,6 @@ func TestReconciler_cleanupProject(t *testing.T) {
 					obj client.Object,
 					_ ...client.DeleteOption,
 				) error {
-					// Only the admin ClusterRole should be deleted
 					name := obj.GetName()
 					if name != kubernetes.ShortenResourceName("kargo-project-admin-test-project") {
 						return fmt.Errorf("unexpected ClusterRole name: %s", name)
@@ -957,6 +953,111 @@ func TestReconciler_cleanupProject(t *testing.T) {
 	}
 }
 
+func TestReconciler_cleanupProject_cleanupContributors(t *testing.T) {
+	testCases := []struct {
+		name        string
+		contributor ProjectCleanupContributorRegistration
+		assertions  func(*testing.T, error)
+	}{
+		{
+			name: "error from cleanup contributor",
+			contributor: ProjectCleanupContributorRegistration{
+				Predicate: func(context.Context, *kargoapi.Project) (bool, error) {
+					return true, nil
+				},
+				Value: func(context.Context, *kargoapi.Project) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+		{
+			name: "contributor runs before OSS deletions",
+			contributor: ProjectCleanupContributorRegistration{
+				Predicate: func(context.Context, *kargoapi.Project) (bool, error) {
+					return true, nil
+				},
+				Value: func(context.Context, *kargoapi.Project) error {
+					return errors.New("contributor ran")
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				// If the contributor runs first and errors, the OSS deletions are
+				// never reached — confirming EE-before-OSS ordering.
+				require.ErrorContains(t, err, "contributor ran")
+			},
+		},
+		{
+			name: "success with cleanup contributor",
+			contributor: ProjectCleanupContributorRegistration{
+				Predicate: func(context.Context, *kargoapi.Project) (bool, error) {
+					return true, nil
+				},
+				Value: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			orig := defaultProjectCleanupContributorRegistry
+			t.Cleanup(func() { defaultProjectCleanupContributorRegistry = orig })
+			defaultProjectCleanupContributorRegistry = component.MustNewPredicateBasedRegistry[
+				*kargoapi.Project,
+				projectCleanupContributorPredicate,
+				projectCleanupContributorFunc,
+				struct{},
+			]()
+			defaultProjectCleanupContributorRegistry.MustRegister(testCase.contributor)
+
+			r := &reconciler{
+				deleteClusterRoleBindingFn: func(
+					context.Context,
+					client.Object,
+					...client.DeleteOption,
+				) error {
+					return nil
+				},
+				deleteClusterRoleFn: func(
+					context.Context,
+					client.Object,
+					...client.DeleteOption,
+				) error {
+					return nil
+				},
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "test-project")
+				},
+				removeFinalizerFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+			}
+			err := r.cleanupProject(
+				t.Context(),
+				&kargoapi.Project{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-project"},
+				},
+			)
+			testCase.assertions(t, err)
+		})
+	}
+}
+
 func TestReconciler_syncProject(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -1166,6 +1267,78 @@ func TestReconciler_syncProject(t *testing.T) {
 				t.Context(),
 				testCase.project,
 			)
+			testCase.assertions(t, status, err)
+		})
+	}
+}
+
+func TestReconciler_syncProject_setupContributors(t *testing.T) {
+	testCases := []struct {
+		name        string
+		contributor ProjectSetupContributorRegistration
+		assertions  func(*testing.T, kargoapi.ProjectStatus, error)
+	}{
+		{
+			name: "error from setup contributor",
+			contributor: ProjectSetupContributorRegistration{
+				Predicate: func(context.Context, *kargoapi.Project) (bool, error) {
+					return true, nil
+				},
+				Value: func(context.Context, *kargoapi.Project) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
+				require.ErrorContains(t, err, "something went wrong")
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionFalse, readyCondition.Status)
+				require.Equal(t, "EnsuringExtendedPermissionsFailed", readyCondition.Reason)
+			},
+		},
+		{
+			name: "success with setup contributor",
+			contributor: ProjectSetupContributorRegistration{
+				Predicate: func(context.Context, *kargoapi.Project) (bool, error) {
+					return true, nil
+				},
+				Value: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.ProjectStatus, err error) {
+				require.NoError(t, err)
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+				require.Equal(t, "Synced", readyCondition.Reason)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			orig := defaultProjectSetupContributorRegistry
+			t.Cleanup(func() { defaultProjectSetupContributorRegistry = orig })
+			defaultProjectSetupContributorRegistry = component.MustNewPredicateBasedRegistry[
+				*kargoapi.Project,
+				projectSetupContributorPredicate,
+				projectSetupContributorFunc,
+				struct{},
+			]()
+			defaultProjectSetupContributorRegistry.MustRegister(testCase.contributor)
+
+			r := &reconciler{
+				ensureNamespaceFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureSystemPermissionsFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureDefaultUserRolesFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+			}
+			status, err := r.syncProject(t.Context(), &kargoapi.Project{})
 			testCase.assertions(t, status, err)
 		})
 	}
@@ -2052,444 +2225,6 @@ func TestReconciler_ensureDefaultUserRoles_contributors(t *testing.T) {
 		})
 	}
 }
-
-func TestReconciler_ensureExtendedPermissions(t *testing.T) {
-	testProject := &kargoapi.Project{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fake-project",
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	require.NoError(t, err)
-	err = rbacv1.AddToScheme(scheme)
-	require.NoError(t, err)
-
-	testCases := []struct {
-		name       string
-		cfg        ReconcilerConfig
-		client     client.Client
-		assertions func(*testing.T, client.Client, error)
-	}{
-		{
-			name: "error creating ServiceAccount",
-			cfg: ReconcilerConfig{
-				ControlPlaneServiceAccountName: "test-control-plane",
-			},
-			client: fake.NewClientBuilder().WithScheme(scheme).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Create: func(
-						context.Context,
-						client.WithWatch,
-						client.Object,
-						...client.CreateOption,
-					) error {
-						return fmt.Errorf("something went wrong")
-					},
-				}).Build(),
-			assertions: func(t *testing.T, _ client.Client, err error) {
-				require.ErrorContains(t, err, "error creating ServiceAccount")
-				require.ErrorContains(t, err, "something went wrong")
-			},
-		},
-		{
-			name: "ServiceAccounts already exist",
-			cfg: ReconcilerConfig{
-				ControlPlaneServiceAccountName: "test-control-plane",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(
-					&corev1.ServiceAccount{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-control-plane",
-							Namespace: testProject.Name,
-							Annotations: map[string]string{
-								rbacapi.AnnotationKeyManaged: rbacapi.AnnotationValueTrue,
-							},
-						},
-					},
-				).Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-				// Verify ServiceAccount still exists
-				sa := &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-control-plane",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "creates control plane ServiceAccount and RoleBinding",
-			cfg: ReconcilerConfig{
-				ControlPlaneServiceAccountName: "test-control-plane",
-				ControlPlaneClusterRoleName:    "test-control-plane-role",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify ServiceAccount was created
-				sa := &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-control-plane",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.NoError(t, err)
-				require.Equal(t, rbacapi.AnnotationValueTrue, sa.Annotations[rbacapi.AnnotationKeyManaged])
-
-				// Verify RoleBinding was created
-				rb := &rbacv1.RoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-control-plane",
-						Namespace: testProject.Name,
-					},
-					rb,
-				)
-				require.NoError(t, err)
-				require.Equal(t, "test-control-plane-role", rb.RoleRef.Name)
-				require.Equal(t, "ClusterRole", rb.RoleRef.Kind)
-				require.Equal(t, rbacapi.AnnotationValueTrue, rb.Annotations[rbacapi.AnnotationKeyManaged])
-			},
-		},
-		{
-			name: "ArgoCD configured - creates ArgoCD ServiceAccount",
-			cfg: ReconcilerConfig{
-				ArgoCDServiceAccountName: "kargo-argocd-service-account",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify ArgoCD ServiceAccount was created
-				sa := &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "kargo-argocd-service-account",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.NoError(t, err)
-				require.Equal(t, rbacapi.AnnotationValueTrue, sa.Annotations[rbacapi.AnnotationKeyManaged])
-			},
-		},
-		{
-			name: "ArgoCD configured and not watching namespace only - creates ClusterRoleBinding",
-			cfg: ReconcilerConfig{
-				ArgoCDServiceAccountName: "kargo-argocd-service-account",
-				ArgoCDClusterRoleName:    "kargo-argocd",
-				ArgoCDWatchNamespaceOnly: false,
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify ClusterRoleBinding was created
-				crb := &rbacv1.ClusterRoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name: kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-%s", testProject.Name)),
-					},
-					crb,
-				)
-				require.NoError(t, err)
-				require.Equal(t, "kargo-argocd", crb.RoleRef.Name)
-				require.Equal(t, rbacapi.AnnotationValueTrue, crb.Annotations[rbacapi.AnnotationKeyManaged])
-				require.Len(t, crb.Subjects, 1)
-				require.Equal(t, "kargo-argocd-service-account", crb.Subjects[0].Name)
-				require.Equal(t, testProject.Name, crb.Subjects[0].Namespace)
-			},
-		},
-		{
-			name: "ArgoCD configured and watching namespace only - creates RoleBinding",
-			cfg: ReconcilerConfig{
-				ArgoCDServiceAccountName: "kargo-argocd-service-account",
-				ArgoCDRoleName:           "kargo-argocd",
-				ArgoCDNamespace:          "argocd",
-				ArgoCDWatchNamespaceOnly: true,
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify ArgoCD RoleBinding was created
-				rb := &rbacv1.RoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-%s", testProject.Name)),
-						Namespace: "argocd",
-					},
-					rb,
-				)
-				require.NoError(t, err)
-				require.Equal(t, "kargo-argocd", rb.RoleRef.Name)
-				require.Equal(t, "Role", rb.RoleRef.Kind)
-				require.Len(t, rb.Subjects, 1)
-				require.Equal(t, "kargo-argocd-service-account", rb.Subjects[0].Name)
-			},
-		},
-		{
-			name: "manage orchestrator enabled without dedicated namespace",
-			cfg: ReconcilerConfig{
-				ManageOrchestrator:             true,
-				OrchestratorServiceAccountName: "test-orchestrator",
-				OrchestratorClusterRoleName:    "test-orchestrator-role",
-				TokenManagerClusterRoleName:    "test-token-manager",
-				ControlPlaneServiceAccountName: "test-control-plane",
-				ControlPlaneClusterRoleName:    "test-control-plane-role",
-				ManagedResourceNamespace:       "", // Empty means use project namespace
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify orchestrator ServiceAccount was created
-				sa := &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-orchestrator",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.NoError(t, err)
-
-				// Verify control plane ServiceAccount was created
-				sa = &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-control-plane",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.NoError(t, err)
-
-				// Verify orchestrator RoleBindings were created
-				roleBindings := []string{
-					"test-orchestrator",
-					"test-token-manager",
-					"test-control-plane",
-					kubernetes.ShortenResourceName(fmt.Sprintf("%s-secrets-reader", "test-orchestrator")),
-				}
-
-				for _, rbName := range roleBindings {
-					rb := &rbacv1.RoleBinding{}
-					err = cl.Get(
-						t.Context(),
-						types.NamespacedName{
-							Name:      rbName,
-							Namespace: testProject.Name,
-						},
-						rb,
-					)
-					require.NoError(t, err, "RoleBinding %s should exist", rbName)
-				}
-			},
-		},
-		{
-			name: "manage orchestrator enabled with dedicated namespace",
-			cfg: ReconcilerConfig{
-				ManageOrchestrator:             true,
-				OrchestratorServiceAccountName: "test-orchestrator",
-				ManagedResourceNamespace:       "kargo-resources",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify orchestrator ServiceAccount was NOT created in project namespace
-				sa := &corev1.ServiceAccount{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "test-orchestrator",
-						Namespace: testProject.Name,
-					},
-					sa,
-				)
-				require.True(t, apierrors.IsNotFound(err))
-			},
-		},
-		{
-			name: "manage resource manager role without dedicated namespace",
-			cfg: ReconcilerConfig{
-				ManagerServiceAccountName: "manager-sa",
-				ManagerClusterRoleName:    "kargo-manager",
-				ManagedResourceNamespace:  "", // Empty means use project namespace
-				KargoNamespace:            "kargo-system",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify manager RoleBinding was created
-				rb := &rbacv1.RoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "kargo-manager",
-						Namespace: testProject.Name,
-					},
-					rb,
-				)
-				require.NoError(t, err)
-				require.Equal(t, "kargo-manager", rb.RoleRef.Name)
-				require.Len(t, rb.Subjects, 1)
-				require.Equal(t, "manager-sa", rb.Subjects[0].Name)
-				require.Equal(t, "kargo-system", rb.Subjects[0].Namespace)
-			},
-		},
-		{
-			name: "do not manage resource manager role with dedicated namespace",
-			cfg: ReconcilerConfig{
-				ManagerServiceAccountName: "manager-sa",
-				ManagedResourceNamespace:  "kargo-resources",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-
-				// Verify manager RoleBinding was NOT created
-				rb := &rbacv1.RoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name:      "kargo-manager",
-						Namespace: testProject.Name,
-					},
-					rb,
-				)
-				require.True(t, apierrors.IsNotFound(err))
-			},
-		},
-		{
-			name: "error creating RoleBinding",
-			cfg: ReconcilerConfig{
-				ControlPlaneServiceAccountName: "test-control-plane",
-				ControlPlaneClusterRoleName:    "test-control-plane-role",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Create: func(
-						_ context.Context,
-						_ client.WithWatch,
-						obj client.Object,
-						_ ...client.CreateOption,
-					) error {
-						if _, ok := obj.(*rbacv1.RoleBinding); ok {
-							return fmt.Errorf("something went wrong")
-						}
-						return nil
-					},
-				}).Build(),
-			assertions: func(t *testing.T, _ client.Client, err error) {
-				require.ErrorContains(t, err, "error creating RoleBinding")
-				require.ErrorContains(t, err, "something went wrong")
-			},
-		},
-		{
-			name: "error creating ClusterRoleBinding",
-			cfg: ReconcilerConfig{
-				ArgoCDServiceAccountName: "kargo-argocd-service-account",
-				ArgoCDClusterRoleName:    "kargo-argocd-role",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Create: func(
-						_ context.Context,
-						_ client.WithWatch,
-						obj client.Object,
-						_ ...client.CreateOption,
-					) error {
-						if _, ok := obj.(*rbacv1.ClusterRoleBinding); ok {
-							return fmt.Errorf("something went wrong")
-						}
-						return nil
-					},
-				}).Build(),
-			assertions: func(t *testing.T, _ client.Client, err error) {
-				require.ErrorContains(t, err, "error creating ClusterRoleBinding")
-				require.ErrorContains(t, err, "something went wrong")
-			},
-		},
-		{
-			name: "ClusterRoleBinding already exists",
-			cfg: ReconcilerConfig{
-				ArgoCDServiceAccountName: "kargo-argocd-service-account",
-				ArgoCDClusterRoleName:    "kargo-argocd-role",
-			},
-			client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(
-					&rbacv1.ClusterRoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-role-%s", testProject.Name)),
-						},
-					},
-				).Build(),
-			assertions: func(t *testing.T, cl client.Client, err error) {
-				require.NoError(t, err)
-				// Verify it still exists
-				crb := &rbacv1.ClusterRoleBinding{}
-				err = cl.Get(
-					t.Context(),
-					types.NamespacedName{
-						Name: kubernetes.ShortenResourceName(fmt.Sprintf("kargo-argocd-role-%s", testProject.Name)),
-					},
-					crb,
-				)
-				require.NoError(t, err)
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			r := newReconciler(testCase.client, testCase.cfg)
-			err := r.ensureExtendedPermissions(t.Context(), testProject)
-			testCase.assertions(t, testCase.client, err)
-		})
-	}
-}
-
 func Test_shouldKeepNamespace(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Follow-up to #6034 (specifically [Kent's ask](https://github.com/akuity/kargo/pull/6034#issuecomment-4284819279)).

Introduces `ProjectSetupContributorRegistration` and `ProjectCleanupContributorRegistration` registries, allowing downstream distributions to inject additional setup and cleanup logic into the project reconciler at startup time.

Both registries follow the same `pkg/component.PredicateBasedRegistry` + `GetAll()` pattern introduced in #6034, with `*kargoapi.Project` as the predicate arg — enabling contributors to opt out for specific projects if needed.

**Ordering** is intentionally symmetric:
- **Setup:** OSS base resources first, then contributors (OSS → EE)
- **Cleanup:** Contributors first, then OSS base resources (EE → OSS), so EE resources that reference OSS ClusterRoles are removed before those ClusterRoles are deleted. This also fixes a non-determinism bug in the previous cleanup, which used map iteration to decide deletion order.

As a result, `ensureExtendedPermissions` and all EE-specific fields in `ReconcilerConfig` are removed from OSS. The EE companion PR registers its logic as contributors instead.

## Test plan

- [x] Unit tests for setup contributor error/success paths in `TestReconciler_syncProject_setupContributors`
- [x] Unit tests for cleanup contributor ordering and error/success paths in `TestReconciler_cleanupProject_cleanupContributors`