### PR TITLE
feat(ui): generic deep links in promotion steps and promotion view

### DIFF
--- a/ui/src/plugins/index.tsx
+++ b/ui/src/plugins/index.tsx
@@ -1,6 +1,7 @@
 import { PluginsInstallation } from './atoms/plugin-interfaces';
+import outputLinksPlugin from './output-links-plugin/output-links-plugin';
 import prPlugin from './pr-plugin/pr-plugin';
 
-const plugins: PluginsInstallation[] = [prPlugin];
+const plugins: PluginsInstallation[] = [prPlugin, outputLinksPlugin];
 
 export default plugins;

--- a/ui/src/plugins/output-links-plugin/deep-link/promotion-step.tsx
+++ b/ui/src/plugins/output-links-plugin/deep-link/promotion-step.tsx
@@ -4,7 +4,7 @@ import { Flex, Tooltip } from 'antd';
 import { DeepLinkPluginsInstallation } from '@ui/plugins/atoms/plugin-interfaces';
 
 import { getOutputLinks } from '../output-links';
-import { resolveIcon } from '../resolve-icon';
+import { iconExists, resolveIcon } from '../resolve-icon';
 
 const plugin: DeepLinkPluginsInstallation['PromotionStep'] = {
   shouldRender({ output }) {
@@ -20,6 +20,7 @@ const plugin: DeepLinkPluginsInstallation['PromotionStep'] = {
           <Tooltip key={idx} title={link.tooltip || link.label}>
             <a href={link.url} target='_blank' rel='noreferrer'>
               <FontAwesomeIcon icon={resolveIcon(link.icon)} />
+              {!iconExists(link.icon) && link.label && <span className='ml-1'>{link.label}</span>}
             </a>
           </Tooltip>
         ))}

--- a/ui/src/plugins/output-links-plugin/deep-link/promotion-step.tsx
+++ b/ui/src/plugins/output-links-plugin/deep-link/promotion-step.tsx
@@ -1,0 +1,31 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Flex, Tooltip } from 'antd';
+
+import { DeepLinkPluginsInstallation } from '@ui/plugins/atoms/plugin-interfaces';
+
+import { getOutputLinks } from '../output-links';
+import { resolveIcon } from '../resolve-icon';
+
+const plugin: DeepLinkPluginsInstallation['PromotionStep'] = {
+  shouldRender({ output }) {
+    return getOutputLinks(output || {}).length > 0;
+  },
+  render(props) {
+    const links = getOutputLinks(props.output || {});
+    if (links.length === 0) return null;
+
+    return (
+      <Flex gap={8}>
+        {links.map((link, idx) => (
+          <Tooltip key={idx} title={link.tooltip || link.label}>
+            <a href={link.url} target='_blank' rel='noreferrer'>
+              <FontAwesomeIcon icon={resolveIcon(link.icon)} />
+            </a>
+          </Tooltip>
+        ))}
+      </Flex>
+    );
+  }
+};
+
+export default plugin;

--- a/ui/src/plugins/output-links-plugin/deep-link/promotion.tsx
+++ b/ui/src/plugins/output-links-plugin/deep-link/promotion.tsx
@@ -6,7 +6,7 @@ import { getPromotionState, getPromotionStepAlias } from '@ui/plugins/atoms/plug
 import { DeepLinkPluginsInstallation } from '@ui/plugins/atoms/plugin-interfaces';
 
 import { getOutputLinks, StepOutputLink } from '../output-links';
