### PR TITLE
feat: promotion orchestrator access for cluster configs + shared secrets

### DIFF
--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -64,6 +64,19 @@ type ReconcilerConfig struct {
 	ArgoCDClusterRoleName    string `envconfig:"ARGOCD_CLUSTER_ROLE_NAME" default:""`
 	ArgoCDNamespace          string `envconfig:"ARGOCD_NAMESPACE" default:"argocd"`
 	ArgoCDWatchNamespaceOnly bool   `envconfig:"ARGOCD_WATCH_ARGOCD_NAMESPACE_ONLY" default:"false"`
+
+	// OrchestratorClusterAccessRoleName is the name of a ClusterRole granting
+	// the orchestrator access to cluster-scoped resources (e.g. ClusterConfig).
+	// When set, a per-project ClusterRoleBinding is created for the orchestrator
+	// ServiceAccount. Distinct from OrchestratorClusterRoleName to avoid
+	// granting namespace-scoped resources cluster-wide via ClusterRoleBinding.
+	OrchestratorClusterAccessRoleName string `envconfig:"ORCHESTRATOR_CLUSTER_ACCESS_ROLE_NAME" default:""`
+
+	// SharedResourcesNamespace is the namespace holding shared credentials
+	// Secrets. When set and an orchestrator ServiceAccount is configured, a
+	// RoleBinding is created in that namespace so the orchestrator can read
+	// those Secrets.
+	SharedResourcesNamespace string `envconfig:"SHARED_RESOURCES_NAMESPACE" default:""`
 }
 
 func ReconcilerConfigFromEnv() ReconcilerConfig {
@@ -180,6 +193,12 @@ type reconciler struct {
 		client.Object,
 		...client.DeleteOption,
 	) error
+
+	deleteRoleBindingFn func(
+		context.Context,
+		client.Object,
+		...client.DeleteOption,
+	) error
 }
 
 // SetupReconcilerWithManager initializes a reconciler for Project resources and
@@ -260,6 +279,7 @@ func newReconciler(kubeClient client.Client, cfg ReconcilerConfig) *reconciler {
 	r.createClusterRoleBindingFn = r.client.Create
 	r.deleteClusterRoleFn = r.client.Delete
 	r.deleteClusterRoleBindingFn = r.client.Delete
+	r.deleteRoleBindingFn = r.client.Delete
 	return r
 }
 
@@ -393,6 +413,9 @@ func (r *reconciler) cleanupProject(ctx context.Context, project *kargoapi.Proje
 	if r.cfg.ManageExtendedPermissions && r.cfg.ArgoCDClusterRoleName != "" {
 		crbs[kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.ArgoCDClusterRoleName, project.Name))] = false
 	}
+	if r.cfg.ManageExtendedPermissions && r.cfg.OrchestratorClusterAccessRoleName != "" {
+		crbs[kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.OrchestratorClusterAccessRoleName, project.Name))] = false
+	}
 	for crbName, hasCR := range crbs {
 		if err := r.deleteClusterRoleBindingFn(
 			ctx,
@@ -412,6 +435,29 @@ func (r *reconciler) cleanupProject(ctx context.Context, project *kargoapi.Proje
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: crName}},
 		); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error deleting ClusterRole %q: %w", crName, err)
+		}
+	}
+
+	// Delete the orchestrator's RoleBinding in the shared resources namespace.
+	// This binding lives outside the project namespace and won't be cleaned up
+	// when the namespace is deleted.
+	if r.cfg.ManageExtendedPermissions &&
+		r.cfg.OrchestratorServiceAccountName != "" &&
+		r.cfg.SharedResourcesNamespace != "" {
+		rbName := kubernetes.ShortenResourceName(
+			fmt.Sprintf("%s-%s", r.cfg.OrchestratorServiceAccountName, project.Name),
+		)
+		if err := r.deleteRoleBindingFn(
+			ctx,
+			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: r.cfg.SharedResourcesNamespace,
+			}},
+		); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf(
+				"error deleting RoleBinding %q in shared resources namespace %q: %w",
+				rbName, r.cfg.SharedResourcesNamespace, err,
+			)
 		}
 	}
 
@@ -1167,6 +1213,34 @@ func (r *reconciler) ensureExtendedPermissions(
 
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
 
+	if r.cfg.OrchestratorServiceAccountName != "" && r.cfg.OrchestratorClusterAccessRoleName != "" {
+		// ClusterRoleBinding for the orchestrator ServiceAccount to read
+		// cluster-scoped resources (e.g. ClusterConfig) that cannot be granted
+		// through a namespace-scoped RoleBinding.
+		clusterRoleBindings = append(clusterRoleBindings, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kubernetes.ShortenResourceName(
+					fmt.Sprintf("%s-%s", r.cfg.OrchestratorClusterAccessRoleName, project.Name),
+				),
+				Annotations: map[string]string{
+					rbacapi.AnnotationKeyManaged: rbacapi.AnnotationValueTrue,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     r.cfg.OrchestratorClusterAccessRoleName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      r.cfg.OrchestratorServiceAccountName,
+					Namespace: project.Name,
+				},
+			},
+		})
+	}
+
 	if r.cfg.ArgoCDServiceAccountName != "" && !r.cfg.ArgoCDWatchNamespaceOnly {
 		// ClusterRoleBinding for the Argo CD ServiceAccount to access and
 		// operate on Argo CD Application resources in any namespace.
@@ -1333,6 +1407,33 @@ func (r *reconciler) ensureExtendedPermissions(
 				},
 			},
 		})
