### PR TITLE
docs: make Stage context explicit in promotion step examples

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -190,7 +190,7 @@ spec:
         as: commit
         config:
           path: ./out
-          message: ${{ outputs['update-image'].commitMessage }}
+          message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
       - uses: git-push
         config:
           path: ./out
@@ -320,7 +320,7 @@ spec:
                 team: platform
             sources:
             - repoURL: https://github.com/example/repo.git
-              desiredRevision: ${{ outputs.commit.commit }}
+              desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources in the
@@ -354,7 +354,7 @@ spec:
                 - production
             sources:
             - repoURL: https://github.com/example/repo.git
-              desiredRevision: ${{ outputs.commit.commit }}
+              desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources that have
@@ -394,7 +394,7 @@ spec:
                 - legacy-system
             sources:
             - repoURL: https://github.com/example/repo.git
-              desiredRevision: ${{ outputs.commit.commit }}
+              desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources that:
@@ -462,7 +462,7 @@ spec:
                 deployment-group: blue
             sources:
             - repoURL: ${{ vars.gitRepo }}
-              desiredRevision: ${{ outputs.commit.commit }}
+              desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will update all Argo CD `Application` resources that have

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -177,23 +177,30 @@ or by a `Promotion` which failed to complete successfully.
 ### Common Usage
 
 ```yaml
-steps:
-# Clone, render manifests, commit, push, etc...
-- uses: git-commit
-  as: commit
-  config:
-    path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
-- uses: git-push
-  config:
-    path: ./out
-- uses: argocd-update
-  config:
-    apps:
-    - name: my-app
-      sources:
-      - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./out
+          message: ${{ outputs['update-image'].commitMessage }}
+      - uses: git-push
+        config:
+          path: ./out
+      - uses: argocd-update
+        config:
+          apps:
+          - name: my-app
+            sources:
+            - repoURL: https://github.com/example/repo.git
+              desiredRevision: ${{ outputs.commit.commit }}
 ```
 
 ### Updating a Target Revision
@@ -295,17 +302,25 @@ simple key-value label matching. All specified labels must match for an
 application to be selected.
 
 ```yaml
-steps:
-- uses: argocd-update
-  config:
-    apps:
-    - selector:
-        matchLabels:
-          environment: production
-          team: platform
-      sources:
-      - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: argocd-update
+        config:
+          apps:
+          - selector:
+              matchLabels:
+                environment: production
+                team: platform
+            sources:
+            - repoURL: https://github.com/example/repo.git
+              desiredRevision: ${{ outputs.commit.commit }}
 ```
 
 This configuration will select all Argo CD `Application` resources in the
@@ -318,20 +333,28 @@ This example demonstrates using `matchExpressions` with the `In` operator to
 select `Application`s that match one of several possible values for a label.
 
 ```yaml
-steps:
-- uses: argocd-update
-  config:
-    apps:
-    - selector:
-        matchExpressions:
-        - key: environment
-          operator: In
-          values:
-          - staging
-          - production
-      sources:
-      - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: argocd-update
+        config:
+          apps:
+          - selector:
+              matchExpressions:
+              - key: environment
+                operator: In
+                values:
+                - staging
+                - production
+            sources:
+            - repoURL: https://github.com/example/repo.git
+              desiredRevision: ${{ outputs.commit.commit }}
 ```
 
 This configuration will select all Argo CD `Application` resources that have
@@ -344,26 +367,34 @@ more precise selection criteria. All criteria must be satisfied for an
 application to be selected.
 
 ```yaml
-steps:
-- uses: argocd-update
-  config:
-    apps:
-    - selector:
-        matchLabels:
-          team: platform
-        matchExpressions:
-        - key: environment
-          operator: In
-          values:
-          - staging
-          - production
-        - key: managed-by
-          operator: NotIn
-          values:
-          - legacy-system
-      sources:
-      - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: argocd-update
+        config:
+          apps:
+          - selector:
+              matchLabels:
+                team: platform
+              matchExpressions:
+              - key: environment
+                operator: In
+                values:
+                - staging
+                - production
+              - key: managed-by
+                operator: NotIn
+                values:
+                - legacy-system
+            sources:
+            - repoURL: https://github.com/example/repo.git
+              desiredRevision: ${{ outputs.commit.commit }}
 ```
 
 This configuration will select all Argo CD `Application` resources that:
