### PR TITLE
feat(ui): freightline ui/ux improvements

### DIFF
--- a/ui/src/features/project/pipelines/freight/freight-card.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-card.tsx
@@ -195,7 +195,7 @@ export const FreightCard = (props: FreightCardProps) => {
         }
       >
         <div
-          className={classNames('relative px-2', {
+          className={classNames('relative px-2 flex-1 flex flex-col', {
             'pl-4': props.inUse
           })}
         >
@@ -286,7 +286,7 @@ export const FreightCard = (props: FreightCardProps) => {
             <div className='text-[10px] text-nowrap mb-2'>{freightAlias}</div>
           )}
 
-          <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
+          <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:block [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
             {props.freight?.commits?.slice(0, 2).map((commit) => (
               <FreightArtifact key={commit?.repoURL} artifact={commit} />
             ))}
@@ -317,7 +317,7 @@ export const FreightCard = (props: FreightCardProps) => {
             )}
           </div>
 
-          <div className='flex flex-col mx-auto w-full gap-0.5 items-center justify-center text-nowrap my-1'>
+          <div className='flex flex-col mx-auto w-full gap-0.5 items-center justify-center text-nowrap py-1 mt-auto'>
             {(noOfGitCommits ? 1 : 0) + (noOfHelmReleases ? 1 : 0) + (noOfContainerImages ? 1 : 0) >
               2 && (
               <>

--- a/ui/src/features/project/pipelines/freight/freight-card.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-card.tsx
@@ -109,7 +109,11 @@ export const FreightCard = (props: FreightCardProps) => {
     : undefined;
 
   return (
-    <div ref={setNodeRef} style={style} className='relative'>
+    <div
+      ref={setNodeRef}
+      style={{ width: 'var(--freight-card-width, 140px)', ...style }}
+      className='relative shrink-0'
+    >
       <div className='absolute bottom-0 left-0 right-0 p-1'>
         {props.promote ? (
           <Tooltip
@@ -195,8 +199,12 @@ export const FreightCard = (props: FreightCardProps) => {
             'pl-4': props.inUse
           })}
         >
-          <Flex align='center' justify='space-between' gap={4} className='-mr-2'>
-            <Typography.Text className='text-xs text-nowrap' type='secondary'>
+          <Flex align='center' justify='space-between' gap={4} className='-mr-2 min-w-0'>
+            <Typography.Text
+              className='text-xs min-w-0 flex-1 truncate'
+              type='secondary'
+              title={props.freight?.origin?.name}
+            >
               <FontAwesomeIcon className='mr-1' icon={faWarehouse} size='xs' />
               {props.freight?.origin?.name}
             </Typography.Text>
@@ -278,7 +286,7 @@ export const FreightCard = (props: FreightCardProps) => {
             <div className='text-[10px] text-nowrap mb-2'>{freightAlias}</div>
           )}
 
-          <div className='flex flex-col gap-1 justify-center items-center'>
+          <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
             {props.freight?.commits?.slice(0, 2).map((commit) => (
               <FreightArtifact key={commit?.repoURL} artifact={commit} />
             ))}

--- a/ui/src/features/project/pipelines/freight/freight-expand-tile.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-expand-tile.tsx
@@ -13,7 +13,8 @@ export const FreightExpandTile = ({ count }: Props) => {
 
   return (
     <div
-      className='flex flex-col justify-center h-full px-2 bg-gray-100 rounded-md text-center cursor-pointer border border-solid border-gray-100 hover:border-gray-200'
+      className='flex flex-col justify-center px-2 bg-gray-100 rounded-md text-center cursor-pointer border border-solid border-gray-100 hover:border-gray-200 shrink-0'
+      style={{ width: 56 }}
       onClick={() =>
         freightTimelineControllerContext?.setPreferredFilter({
           ...freightTimelineControllerContext?.preferredFilter,

--- a/ui/src/features/project/pipelines/freight/freight-timeline-filter-button.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline-filter-button.tsx
@@ -1,0 +1,55 @@
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Badge, Button, Popover } from 'antd';
+import classNames from 'classnames';
+
+import {
+  FreightTimelineControllerContextType,
+  useFreightTimelineControllerContext
+} from '@ui/features/project/pipelines/context/freight-timeline-controller-context';
+import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
+
+import { FreightTimelineFilters } from './freight-timeline-filters';
+
+type Props = {
+  className?: string;
+  freights: Freight[];
+};
+
+const isFilterActive = (
+  preferredFilter: FreightTimelineControllerContextType['preferredFilter']
+): boolean =>
+  (preferredFilter?.sources?.length ?? 0) > 0 ||
+  preferredFilter?.timerange !== 'all-time' ||
+  preferredFilter?.hideUnusedFreights === true;
+
+export const FreightTimelineFilterButton = (props: Props) => {
+  const ctx = useFreightTimelineControllerContext();
+
+  if (!ctx) {
+    throw new Error('missing context freightTimelineControllerContext');
+  }
+
+  const active = isFilterActive(ctx.preferredFilter);
+
+  return (
+    <Popover
+      trigger='click'
+      placement='bottomRight'
+      content={
+        <FreightTimelineFilters
+          preferredFilter={ctx.preferredFilter}
+          onPreferredFilterChange={ctx.setPreferredFilter}
+          freights={props.freights}
+        />
+      }
+    >
+      <Badge dot={active} offset={[-4, 4]}>
+        <Button
+          className={classNames(props.className)}
+          icon={<FontAwesomeIcon icon={faFilter} />}
+        />
+      </Badge>
+    </Popover>
+  );
+};

--- a/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
@@ -1,7 +1,7 @@
 import { faDocker, faGitAlt } from '@fortawesome/free-brands-svg-icons';
-import { faAnchor, faFilter, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faAnchor, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Badge, Button, Checkbox, Select, SelectProps } from 'antd';
+import { Checkbox, Select, SelectProps } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 
@@ -13,22 +13,13 @@ import { timerangeOrderedOptions, timerangeToLabel } from './filter-timerange-ut
 import { catalogueFreights } from './source-catalogue-utils';
 
 type FreightTimelineFiltersProps = {
-  collapsed: boolean;
-  onCollapseToggle(): void;
   className?: string;
   preferredFilter: FreightTimelineControllerContextType['preferredFilter'];
   onPreferredFilterChange(next: FreightTimelineControllerContextType['preferredFilter']): void;
-  // all freights to cataloging
   freights: Freight[];
-  filteredFreights: Freight[];
 };
 
 export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
-  const isFilterActive =
-    (props.preferredFilter?.sources?.length ?? 0) > 0 ||
-    props.preferredFilter?.timerange !== 'all-time' ||
-    props.preferredFilter?.hideUnusedFreights === true;
-
   const sourcesDropdownOptions: SelectProps['options'] = useMemo(() => {
     const freightSourcesCatalogue = catalogueFreights(props.freights);
 
@@ -60,101 +51,80 @@ export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
   }, [props.freights]);
 
   return (
-    <div className={classNames(props.className)}>
-      <span className='text-xs flex items-center gap-2'>
-        {!props.collapsed && (
-          <div className='font-semibold flex items-center gap-2'>
-            <FontAwesomeIcon icon={faFilter} /> Filters
-          </div>
-        )}
+    <div className={classNames('min-w-[300px]', props.className)}>
+      <div className='text-xs flex items-center gap-3'>
+        <label>Source: </label>
+        <Select
+          mode='multiple'
+          className='min-w-[200px] ml-auto'
+          styles={{ popup: { root: { width: '50%' } } }}
+          size='small'
+          value={props.preferredFilter?.sources}
+          onChange={(sources) =>
+            props.onPreferredFilterChange({ ...props.preferredFilter, sources })
+          }
+          labelRender={(props) => humanComprehendableArtifact(props.value.toString())}
+          placeholder='All'
+          options={sourcesDropdownOptions}
+          maxTagCount={1}
+        />
+      </div>
+      <div className='text-xs flex items-center gap-3 mt-2'>
+        <label>Timerange: </label>
+        <Select
+          className='min-w-[200px] ml-auto'
+          size='small'
+          value={props.preferredFilter?.timerange}
+          options={timerangeOrderedOptions.map((opt) => ({
+            value: opt,
+            label: <>{timerangeToLabel(opt)}</>
+          }))}
+          maxTagCount={1}
+          onChange={(timerange) =>
+            props.onPreferredFilterChange({ ...props.preferredFilter, timerange: timerange })
+          }
+        />
+      </div>
 
-        <Badge dot={props.collapsed && isFilterActive} offset={[-2, 2]} className='ml-auto'>
-          <Button size='small' onClick={props.onCollapseToggle}>
-            <FontAwesomeIcon icon={props.collapsed ? faFilter : faTimes} />
-          </Button>
-        </Badge>
-      </span>
+      <div className='flex mt-3 gap-2'>
+        <Checkbox
+          className='text-xs'
+          checked={props.preferredFilter?.showAlias}
+          onChange={(e) =>
+            props.onPreferredFilterChange({
+              ...props.preferredFilter,
+              showAlias: e.target.checked
+            })
+          }
+        >
+          Alias
+        </Checkbox>
 
-      <div
-        className={classNames('transition-all', {
-          'w-0 h-0 opacity-0 invisible': props.collapsed,
-          'w-full': !props.collapsed
-        })}
-      >
-        <div className={'text-xs flex items-center gap-3 mt-2'}>
-          <label>Source: </label>
-          <Select
-            mode='multiple'
-            className='min-w-[200px] ml-auto'
-            styles={{ popup: { root: { width: '50%' } } }}
-            size='small'
-            value={props.preferredFilter?.sources}
-            onChange={(sources) =>
-              props.onPreferredFilterChange({ ...props.preferredFilter, sources })
-            }
-            labelRender={(props) => humanComprehendableArtifact(props.value.toString())}
-            placeholder='All'
-            options={sourcesDropdownOptions}
-            maxTagCount={1}
-          />
-        </div>
-        <div className='text-xs flex items-center gap-3 mt-2'>
-          <label>Timerange: </label>
-          <Select
-            className='min-w-[200px]'
-            size='small'
-            value={props.preferredFilter?.timerange}
-            options={timerangeOrderedOptions.map((opt) => ({
-              value: opt,
-              label: <>{timerangeToLabel(opt)}</>
-            }))}
-            maxTagCount={1}
-            onChange={(timerange) =>
-              props.onPreferredFilterChange({ ...props.preferredFilter, timerange: timerange })
-            }
-          />
-        </div>
+        <Checkbox
+          className='text-xs'
+          checked={props.preferredFilter?.showColors}
+          onChange={(e) =>
+            props.onPreferredFilterChange({
+              ...props.preferredFilter,
+              showColors: e.target.checked
+            })
+          }
+        >
+          Colors
+        </Checkbox>
 
-        <div className='flex mt-3 gap-2'>
-          <Checkbox
-            className='text-xs'
-            checked={props.preferredFilter?.showAlias}
-            onChange={(e) =>
-              props.onPreferredFilterChange({
-                ...props.preferredFilter,
-                showAlias: e.target.checked
-              })
-            }
-          >
-            Alias
-          </Checkbox>
-
-          <Checkbox
-            className='text-xs'
-            checked={props.preferredFilter?.showColors}
-            onChange={(e) =>
-              props.onPreferredFilterChange({
-                ...props.preferredFilter,
-                showColors: e.target.checked
-              })
-            }
-          >
-            Colors
-          </Checkbox>
-
-          <Checkbox
-            className='text-xs'
-            checked={props.preferredFilter?.hideUnusedFreights}
-            onChange={(e) =>
-              props.onPreferredFilterChange({
-                ...props.preferredFilter,
-                hideUnusedFreights: e.target.checked
-              })
-            }
-          >
-            Hide unused
-          </Checkbox>
-        </div>
+        <Checkbox
+          className='text-xs'
+          checked={props.preferredFilter?.hideUnusedFreights}
+          onChange={(e) =>
+            props.onPreferredFilterChange({
+              ...props.preferredFilter,
+              hideUnusedFreights: e.target.checked
+            })
+          }
+        >
+          Hide unused freights
+        </Checkbox>
       </div>
     </div>
   );

--- a/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
@@ -57,7 +57,7 @@ export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
         <Select
           mode='multiple'
           className='min-w-[200px] ml-auto'
-          styles={{ popup: { root: { width: '50%' } } }}
+          styles={{ popup: { root: { width: '500px' } } }}
           size='small'
           value={props.preferredFilter?.sources}
           onChange={(sources) =>

--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -2,15 +2,7 @@ import { useDndContext } from '@dnd-kit/core';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
-import {
-  CSSProperties,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { CSSProperties, useContext, useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
@@ -20,22 +12,18 @@ import { IAction, useActionContext } from '@ui/features/project/pipelines/contex
 import { useDictionaryContext } from '@ui/features/project/pipelines/context/dictionary-context';
 import { useFreightTimelineControllerContext } from '@ui/features/project/pipelines/context/freight-timeline-controller-context';
 import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
-import { timestampDate } from '@ui/utils/connectrpc-utils';
 
-import { timerangeToDate } from './filter-timerange-utils';
 import { FreightCard } from './freight-card';
 import { FreightExpandTile } from './freight-expand-tile';
 import { PromotionModeHeader } from './promotion-mode-header';
-import { filterFreightBySource, filterFreightByTimerange } from './source-catalogue-utils';
+import { useFilteredFreights } from './use-filtered-freights';
+import { useFreightCarousel } from './use-freight-carousel';
 import { usePromotionEligibleFreight } from './use-promotion-eligible-freight';
 import { useSoakTime } from './use-soak-time';
 
 import './freight-timeline.less';
 
-const PAGE_SIZE = 20;
 const ARROW_BUTTON_WIDTH = 28;
-const MIN_CARD_WIDTH = 140;
-const CARD_GAP = 4;
 
 export const FreightTimeline = (props: { freights: Freight[]; project: string }) => {
   const navigate = useNavigate();
@@ -44,6 +32,12 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
   const freightTimelineControllerContext = useFreightTimelineControllerContext();
   const dictionaryContext = useDictionaryContext();
   const actionContext = useActionContext();
+
+  if (!freightTimelineControllerContext) {
+    throw new Error('missing context freightTimelineControllerContext');
+  }
+
+  const { preferredFilter } = freightTimelineControllerContext;
 
   const isPromotionMode =
     actionContext?.action?.type === IAction.PROMOTE ||
@@ -54,185 +48,24 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
 
   const soakTime = useSoakTime(props.freights);
 
-  if (!freightTimelineControllerContext) {
-    throw new Error('missing context freightTimelineControllerContext');
-  }
-
   const [viewingFreight, setViewingFreight] = useState<Freight | null>(null);
 
-  const filteredFreights: (Freight & {
-    count?: number;
-  })[] = useMemo(() => {
-    let filtered = [...(props.freights || [])].sort((a, b) => {
-      const t1 = timestampDate(a?.metadata?.creationTimestamp);
+  const filteredFreights = useFilteredFreights(props.freights, preferredFilter);
 
-      const t2 = timestampDate(b?.metadata?.creationTimestamp);
-
-      return (t2?.getTime() || 0) - (t1?.getTime() || 0);
-    });
-
-    filtered = filtered
-      .map(filterFreightBySource(freightTimelineControllerContext.preferredFilter?.sources))
-      .filter(Boolean) as Freight[];
-
-    if (freightTimelineControllerContext.preferredFilter.timerange !== 'all-time') {
-      filtered = filtered.filter(
-        filterFreightByTimerange(
-          timerangeToDate(freightTimelineControllerContext.preferredFilter.timerange)
-        )
-      );
-    }
-
-    if (freightTimelineControllerContext.preferredFilter.warehouses?.length > 0) {
-      filtered = filtered.filter((f) =>
-        freightTimelineControllerContext.preferredFilter.warehouses.includes(f.origin?.name || '')
-      );
-    }
-
-    if (freightTimelineControllerContext.preferredFilter.hideUnusedFreights) {
-      const newFiltered: (Freight & {
-        count?: number;
-      })[] = [];
-
-      let count = 0;
-
-      for (const f of filtered) {
-        const inUse =
-          (dictionaryContext?.freightInStages[f?.metadata?.name || '']?.length || 0) > 0;
-
-        if (inUse) {
-          if (count > 0) {
-            newFiltered.push({
-              ...f,
-              count
-            });
-            count = 0;
-          }
-
-          newFiltered.push(f);
-        } else {
-          count++;
-        }
-      }
-
-      filtered = [...newFiltered];
-    }
-
-    if (isPromotionMode) {
-      filtered = filtered.filter((f) =>
-        actionContext?.action?.stage?.spec?.requestedFreight?.find(
-          (fr) => fr.origin?.name === f?.origin?.name
-        )
-      );
-    }
-
-    return filtered;
-  }, [
-    props.freights,
-    props.freights.length,
-    freightTimelineControllerContext.preferredFilter.sources,
-    freightTimelineControllerContext.preferredFilter.timerange,
-    freightTimelineControllerContext.preferredFilter.warehouses,
-    freightTimelineControllerContext.preferredFilter.hideUnusedFreights,
-    dictionaryContext?.freightInStages,
-    isPromotionMode,
-    actionContext
-  ]);
-
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const stripRef = useRef<HTMLDivElement>(null);
-  const [offset, setOffset] = useState(0);
-  const [cardWidth, setCardWidth] = useState(MIN_CARD_WIDTH);
-
-  useEffect(() => {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-
-    const compute = () => {
-      // Use sub-pixel viewport width and keep exact card width — flooring
-      // discards fractional pixels, and the accumulated loss across N cards
-      // makes the next card peek through on certain resolutions.
-      const W = viewport.getBoundingClientRect().width;
-      if (W <= 0) return;
-      const n = Math.max(1, Math.floor((W + CARD_GAP) / (MIN_CARD_WIDTH + CARD_GAP)));
-      const exactW = (W - (n - 1) * CARD_GAP) / n;
-      setCardWidth(exactW);
-      setOffset(0);
-    };
-
-    compute();
-    const ro = new ResizeObserver(compute);
-    ro.observe(viewport);
-    return () => ro.disconnect();
-  }, []);
-
-  // Reset visible count and scroll position when filters change
-  useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-    setOffset(0);
-  }, [
-    freightTimelineControllerContext.preferredFilter.sources,
-    freightTimelineControllerContext.preferredFilter.timerange,
-    freightTimelineControllerContext.preferredFilter.warehouses,
-    freightTimelineControllerContext.preferredFilter.hideUnusedFreights
-  ]);
-
-  const loadMore = useCallback(() => {
-    setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, filteredFreights.length));
-  }, [filteredFreights.length]);
-
-  const slideLeft = useCallback(() => {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-    // With exact card widths, a page is W + gap (the trailing gap after the
-    // last card on the page); using just W would drift by `gap` per slide.
-    const stride = viewport.getBoundingClientRect().width + CARD_GAP;
-    setOffset((prev) => Math.max(0, prev - stride));
-  }, []);
-
-  const slideRight = useCallback(() => {
-    const viewport = viewportRef.current;
-    const strip = stripRef.current;
-    if (!viewport || !strip) return;
-
-    const W = viewport.getBoundingClientRect().width;
-    const stride = W + CARD_GAP;
-    const maxOffset = Math.max(0, strip.scrollWidth - W);
-    const hasMore = visibleCount < filteredFreights.length;
-
-    setOffset((prev) => {
-      const next = prev + stride;
-      if (next > maxOffset) {
-        if (hasMore) {
-          // Load more so the next page renders; keep the full-stride slide
-          loadMore();
-          return next;
-        }
-        return maxOffset;
-      }
-      return next;
-    });
-  }, [filteredFreights.length, loadMore, visibleCount]);
+  const {
+    viewportRef,
+    stripRef,
+    cardWidth,
+    offset,
+    visibleCount,
+    slideLeft,
+    slideRight,
+    canSlideLeft,
+    canSlideRight
+  } = useFreightCarousel(filteredFreights.length, preferredFilter);
 
   const dndContext = useDndContext();
   const isDragging = !!dndContext.active;
-
-  const [canSlideRight, setCanSlideRight] = useState(false);
-
-  useEffect(() => {
-    const viewport = viewportRef.current;
-    const strip = stripRef.current;
-    if (!viewport || !strip) {
-      setCanSlideRight(false);
-      return;
-    }
-    const maxOffset = Math.max(0, strip.scrollWidth - viewport.clientWidth);
-    setCanSlideRight(offset < maxOffset - 1 || visibleCount < filteredFreights.length);
-  }, [offset, visibleCount, filteredFreights.length]);
-
-  const canSlideLeft = offset > 0;
 
   return (
     <>
@@ -272,13 +105,6 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
           className={classNames('flex-1 min-w-0 relative', {
             'overflow-hidden': !isDragging
           })}
-          onWheel={(e) => {
-            if (e.deltaY > 0) {
-              slideRight();
-            } else if (e.deltaY < 0) {
-              slideLeft();
-            }
-          }}
         >
           <div
             ref={stripRef}
@@ -315,7 +141,7 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
                     dictionaryContext?.freightInStages?.[freight?.metadata?.name || ''] || []
                   }
                   freight={freight}
-                  preferredFilter={freightTimelineControllerContext.preferredFilter}
+                  preferredFilter={preferredFilter}
                   setViewingFreight={setViewingFreight}
                   viewingFreight={viewingFreight}
                   inUse={

--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -269,7 +269,7 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
 
         <div
           ref={viewportRef}
-          className={classNames('flex-1 relative', {
+          className={classNames('flex-1 min-w-0 relative', {
             'overflow-hidden': !isDragging
           })}
           onWheel={(e) => {

--- a/ui/src/features/project/pipelines/freight/freight-timeline.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline.tsx
@@ -1,8 +1,16 @@
 import { useDndContext } from '@dnd-kit/core';
-import { faCaretLeft, faCaretRight } from '@fortawesome/free-solid-svg-icons';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CSSProperties,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
@@ -17,13 +25,17 @@ import { timestampDate } from '@ui/utils/connectrpc-utils';
 import { timerangeToDate } from './filter-timerange-utils';
 import { FreightCard } from './freight-card';
 import { FreightExpandTile } from './freight-expand-tile';
-import { FreightTimelineFilters } from './freight-timeline-filters';
 import { PromotionModeHeader } from './promotion-mode-header';
 import { filterFreightBySource, filterFreightByTimerange } from './source-catalogue-utils';
 import { usePromotionEligibleFreight } from './use-promotion-eligible-freight';
 import { useSoakTime } from './use-soak-time';
 
 import './freight-timeline.less';
+
+const PAGE_SIZE = 20;
+const ARROW_BUTTON_WIDTH = 28;
+const MIN_CARD_WIDTH = 140;
+const CARD_GAP = 4;
 
 export const FreightTimeline = (props: { freights: Freight[]; project: string }) => {
   const navigate = useNavigate();
@@ -45,8 +57,6 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
   if (!freightTimelineControllerContext) {
     throw new Error('missing context freightTimelineControllerContext');
   }
-
-  const [filtersCollapsed, setFilterCollapsed] = useState(true);
 
   const [viewingFreight, setViewingFreight] = useState<Freight | null>(null);
 
@@ -129,13 +139,39 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
     actionContext
   ]);
 
-  const PAGE_SIZE = 20;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
+  const [offset, setOffset] = useState(0);
+  const [cardWidth, setCardWidth] = useState(MIN_CARD_WIDTH);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const compute = () => {
+      // Use sub-pixel viewport width and keep exact card width — flooring
+      // discards fractional pixels, and the accumulated loss across N cards
+      // makes the next card peek through on certain resolutions.
+      const W = viewport.getBoundingClientRect().width;
+      if (W <= 0) return;
+      const n = Math.max(1, Math.floor((W + CARD_GAP) / (MIN_CARD_WIDTH + CARD_GAP)));
+      const exactW = (W - (n - 1) * CARD_GAP) / n;
+      setCardWidth(exactW);
+      setOffset(0);
+    };
+
+    compute();
+    const ro = new ResizeObserver(compute);
+    ro.observe(viewport);
+    return () => ro.disconnect();
+  }, []);
 
   // Reset visible count and scroll position when filters change
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-    freightListStyleRef.current?.style.setProperty('right', '0px');
+    setOffset(0);
   }, [
     freightTimelineControllerContext.preferredFilter.sources,
     freightTimelineControllerContext.preferredFilter.timerange,
@@ -143,40 +179,60 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
     freightTimelineControllerContext.preferredFilter.hideUnusedFreights
   ]);
 
-  const freightListStyleRef = useRef<HTMLDivElement>(null);
-
   const loadMore = useCallback(() => {
     setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, filteredFreights.length));
   }, [filteredFreights.length]);
 
-  const scrollCarouselLeft = () => {
-    const right = freightListStyleRef.current?.style.right || '0px';
+  const slideLeft = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    // With exact card widths, a page is W + gap (the trailing gap after the
+    // last card on the page); using just W would drift by `gap` per slide.
+    const stride = viewport.getBoundingClientRect().width + CARD_GAP;
+    setOffset((prev) => Math.max(0, prev - stride));
+  }, []);
 
-    let nextRight = +right.slice(0, -2) - 160;
+  const slideRight = useCallback(() => {
+    const viewport = viewportRef.current;
+    const strip = stripRef.current;
+    if (!viewport || !strip) return;
 
-    if (nextRight < 0) {
-      nextRight = 0;
-    }
+    const W = viewport.getBoundingClientRect().width;
+    const stride = W + CARD_GAP;
+    const maxOffset = Math.max(0, strip.scrollWidth - W);
+    const hasMore = visibleCount < filteredFreights.length;
 
-    freightListStyleRef.current?.style.setProperty('right', `${nextRight}px`);
-  };
-
-  const scrollCarouselRight = () => {
-    const right = freightListStyleRef.current?.style.right || '0px';
-
-    const nextRight = +right.slice(0, -2) + 160;
-
-    if (
-      nextRight >= (freightListStyleRef.current?.clientWidth || 0) / 2 &&
-      visibleCount < filteredFreights.length
-    ) {
-      loadMore();
-    }
-
-    freightListStyleRef.current?.style.setProperty('right', `${nextRight}px`);
-  };
+    setOffset((prev) => {
+      const next = prev + stride;
+      if (next > maxOffset) {
+        if (hasMore) {
+          // Load more so the next page renders; keep the full-stride slide
+          loadMore();
+          return next;
+        }
+        return maxOffset;
+      }
+      return next;
+    });
+  }, [filteredFreights.length, loadMore, visibleCount]);
 
   const dndContext = useDndContext();
+  const isDragging = !!dndContext.active;
+
+  const [canSlideRight, setCanSlideRight] = useState(false);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const strip = stripRef.current;
+    if (!viewport || !strip) {
+      setCanSlideRight(false);
+      return;
+    }
+    const maxOffset = Math.max(0, strip.scrollWidth - viewport.clientWidth);
+    setCanSlideRight(offset < maxOffset - 1 || visibleCount < filteredFreights.length);
+  }, [offset, visibleCount, filteredFreights.length]);
+
+  const canSlideLeft = offset > 0;
 
   return (
     <>
@@ -196,33 +252,44 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
         </div>
       )}
       <div
-        className={classNames('freightTimeline', 'bg-white py-2 flex gap-0 relative z-20')}
+        className={classNames('freightTimeline', 'bg-white py-2 flex relative z-20')}
         style={{ borderBottom: '2px solid rgba(0,0,0,.05)' }}
       >
-        <FreightTimelineFilters
-          className='bg-white px-3 z-10'
-          collapsed={filtersCollapsed}
-          filteredFreights={filteredFreights}
-          freights={props.freights}
-          onCollapseToggle={() => setFilterCollapsed(!filtersCollapsed)}
-          onPreferredFilterChange={freightTimelineControllerContext.setPreferredFilter}
-          preferredFilter={freightTimelineControllerContext.preferredFilter}
-        />
         <div
-          className={classNames('w-full flex relative px-5', {
-            'overflow-hidden': !dndContext.active
+          className='flex items-stretch shrink-0 cursor-pointer select-none text-gray-500 hover:text-gray-700 mx-1'
+          style={{ width: ARROW_BUTTON_WIDTH, opacity: canSlideLeft ? 1 : 0.4 }}
+          onClick={() => {
+            if (canSlideLeft) slideLeft();
+          }}
+        >
+          <div className='m-auto'>
+            <FontAwesomeIcon icon={faChevronLeft} />
+          </div>
+        </div>
+
+        <div
+          ref={viewportRef}
+          className={classNames('flex-1 relative', {
+            'overflow-hidden': !isDragging
           })}
           onWheel={(e) => {
             if (e.deltaY > 0) {
-              scrollCarouselRight();
+              slideRight();
             } else if (e.deltaY < 0) {
-              scrollCarouselLeft();
+              slideLeft();
             }
           }}
         >
           <div
-            className='flex gap-1 relative right-0 transition-[right] duration-300 ease-out'
-            ref={freightListStyleRef}
+            ref={stripRef}
+            className='flex gap-1 transition-transform duration-300 ease-out'
+            style={
+              {
+                transform: `translateX(-${offset}px)`,
+                width: 'max-content',
+                '--freight-card-width': `${cardWidth}px`
+              } as CSSProperties
+            }
           >
             {filteredFreights.slice(0, visibleCount).map((freight) => {
               const freightSoakTime = soakTime?.[freight?.metadata?.name || ''];
@@ -275,23 +342,17 @@ export const FreightTimeline = (props: { freights: Freight[]; project: string })
               );
             })}
           </div>
+        </div>
 
-          <div
-            className='absolute left-0 h-full bg-gray-100 px-1 flex items-center cursor-pointer rounded-sm hover:bg-gray-200'
-            onClick={() => {
-              scrollCarouselLeft();
-            }}
-          >
-            <FontAwesomeIcon icon={faCaretLeft} />
-          </div>
-
-          <div
-            className='absolute right-0 h-full bg-gray-100 px-1 flex items-center cursor-pointer rounded-sm hover:bg-gray-200'
-            onClick={() => {
-              scrollCarouselRight();
-            }}
-          >
-            <FontAwesomeIcon icon={faCaretRight} />
+        <div
+          className='flex items-stretch shrink-0 cursor-pointer select-none text-gray-500 hover:text-gray-700 mx-1'
+          style={{ width: ARROW_BUTTON_WIDTH, opacity: canSlideRight ? 1 : 0.4 }}
+          onClick={() => {
+            if (canSlideRight) slideRight();
+          }}
+        >
+          <div className='m-auto'>
+            <FontAwesomeIcon icon={faChevronRight} />
           </div>
         </div>
       </div>

--- a/ui/src/features/project/pipelines/freight/use-filtered-freights.ts
+++ b/ui/src/features/project/pipelines/freight/use-filtered-freights.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+
+import { IAction, useActionContext } from '@ui/features/project/pipelines/context/action-context';
+import { useDictionaryContext } from '@ui/features/project/pipelines/context/dictionary-context';
+import { FreightTimelineControllerContextType } from '@ui/features/project/pipelines/context/freight-timeline-controller-context';
+import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
+import { timestampDate } from '@ui/utils/connectrpc-utils';
+
+import { timerangeToDate } from './filter-timerange-utils';
+import { filterFreightBySource, filterFreightByTimerange } from './source-catalogue-utils';
+
+export type FilteredFreight = Freight & { count?: number };
+
+export const useFilteredFreights = (
+  freights: Freight[],
+  preferredFilter: FreightTimelineControllerContextType['preferredFilter']
+): FilteredFreight[] => {
+  const dictionaryContext = useDictionaryContext();
+  const actionContext = useActionContext();
+
+  const isPromotionMode =
+    actionContext?.action?.type === IAction.PROMOTE ||
+    actionContext?.action?.type === IAction.PROMOTE_DOWNSTREAM;
+
+  return useMemo(() => {
+    let filtered = [...(freights || [])].sort((a, b) => {
+      const t1 = timestampDate(a?.metadata?.creationTimestamp);
+      const t2 = timestampDate(b?.metadata?.creationTimestamp);
+      return (t2?.getTime() || 0) - (t1?.getTime() || 0);
+    });
+
+    filtered = filtered
+      .map(filterFreightBySource(preferredFilter.sources))
+      .filter(Boolean) as Freight[];
+
+    if (preferredFilter.timerange !== 'all-time') {
+      filtered = filtered.filter(
+        filterFreightByTimerange(timerangeToDate(preferredFilter.timerange))
+      );
+    }
+
+    if (preferredFilter.warehouses?.length > 0) {
+      filtered = filtered.filter((f) => preferredFilter.warehouses.includes(f.origin?.name || ''));
+    }
+
+    if (preferredFilter.hideUnusedFreights) {
+      const collapsed: FilteredFreight[] = [];
+      let count = 0;
+
+      for (const f of filtered) {
+        const inUse =
+          (dictionaryContext?.freightInStages[f?.metadata?.name || '']?.length || 0) > 0;
+
+        if (inUse) {
+          if (count > 0) {
+            collapsed.push({ ...f, count });
+            count = 0;
+          }
+          collapsed.push(f);
+        } else {
+          count++;
+        }
+      }
+
+      filtered = collapsed;
+    }
+
+    if (isPromotionMode) {
+      filtered = filtered.filter((f) =>
+        actionContext?.action?.stage?.spec?.requestedFreight?.find(
+          (fr) => fr.origin?.name === f?.origin?.name
+        )
+      );
+    }
+
+    return filtered;
+  }, [
+    freights,
+    preferredFilter.sources,
+    preferredFilter.timerange,
+    preferredFilter.warehouses,
+    preferredFilter.hideUnusedFreights,
+    dictionaryContext?.freightInStages,
+    isPromotionMode,
+    actionContext
+  ]);
+};

--- a/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
+++ b/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
@@ -125,7 +125,10 @@ export const useFreightCarousel = (
     }
     const maxOffset = Math.max(0, strip.scrollWidth - viewport.clientWidth);
     setCanSlideRight(offset < maxOffset - 1 || visibleCount < itemCount);
-  }, [offset, visibleCount, itemCount]);
+    // cardWidth tracks viewport size changes from the ResizeObserver. Without
+    // it, a resize that leaves offset at 0 would not re-run this effect, so
+    // canSlideRight could stay stale when the strip starts/stops overflowing.
+  }, [offset, visibleCount, itemCount, cardWidth]);
 
   return {
     viewportRef,

--- a/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
+++ b/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { FreightTimelineControllerContextType } from '@ui/features/project/pipelines/context/freight-timeline-controller-context';
+
+const PAGE_SIZE = 20;
+const MIN_CARD_WIDTH = 140;
+const CARD_GAP = 4;
+
+type PreferredFilter = FreightTimelineControllerContextType['preferredFilter'];
+
+export type FreightCarousel = {
+  viewportRef: React.RefObject<HTMLDivElement | null>;
+  stripRef: React.RefObject<HTMLDivElement | null>;
+  cardWidth: number;
+  offset: number;
+  visibleCount: number;
+  loadMore: () => void;
+  slideLeft: () => void;
+  slideRight: () => void;
+  canSlideLeft: boolean;
+  canSlideRight: boolean;
+};
+
+/**
+ * Drives the freight strip's horizontal pagination: computes per-card width
+ * from the viewport, tracks scroll offset, and lazily reveals more items as
+ * the user pages right. Resets visible count and offset whenever the filter
+ * inputs that affect the displayed set change.
+ */
+export const useFreightCarousel = (
+  itemCount: number,
+  preferredFilter: PreferredFilter
+): FreightCarousel => {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
+  // Cards-per-viewport, derived from width. Tracked in a ref so the
+  // filter-reset effect can size visibleCount to the viewport without
+  // depending on resize-effect state.
+  const cardsPerPageRef = useRef(1);
+
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [offset, setOffset] = useState(0);
+  const [cardWidth, setCardWidth] = useState(MIN_CARD_WIDTH);
+  const [canSlideRight, setCanSlideRight] = useState(false);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const compute = () => {
+      // Use sub-pixel viewport width and keep exact card width — flooring
+      // discards fractional pixels, and the accumulated loss across N cards
+      // makes the next card peek through on certain resolutions.
+      const W = viewport.getBoundingClientRect().width;
+      if (W <= 0) return;
+      const n = Math.max(1, Math.floor((W + CARD_GAP) / (MIN_CARD_WIDTH + CARD_GAP)));
+      const exactW = (W - (n - 1) * CARD_GAP) / n;
+      cardsPerPageRef.current = n;
+      setCardWidth(exactW);
+      setOffset(0);
+      // Ensure the strip fills the viewport (n cards) and keeps a page of
+      // buffer ready for the first slide-right. Never shrink — the user may
+      // have already paged past this point.
+      setVisibleCount((prev) => Math.max(prev, n * 2));
+    };
+
+    compute();
+    const ro = new ResizeObserver(compute);
+    ro.observe(viewport);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    setVisibleCount(Math.max(PAGE_SIZE, cardsPerPageRef.current * 2));
+    setOffset(0);
+  }, [
+    preferredFilter.sources,
+    preferredFilter.timerange,
+    preferredFilter.warehouses,
+    preferredFilter.hideUnusedFreights
+  ]);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, itemCount));
+  }, [itemCount]);
+
+  const slideLeft = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    // With exact card widths, a page is W + gap (the trailing gap after the
+    // last card on the page); using just W would drift by `gap` per slide.
+    const stride = viewport.getBoundingClientRect().width + CARD_GAP;
+    setOffset((prev) => Math.max(0, prev - stride));
+  }, []);
+
+  const slideRight = useCallback(() => {
+    const viewport = viewportRef.current;
+    const strip = stripRef.current;
+    if (!viewport || !strip) return;
+
+    const W = viewport.getBoundingClientRect().width;
+    const stride = W + CARD_GAP;
+    const maxOffset = Math.max(0, strip.scrollWidth - W);
+    const hasMore = visibleCount < itemCount;
+
+    setOffset((prev) => {
+      const next = prev + stride;
+      if (next > maxOffset) {
+        if (hasMore) {
+          loadMore();
+          return next;
+        }
+        return maxOffset;
+      }
+      return next;
+    });
+  }, [itemCount, loadMore, visibleCount]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const strip = stripRef.current;
+    if (!viewport || !strip) {
+      setCanSlideRight(false);
+      return;
+    }
+    const maxOffset = Math.max(0, strip.scrollWidth - viewport.clientWidth);
+    setCanSlideRight(offset < maxOffset - 1 || visibleCount < itemCount);
+  }, [offset, visibleCount, itemCount]);
+
+  return {
+    viewportRef,
+    stripRef,
+    cardWidth,
+    offset,
+    visibleCount,
+    loadMore,
+    slideLeft,
+    slideRight,
+    canSlideLeft: offset > 0,
+    canSlideRight
+  };
+};

