### PR TITLE
fix(ui): clone the freight without missing any artifacts

### DIFF
--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -76,6 +76,7 @@ export const useWarehouseWithClonedFreight = (
       );
       if (!subscription) {
         subscription = {
+          $typeName: 'github.com.akuity.kargo.api.v1alpha1.ChartDiscoveryResult',
           repoURL: chart.repoURL,
           name: chart.name,
           versions: []

--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -44,7 +44,7 @@ export const useWarehouseWithClonedFreight = (
       return warehouse;
     }
 
-    const discoveredArtifacts = warehouse.status?.discoveredArtifacts;
+    const discoveredArtifacts = structuredClone(warehouse.status?.discoveredArtifacts);
     const images: ImageDiscoveryResult[] = [...(discoveredArtifacts?.images || [])];
     const charts: ChartDiscoveryResult[] = [...(discoveredArtifacts?.charts || [])];
     const git: GitDiscoveryResult[] = [...(discoveredArtifacts?.git || [])];

--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -50,14 +50,15 @@ export const useWarehouseWithClonedFreight = (
     const git: GitDiscoveryResult[] = [...(discoveredArtifacts?.git || [])];
 
     for (const image of cloneFreightData.images || []) {
-      const subscription = images.find(
+      let subscription = images.find(
         (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(image)
       );
       if (!subscription) {
-        images.push({
+        subscription = {
           repoURL: image.repoURL,
           references: []
-        } as unknown as ImageDiscoveryResult);
+        } as unknown as ImageDiscoveryResult;
+        images.push(subscription);
       }
 
       if (!subscription?.references.find((r) => r.tag === image.tag)) {
@@ -70,16 +71,17 @@ export const useWarehouseWithClonedFreight = (
     }
 
     for (const chart of cloneFreightData.charts || []) {
-      const subscription = charts.find(
+      let subscription = charts.find(
         (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(chart)
       );
       if (!subscription) {
-        charts.push({
+        subscription = {
           $typeName: 'github.com.akuity.kargo.api.v1alpha1.ChartDiscoveryResult',
           repoURL: chart.repoURL,
           name: chart.name,
           versions: []
-        } as unknown as ChartDiscoveryResult);
+        } as unknown as ChartDiscoveryResult;
+        charts.push(subscription);
       }
 
       if (!subscription?.versions.find((v) => v === chart.version)) {
@@ -88,14 +90,15 @@ export const useWarehouseWithClonedFreight = (
     }
 
     for (const commit of cloneFreightData.commits || []) {
-      const subscription = git.find(
+      let subscription = git.find(
         (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(commit)
       );
       if (!subscription) {
-        git.push({
+        subscription = {
           repoURL: commit.repoURL,
           commits: []
-        } as unknown as GitDiscoveryResult);
+        } as unknown as GitDiscoveryResult;
+        git.push(subscription);
       }
 
       if (!subscription?.commits.find((c) => c.id === commit.id && c.tag === commit.tag)) {

--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -45,9 +45,9 @@ export const useWarehouseWithClonedFreight = (
     }
 
     const discoveredArtifacts = structuredClone(warehouse.status?.discoveredArtifacts);
-    const images: ImageDiscoveryResult[] = [...(discoveredArtifacts?.images || [])];
-    const charts: ChartDiscoveryResult[] = [...(discoveredArtifacts?.charts || [])];
-    const git: GitDiscoveryResult[] = [...(discoveredArtifacts?.git || [])];
+    const images: ImageDiscoveryResult[] = discoveredArtifacts?.images || [];
+    const charts: ChartDiscoveryResult[] = discoveredArtifacts?.charts || [];
+    const git: GitDiscoveryResult[] = discoveredArtifacts?.git || [];
 
     for (const image of cloneFreightData.images || []) {
       let subscription = images.find(
@@ -76,7 +76,6 @@ export const useWarehouseWithClonedFreight = (
       );
       if (!subscription) {
         subscription = {
-          $typeName: 'github.com.akuity.kargo.api.v1alpha1.ChartDiscoveryResult',
           repoURL: chart.repoURL,
           name: chart.name,
           versions: []
@@ -117,7 +116,7 @@ export const useWarehouseWithClonedFreight = (
       ...warehouse,
       status: {
         ...warehouse.status,
-        discoveredArtifacts: { ...discoveredArtifacts, images, charts, git }
+        discoveredArtifacts
       }
     } as WarehouseExpanded;
   }, [warehouse, cloneFreightData]);

--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -10,6 +10,8 @@ import {
   ImageDiscoveryResult
 } from '@ui/gen/api/v1alpha1/generated_pb';
 
+import { getSubscriptionKey, getSubscriptionKeyFreight } from './unique-subscription-key';
+
 // WHY: A Warehouse's discoveredArtifacts is a rolling window of recently seen
 // artifact versions — it does not retain a full history. When a user wants to
 // clone an existing piece of Freight (i.e. assemble a new Freight starting from
@@ -42,20 +44,24 @@ export const useWarehouseWithClonedFreight = (
       return warehouse;
     }
 
-    const da = warehouse.status?.discoveredArtifacts;
-    const images: ImageDiscoveryResult[] = [...(da?.images || [])];
-    const charts: ChartDiscoveryResult[] = [...(da?.charts || [])];
-    const git: GitDiscoveryResult[] = [...(da?.git || [])];
+    const discoveredArtifacts = warehouse.status?.discoveredArtifacts;
+    const images: ImageDiscoveryResult[] = [...(discoveredArtifacts?.images || [])];
+    const charts: ChartDiscoveryResult[] = [...(discoveredArtifacts?.charts || [])];
+    const git: GitDiscoveryResult[] = [...(discoveredArtifacts?.git || [])];
 
     for (const image of cloneFreightData.images || []) {
-      const sub = images.find((s) => s.repoURL === image.repoURL);
-      if (!sub) {
+      const subscription = images.find(
+        (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(image)
+      );
+      if (!subscription) {
         images.push({
           repoURL: image.repoURL,
-          references: [{ tag: image.tag, digest: image.digest, annotations: image.annotations }]
+          references: []
         } as unknown as ImageDiscoveryResult);
-      } else if (!sub.references.find((r) => r.tag === image.tag)) {
-        sub.references.unshift({
+      }
+
+      if (!subscription?.references.find((r) => r.tag === image.tag)) {
+        subscription?.references.unshift({
           tag: image.tag,
           digest: image.digest,
           annotations: image.annotations
@@ -64,37 +70,36 @@ export const useWarehouseWithClonedFreight = (
     }
 
     for (const chart of cloneFreightData.charts || []) {
-      const sub = charts.find((s) => s.repoURL === chart.repoURL && s.name === chart.name);
-      if (!sub) {
+      const subscription = charts.find(
+        (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(chart)
+      );
+      if (!subscription) {
         charts.push({
           $typeName: 'github.com.akuity.kargo.api.v1alpha1.ChartDiscoveryResult',
           repoURL: chart.repoURL,
           name: chart.name,
-          versions: [chart.version]
+          versions: []
         } as unknown as ChartDiscoveryResult);
-      } else if (!sub.versions.find((v) => v === chart.version)) {
-        sub.versions.unshift(chart.version);
+      }
+
+      if (!subscription?.versions.find((v) => v === chart.version)) {
+        subscription?.versions.unshift(chart.version);
       }
     }
 
     for (const commit of cloneFreightData.commits || []) {
-      const sub = git.find((s) => s.repoURL === commit.repoURL);
-      if (!sub) {
+      const subscription = git.find(
+        (s) => getSubscriptionKey(s) === getSubscriptionKeyFreight(commit)
+      );
+      if (!subscription) {
         git.push({
           repoURL: commit.repoURL,
-          commits: [
-            {
-              id: commit.id,
-              branch: commit.branch,
-              tag: commit.tag,
-              author: commit.author,
-              committer: commit.committer,
-              subject: commit.message
-            }
-          ]
+          commits: []
         } as unknown as GitDiscoveryResult);
-      } else if (!sub.commits.find((c) => c.id === commit.id && c.tag === commit.tag)) {
-        sub.commits.unshift({
+      }
+
+      if (!subscription?.commits.find((c) => c.id === commit.id && c.tag === commit.tag)) {
+        subscription?.commits.unshift({
           id: commit.id,
           branch: commit.branch,
           tag: commit.tag,
@@ -109,7 +114,7 @@ export const useWarehouseWithClonedFreight = (
       ...warehouse,
       status: {
         ...warehouse.status,
-        discoveredArtifacts: { ...da, images, charts, git }
+        discoveredArtifacts: { ...discoveredArtifacts, images, charts, git }
       }
     } as WarehouseExpanded;
   }, [warehouse, cloneFreightData]);

--- a/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
+++ b/ui/src/features/assemble-freight/use-warehouse-with-cloned-freight.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+
+import { WarehouseExpanded } from '@ui/extend/types';
+import {
+  ChartDiscoveryResult,
+  DiscoveredCommit,
+  DiscoveredImageReference,
+  Freight,
+  GitDiscoveryResult,
+  ImageDiscoveryResult
+} from '@ui/gen/api/v1alpha1/generated_pb';
+
+// WHY: A Warehouse's discoveredArtifacts is a rolling window of recently seen
+// artifact versions — it does not retain a full history. When a user wants to
+// clone an existing piece of Freight (i.e. assemble a new Freight starting from
+// the same artifact versions), the specific image tags, chart versions, or git
+// commits referenced by that Freight may have aged out of the discovery window
+// and therefore no longer appear in discoveredArtifacts.
+//
+// Without this injection, the assembly UI (ImageTable, CommitTable, ChartTable)
+// would have no knowledge of those versions. They would not appear as selectable
+// options, and mergeWithClonedFreight would fail to pre-select them because it
+// looks up artifacts by repoURL in the discovered data.
+//
+// This hook solves that by merging the cloned Freight's artifacts back into the
+// warehouse's discoveredArtifacts before the assembly UI renders:
+//   - If a subscription (repoURL) is entirely absent, a synthetic DiscoveryResult
+//     is created for it so the sidebar menu shows the entry at all.
+//   - If the subscription exists but the specific version is missing, it is
+//     prepended (unshift) to the front of the version list so it appears first
+//     and is the default selection.
+//
+// The enriched warehouse is passed down to AssembleFreight as if the warehouse
+// had always discovered those versions, giving the user a coherent "clone this
+// Freight" experience even when the source versions are no longer current.
+export const useWarehouseWithClonedFreight = (
+  warehouse: WarehouseExpanded,
+  cloneFreightData: Freight | undefined
+): WarehouseExpanded =>
+  useMemo(() => {
+    if (!cloneFreightData) {
+      return warehouse;
+    }
+
+    const da = warehouse.status?.discoveredArtifacts;
+    const images: ImageDiscoveryResult[] = [...(da?.images || [])];
+    const charts: ChartDiscoveryResult[] = [...(da?.charts || [])];
+    const git: GitDiscoveryResult[] = [...(da?.git || [])];
+
+    for (const image of cloneFreightData.images || []) {
+      const sub = images.find((s) => s.repoURL === image.repoURL);
+      if (!sub) {
+        images.push({
+          repoURL: image.repoURL,
+          references: [{ tag: image.tag, digest: image.digest, annotations: image.annotations }]
+        } as unknown as ImageDiscoveryResult);
+      } else if (!sub.references.find((r) => r.tag === image.tag)) {
+        sub.references.unshift({
+          tag: image.tag,
+          digest: image.digest,
+          annotations: image.annotations
+        } as DiscoveredImageReference);
+      }
+    }
+
+    for (const chart of cloneFreightData.charts || []) {
+      const sub = charts.find((s) => s.repoURL === chart.repoURL && s.name === chart.name);
+      if (!sub) {
+        charts.push({
+          $typeName: 'github.com.akuity.kargo.api.v1alpha1.ChartDiscoveryResult',
+          repoURL: chart.repoURL,
+          name: chart.name,
+          versions: [chart.version]
+        } as unknown as ChartDiscoveryResult);
+      } else if (!sub.versions.find((v) => v === chart.version)) {
+        sub.versions.unshift(chart.version);
+      }
+    }
+
+    for (const commit of cloneFreightData.commits || []) {
+      const sub = git.find((s) => s.repoURL === commit.repoURL);
+      if (!sub) {
+        git.push({
+          repoURL: commit.repoURL,
+          commits: [
+            {
+              id: commit.id,
+              branch: commit.branch,
+              tag: commit.tag,
+              author: commit.author,
+              committer: commit.committer,
+              subject: commit.message
+            }
+          ]
+        } as unknown as GitDiscoveryResult);
+      } else if (!sub.commits.find((c) => c.id === commit.id && c.tag === commit.tag)) {
+        sub.commits.unshift({
+          id: commit.id,
+          branch: commit.branch,
+          tag: commit.tag,
+          author: commit.author,
+          committer: commit.committer,
+          subject: commit.message
+        } as DiscoveredCommit);
+      }
+    }
+
+    return {
+      ...warehouse,
+      status: {
+        ...warehouse.status,
+        discoveredArtifacts: { ...da, images, charts, git }
+      }
+    } as WarehouseExpanded;
+  }, [warehouse, cloneFreightData]);

--- a/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
+++ b/ui/src/features/project/pipelines/warehouse/warehouse-details.tsx
@@ -15,6 +15,7 @@ import { generatePath, useNavigate, useParams, useSearchParams } from 'react-rou
 import { paths } from '@ui/config/paths';
 import { WarehouseExpanded } from '@ui/extend/types';
 import { AssembleFreight } from '@ui/features/assemble-freight/assemble-freight';
+import { useWarehouseWithClonedFreight } from '@ui/features/assemble-freight/use-warehouse-with-cloned-freight';
 import YamlEditor from '@ui/features/common/code-editor/yaml-editor-lazy';
 import {
   getFreight,
@@ -67,6 +68,10 @@ export const WarehouseDetails = ({
       enabled: !!cloneFreight && tab === 'create-freight'
     }
   );
+
+  const cloneFreightData = freightQuery.data?.result.value as Freight | undefined;
+
+  const warehouseWithClonedFreight = useWarehouseWithClonedFreight(warehouse, cloneFreightData);
 
   return (
     <Drawer
@@ -127,8 +132,8 @@ export const WarehouseDetails = ({
                 <Skeleton />
               ) : (
                 <AssembleFreight
-                  warehouse={warehouse}
-                  cloneFreight={freightQuery.data?.result.value as Freight}
+                  warehouse={warehouseWithClonedFreight}
+                  cloneFreight={cloneFreightData}
                   onSuccess={() => {
                     onClose();
                     refetchFreight();


### PR DESCRIPTION
## Problem

When a user clones an existing piece of Freight to assemble a new one, the Freight Assembly UI may not show the artifact versions from the source Freight as selectable options.

A Warehouse's `discoveredArtifacts` is a rolling window of recently discovered artifact versions — it does not retain a full history. If the image tag, chart version, or git commit referenced by the cloned Freight has aged out of that window, it simply does not appear in `discoveredArtifacts`. As a result, the assembly UI tables (images, charts, commits) have no entry for those versions, `mergeWithClonedFreight` cannot pre-select them (it looks up artifacts by `repoURL` in the discovered data), and the user is left with the latest versions pre-selected and there is no way for them to select the outdated version.

https://github.com/user-attachments/assets/d2e2df43-e28c-4ff9-8bec-0b7c4ac7bd68

## Solution

When cloning a freight.. if any of artifact(s) are missing in warehouse discoveredArtifact results, just add it. Eventually the freight-assembly table will have those available

**All pull requests must reference an existing issue with no blocking labels.**
PRs that do not meet this requirement will be automatically closed. See the
[Contributor Guide](https://docs.kargo.io/contributor-guide) for details.

## Issue Reference

None

## Checklist

- [ ] The PR is linked to an existing issue.
- [ ] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [x] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [x] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