@@ -402,29 +433,36 @@ environments in a single step. This is useful for rolling out changes to
 multiple stages simultaneously, such as in a blue/green deployment scenario.
 
 ```yaml
-vars:
-- name: gitRepo
-  value: https://github.com/example/repo.git
-steps:
-# Clone, render manifests, commit, push, etc...
-- uses: git-commit
-  as: commit
-  config:
-    path: ./out
-    message: Update to new version
-- uses: git-push
-  config:
-    path: ./out
-- uses: argocd-update
-  config:
-    apps:
-    - selector:
-        matchLabels:
-          app: my-microservice
-          deployment-group: blue
-      sources:
-      - repoURL: ${{ vars.gitRepo }}
-        desiredRevision: ${{ outputs.commit.commit }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      vars:
+      - name: gitRepo
+        value: https://github.com/example/repo.git
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./out
+          message: Update to new version
+      - uses: git-push
+        config:
+          path: ./out
+      - uses: argocd-update
+        config:
+          apps:
+          - selector:
+              matchLabels:
+                app: my-microservice
+                deployment-group: blue
+            sources:
+            - repoURL: ${{ vars.gitRepo }}
+              desiredRevision: ${{ outputs.commit.commit }}
 ```
 
 This configuration will update all Argo CD `Application` resources that have

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
@@ -90,27 +90,34 @@ to confirm that the `Application` has reached a healthy and synced state before
 the `Promotion` is marked as succeeded.
 
 ```yaml
-steps:
-# Clone, render manifests, commit, push, etc...
-- uses: git-commit
-  as: commit
-  config:
-    path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
-- uses: git-push
-  config:
-    path: ./out
-- uses: argocd-update
-  config:
-    apps:
-    - name: my-app
-      sources:
-      - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
-- uses: argocd-wait
-  config:
-    apps:
-    - name: my-app
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, render manifests, commit, push, etc...
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./out
+          message: ${{ outputs['update-image'].commitMessage }}
+      - uses: git-push
+        config:
+          path: ./out
+      - uses: argocd-update
+        config:
+          apps:
+          - name: my-app
+            sources:
+            - repoURL: https://github.com/example/repo.git
+              desiredRevision: ${{ outputs.commit.commit }}
+      - uses: argocd-wait
+        config:
+          apps:
+          - name: my-app
 ```
 
 ### Waiting Only for Operation Completion

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
@@ -103,7 +103,7 @@ spec:
         as: commit
         config:
           path: ./out
-          message: ${{ outputs['update-image'].commitMessage }}
+          message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
       - uses: git-push
         config:
           path: ./out

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
@@ -124,27 +124,41 @@ Valid values for `expectedConclusion`:
 This example waits for a previously dispatched workflow to complete successfully using the new configuration format.
 
 ```yaml
-steps:
-- uses: gha-wait-for-workflow
-  config:
-    repoURL: https://github.com/myorg/my-app
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
-    expectedConclusion: success
-    insecureSkipTLSVerify: false
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: gha-wait-for-workflow
+        config:
+          repoURL: https://github.com/myorg/my-app
+          runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
+          expectedConclusion: success
+          insecureSkipTLSVerify: false
 ```
 
 ### v1.8 (Deprecated)
 
 ```yaml
-steps:
-- uses: gha-wait-for-workflow
-  config:
-    credentials:
-      secretName: github-credentials
-    owner: myorg
-    repo: my-app
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
-    expectedConclusion: success
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: gha-wait-for-workflow
+        config:
+          credentials:
+            secretName: github-credentials
+          owner: myorg
+          repo: my-app
+          runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
+          expectedConclusion: success
 ```
 
 ## Multi-Step Workflow Example
@@ -152,26 +166,33 @@ steps:
 This example shows how to combine `gha-dispatch-workflow` and `gha-wait-for-workflow` steps using the new configuration format:
 
 ```yaml
-steps:
-# Dispatch the workflow
-- uses: gha-dispatch-workflow
-  as: dispatch-deployment
-  config:
-    repoURL: https://github.com/example/test
-    workflowFile: test.yaml
-    ref: master
-    inputs:
-      greeting: "hola"
-    timeout: 120
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Dispatch the workflow
+      - uses: gha-dispatch-workflow
+        as: dispatch-deployment
+        config:
+          repoURL: https://github.com/example/test
+          workflowFile: test.yaml
+          ref: master
+          inputs:
+            greeting: "hola"
+          timeout: 120
 
-# Wait for the workflow to complete
-- uses: gha-wait-for-workflow
-  config:
-    repoURL: https://github.com/example/test
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
-    expectedConclusion: success
+      # Wait for the workflow to complete
+      - uses: gha-wait-for-workflow
+        config:
+          repoURL: https://github.com/example/test
+          runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
+          expectedConclusion: success
 
-# Continue with other promotion steps after workflow completes...
+      # Continue with other promotion steps after workflow completes...
 ```
 
 ## Migration from v1.8 to v1.9

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -44,36 +44,43 @@ with a message from the [`kustomize-set-image` step](kustomize-set-image.md) tha
 updated the `kustomization.yaml` file, summarizing the changes made.
 
 ```yaml
-vars:
-- name: gitRepo
-  value: https://github.com/example/repo.git
-steps:
-- uses: git-clone
-  config:
-    repoURL: ${{ vars.gitRepo }}
-    checkout:
-    - commit: ${{ commitFrom(vars.gitRepo).ID }}
-      path: ./src
-    - branch: stage/${{ ctx.stage }}
-      create: true
-      path: ./out
-- uses: git-clear
-  config:
-    path: ./out
-- uses: kustomize-set-image
-  as: update-image
-  config:
-    images:
-    - image: my/image
-- uses: kustomize-build
-  config:
-    path: ./src/stages/${{ ctx.stage }}
-    outPath: ./out
-- uses: git-commit
-  config:
-    path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
-# Push, etc...
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      vars:
+      - name: gitRepo
+        value: https://github.com/example/repo.git
+      steps:
+      - uses: git-clone
+        config:
+          repoURL: ${{ vars.gitRepo }}
+          checkout:
+          - commit: ${{ commitFrom(vars.gitRepo).ID }}
+            path: ./src
+          - branch: stage/${{ ctx.stage }}
+            create: true
+            path: ./out
+      - uses: git-clear
+        config:
+          path: ./out
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          images:
+          - image: my/image
+      - uses: kustomize-build
+        config:
+          path: ./src/stages/${{ ctx.stage }}
+          outPath: ./out
+      - uses: git-commit
+        config:
+          path: ./out
+          message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
+      # Push, etc...
 ```
 
 ### Composed Commit Message
