### PR TITLE
fix: improve error message when step kind is not registered

### DIFF
--- a/pkg/promotion/local_orchestrator.go
+++ b/pkg/promotion/local_orchestrator.go
@@ -130,7 +130,9 @@ func (o *LocalOrchestrator) ExecuteSteps(
 		reg, err := o.registry.Get(step.Kind)
 		if err != nil {
 			meta.WithStatus(kargoapi.PromotionStepStatusErrored).WithMessagef(
-				"error getting runner for step kind %q", step.Kind,
+				"step kind %q is not registered; verify the kind is correct; if you "+
+					"are a Kargo Enterprise user, you may need to enable the promotion controller",
+				step.Kind,
 			)
 			// Continue, because despite this failure, some steps' "if" conditions may
 			// still allow them to run.

--- a/pkg/promotion/local_orchestrator_test.go
+++ b/pkg/promotion/local_orchestrator_test.go
@@ -29,13 +29,14 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 			assertions: func(t *testing.T, result Result, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, kargoapi.PromotionPhaseErrored, result.Status)
-				assert.Contains(t, result.Message, "error getting runner for step kind")
+				assert.Contains(t, result.Message, "step kind \"unknown-step\" is not registered")
+				assert.Contains(t, result.Message, "promotion controller")
 				assert.Equal(t, int64(0), result.CurrentStep)
 
 				require.Len(t, result.StepExecutionMetadata, 1)
 
 				assert.Equal(t, kargoapi.PromotionStepStatusErrored, result.StepExecutionMetadata[0].Status)
-				assert.Contains(t, result.StepExecutionMetadata[0].Message, "error getting runner for step kind")
+				assert.Contains(t, result.StepExecutionMetadata[0].Message, "step kind \"unknown-step\" is not registered")
 				assert.Nil(t, result.StepExecutionMetadata[0].StartedAt)
 				assert.Nil(t, result.StepExecutionMetadata[0].FinishedAt)
 			},


### PR DESCRIPTION
## What changed and why

When `LocalOrchestrator` cannot find a step runner for a given step kind, the previous message was:

```
error getting runner for step kind "my-step"
```

This dropped the underlying reason and gave no guidance on what to do. The new message is:

```
step kind "my-step" is not registered; verify the kind is correct; if you are a Kargo Enterprise user, you may need to enable the promotion controller
```

This is especially helpful when the promotion controller is not enabled — the most common cause of this error in practice (akuityio/kargo-enterprise#624).

## How was this tested

- Updated unit test in `local_orchestrator_test.go` to assert the new message text