### PR TITLE
fix: unknown namespace for service accounts cache

### DIFF
--- a/cmd/controlplane/management_controller.go
+++ b/cmd/controlplane/management_controller.go
@@ -239,6 +239,7 @@ func (o *managementControllerOptions) setupManager(
 			PprofBindAddress: o.PprofBindAddress,
 			Cache: cache.Options{
 				ByObject: map[client.Object]cache.ByObject{
+					&corev1.ServiceAccount{}: {},
 					&corev1.Secret{}: {
 						Namespaces: namespaceCacheConfigs,
 					},


### PR DESCRIPTION
Offending commit: https://github.com/akuity/kargo/commit/c6e6189b623344fc2e206dd709b9c703a70d0335

The intention was to remove the kargo-namespace constraint so that we cached all service accounts ( not just the ones in the kargo namespace ) but we ended omitting service accounts from the cache all together.