+
+		if r.cfg.SharedResourcesNamespace != "" {
+			// RoleBinding for the orchestrator ServiceAccount to access Secrets
+			// in the shared resources namespace. This is needed so the credentials
+			// server can look up shared credentials during Promotion step execution.
+			roleBindings = append(roleBindings, &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: kubernetes.ShortenResourceName(
+						fmt.Sprintf("%s-%s", r.cfg.OrchestratorServiceAccountName, project.Name),
+					),
+					Namespace:   r.cfg.SharedResourcesNamespace,
+					Annotations: rbAnnotations,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     projectSecretsReaderClusterRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						Name:      r.cfg.OrchestratorServiceAccountName,
+						Namespace: project.Name,
+					},
+				},
+			})
+		}
 	}
 
 	if r.cfg.ArgoCDServiceAccountName != "" && r.cfg.ArgoCDNamespace != "" && r.cfg.ArgoCDWatchNamespaceOnly {

--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -414,7 +414,9 @@ func (r *reconciler) cleanupProject(ctx context.Context, project *kargoapi.Proje
 		crbs[kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.ArgoCDClusterRoleName, project.Name))] = false
 	}
 	if r.cfg.ManageExtendedPermissions && r.cfg.OrchestratorClusterAccessRoleName != "" {
-		crbs[kubernetes.ShortenResourceName(fmt.Sprintf("%s-%s", r.cfg.OrchestratorClusterAccessRoleName, project.Name))] = false
+		crbs[kubernetes.ShortenResourceName(
+			fmt.Sprintf("%s-%s", r.cfg.OrchestratorClusterAccessRoleName, project.Name),
+		)] = false
 	}
 	for crbName, hasCR := range crbs {
 		if err := r.deleteClusterRoleBindingFn(

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -564,6 +564,129 @@ func TestReconciler_cleanupProject(t *testing.T) {
 			},
 		},
 		{
+			name: "deletes orchestrator cluster access ClusterRoleBinding",
+			project: &kargoapi.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-project",
+				},
+			},
+			reconciler: &reconciler{
+				cfg: ReconcilerConfig{
+					ManageExtendedPermissions:         true,
+					OrchestratorClusterAccessRoleName: "test-cluster-access",
+				},
+				deleteClusterRoleBindingFn: func(
+					_ context.Context,
+					obj client.Object,
+					_ ...client.DeleteOption,
+				) error {
+					name := obj.GetName()
+					if name != kubernetes.ShortenResourceName("kargo-project-admin-test-project") &&
+						name != kubernetes.ShortenResourceName("test-cluster-access-test-project") {
+						return fmt.Errorf("unexpected ClusterRoleBinding name: %s", name)
+					}
+					return nil
+				},
+				deleteClusterRoleFn: func(
+					_ context.Context,
+					obj client.Object,
+					_ ...client.DeleteOption,
+				) error {
+					name := obj.GetName()
+					if name != kubernetes.ShortenResourceName("kargo-project-admin-test-project") {
+						return fmt.Errorf("unexpected ClusterRole name: %s", name)
+					}
+					return nil
+				},
+				deleteRoleBindingFn: func(
+					context.Context,
+					client.Object,
+					...client.DeleteOption,
+				) error {
+					return nil
+				},
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "test-project")
+				},
+				removeFinalizerFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "deletes shared resources RoleBinding",
+			project: &kargoapi.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-project",
+				},
+			},
+			reconciler: &reconciler{
+				cfg: ReconcilerConfig{
+					ManageExtendedPermissions:      true,
+					OrchestratorServiceAccountName: "test-orchestrator",
+					SharedResourcesNamespace:       "kargo-shared-resources",
+				},
+				deleteClusterRoleBindingFn: func(
+					context.Context,
+					client.Object,
+					...client.DeleteOption,
+				) error {
+					return nil
+				},
+				deleteClusterRoleFn: func(
+					context.Context,
+					client.Object,
+					...client.DeleteOption,
+				) error {
+					return nil
+				},
+				deleteRoleBindingFn: func(
+					_ context.Context,
+					obj client.Object,
+					_ ...client.DeleteOption,
+				) error {
+					expectedName := kubernetes.ShortenResourceName("test-orchestrator-test-project")
+					if obj.GetName() != expectedName || obj.GetNamespace() != "kargo-shared-resources" {
+						return fmt.Errorf(
+							"unexpected RoleBinding %s/%s",
+							obj.GetNamespace(), obj.GetName(),
+						)
+					}
+					return nil
+				},
+				getNamespaceFn: func(
+					context.Context,
+					types.NamespacedName,
+					client.Object,
+					...client.GetOption,
+				) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, "test-project")
+				},
+				removeFinalizerFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
 			name: "error getting namespace",
 			project: &kargoapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2251,6 +2374,71 @@ func TestReconciler_ensureExtendedPermissions(t *testing.T) {
 				require.Equal(t, "Role", rb.RoleRef.Kind)
 				require.Len(t, rb.Subjects, 1)
 				require.Equal(t, "kargo-argocd-service-account", rb.Subjects[0].Name)
+			},
+		},
+		{
+			name: "orchestrator cluster access role set - creates ClusterRoleBinding",
+			cfg: ReconcilerConfig{
+				ManageOrchestrator:                true,
+				OrchestratorServiceAccountName:    "test-orchestrator",
+				OrchestratorClusterRoleName:       "test-orchestrator-role",
+				OrchestratorClusterAccessRoleName: "test-orchestrator-cluster-access",
+			},
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build(),
+			assertions: func(t *testing.T, cl client.Client, err error) {
+				require.NoError(t, err)
+
+				crb := &rbacv1.ClusterRoleBinding{}
+				err = cl.Get(
+					t.Context(),
+					types.NamespacedName{
+						Name: kubernetes.ShortenResourceName(
+							fmt.Sprintf("test-orchestrator-cluster-access-%s", testProject.Name),
+						),
+					},
+					crb,
+				)
+				require.NoError(t, err)
+				require.Equal(t, "test-orchestrator-cluster-access", crb.RoleRef.Name)
+				require.Equal(t, rbacapi.AnnotationValueTrue, crb.Annotations[rbacapi.AnnotationKeyManaged])
+				require.Len(t, crb.Subjects, 1)
+				require.Equal(t, "test-orchestrator", crb.Subjects[0].Name)
+				require.Equal(t, testProject.Name, crb.Subjects[0].Namespace)
+			},
+		},
+		{
+			name: "shared resources namespace set - creates RoleBinding for orchestrator",
+			cfg: ReconcilerConfig{
+				ManageOrchestrator:             true,
+				OrchestratorServiceAccountName: "test-orchestrator",
+				OrchestratorClusterRoleName:    "test-orchestrator-role",
+				SharedResourcesNamespace:       "kargo-shared-resources",
+			},
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build(),
+			assertions: func(t *testing.T, cl client.Client, err error) {
+				require.NoError(t, err)
+
+				rb := &rbacv1.RoleBinding{}
+				err = cl.Get(
+					t.Context(),
+					types.NamespacedName{
+						Name: kubernetes.ShortenResourceName(
+							fmt.Sprintf("test-orchestrator-%s", testProject.Name),
+						),
+						Namespace: "kargo-shared-resources",
+					},
+					rb,
+				)
+				require.NoError(t, err)
+				require.Equal(t, projectSecretsReaderClusterRoleName, rb.RoleRef.Name)
+				require.Equal(t, rbacapi.AnnotationValueTrue, rb.Annotations[rbacapi.AnnotationKeyManaged])
+				require.Len(t, rb.Subjects, 1)
+				require.Equal(t, "test-orchestrator", rb.Subjects[0].Name)
+				require.Equal(t, testProject.Name, rb.Subjects[0].Namespace)
 			},
 		},
 		{


### PR DESCRIPTION
### Problem

The promotion orchestrator needs to read two resources it currently has no RBAC access to:

- `ClusterConfig`: Needs to be read at step execution time to resolve the system-level git user (name, email, signing key). 
- `Secret`s in the shared resources namespace: The orchestrator's existing `secrets-reader` `RoleBinding` is scoped to the project namespace only, so shared credentials are unreachable.

### Solution

Two new fields in ReconcilerConfig:

`OrchestratorClusterAccessRoleName` (`ORCHESTRATOR_CLUSTER_ACCESS_ROLE_NAME`)

When set, `ensureExtendedPermissions` creates a per-project `ClusterRoleBinding` to this role. A separate, narrow `ClusterRole` is used (rather than the existing `OrchestratorClusterRoleName`) to avoid granting namespace-scoped resources cluster-wide.

`SharedResourcesNamespace` (`SHARED_RESOURCES_NAMESPACE`)

When set, `ensureExtendedPermissions` creates a per-project `RoleBinding` in that namespace binding the orchestrator SA to `kargo-project-secrets-reader`.

Both resources are cleaned up in `cleanupProject `when the project is deleted, since they live outside the project namespace and won't be removed by namespace deletion.