### PR TITLE
fix(ui): Improve pipeline graph readability

### DIFF
--- a/ui/src/features/project/pipelines/context/freight-timeline-controller-context.ts
+++ b/ui/src/features/project/pipelines/context/freight-timeline-controller-context.ts
@@ -19,6 +19,7 @@ export type FreightTimelineControllerContextType = {
     images: boolean;
     view: 'graph' | 'list';
     showMinimap: boolean;
+    stepEdges: boolean;
   };
   setPreferredFilter: (filter: FreightTimelineControllerContextType['preferredFilter']) => void;
 };

--- a/ui/src/features/project/pipelines/context/graph-context.ts
+++ b/ui/src/features/project/pipelines/context/graph-context.ts
@@ -15,6 +15,11 @@ export type GraphContextType = {
   // with onlyRenderVisibleElements -- so this skips heavy node bodies on init
   // and lets the real components mount only when actually visible.
   ready: boolean;
+
+  // name of the warehouse node currently being hovered, used to highlight
+  // edges belonging to that warehouse
+  hoveredWarehouseName: string | null;
+  setHoveredWarehouseName(name: string | null): void;
 };
 
 export const GraphContext = createContext<GraphContextType | null>(null);

--- a/ui/src/features/project/pipelines/graph/custom-node.tsx
+++ b/ui/src/features/project/pipelines/graph/custom-node.tsx
@@ -82,6 +82,8 @@ CustomNode.Container = (
     id?: string;
   }>
 ) => {
+  const graphContext = useGraphContext();
+
   let id = '';
   let height = 0;
 
@@ -96,11 +98,24 @@ CustomNode.Container = (
     height = repoSubscriptionSizer.size().height;
   }
 
+  const warehouseHoverProps = props.warehouse
+    ? {
+        onMouseEnter: () =>
+          graphContext?.setHoveredWarehouseName(props.warehouse?.metadata?.name || ''),
+        onMouseLeave: () => graphContext?.setHoveredWarehouseName(null)
+      }
+    : {};
+
   // Fixed-height slot with content vertically centered. The slot height matches
   // the predefined size used by dagre for layout, so handles -- positioned at
   // 50% of this slot -- line up with the dagre-computed edge endpoints.
   const Children = (
-    <div id={props.id} className='nodrag cursor-default flex items-center' style={{ height }}>
+    <div
+      id={props.id}
+      className='nodrag cursor-default flex items-center'
+      style={{ height }}
+      {...warehouseHoverProps}
+    >
       {props.children}
     </div>
   );
@@ -121,7 +136,9 @@ CustomNode.Container = (
             position={Position.Left}
             style={{
               top: handleTop(idx),
-              backgroundColor: 'transparent'
+              backgroundColor: 'transparent',
+              border: 'none',
+              left: 2
             }}
           />
         ))}
@@ -134,14 +151,16 @@ CustomNode.Container = (
             position={Position.Right}
             style={{
               top: handleTop(idx),
-              backgroundColor: 'transparent'
+              backgroundColor: 'transparent',
+              border: 'none',
+              right: 4
             }}
           />
         ))}
         <Handle
           type='source'
           position={Position.Right}
-          style={{ top: '50%', backgroundColor: 'transparent' }}
+          style={{ top: '50%', backgroundColor: 'transparent', border: 'none', right: 4 }}
         />
       </>
     );
@@ -157,7 +176,8 @@ CustomNode.Container = (
           top: '50%',
           backgroundColor: 'transparent',
           stroke: 'none',
-          border: 'none'
+          border: 'none',
+          left: 2
         }}
       />
       {Children}
@@ -169,11 +189,12 @@ CustomNode.Container = (
           top: '50%',
           backgroundColor: 'transparent',
           stroke: 'none',
-          border: 'none'
+          border: 'none',
+          right: 4
         }}
       />
     </>
   );
 };
 
-const EDGE_GAP = 10;
+const EDGE_GAP = 16;

--- a/ui/src/features/project/pipelines/graph/custom-node.tsx
+++ b/ui/src/features/project/pipelines/graph/custom-node.tsx
@@ -152,7 +152,7 @@ CustomNode.Container = (
               top: handleTop(idx),
               backgroundColor: 'transparent',
               border: 'none',
-              left: 2
+              left: 1
             }}
           />
         ))}

