### PR TITLE
fix(chart): use explicit verbs instead of "*" in kargo-admin clusterrole

### DIFF
--- a/charts/kargo/templates/users/cluster-roles.yaml
+++ b/charts/kargo/templates/users/cluster-roles.yaml
@@ -39,7 +39,14 @@ rules:
   - stages
   - warehouses
   verbs:
-  - "*" # full access to all mutable Kargo resource types
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - kargo.akuity.io
   resources:


### PR DESCRIPTION
## Issue Reference

Closes #6239

## Description

Kubernetes' RBAC authorizer treats "*" as matching any verb, including custom ones. Using "*" in the installed cluster role prevented operators from defining their own custom verbs without those verbs being implicitly granted to every kargo-admin.

Expand it out to the standard verbs, matching what the API server uses for project-level Kargo roles in pkg/server/rbac/policy_rules.go.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [x] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