@@ -94,11 +101,18 @@ commit messages when several changes are being committed together.
 :::
 
 ```yaml
-steps:
-# Update Kustomize manifests, etc...
-- uses: git-commit
-  config:
-    path: ./out
-    message: |
-      ${{ ctx.stage }}: ${{ outputs['update-image'].commitMessage }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Update Kustomize manifests, etc...
+      - uses: git-commit
+        config:
+          path: ./out
+          message: |
+            ${{ ctx.stage }}: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -70,20 +70,27 @@ The `git-open-pr` step will fail if the `targetBranch` doesn't exist.
 :::
 
 ```yaml
-steps:
-# Clone, prepare the contents of ./out, commit, etc...
-- uses: git-push
-  as: push
-  config:
-    path: ./out
-    generateTargetBranch: true
-- uses: git-open-pr
-  as: open-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
-    targetBranch: stage/${{ ctx.stage }}
-# Wait for the PR to be merged or closed...
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, prepare the contents of ./out, commit, etc...
+      - uses: git-push
+        as: push
+        config:
+          path: ./out
+          generateTargetBranch: true
+      - uses: git-open-pr
+        as: open-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          sourceBranch: ${{ outputs.push.branch }}
+          targetBranch: stage/${{ ctx.stage }}
+      # Wait for the PR to be merged or closed...
 ```
 
 ### Custom Title and Labels
@@ -99,28 +106,34 @@ proposed or need to integrate with existing PR review workflows that rely on
 specific labels for automation or filtering.
 
 ```yaml
