### PR TITLE
feat: add delete freight command

### DIFF
--- a/pkg/cli/cmd/delete/delete.go
+++ b/pkg/cli/cmd/delete/delete.go
@@ -57,6 +57,9 @@ kargo delete stage --project=my-project my-stage
 
 # Delete a warehouse
 kargo delete warehouse --project=my-project my-warehouse
+
+# Delete freight
+kargo delete freight --project=my-project abc1234
 `),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmdOpts.validate(); err != nil {
@@ -76,6 +79,7 @@ kargo delete warehouse --project=my-project my-warehouse
 	// Register subcommands.
 	cmd.AddCommand(newClusterConfigCommand(cfg, streams))
 	cmd.AddCommand(newConfigMapCommand(cfg, streams))
+	cmd.AddCommand(newFreightCommand(cfg, streams))
 	cmd.AddCommand(newGenericCredentialsCommand(cfg, streams))
 	cmd.AddCommand(newRepoCredentialsCommand(cfg, streams))
 	cmd.AddCommand(newProjectCommand(cfg, streams))

--- a/pkg/cli/cmd/delete/freight.go
+++ b/pkg/cli/cmd/delete/freight.go
@@ -1,0 +1,153 @@
+package delete
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/cli/client"
+	"github.com/akuity/kargo/pkg/cli/config"
+	"github.com/akuity/kargo/pkg/cli/io"
+	"github.com/akuity/kargo/pkg/cli/kubernetes"
+	"github.com/akuity/kargo/pkg/cli/option"
+	"github.com/akuity/kargo/pkg/cli/templates"
+	"github.com/akuity/kargo/pkg/client/generated/core"
+)
+
+type deleteFreightOptions struct {
+	genericiooptions.IOStreams
+	*genericclioptions.PrintFlags
+
+	Config        config.CLIConfig
+	ClientOptions client.Options
+
+	Project string
+	Names   []string
+}
+
+func newFreightCommand(
+	cfg config.CLIConfig,
+	streams genericiooptions.IOStreams,
+) *cobra.Command {
+	cmdOpts := &deleteFreightOptions{
+		Config:     cfg,
+		IOStreams:   streams,
+		PrintFlags: genericclioptions.NewPrintFlags("deleted").WithTypeSetter(kubernetes.GetScheme()),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "freight [--project=project] (NAME-OR-ALIAS ...)",
+		Short: "Delete freight by name or alias",
+		Args:  option.MinimumNArgs(1),
+		Example: templates.Example(`
+# Delete a Freight resource
+kargo delete freight --project=my-project abc1234
+
+# Delete a Freight resource by alias
+kargo delete freight --project=my-project wonky-wombat
+
+# Delete multiple Freight resources
+kargo delete freight --project=my-project abc1234 def5678
+
+# Delete a Freight resource in the default project
+kargo config set-project my-project
+kargo delete freight abc1234
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdOpts.complete(args)
+
+			if err := cmdOpts.validate(); err != nil {
+				return err
+			}
+
+			return cmdOpts.run(cmd.Context())
+		},
+	}
+
+	// Register the option flags on the command.
+	cmdOpts.addFlags(cmd)
+
+	// Set the input/output streams for the command.
+	io.SetIOStreams(cmd, cmdOpts.IOStreams)
+
+	return cmd
+}
+
+// addFlags adds the flags for the delete freight options to the provided
+// command.
+func (o *deleteFreightOptions) addFlags(cmd *cobra.Command) {
+	o.ClientOptions.AddFlags(cmd.PersistentFlags())
+	o.AddFlags(cmd)
+
+	option.Project(
+		cmd.Flags(), &o.Project, o.Config.Project,
+		"The Project for which to delete Freight. "+
+			"If not set, the default project will be used.",
+	)
+}
+
+// complete sets the options from the command arguments.
+func (o *deleteFreightOptions) complete(args []string) {
+	o.Names = slices.Compact(args)
+}
+
+// validate performs validation of the options. If the options are invalid, an
+// error is returned.
+func (o *deleteFreightOptions) validate() error {
+	var errs []error
+
+	if o.Project == "" {
+		errs = append(errs, errors.New("project is required"))
+	}
+
+	if len(o.Names) == 0 {
+		errs = append(
+			errs,
+			errors.New("at least one freight name or alias is required"),
+		)
+	}
+
+	return errors.Join(errs...)
+}
+
+// run removes the Freight resource(s) based on the options.
+func (o *deleteFreightOptions) run(ctx context.Context) error {
+	apiClient, err := client.GetClientFromConfig(
+		ctx, o.Config, o.ClientOptions,
+	)
+	if err != nil {
+		return fmt.Errorf("get client from config: %w", err)
+	}
+
+	printer, err := o.ToPrinter()
+	if err != nil {
+		return fmt.Errorf("create printer: %w", err)
+	}
+
+	var errs []error
+	for _, name := range o.Names {
+		if _, err := apiClient.Core.DeleteFreight(
+			core.NewDeleteFreightParams().
+				WithProject(o.Project).
+				WithFreightNameOrAlias(name),
+			nil,
+		); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		_ = printer.PrintObj(&kargoapi.Freight{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: o.Project,
+			},
+		}, o.Out)
+	}
+	return errors.Join(errs...)
+}


### PR DESCRIPTION
## Summary

Add a CLI command to delete Freight resources by name or alias.
The API and UI already support this operation but the CLI was missing it.

- Supports deletion by name or alias (uses the existing `FreightNameOrAlias` API parameter)
- Supports deleting multiple Freight resources in a single invocation
- Follows the same patterns as the existing `delete stage` and `delete warehouse` commands

## Usage

```bash
# Delete by name
kargo delete freight --project=my-project abc1234

# Delete by alias
kargo delete freight --project=my-project wonky-wombat

# Delete multiple
kargo delete freight --project=my-project abc1234 def5678
Closes #6162