-import { resolveIcon } from '../resolve-icon';
+import { iconExists, resolveIcon } from '../resolve-icon';
 
 function collectLinks(
   props: Parameters<NonNullable<DeepLinkPluginsInstallation['Promotion']>['render']>[0]
@@ -55,6 +55,7 @@ const plugin: DeepLinkPluginsInstallation['Promotion'] = {
         <Tooltip title={link.tooltip || link.label}>
           <a href={link.url} target='_blank' rel='noreferrer'>
             <FontAwesomeIcon icon={resolveIcon(link.icon)} />
+            {!iconExists(link.icon) && link.label && <span className='ml-1'>{link.label}</span>}
           </a>
         </Tooltip>
       );

--- a/ui/src/plugins/output-links-plugin/deep-link/promotion.tsx
+++ b/ui/src/plugins/output-links-plugin/deep-link/promotion.tsx
@@ -1,0 +1,87 @@
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Dropdown, Space, Tooltip } from 'antd';
+
+import { getPromotionState, getPromotionStepAlias } from '@ui/plugins/atoms/plugin-helper';
+import { DeepLinkPluginsInstallation } from '@ui/plugins/atoms/plugin-interfaces';
+
+import { getOutputLinks, StepOutputLink } from '../output-links';
+import { resolveIcon } from '../resolve-icon';
+
+function collectLinks(
+  props: Parameters<NonNullable<DeepLinkPluginsInstallation['Promotion']>['render']>[0]
+): { alias: string; link: StepOutputLink }[] {
+  try {
+    const state = getPromotionState(props.promotion);
+    const result: { alias: string; link: StepOutputLink }[] = [];
+
+    for (const [idx, step] of Object.entries(props.promotion?.spec?.steps || [])) {
+      const alias = getPromotionStepAlias(step, idx);
+      try {
+        const links = getOutputLinks(state[alias] as Record<string, unknown>);
+        for (const link of links) {
+          result.push({ alias, link });
+        }
+      } catch {
+        // malformed step output - skip
+      }
+    }
+
+    return result;
+  } catch {
+    return [];
+  }
+}
+
+const plugin: DeepLinkPluginsInstallation['Promotion'] = {
+  shouldRender(opts) {
+    try {
+      const state = getPromotionState(opts.promotion);
+      return Object.values(state || {}).some(
+        (stepOutput) => getOutputLinks(stepOutput as Record<string, unknown>).length > 0
+      );
+    } catch {
+      return false;
+    }
+  },
+  render(props) {
+    const allLinks = collectLinks(props);
+
+    if (allLinks.length === 0) return null;
+
+    if (allLinks.length === 1) {
+      const { link } = allLinks[0];
+      return (
+        <Tooltip title={link.tooltip || link.label}>
+          <a href={link.url} target='_blank' rel='noreferrer'>
+            <FontAwesomeIcon icon={resolveIcon(link.icon)} />
+          </a>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <Dropdown
+        menu={{
+          items: allLinks.map(({ alias, link }, idx) => ({
+            key: idx,
+            label: (
+              <a href={link.url} target='_blank' rel='noreferrer'>
+                {link.label || alias} <FontAwesomeIcon icon={resolveIcon(link.icon)} />
+              </a>
+            )
+          }))
+        }}
+      >
+        <a onClick={(e) => e.preventDefault()}>
+          <Space>
+            Links
+            <FontAwesomeIcon icon={faChevronDown} className='text-xs' />
+          </Space>
+        </a>
+      </Dropdown>
+    );
+  }
+};
+
+export default plugin;

--- a/ui/src/plugins/output-links-plugin/output-links-plugin.tsx
+++ b/ui/src/plugins/output-links-plugin/output-links-plugin.tsx
@@ -1,0 +1,13 @@
+import { PluginsInstallation } from '../atoms/plugin-interfaces';
+
+import promotionPlugin from './deep-link/promotion';
+import promotionStepPlugin from './deep-link/promotion-step';
+
+const plugin: PluginsInstallation = {
+  DeepLinkPlugin: {
+    PromotionStep: promotionStepPlugin,
+    Promotion: promotionPlugin
+  }
+};
+
+export default plugin;

--- a/ui/src/plugins/output-links-plugin/output-links.ts
+++ b/ui/src/plugins/output-links-plugin/output-links.ts
@@ -1,15 +1,19 @@
-export interface StepOutputLink {
-  url: string;
-  icon?: string;
-  tooltip?: string;
-  label?: string;
-}
+import { z } from 'zod';
+
+const stepOutputLinkSchema = z.object({
+  url: z.string().min(1),
+  icon: z.string().optional(),
+  tooltip: z.string().optional(),
+  label: z.string().optional()
+});
+
+export type StepOutputLink = z.infer<typeof stepOutputLinkSchema>;
 
 export function getOutputLinks(output: Record<string, unknown>): StepOutputLink[] {
   const links = (output as { links?: unknown })?.links;
   if (!Array.isArray(links) || links.length === 0) return [];
-  return links.filter(
-    (l): l is StepOutputLink =>
-      l !== null && typeof l === 'object' && typeof l.url === 'string' && l.url !== ''
-  );
+  return links.flatMap((l) => {
+    const result = stepOutputLinkSchema.safeParse(l);
+    return result.success ? [result.data] : [];
+  });
 }

--- a/ui/src/plugins/output-links-plugin/output-links.ts
+++ b/ui/src/plugins/output-links-plugin/output-links.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 const stepOutputLinkSchema = z.object({
-  url: z.string().min(1),
+  url: z
+    .url()
+    .refine((v) => /^https?:\/\//i.test(v), { message: 'only http/https URLs are allowed' }),
   icon: z.string().optional(),
   tooltip: z.string().optional(),
   label: z.string().optional()

--- a/ui/src/plugins/output-links-plugin/output-links.ts
+++ b/ui/src/plugins/output-links-plugin/output-links.ts
@@ -1,0 +1,15 @@
+export interface StepOutputLink {
+  url: string;
+  icon?: string;
+  tooltip?: string;
+  label?: string;
+}
+
+export function getOutputLinks(output: Record<string, unknown>): StepOutputLink[] {
+  const links = (output as { links?: unknown })?.links;
+  if (!Array.isArray(links) || links.length === 0) return [];
+  return links.filter(
+    (l): l is StepOutputLink =>
+      l !== null && typeof l === 'object' && typeof l.url === 'string' && l.url !== ''
+  );
+}

--- a/ui/src/plugins/output-links-plugin/resolve-icon.ts
+++ b/ui/src/plugins/output-links-plugin/resolve-icon.ts
@@ -1,0 +1,12 @@
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import * as brandIcons from '@fortawesome/free-brands-svg-icons';
+import * as solidIcons from '@fortawesome/free-solid-svg-icons';
+
+export function resolveIcon(name?: string): IconDefinition {
+  if (!name) return solidIcons.faLink;
+  return (
+    (solidIcons[name as keyof typeof solidIcons] as IconDefinition) ??
+    (brandIcons[name as keyof typeof brandIcons] as IconDefinition) ??
+    solidIcons.faLink
+  );
+}

--- a/ui/src/plugins/output-links-plugin/resolve-icon.ts
+++ b/ui/src/plugins/output-links-plugin/resolve-icon.ts
@@ -2,6 +2,11 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import * as brandIcons from '@fortawesome/free-brands-svg-icons';
 import * as solidIcons from '@fortawesome/free-solid-svg-icons';
 
+export function iconExists(name?: string): boolean {
+  if (!name) return false;
+  return name in solidIcons || name in brandIcons;
+}
+
 export function resolveIcon(name?: string): IconDefinition {
   if (!name) return solidIcons.faLink;
   return (

--- a/ui/src/plugins/output-links-plugin/resolve-icon.ts
+++ b/ui/src/plugins/output-links-plugin/resolve-icon.ts
@@ -1,17 +1,69 @@
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import * as brandIcons from '@fortawesome/free-brands-svg-icons';
-import * as solidIcons from '@fortawesome/free-solid-svg-icons';
+import {
+  faBitbucket,
+  faDocker,
+  faGitAlt,
+  faGithub,
+  faGitlab,
+  faJira,
+  faAtlassian,
+  faSlack,
+  faRedhat,
+  faGit,
+  faJenkins,
+  faDigitalOcean,
+  faGithubAlt
+} from '@fortawesome/free-brands-svg-icons';
+import {
+  faArrowUpRightFromSquare,
+  faBox,
+  faChartLine,
+  faCheckCircle,
+  faCircleNodes,
+  faCode,
+  faDatabase,
+  faExternalLink,
+  faFileCode,
+  faGlobe,
+  faLink,
+  faServer,
+  faTag
+} from '@fortawesome/free-solid-svg-icons';
+
+const ICONS: Record<string, IconDefinition> = {
+  // brand
+  faBitbucket,
+  faDocker,
+  faGitAlt,
+  faGithub,
+  faGitlab,
+  faJira,
+  faSlack,
+  faAtlassian,
+  faRedhat,
+  faGit,
+  faJenkins,
+  faDigitalOcean,
+  faGithubAlt,
+  // solid
+  faArrowUpRightFromSquare,
+  faBox,
+  faChartLine,
+  faCheckCircle,
+  faCircleNodes,
+  faCode,
+  faDatabase,
+  faFileCode,
+  faGlobe,
+  faLink,
+  faServer,
+  faTag
+};
 
 export function iconExists(name?: string): boolean {
-  if (!name) return false;
-  return name in solidIcons || name in brandIcons;
+  return !!name && name in ICONS;
 }
 
 export function resolveIcon(name?: string): IconDefinition {
-  if (!name) return solidIcons.faLink;
-  return (
-    (solidIcons[name as keyof typeof solidIcons] as IconDefinition) ??
-    (brandIcons[name as keyof typeof brandIcons] as IconDefinition) ??
-    solidIcons.faLink
-  );
+  return (name && ICONS[name]) || faExternalLink;
 }


### PR DESCRIPTION
## Summary

Adds a new `output-links` UI plugin that surfaces deep links from promotion step outputs directly in the Kargo UI. Promotion steps can emit a `links` array in their output and the UI will render clickable icons or labeled links inline on the step and promotion views.

## What's included

**`output-links-plugin`** — a new `DeepLinkPlugin` registered alongside the existing `pr-plugin`:

- **`PromotionStep` view** — renders one icon/link per entry in the step's `links` output, shown inline next to the step
- **`Promotion` view** — aggregates links from all steps; renders a single icon when there is one link across all steps, or a labeled dropdown when there are multiple
- **`resolve-icon`** — resolves a FontAwesome icon name (solid or brand) from a string; falls back to `faLink`. Exports `iconExists` so callers can detect the fallback and conditionally show a visible label

**Label fallback behavior**: when the specified icon name does not exist in either the solid or brand icon sets, the external-link fallback icon is shown alongside the link's `label` as visible text, so users can always identify the link.

## Step output contract

Promotion steps signal links by including a `links` array in their output:

```json
{
 "links": [
  {
   "icon": "faJira",
   "label": "PR #42",
   "tooltip": "Jira ticker",
   "url": "https://github.com/my-org/my-repo/pull/42"
  }
 ]
}
```

```json
{
 "links": [
  {
   "icon": "faGithub",
   "label": "Pull Request",
   "url": "https://github.com/my-org/my-repo/pull/42"
  },
  {
   "icon": "faArrowUpRightFromSquare",
   "label": "Argo CD App",
   "url": "https://argo.example.com/applications/my-app"
  },
  {
   "label": "Service Now",
   "tooltip": "Service Now App",
   "url": "https://argo.example.com/applications/my-app"
  }
 ]
}
```
<img width="1191" height="577" alt="Screenshot 2026-05-04 at 3 13 03 PM (2)" src="https://github.com/user-attachments/assets/4f38f2b2-f66e-4d68-8f6e-e72e24fc118c" />
<img width="1163" height="376" alt="Screenshot 2026-05-04 at 3 12 30 PM (2)" src="https://github.com/user-attachments/assets/e05f55d4-8ffa-4ae7-b6c4-485945f3d747" />