--- a/ui/src/features/project/pipelines/graph-filters.tsx
+++ b/ui/src/features/project/pipelines/graph-filters.tsx
@@ -4,14 +4,16 @@ import { Button, Card, Segmented, Select, Typography } from 'antd';
 import { useMemo } from 'react';
 
 import { WarehouseExpanded } from '@ui/extend/types';
-import { Stage } from '@ui/gen/api/v1alpha1/generated_pb';
+import { Freight, Stage } from '@ui/gen/api/v1alpha1/generated_pb';
 
 import { useFreightTimelineControllerContext } from './context/freight-timeline-controller-context';
+import { FreightTimelineFilterButton } from './freight/freight-timeline-filter-button';
 import { groupNodes } from './group-nodes';
 
 type GraphFiltersProps = {
   warehouses: WarehouseExpanded[];
   stages: Stage[];
+  freights: Freight[];
   pipelineView: 'graph' | 'list';
   setPipelineView: (view: 'graph' | 'list') => void;
   className?: string;
@@ -33,7 +35,7 @@ export const GraphFilters = (props: GraphFiltersProps) => {
       <Select
         size='small'
         mode='multiple'
-        className='ml-1 min-w-[300px]'
+        className='ml-1 min-w-[240px]'
         maxTagCount={2}
         placeholder='All'
         value={filterContext?.preferredFilter?.warehouses || []}
@@ -48,6 +50,8 @@ export const GraphFilters = (props: GraphFiltersProps) => {
           })
         }
       />