--- a/ui/src/features/project/pipelines/graph/custom-node.tsx
+++ b/ui/src/features/project/pipelines/graph/custom-node.tsx
@@ -22,6 +22,7 @@ export const CustomNode = (props: {
     label: string;
     value: WarehouseExpanded | RepoSubscription | Stage;
     subscriptionParent?: Warehouse;
+    warehouseY?: Record<string, number>;
   };
   id?: string;
 }) => {
@@ -61,7 +62,11 @@ export const CustomNode = (props: {
 
   if (props.data.value.$typeName === 'github.com.akuity.kargo.api.v1alpha1.Stage') {
     return (
-      <CustomNode.Container id={props.id} stage={props.data.value}>
+      <CustomNode.Container
+        id={props.id}
+        stage={props.data.value}
+        warehouseY={props.data.warehouseY}
+      >
         {ready ? (
           <StageNode stage={props.data.value} />
         ) : (
@@ -79,6 +84,7 @@ CustomNode.Container = (
     stage?: Stage;
     warehouse?: WarehouseExpanded;
     repoSubscription?: { data: RepoSubscription; parent: WarehouseExpanded };
+    warehouseY?: Record<string, number>;
     id?: string;
   }>
 ) => {
@@ -121,14 +127,22 @@ CustomNode.Container = (
   );
 
   if (props.stage) {
-    const howManyStagesDoThisStageSubscribe = props.stage.spec?.requestedFreight?.length || 0;
+    // Sort the per-warehouse handles by the y-coordinate of their source
+    // warehouse in the dagre layout. This makes the handles' top-to-bottom
+    // order match the warehouses' top-to-bottom order, so edges enter the
+    // stage without crossing each other.
+    const sortedRequestedFreight = [...(props.stage.spec?.requestedFreight || [])].sort((a, b) => {
+      const yA = props.warehouseY?.[a?.origin?.name || ''] ?? 0;
+      const yB = props.warehouseY?.[b?.origin?.name || ''] ?? 0;
+      return yA - yB;
+    });
 
     const handleTop = (idx: number) =>
-      `calc(50% + ${-((howManyStagesDoThisStageSubscribe - 1) * EDGE_GAP) / 2 + idx * EDGE_GAP}px)`;
+      `calc(50% + ${-((sortedRequestedFreight.length - 1) * EDGE_GAP) / 2 + idx * EDGE_GAP}px)`;
 
     return (
       <>
-        {props.stage?.spec?.requestedFreight?.map((freight, idx) => (
+        {sortedRequestedFreight.map((freight, idx) => (
           <Handle
             key={idx}
             id={freight?.origin?.name}
@@ -143,7 +157,7 @@ CustomNode.Container = (
           />
         ))}
         {Children}
-        {props.stage?.spec?.requestedFreight?.map((freight, idx) => (
+        {sortedRequestedFreight.map((freight, idx) => (
           <Handle
             key={idx}
             id={freight?.origin?.name}

--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -166,20 +166,26 @@ export const Graph = (props: GraphProps) => {
     if (!hoveredWarehouseName || distinctEdgeWarehouses < 2) {
       return graph.edges;
     }
-    return graph.edges.map((edge) => {
+    const dimmed: typeof graph.edges = [];
+    const highlighted: typeof graph.edges = [];
+    for (const edge of graph.edges) {
       if (edge.data?.warehouseName !== hoveredWarehouseName) {
-        return edge;
+        dimmed.push(edge);
+        continue;
       }
       const color = (edge.style?.stroke as string) || '#000';
-      return {
+      highlighted.push({
         ...edge,
         style: {
           ...edge.style,
           strokeOpacity: 0.8,
           filter: `drop-shadow(0 0 7px ${color}50)`
         }
-      };
-    });
+      });
+    }
+    // Highlighted edges paint last so they sit on top of overlapping dimmed
+    // edges from other warehouses.
+    return [...dimmed, ...highlighted];
   }, [graph.edges, hoveredWarehouseName, distinctEdgeWarehouses]);
 
   const nodesExcludingSubscriptionNodes = useMemo(() => {

--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -153,6 +153,28 @@ export const Graph = (props: GraphProps) => {
     return warehouseByName;
   }, [props.warehouses]);
 
+  const [hoveredWarehouseName, setHoveredWarehouseName] = useState<string | null>(null);
+
+  const edges = useMemo(() => {
+    if (!hoveredWarehouseName) {
+      return graph.edges;
+    }
+    return graph.edges.map((edge) => {
+      if (edge.data?.warehouseName !== hoveredWarehouseName) {
+        return edge;
+      }
+      const color = (edge.style?.stroke as string) || '#000';
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          strokeOpacity: 0.8,
+          filter: `drop-shadow(0 0 4px ${color}60)`
+        }
+      };
+    });
+  }, [graph.edges, hoveredWarehouseName]);
+
   const nodesExcludingSubscriptionNodes = useMemo(() => {
     const subscriptionNodes = nodes.filter((n) => repoSubscriptionIndexer.is(n.id));
 
@@ -186,11 +208,19 @@ export const Graph = (props: GraphProps) => {
 
   return (
     <GraphContext.Provider
-      value={{ warehouseByName, stackedNodesParents, onStack, onUnstack, ready }}
+      value={{
+        warehouseByName,
+        stackedNodesParents,
+        onStack,
+        onUnstack,
+        ready,
+        hoveredWarehouseName,
+        setHoveredWarehouseName
+      }}
     >
       <ReactFlow
         nodes={nodes}
-        edges={graph.edges}
+        edges={edges}
         nodeTypes={nodeTypes}
         fitView
         fitViewOptions={{

--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -1,4 +1,4 @@
-import { faMap } from '@fortawesome/free-solid-svg-icons';
+import { faShareNodes, faMap } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   ControlButton,
@@ -162,13 +162,20 @@ export const Graph = (props: GraphProps) => {
     [graph.edges]
   );
 
+  const edgeType = filterContext?.preferredFilter?.stepEdges ? 'step' : 'default';
+
+  const typedEdges = useMemo(
+    () => graph.edges.map((e) => (e.type === edgeType ? e : { ...e, type: edgeType })),
+    [graph.edges, edgeType]
+  );
+
   const edges = useMemo(() => {
     if (!hoveredWarehouseName || distinctEdgeWarehouses < 2) {
-      return graph.edges;
+      return typedEdges;
     }
-    const dimmed: typeof graph.edges = [];
-    const highlighted: typeof graph.edges = [];
-    for (const edge of graph.edges) {
+    const dimmed: typeof typedEdges = [];
+    const highlighted: typeof typedEdges = [];
+    for (const edge of typedEdges) {
       if (edge.data?.warehouseName !== hoveredWarehouseName) {
         dimmed.push(edge);
         continue;
@@ -186,7 +193,7 @@ export const Graph = (props: GraphProps) => {
     // Highlighted edges paint last so they sit on top of overlapping dimmed
     // edges from other warehouses.
     return [...dimmed, ...highlighted];
-  }, [graph.edges, hoveredWarehouseName, distinctEdgeWarehouses]);
+  }, [typedEdges, hoveredWarehouseName, distinctEdgeWarehouses]);
 
   const nodesExcludingSubscriptionNodes = useMemo(() => {
     const subscriptionNodes = nodes.filter((n) => repoSubscriptionIndexer.is(n.id));
@@ -268,6 +275,19 @@ export const Graph = (props: GraphProps) => {
             }
           >
             <FontAwesomeIcon icon={faMap} />
+          </ControlButton>
+          <ControlButton
+            title={
+              filterContext?.preferredFilter?.stepEdges ? 'Use Curved Edges' : 'Use Step Edges'
+            }
+            onClick={() =>
+              filterContext?.setPreferredFilter({
+                ...filterContext?.preferredFilter,
+                stepEdges: !filterContext?.preferredFilter?.stepEdges
+              })
+            }
+          >
+            <FontAwesomeIcon icon={faShareNodes} />
           </ControlButton>
         </Controls>
       </ReactFlow>

--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -155,8 +155,15 @@ export const Graph = (props: GraphProps) => {
 
   const [hoveredWarehouseName, setHoveredWarehouseName] = useState<string | null>(null);
 
+  const distinctEdgeWarehouses = useMemo(
+    () =>
+      new Set(graph.edges.map((e) => e.data?.warehouseName as string | undefined).filter(Boolean))
+        .size,
+    [graph.edges]
+  );
+
   const edges = useMemo(() => {
-    if (!hoveredWarehouseName) {
+    if (!hoveredWarehouseName || distinctEdgeWarehouses < 2) {
       return graph.edges;
     }
     return graph.edges.map((edge) => {
@@ -169,11 +176,11 @@ export const Graph = (props: GraphProps) => {
         style: {
           ...edge.style,
           strokeOpacity: 0.8,
-          filter: `drop-shadow(0 0 4px ${color}60)`
+          filter: `drop-shadow(0 0 7px ${color}50)`
         }
       };
     });
-  }, [graph.edges, hoveredWarehouseName]);
+  }, [graph.edges, hoveredWarehouseName, distinctEdgeWarehouses]);
 
   const nodesExcludingSubscriptionNodes = useMemo(() => {
     const subscriptionNodes = nodes.filter((n) => repoSubscriptionIndexer.is(n.id));

--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -235,6 +235,7 @@ export const Graph = (props: GraphProps) => {
         }}
         proOptions={{ hideAttribution: true }}
         minZoom={nodes.length > 100 ? 0.4 : 0.1}
+        maxZoom={1.4}
         onlyRenderVisibleElements
         panOnDrag
         onInit={(inst) => (reactFlowInstance.current = inst)}

--- a/ui/src/features/project/pipelines/graph/layout-graph.ts
+++ b/ui/src/features/project/pipelines/graph/layout-graph.ts
@@ -32,7 +32,7 @@ export const layoutGraph = (
 ) => {
   const graph = new graphlib.Graph<GraphMeta>({ multigraph: true });
 
-  graph.setGraph({ rankdir: 'LR', ranksep: 100 });
+  graph.setGraph({ rankdir: 'LR', ranksep: 150, nodesep: 60 });
   graph.setDefaultEdgeLabel(() => ({}));
 
   const warehouseByName: Record<string, WarehouseExpanded> = {};

--- a/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
+++ b/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
@@ -69,6 +69,17 @@ export const useReactFlowPipelineGraph = (
       const reactFlowNodes: Node[] = [];
       const reactFlowEdges: Edge[] = [];
 
+      // y-coordinate of each warehouse after layout. Stage nodes use this to
+      // sort their per-warehouse handles top-to-bottom so edges enter in the
+      // same vertical order as the source warehouses, avoiding crossings.
+      const warehouseY: Record<string, number> = {};
+      for (const node of graph.nodes()) {
+        const dagreNode = graph.node(node);
+        if (dagreNode?.warehouse) {
+          warehouseY[dagreNode.warehouse?.metadata?.name || ''] = dagreNode.y;
+        }
+      }
+
       for (const node of graph.nodes()) {
         const dagreNode = graph.node(node);
 
@@ -109,7 +120,8 @@ export const useReactFlowPipelineGraph = (
           data: {
             label: node,
             value: dagreNode?.warehouse || dagreNode?.subscription || dagreNode?.stage,
-            subscriptionParent: dagreNode?.subscriptionParent
+            subscriptionParent: dagreNode?.subscriptionParent,
+            warehouseY
           }
         });
       }
@@ -131,9 +143,9 @@ export const useReactFlowPipelineGraph = (
           markerEnd: {
             type: MarkerType.ArrowClosed,
             color: '#777',
-            strokeWidth: 1,
             width: 8,
-            height: 8
+            height: 8,
+            strokeWidth: 2
           },
           style: {
             strokeWidth: 4,

--- a/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
+++ b/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
@@ -149,7 +149,7 @@ export const useReactFlowPipelineGraph = (
           },
           style: {
             strokeWidth: 4,
-            stroke: dagreEdge.edgeColor || '',
+            stroke: dagreEdge.edgeColor || '#9ca3af',
             strokeOpacity: 0.3,
             transition: 'd 0.3s ease, stroke-opacity 0.2s ease, filter 0.2s ease'
           }

--- a/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
+++ b/ui/src/features/project/pipelines/graph/use-pipeline-graph.ts
@@ -124,21 +124,22 @@ export const useReactFlowPipelineGraph = (
           source: edge.v,
           target: edge.w,
           animated: false,
-          type:
-            (graph.successors(edge.v)?.length || 0) > 1 ||
-            (graph.predecessors(edge.w)?.length || 0) > 1
-              ? 'step'
-              : '',
+          type: 'default',
           sourceHandle: belongsToWarehouse,
           targetHandle: belongsToWarehouse,
+          data: { warehouseName: belongsToWarehouse },
           markerEnd: {
             type: MarkerType.ArrowClosed,
-            color: dagreEdge.edgeColor || ''
+            color: '#777',
+            strokeWidth: 1,
+            width: 8,
+            height: 8
           },
           style: {
-            strokeWidth: 2,
+            strokeWidth: 4,
             stroke: dagreEdge.edgeColor || '',
-            transition: 'd 0.3s ease'
+            strokeOpacity: 0.3,
+            transition: 'd 0.3s ease, stroke-opacity 0.2s ease, filter 0.2s ease'
           }
         });
       }

--- a/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/warehouse-node.tsx
@@ -93,7 +93,7 @@ export const WarehouseNode = (props: { warehouse: WarehouseExpanded }) => {
       <Button
         size='small'
         icon={<FontAwesomeIcon icon={isSubscriptionHidden ? faPlus : faMinus} />}
-        className='absolute -left-2 top-[50%] translate-y-[-50%] text-[10px]'
+        className='absolute -left-3 top-[50%] translate-y-[-50%] text-[10px]'
         onClick={(e) => {
           e.stopPropagation();
 

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -123,15 +123,13 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
   const stageDetails =
     stageName && listStagesQuery.data?.stages?.find((s: Stage) => s?.metadata?.name === stageName);
 
-  const warehouseColorMap = useMemo(
-    () =>
-      getColors(
-        project?.metadata?.name || '',
-        listWarehousesQuery.data?.warehouses || [],
-        'warehouses'
-      ),
-    [project, listWarehousesQuery.data?.warehouses]
-  );
+  const warehouseColorMap = useMemo(() => {
+    const warehouses = listWarehousesQuery.data?.warehouses || [];
+    if (warehouses.length < 2) {
+      return {};
+    }
+    return getColors(project?.metadata?.name || '', warehouses, 'warehouses');
+  }, [project, listWarehousesQuery.data?.warehouses]);
 
   const stageColorMap = useMemo(
     () => getColors(project?.metadata?.name || '', listStagesQuery.data?.stages || []),

--- a/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
+++ b/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
@@ -21,7 +21,8 @@ export const useFreightTimelineControllerStore = (project: string) => {
       hideSubscriptions: {},
       images: false,
       view: 'graph',
-      showMinimap: true
+      showMinimap: true,
+      stepEdges: false
     };
 
     const hasFilterParams = Object.keys(filters).some((name) => searchParams.has(name));
@@ -43,6 +44,11 @@ export const useFreightTimelineControllerStore = (project: string) => {
     const showMinimap = searchParams.get('showMinimap');
     if (showMinimap && showMinimap !== '') {
       filters.showMinimap = showMinimap === 'true';
+    }
+
+    const stepEdges = searchParams.get('stepEdges');
+    if (stepEdges && stepEdges !== '') {
+      filters.stepEdges = stepEdges === 'true';
     }
 
     const sourcesParam = searchParams.getAll('sources');
@@ -109,6 +115,8 @@ export const useFreightTimelineControllerStore = (project: string) => {
         currentSearchParams.set('view', `${nextPartial.view}`);
 
         currentSearchParams.set('showMinimap', `${nextPartial.showMinimap}`);
+
+        currentSearchParams.set('stepEdges', `${nextPartial.stepEdges}`);
 
         currentSearchParams.set('showColors', `${nextPartial.showColors}`);
 


### PR DESCRIPTION
fixes #6205 

- By default, pipeline graph edges are now smooth curves instead of sharp 90° lines.
- There is a toggle to switch to the step lines
- Subscription handles on a stage are ordered, which reduces edges crossing each other.
- More breathing room between nodes, and per-subscription connection points spread further apart on stages with multiple warehouses.
- Lines are slightly thicker but dimmed, so the overall graph reads as a soft background rather than a wall of color.
- Arrowheads are neutral grey (the line color already conveys the warehouse).
- Eliminated the small white ring and gap where edges met nodes — lines now hug the nodes.
- New: hovering a warehouse node highlights all of its edges (full opacity + a soft glow in the warehouse's color) with a smooth fade, making it easy to trace which stages it feeds — even when another warehouse's line was visually on top.
- No custom colors for a single warehouse

<img width="1508" height="1005" alt="image" src="https://github.com/user-attachments/assets/3a476750-2aab-472d-92aa-d64c8114b235" />

https://github.com/user-attachments/assets/5240ab03-8d9a-48ab-b778-53704d662c14