-
-steps:
-# Clone, prepare the contents of ./out, commit, etc...
-- uses: git-push
-  as: push
-  config:
-    path: ./out
-    generateTargetBranch: true
-- uses: git-open-pr
-  as: open-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
-    targetBranch: stage/${{ ctx.stage }}
-    title: Deploy to ${{ ctx.stage }}
-    labels: ["infra", "needs-review"]
-- if: ${{ status('open-pr') != 'Skipped' }}
-  uses: git-wait-for-pr
-  as: wait-for-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    prNumber: ${{ outputs['open-pr'].pr.id }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, prepare the contents of ./out, commit, etc...
+      - uses: git-push
+        as: push
+        config:
+          path: ./out
+          generateTargetBranch: true
+      - uses: git-open-pr
+        as: open-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          sourceBranch: ${{ outputs.push.branch }}
+          targetBranch: stage/${{ ctx.stage }}
+          title: Deploy to ${{ ctx.stage }}
+          labels: ["infra", "needs-review"]
+      - if: ${{ status('open-pr') != 'Skipped' }}
+        uses: git-wait-for-pr
+        as: wait-for-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          prNumber: ${{ outputs['open-pr'].pr.id }}
 ```
 
 ### Skipped
@@ -133,21 +146,29 @@ The following example conditionally runs the
 by subsequent steps to determine if a preceding step was skipped.
 
 ```yaml
-- uses: git-push
-  as: push
-  config:
-    path: ./out
-    generateTargetBranch: true
-- uses: git-open-pr
-  as: open-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
-    targetBranch: stage/${{ ctx.stage }}
-- if: ${{ status('open-pr') != 'Skipped' }}
-  uses: git-wait-for-pr
-  as: wait-for-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    prNumber: ${{ outputs['open-pr'].pr.id }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: git-push
+        as: push
+        config:
+          path: ./out
+          generateTargetBranch: true
+      - uses: git-open-pr
+        as: open-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          sourceBranch: ${{ outputs.push.branch }}
+          targetBranch: stage/${{ ctx.stage }}
+      - if: ${{ status('open-pr') != 'Skipped' }}
+        uses: git-wait-for-pr
+        as: wait-for-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          prNumber: ${{ outputs['open-pr'].pr.id }}
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -88,7 +88,7 @@ spec:
         as: open-pr
         config:
           repoURL: https://github.com/example/repo.git
-          sourceBranch: ${{ outputs.push.branch }}
+          sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
           targetBranch: stage/${{ ctx.stage }}
       # Wait for the PR to be merged or closed...
 ```
@@ -124,7 +124,7 @@ spec:
         as: open-pr
         config:
           repoURL: https://github.com/example/repo.git
-          sourceBranch: ${{ outputs.push.branch }}
+          sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
           targetBranch: stage/${{ ctx.stage }}
           title: Deploy to ${{ ctx.stage }}
           labels: ["infra", "needs-review"]
@@ -163,7 +163,7 @@ spec:
         as: open-pr
         config:
           repoURL: https://github.com/example/repo.git
-          sourceBranch: ${{ outputs.push.branch }}
+          sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
           targetBranch: stage/${{ ctx.stage }}
       - if: ${{ status('open-pr') != 'Skipped' }}
         uses: git-wait-for-pr

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
@@ -85,7 +85,7 @@ spec:
         config:
           repoURL: https://github.com/example/repo.git
           createTargetBranch: true
-          sourceBranch: ${{ outputs.push.branch }}
+          sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
           targetBranch: stage/${{ ctx.stage }}
       - uses: git-wait-for-pr
         as: wait-for-pr

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
@@ -66,23 +66,30 @@ reviewed and merged before proceeding with subsequent steps in your promotion
 process, such as [updating Argo CD applications](argocd-update.md).
 
 ```yaml
-steps:
-# Clone, prepare the contents of ./out, commit, etc...
-- uses: git-push
-  as: push
-  config:
-    path: ./out
-    generateTargetBranch: true
-- uses: git-open-pr
-  as: open-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    createTargetBranch: true
-    sourceBranch: ${{ outputs.push.branch }}
-    targetBranch: stage/${{ ctx.stage }}
-- uses: git-wait-for-pr
-  as: wait-for-pr
-  config:
-    repoURL: https://github.com/example/repo.git
-    prNumber: ${{ outputs['open-pr'].pr.id }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, prepare the contents of ./out, commit, etc...
+      - uses: git-push
+        as: push
+        config:
+          path: ./out
+          generateTargetBranch: true
+      - uses: git-open-pr
+        as: open-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          createTargetBranch: true
+          sourceBranch: ${{ outputs.push.branch }}
+          targetBranch: stage/${{ ctx.stage }}
+      - uses: git-wait-for-pr
+        as: wait-for-pr
+        config:
+          repoURL: https://github.com/example/repo.git
+          prNumber: ${{ outputs['open-pr'].pr.id }}
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
@@ -135,18 +135,25 @@ This step does not produce any output.
 This example deletes evidence when a promotion fails, using the evidence name from a previous step.
 
 ```yaml
-steps:
-- uses: jfrog-evidence
-  as: cleanup-failed-evidence
-  if: ${{ failure() && status('create-test-evidence') == 'Succeeded' }}
-  config:
-    credentials:
-      secretName: jfrog-credentials
-    delete:
-      packageRepo: ${{ vars.packageRepo }}
-      packageName: ${{ vars.packageName }}
-      packageVersion: ${{ imageFrom(vars.packageRegistry+"/"+vars.packageRepo+"/"+vars.packageName).Tag }}
-      evidenceName: ${{ outputs['create-test-evidence'].name }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jfrog-evidence
+        as: cleanup-failed-evidence
+        if: ${{ failure() && status('create-test-evidence') == 'Succeeded' }}
+        config:
+          credentials:
+            secretName: jfrog-credentials
+          delete:
+            packageRepo: ${{ vars.packageRepo }}
+            packageName: ${{ vars.packageName }}
+            packageVersion: ${{ imageFrom(vars.packageRegistry+"/"+vars.packageRepo+"/"+vars.packageName).Tag }}
+            evidenceName: ${{ outputs['create-test-evidence'].name }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Process Evidence (Query and Verify)
@@ -195,53 +202,60 @@ The outputs are dynamic based on the `process.outputs` configuration. Each outpu
 This example verifies test evidence and extracts relevant information for subsequent steps.
 
 ```yaml
-steps:
-- uses: jfrog-evidence
-  as: verify-test-evidence
-  config:
-    credentials:
-      secretName: jfrog-credentials
-    process:
-      query:
-        packageRepo: ${{ vars.packageRepo }}
-        packageName: ${{ vars.packageName }}
-        packageVersion: ${{ imageFrom(vars.packageRegistry+"/"+vars.packageRepo+"/"+vars.packageName).Tag }}
-        predicateType: "https://in-toto.io/attestation/test-result/v0.1"
-        evidenceNameRegex: ".*-test-result-.*"
-      verify:
-        localKeys:
-          - ${{ secret("jfrog-credentials").privateKey }}
-        useArtifactoryKeys: true
-        verifyExpression: |
-          evidence.predicate.result == "pass" && 
-          evidence.predicate.coverage >= 80
-      outputs:
-        - name: testResult
-          expression: evidence.predicate.result
-        - name: coverage
-          expression: evidence.predicate.coverage
-        - name: createdAt
-          expression: evidence.createdAt
-        - name: environment
-          expression: evidence.predicate.metadata.env
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jfrog-evidence
+        as: verify-test-evidence
+        config:
+          credentials:
+            secretName: jfrog-credentials
+          process:
+            query:
+              packageRepo: ${{ vars.packageRepo }}
+              packageName: ${{ vars.packageName }}
+              packageVersion: ${{ imageFrom(vars.packageRegistry+"/"+vars.packageRepo+"/"+vars.packageName).Tag }}
+              predicateType: "https://in-toto.io/attestation/test-result/v0.1"
+              evidenceNameRegex: ".*-test-result-.*"
+            verify:
+              localKeys:
+                - ${{ secret("jfrog-credentials").privateKey }}
+              useArtifactoryKeys: true
+              verifyExpression: |
+                evidence.predicate.result == "pass" &&
+                evidence.predicate.coverage >= 80
+            outputs:
+              - name: testResult
+                expression: evidence.predicate.result
+              - name: coverage
+                expression: evidence.predicate.coverage
+              - name: createdAt
+                expression: evidence.createdAt
+              - name: environment
+                expression: evidence.predicate.metadata.env
 
-# Use the extracted values in subsequent steps
-- uses: http
-  config:
-    method: POST
-    url: https://api.slack.com/api/chat.postMessage
-    headers:
-    - name: Authorization
-      value: "Bearer ${{ secret('slack-token').token }}"
-    - name: Content-Type
-      value: application/json
-    body: |
-      ${{ quote({
-        "channel": "#deployments",
-        "text": "Test evidence verified! Result: " + outputs['verify-test-evidence'].testResult + 
-                ", Coverage: " + string(outputs['verify-test-evidence'].coverage) + "%" +
-                ", Environment: " + outputs['verify-test-evidence'].environment
-      }) }}
+      # Use the extracted values in subsequent steps
+      - uses: http
+        config:
+          method: POST
+          url: https://api.slack.com/api/chat.postMessage
+          headers:
+          - name: Authorization
+            value: "Bearer ${{ secret('slack-token').token }}"
+          - name: Content-Type
+            value: application/json
+          body: |
+            ${{ quote({
+              "channel": "#deployments",
+              "text": "Test evidence verified! Result: " + outputs['verify-test-evidence'].testResult +
+                      ", Coverage: " + string(outputs['verify-test-evidence'].coverage) + "%" +
+                      ", Environment: " + outputs['verify-test-evidence'].environment
+            }) }}
 ```
 
 #### Trusted Release Evidence Verification

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
@@ -78,30 +78,37 @@ This example creates a new Jira issue to track a promotion, assigns it to a team
 member, and adds relevant labels.
 
 ```yaml
-steps:
-- uses: jira
-  as: create-promotion-issue
-  config:
-    credentials:
-      secretName: jira-credentials
-    createIssue:
-      projectKey: PROMOTE
-      summary: "Promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
-      description: "Promoteing ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }} environment. Promotion ID: ${{ ctx.promotion }}. Freight: ${{ ctx.targetFreight.name }}."
-      issueType: Task
-      assigneeEmail: devops@company.com
-      labels:
-      - promotion
-      - "${{ ctx.stage }}"
-      - "release-${{ imageFrom(vars.imageRepo).Tag }}"
-# Use the created issue key in subsequent steps
-- uses: jira
-  config:
-    credentials:
-      secretName: jira-credentials
-    updateIssue:
-      issueKey: "${{ outputs['create-promotion-issue'].key }}"
-      status: "IN PROGRESS"
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jira
+        as: create-promotion-issue
+        config:
+          credentials:
+            secretName: jira-credentials
+          createIssue:
+            projectKey: PROMOTE
+            summary: "Promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
+            description: "Promoting ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }} environment. Promotion ID: ${{ ctx.promotion }}. Freight: ${{ ctx.targetFreight.name }}."
+            issueType: Task
+            assigneeEmail: devops@company.com
+            labels:
+            - promotion
+            - "${{ ctx.stage }}"
+            - "release-${{ imageFrom(vars.imageRepo).Tag }}"
+      # Use the created issue key in subsequent steps
+      - uses: jira
+        config:
+          credentials:
+            secretName: jira-credentials
+          updateIssue:
+            issueKey: "${{ outputs['create-promotion-issue'].key }}" # Or task.outputs in a (Cluster)PromotionTask
+            status: "IN PROGRESS"
 ```
 
 ### Update Issue
@@ -211,38 +218,45 @@ Searches for Jira issues using JQL
 This example searches for open promotion issues in a specific project and expects multiple results.
 
 ```yaml
-steps:
-- uses: jira
-  as: find-open-promotions
-  config:
-    credentials:
-      secretName: jira-credentials
-    searchIssue:
-      jql: 'project = PROMOTE AND status != "Done" AND labels = "${{ ctx.stage }}-promotion" AND created >= -7d'
-      expectMultiple: true
-      fields:
-      - summary
-      - status
-      - assignee
-      - created
-      expands:
-      - changelog
-# Use search results in subsequent steps to notify team
-# Note: This is just an example of using search outputs and may not be syntactically valid
-- uses: http
-  config:
-    method: POST
-    url: https://slack.com/api/chat.postMessage
-    headers:
-    - name: Authorization
-      value: "Bearer ${{ secret('slack-credentials').token }}"
-    - name: Content-Type
-      value: application/json
-    body: |
-      ${{ quote({
-        "channel": "#promotions",
-        "text": "Found issue" + outputs['find-open-promotions'].issue.key + " for " + ctx.stage + " environment"
-      }) }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jira
+        as: find-open-promotions
+        config:
+          credentials:
+            secretName: jira-credentials
+          searchIssue:
+            jql: 'project = PROMOTE AND status != "Done" AND labels = "${{ ctx.stage }}-promotion" AND created >= -7d'
+            expectMultiple: true
+            fields:
+            - summary
+            - status
+            - assignee
+            - created
+            expands:
+            - changelog
+      # Use search results in subsequent steps to notify team
+      # Note: This is just an example of using search outputs and may not be syntactically valid
+      - uses: http
+        config:
+          method: POST
+          url: https://slack.com/api/chat.postMessage
+          headers:
+          - name: Authorization
+            value: "Bearer ${{ secret('slack-credentials').token }}"
+          - name: Content-Type
+            value: application/json
+          body: |
+            ${{ quote({
+              "channel": "#promotions",
+              "text": "Found issue" + outputs['find-open-promotions'].issue.key + " for " + ctx.stage + " environment"
+            }) }}
 ```
 
 ## Comment Management
@@ -270,23 +284,30 @@ Adds a comment to an existing Jira issue.
 This example adds a comment to a Jira issue with promotion progress information.
 
 ```yaml
-steps:
-- uses: jira
-  as: add-progress-comment
-  config:
-    credentials:
-      secretName: jira-credentials
-    commentOnIssue:
-      issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
-      body: "Promotion started. Environment: ${{ ctx.stage }}. Image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}. Promotion: ${{ ctx.promotion }}. Status: Promoting to ${{ ctx.stage }} environment..."
-# Later use the comment ID if needed
-- uses: jira
-  config:
-    credentials:
-      secretName: jira-credentials
-    deleteComment:
-      issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
-      commentID: "${{ quote(outputs['add-progress-comment'].commentID) }}"
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jira
+        as: add-progress-comment
+        config:
+          credentials:
+            secretName: jira-credentials
+          commentOnIssue:
+            issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
+            body: "Promotion started. Environment: ${{ ctx.stage }}. Image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}. Promotion: ${{ ctx.promotion }}. Status: Promoting to ${{ ctx.stage }} environment..."
+      # Later use the comment ID if needed
+      - uses: jira
+        config:
+          credentials:
+            secretName: jira-credentials
+          deleteComment:
+            issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
+            commentID: "${{ quote(outputs['add-progress-comment'].commentID) }}" # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Delete Comment
@@ -309,14 +330,21 @@ This step does not produce any output.
 This example deletes a specific comment from a Jira issue.
 
 ```yaml
-steps:
-- uses: jira
-  config:
-    credentials:
-      secretName: jira-credentials
-    deleteComment:
-      issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
-      commentID: "${{ outputs['previous-comment-step'].commentID }}"
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: jira
+        config:
+          credentials:
+            secretName: jira-credentials
+          deleteComment:
+            issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
+            commentID: "${{ outputs['previous-comment-step'].commentID }}" # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ## Status Tracking
@@ -495,7 +523,7 @@ spec:
           credentials:
             secretName: jira
           commentOnIssue:
-            issueKey: ${{ outputs['create-promotion-issue'].key }}
+            issueKey: ${{ outputs['create-promotion-issue'].key }} # Or task.outputs in a (Cluster)PromotionTask
             body: "Release ${{ imageFrom(vars.imageRepo).Tag }} has been promoted to ${{ ctx.stage }} environment. Freight: ${{ ctx.targetFreight.name }}. Ready for testing."
 
       # Cleanup on failure
@@ -586,7 +614,7 @@ spec:
             secretName: jira
           deleteComment:
             issueKey: ${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}
-            commentID: ${{ quote(outputs['comment-on-issue'].commentID) }}
+            commentID: ${{ quote(outputs['comment-on-issue'].commentID) }} # Or task.outputs in a (Cluster)PromotionTask
 
 ---
 apiVersion: kargo.akuity.io/v1alpha1
@@ -627,7 +655,7 @@ spec:
           credentials:
             secretName: jira
           waitForStatus:
-            issueKey: ${{ outputs['search-issue'].key }}
+            issueKey: ${{ outputs['search-issue'].key }} # Or task.outputs in a (Cluster)PromotionTask
             expectedStatus: RELEASED
 
       # Update the Argo CD Application directly. Not ideal for practical purposes.

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
@@ -78,19 +78,26 @@ garbage collection policies that limit images per repository). The step output
 is then used by `kustomize-set-image` to update the deployment manifest.
 
 ```yaml
-steps:
-- uses: oci-push
-  as: push-to-stage
-  config:
-    srcRef: registry.example.com/widget-service@${{ imageFrom("registry.example.com/widget-service").digest }}
-    destRef: registry.example.com/widget-service/${{ ctx.stage }}:${{ imageFrom("registry.example.com/widget-service").tag }}
-- uses: kustomize-set-image
-  config:
-    path: ./out
-    images:
-    - image: registry.example.com/widget-service
-      newName: registry.example.com/widget-service/${{ ctx.stage }}
-      digest: ${{ outputs["push-to-stage"].digest }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: oci-push
+        as: push-to-stage
+        config:
+          srcRef: registry.example.com/widget-service@${{ imageFrom("registry.example.com/widget-service").digest }}
+          destRef: registry.example.com/widget-service/${{ ctx.stage }}:${{ imageFrom("registry.example.com/widget-service").tag }}
+      - uses: kustomize-set-image
+        config:
+          path: ./out
+          images:
+          - image: registry.example.com/widget-service
+            newName: registry.example.com/widget-service/${{ ctx.stage }}
+            digest: ${{ outputs["push-to-stage"].digest }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Promoting an OCI Helm Chart

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
@@ -193,25 +193,32 @@ It leverages the `set-metadata` step to store and retrieve the thread timestamp 
 freight. This allows messages related to the same freight to be grouped together in a single thread.
 
 ```yaml
-steps:
-- uses: send-message
-  as: send-slack
-  config:
-    channel:
-      kind: MessageChannel
-      name: slack
-    message: "Kargo has kicked off promotion to stage: ${{ ctx.stage }}."
-    slack:
-      # NOTE: Make sure to wrap this in quotes with `quote` otherwise it will get rendered as
-      # a number
-      threadTS: "${{ quote(freightMetadata(ctx.targetFreight.name)?.slackThreadTS ?? '') }}"
-- uses: set-metadata
-  config:
-    updates:
-      - kind: Freight
-        name: ${{ ctx.targetFreight.name }}
-        values:
-          # NOTE: Make sure to wrap this in quotes with `quote` otherwise it will get rendered
-          # as a number
-          slackThreadTS: "${{ quote(outputs['send-slack']?.slack?.threadTS ?? '') }}"
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      - uses: send-message
+        as: send-slack
+        config:
+          channel:
+            kind: MessageChannel
+            name: slack
+          message: "Kargo has kicked off promotion to stage: ${{ ctx.stage }}."
+          slack:
+            # NOTE: Make sure to wrap this in quotes with `quote` otherwise it will get rendered as
+            # a number
+            threadTS: "${{ quote(freightMetadata(ctx.targetFreight.name)?.slackThreadTS ?? '') }}"
+      - uses: set-metadata
+        config:
+          updates:
+            - kind: Freight
+              name: ${{ ctx.targetFreight.name }}
+              values:
+                # NOTE: Make sure to wrap this in quotes with `quote` otherwise it will get rendered
+                # as a number
+                slackThreadTS: "${{ quote(outputs['send-slack']?.slack?.threadTS ?? '') }}" # Or task.outputs in a (Cluster)PromotionTask
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
@@ -126,7 +126,7 @@ spec:
       # Commit and push state changes...
       - uses: http
         config:
-          url: ${{ outputs.infra.function_url.value }}
+          url: ${{ outputs.infra.function_url.value }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Retrieving a Specific Output
@@ -159,7 +159,7 @@ spec:
             value: ${{ secret('aws-creds').awsSecretAccessKey }}
       - uses: http
         config:
-          url: ${{ outputs.endpoint.function_url }}
+          url: ${{ outputs.endpoint.function_url }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Writing Outputs to a File

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
@@ -77,54 +77,56 @@ state after applying configuration. This example retrieves the function URL
 from an AWS Lambda deployment for use in subsequent steps.
 
 ```yaml
-vars:
-- name: repoURL
-  value: https://github.com/example/infra.git
-- name: image
-  value: 123456789.dkr.ecr.us-west-2.amazonaws.com/my-app
-steps:
-- uses: git-clone
-  config:
-    repoURL: ${{ vars.repoURL }}
-    checkout:
-    - branch: main
-      path: ./src
-- uses: hcl-update
-  config:
-    path: ./src/opentofu/${{ ctx.stage }}/env.auto.tfvars
-    updates:
-    - key: image_uri
-      value: ${{ vars.image }}:${{ imageFrom(vars.image).Tag }}
-- uses: tf-apply
-  config:
-    dir: ./src/opentofu/${{ ctx.stage }}
-    env:
-    - name: AWS_REGION
-      value: us-west-2
-    - name: AWS_ACCESS_KEY_ID
-      value: ${{ secret('aws-creds').awsAccessKeyID }}
-    - name: AWS_SECRET_ACCESS_KEY
-      value: ${{ secret('aws-creds').awsSecretAccessKey }}
-- uses: tf-output
-  as: infra
-  config:
-    dir: ./src/opentofu/${{ ctx.stage }}
-    env:
-    - name: AWS_REGION
-      value: us-west-2
-    - name: AWS_ACCESS_KEY_ID
-      value: ${{ secret('aws-creds').awsAccessKeyID }}
-    - name: AWS_SECRET_ACCESS_KEY
-      value: ${{ secret('aws-creds').awsSecretAccessKey }}
-# Commit and push state changes...
-```
-
-The outputs can then be referenced in subsequent steps:
-
-```yaml
-- uses: http
-  config:
-    url: ${{ outputs.infra.function_url.value }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      vars:
+      - name: repoURL
+        value: https://github.com/example/infra.git
+      - name: image
+        value: 123456789.dkr.ecr.us-west-2.amazonaws.com/my-app
+      steps:
+      - uses: git-clone
+        config:
+          repoURL: ${{ vars.repoURL }}
+          checkout:
+          - branch: main
+            path: ./src
+      - uses: hcl-update
+        config:
+          path: ./src/opentofu/${{ ctx.stage }}/env.auto.tfvars
+          updates:
+          - key: image_uri
+            value: ${{ vars.image }}:${{ imageFrom(vars.image).Tag }}
+      - uses: tf-apply
+        config:
+          dir: ./src/opentofu/${{ ctx.stage }}
+          env:
+          - name: AWS_REGION
+            value: us-west-2
+          - name: AWS_ACCESS_KEY_ID
+            value: ${{ secret('aws-creds').awsAccessKeyID }}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${{ secret('aws-creds').awsSecretAccessKey }}
+      - uses: tf-output
+        as: infra
+        config:
+          dir: ./src/opentofu/${{ ctx.stage }}
+          env:
+          - name: AWS_REGION
+            value: us-west-2
+          - name: AWS_ACCESS_KEY_ID
+            value: ${{ secret('aws-creds').awsAccessKeyID }}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${{ secret('aws-creds').awsSecretAccessKey }}
+      # Commit and push state changes...
+      - uses: http
+        config:
+          url: ${{ outputs.infra.function_url.value }}
 ```
 
 ### Retrieving a Specific Output
@@ -134,28 +136,30 @@ step returns only the value without the metadata wrapper, making it easier to
 use in subsequent steps.
 
 ```yaml
-steps:
-# Clone, plan, apply, etc...
-- uses: tf-output
-  as: endpoint
-  config:
-    dir: ./src/opentofu/${{ ctx.stage }}
-    name: function_url
-    env:
-    - name: AWS_REGION
-      value: us-west-2
-    - name: AWS_ACCESS_KEY_ID
-      value: ${{ secret('aws-creds').awsAccessKeyID }}
-    - name: AWS_SECRET_ACCESS_KEY
-      value: ${{ secret('aws-creds').awsSecretAccessKey }}
-```
-
-The output value can be referenced directly:
-
-```yaml
-- uses: http
-  config:
-    url: ${{ outputs.endpoint.function_url }}
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+# ...
+spec:
+  # ...
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone, plan, apply, etc...
+      - uses: tf-output
+        as: endpoint
+        config:
+          dir: ./src/opentofu/${{ ctx.stage }}
+          name: function_url
+          env:
+          - name: AWS_REGION
+            value: us-west-2
+          - name: AWS_ACCESS_KEY_ID
+            value: ${{ secret('aws-creds').awsAccessKeyID }}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: ${{ secret('aws-creds').awsSecretAccessKey }}
+      - uses: http
+        config:
+          url: ${{ outputs.endpoint.function_url }}
 ```
 
 ### Writing Outputs to a File


### PR DESCRIPTION
## Issue Reference

Closes #6275

## Description

Several promotion step reference examples used `${{ outputs.alias.field }}`
  without any surrounding YAML context. This created an unstated assumption                                                                                    
  that the reader understood the snippet to be inside a `Stage`'s          
  `spec.promotionTemplate` — not inside a `(Cluster)PromotionTask`, where                                                                                      
  the correct syntax is `${{ task.outputs['alias'].field }}`.                                                                                                  
                                                             
  As noted in the original review on #6273, the fix is to make the context                                                                                     
  explicit in each affected example rather than leaving it as an assumption.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [ ] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [x] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [x] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
