### PR TITLE
fix: indentation in examples for git-open-pr.md 

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -81,7 +81,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ task.outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
 # Wait for the PR to be merged or closed...
 ```
@@ -111,7 +111,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ task.outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
     title: Deploy to ${{ ctx.stage }}
     labels: ["infra", "needs-review"]
@@ -120,7 +120,7 @@ steps:
   as: wait-for-pr
   config:
     repoURL: https://github.com/example/repo.git
-    prNumber: ${{ outputs['open-pr'].pr.id }}
+    prNumber: ${{ task.outputs['open-pr'].pr.id }}
 ```
 
 ### Skipped
@@ -138,16 +138,16 @@ by subsequent steps to determine if a preceding step was skipped.
   config:
     path: ./out
     generateTargetBranch: true
-  - uses: git-open-pr
-    as: open-pr
-    config:
-      repoURL: https://github.com/example/repo.git
-      sourceBranch: ${{ outputs.push.branch }}
-      targetBranch: stage/${{ ctx.stage }}
-  - if: ${{ status('open-pr') != 'Skipped' }}
-    uses: git-wait-for-pr
-    as: wait-for-pr
-    config:
-      repoURL: https://github.com/example/repo.git
-      prNumber: ${{ outputs['open-pr'].pr.id }}
+- uses: git-open-pr
+  as: open-pr
+  config:
+    repoURL: https://github.com/example/repo.git
+    sourceBranch: ${{ task.outputs.push.branch }}
+    targetBranch: stage/${{ ctx.stage }}
+- if: ${{ status('open-pr') != 'Skipped' }}
+  uses: git-wait-for-pr
+  as: wait-for-pr
+  config:
+    repoURL: https://github.com/example/repo.git
+    prNumber: ${{ task.outputs['open-pr'].pr.id }}
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -81,7 +81,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ task.outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
 # Wait for the PR to be merged or closed...
 ```
@@ -111,7 +111,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ task.outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
     title: Deploy to ${{ ctx.stage }}
     labels: ["infra", "needs-review"]
@@ -120,7 +120,7 @@ steps:
   as: wait-for-pr
   config:
     repoURL: https://github.com/example/repo.git
-    prNumber: ${{ task.outputs['open-pr'].pr.id }}
+    prNumber: ${{ outputs['open-pr'].pr.id }}
 ```
 
 ### Skipped
@@ -142,12 +142,12 @@ by subsequent steps to determine if a preceding step was skipped.
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ task.outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }}
     targetBranch: stage/${{ ctx.stage }}
 - if: ${{ status('open-pr') != 'Skipped' }}
   uses: git-wait-for-pr
   as: wait-for-pr
   config:
     repoURL: https://github.com/example/repo.git
-    prNumber: ${{ task.outputs['open-pr'].pr.id }}
+    prNumber: ${{ outputs['open-pr'].pr.id }}
 ```


### PR DESCRIPTION
**All pull requests must reference an existing issue with no blocking labels.**
PRs that do not meet this requirement will be automatically closed. See the
[Contributor Guide](https://docs.kargo.io/contributor-guide) for details.

## Issue Reference

Closes #6272

## Description

Fixes indentation in the git-open-pr docs.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [x] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [x] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