+
+      <FreightTimelineFilterButton className='ml-3' freights={props.freights} />
 
       {props.pipelineView === 'graph' && (
         <Button

--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -229,6 +229,7 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
                     <GraphFilters
                       warehouses={listWarehousesQuery.data?.warehouses || []}
                       stages={listStagesQuery.data?.stages || []}
+                      freights={freights}
                       pipelineView={pipelineView}
                       setPipelineView={setPipelineView}
                       className='z-10'


### PR DESCRIPTION
## Summary

Redesign of the freight timeline (freightline) - cleaner layout, smarter sizing, and filters tucked away when not in use.

## Changes

- **Filters moved into a popover** - the always-visible filter button/panel is gone; opens from a filter button in the top bar with a dot indicator when any filter is active.
- **Cards fit the row exactly** - freight cards now auto-size to evenly fill the available width, so there's no awkward half-card peeking at the edge regardless of screen size.
- **Smoother paging** - left/right buttons advance by a full page worth of cards instead of a fixed 160px nudge, and dim out when there's nothing more to scroll in that direction.
- **New nav icons** - caret arrows replaced with chevrons, repositioned outside the strip so they don't overlap content.
- **Tidier card content** - long warehouse names and artifact tags truncate cleanly instead of overflowing or pushing the layout.
- **No more wheel-scroll hijack** - scrolling the mouse wheel over the timeline no longer pages it sideways; use the arrow buttons.

<img width="1513" height="1085" alt="image" src="https://github.com/user-attachments/assets/1066faa6-bb82-4818-8041-21d25db5329e" />

