### PR TITLE
fix: use b64url, not b64, in jwt decode

### DIFF
--- a/ui/src/config/transport.ts
+++ b/ui/src/config/transport.ts
@@ -2,6 +2,8 @@ import { Code, ConnectError, Interceptor } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { notification } from 'antd';
 
+import { parseJwtPayload } from '@ui/utils/jwt-payload';
+
 import { authTokenKey, redirectToQueryParam, refreshTokenKey } from './auth';
 import { paths } from './paths';
 
@@ -22,7 +24,9 @@ const authHandler: Interceptor = (next) => async (req) => {
   let isTokenExpired;
 
   try {
-    isTokenExpired = token && Date.now() >= JSON.parse(atob(token.split('.')[1])).exp * 1000;
+    const payload = token ? parseJwtPayload<{ exp?: number }>(token) : null;
+    isTokenExpired =
+      Boolean(token) && typeof payload?.exp === 'number' && Date.now() >= payload.exp * 1000;
   } catch (_) {
     logout();
 

--- a/ui/src/features/auth/jwt-utils.ts
+++ b/ui/src/features/auth/jwt-utils.ts
@@ -1,3 +1,5 @@
+import { parseJwtPayload } from '@ui/utils/jwt-payload';
+
 // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 export type JWTInfo = {
   sub: string;
@@ -11,7 +13,7 @@ export type JWTInfo = {
 // jwt claims register with "admin" subject on admin login
 export const isAdmin = (user?: JWTInfo | null) => user?.sub === 'admin';
 
-export const extractInfoFromJWT = (token: string): JWTInfo => JSON.parse(atob(token.split('.')[1]));
+export const extractInfoFromJWT = (token: string): JWTInfo => parseJwtPayload<JWTInfo>(token);
 
 export const isJWTValid = (token: string): boolean => {
   try {

--- a/ui/src/lib/api/custom-fetch.ts
+++ b/ui/src/lib/api/custom-fetch.ts
@@ -12,6 +12,7 @@
 
 import { authTokenKey, redirectToQueryParam, refreshTokenKey } from '@ui/config/auth';
 import { paths } from '@ui/config/paths';
+import { parseJwtPayload } from '@ui/utils/jwt-payload';
 
 const getBaseUrl = (): string => {
   if (import.meta.env.VITE_API_URL) {
@@ -52,7 +53,9 @@ export const customFetch = async <T>(url: string, options?: RequestInit): Promis
   if (token) {
     let isTokenExpired: boolean;
     try {
-      isTokenExpired = Date.now() >= JSON.parse(atob(token.split('.')[1])).exp * 1000;
+      const payload = parseJwtPayload<{ exp?: number }>(token);
+      isTokenExpired =
+        typeof payload.exp === 'number' && Date.now() >= payload.exp * 1000;
     } catch (_) {
       logout();
       throw new ApiError(401, 'Unauthorized', 'Invalid token');

--- a/ui/src/lib/api/custom-fetch.ts
+++ b/ui/src/lib/api/custom-fetch.ts
@@ -54,8 +54,7 @@ export const customFetch = async <T>(url: string, options?: RequestInit): Promis
     let isTokenExpired: boolean;
     try {
       const payload = parseJwtPayload<{ exp?: number }>(token);
-      isTokenExpired =
-        typeof payload.exp === 'number' && Date.now() >= payload.exp * 1000;
+      isTokenExpired = typeof payload.exp === 'number' && Date.now() >= payload.exp * 1000;
     } catch (_) {
       logout();
       throw new ApiError(401, 'Unauthorized', 'Invalid token');

--- a/ui/src/utils/jwt-payload.test.ts
+++ b/ui/src/utils/jwt-payload.test.ts
@@ -36,17 +36,14 @@ test('parseJwtPayload decodes UTF-8 claims (diacritics)', () => {
  * other lengths/compositions decode fine.
  */
 describe('parseJwtPayload familyName regression cases', () => {
-  test.each([
-    'abcdef',
-    'abcdeï',
-    'abcdeoï',
-    'abcdoï',
-    'abcdoñ'
-  ] as const)('round-trips familyName %s', (familyName) => {
-    const payload = { sub: 'u1', familyName, exp: 2_000_000_000 };
-    const token = makeJwt(payload);
-    expect(parseJwtPayload<typeof payload>(token)).toEqual(payload);
-  });
+  test.each(['abcdef', 'abcdeï', 'abcdeoï', 'abcdoï', 'abcdoñ'] as const)(
+    'round-trips familyName %s',
+    (familyName) => {
+      const payload = { sub: 'u1', familyName, exp: 2_000_000_000 };
+      const token = makeJwt(payload);
+      expect(parseJwtPayload<typeof payload>(token)).toEqual(payload);
+    }
+  );
 });
 
 test('parseJwtPayload handles Base64URL alphabet (+ → -) and restored padding', () => {

--- a/ui/src/utils/jwt-payload.test.ts
+++ b/ui/src/utils/jwt-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseJwtPayload } from './jwt-payload';
+
+/** JWT-style Base64URL of UTF-8 JSON (no `=` padding, `-`/`_` alphabet). */
+function base64UrlEncodeUtf8Json(value: unknown): string {
+  const json = JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = base64UrlEncodeUtf8Json({ alg: 'none', typ: 'JWT' });
+  const payloadSegment = base64UrlEncodeUtf8Json(payload);
+  return `${header}.${payloadSegment}.signature`;
+}
+
+test('parseJwtPayload decodes UTF-8 claims (diacritics)', () => {
+  const exp = 2_000_000_000;
+  const token = makeJwt({ sub: 'user-1', name: 'José García', exp });
+
+  expect(parseJwtPayload(token)).toEqual({
+    sub: 'user-1',
+    name: 'José García',
+    exp
+  });
+});
+
+/**
+ * Regression: naive `JSON.parse(atob(segment))` mishandles UTF-8 bytes for some
+ * six-character family names ending in `o` + a diacritic (e.g. ï, ñ), while
+ * other lengths/compositions decode fine.
+ */
+describe('parseJwtPayload familyName regression cases', () => {
+  test.each([
+    'abcdef',
+    'abcdeï',
+    'abcdeoï',
+    'abcdoï',
+    'abcdoñ'
+  ] as const)('round-trips familyName %s', (familyName) => {
+    const payload = { sub: 'u1', familyName, exp: 2_000_000_000 };
+    const token = makeJwt(payload);
+    expect(parseJwtPayload<typeof payload>(token)).toEqual(payload);
+  });
+});
+
+test('parseJwtPayload handles Base64URL alphabet (+ → -) and restored padding', () => {
+  // Single-character claim whose UTF-8 JSON base64 includes "+" (must become "-" in JWT).
+  const payload = { n: String.fromCodePoint(0x83e) };
+  const token = makeJwt(payload);
+  const segment = token.split('.')[1];
+  expect(segment).toContain('-');
+
+  expect(parseJwtPayload(token)).toEqual(payload);
+});
+
+test('parseJwtPayload throws on missing payload segment', () => {
+  expect(() => parseJwtPayload('only-one')).toThrow(/missing payload/);
+});
+
+test('parseJwtPayload throws on invalid base64', () => {
+  expect(() => parseJwtPayload('a.b!!!.c')).toThrow();
+});

--- a/ui/src/utils/jwt-payload.ts
+++ b/ui/src/utils/jwt-payload.ts
@@ -1,0 +1,24 @@
+/**
+ * Decode a JWT payload segment per RFC 7519: Base64URL → UTF-8 JSON.
+ * Safe for non-ASCII claims and segments using `-`/`_` (unlike atob alone).
+ */
+export function parseJwtPayload<T = Record<string, unknown>>(token: string): T {
+  const parts = token.split('.');
+  const segment = parts[1];
+  if (!segment) {
+    throw new Error('Invalid JWT: missing payload segment');
+  }
+
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(pad);
+
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  const json = new TextDecoder('utf-8').decode(bytes);
+  return JSON.parse(json) as T;
+}


### PR DESCRIPTION
This fixes https://github.com/akuity/kargo/issues/4601

[JWTs use the `base64Url` encoding](https://www.rfc-editor.org/rfc/rfc7519), not `base64`, and `atob/btoa` use the base64 alphabet. This means that certain combinations of bytes (which is why this issue is so unreliable) cannot be decoded, and the user is silently logged out.

