### PR TITLE
docs: clarify promotion output context

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -174,15 +174,6 @@ or by a `Promotion` which failed to complete successfully.
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 ```yaml
@@ -192,7 +183,7 @@ steps:
   as: commit
   config:
     path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
+    message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
 - uses: git-push
   config:
     path: ./out
@@ -314,7 +305,7 @@ steps:
           team: platform
       sources:
       - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+        desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources in the
@@ -340,7 +331,7 @@ steps:
           - production
       sources:
       - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+        desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources that have
@@ -372,7 +363,7 @@ steps:
           - legacy-system
       sources:
       - repoURL: https://github.com/example/repo.git
-        desiredRevision: ${{ outputs.commit.commit }}
+        desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will select all Argo CD `Application` resources that:
@@ -433,7 +424,7 @@ steps:
           deployment-group: blue
       sources:
       - repoURL: ${{ vars.gitRepo }}
-        desiredRevision: ${{ outputs.commit.commit }}
+        desiredRevision: ${{ outputs.commit.commit }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 This configuration will update all Argo CD `Application` resources that have

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -174,6 +174,15 @@ or by a `Promotion` which failed to complete successfully.
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 ```yaml

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
@@ -83,6 +83,15 @@ during the wait.
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 In this example, `argocd-wait` is used after [`argocd-update`](argocd-update.md)

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
@@ -83,15 +83,6 @@ during the wait.
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 In this example, `argocd-wait` is used after [`argocd-update`](argocd-update.md)
@@ -105,7 +96,7 @@ steps:
   as: commit
   config:
     path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
+    message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
 - uses: git-push
   config:
     path: ./out

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
@@ -119,6 +119,15 @@ Valid values for `expectedConclusion`:
 
 ## Example
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### v1.9 and Above
 
 This example waits for a previously dispatched workflow to complete successfully using the new configuration format.

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/gha-wait-for-workflow.md
@@ -119,15 +119,6 @@ Valid values for `expectedConclusion`:
 
 ## Example
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### v1.9 and Above
 
 This example waits for a previously dispatched workflow to complete successfully using the new configuration format.
@@ -137,7 +128,7 @@ steps:
 - uses: gha-wait-for-workflow
   config:
     repoURL: https://github.com/myorg/my-app
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
+    runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
     expectedConclusion: success
     insecureSkipTLSVerify: false
 ```
@@ -152,7 +143,7 @@ steps:
       secretName: github-credentials
     owner: myorg
     repo: my-app
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
+    runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
     expectedConclusion: success
 ```
 
@@ -177,7 +168,7 @@ steps:
 - uses: gha-wait-for-workflow
   config:
     repoURL: https://github.com/example/test
-    runID: "${{ outputs['dispatch-deployment'].runID }}"
+    runID: "${{ outputs['dispatch-deployment'].runID }}" # Or task.outputs in a (Cluster)PromotionTask
     expectedConclusion: success
 
 # Continue with other promotion steps after workflow completes...

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -37,6 +37,15 @@ If authorship differing from any system-level default is required, configure it 
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 In this example, the working tree is prepared by previous steps and then committed

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-commit.md
@@ -37,15 +37,6 @@ If authorship differing from any system-level default is required, configure it 
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 In this example, the working tree is prepared by previous steps and then committed
@@ -81,7 +72,7 @@ steps:
 - uses: git-commit
   config:
     path: ./out
-    message: ${{ outputs['update-image'].commitMessage }}
+    message: ${{ outputs['update-image'].commitMessage }} # Or task.outputs in a (Cluster)PromotionTask
 # Push, etc...
 ```
 
@@ -108,6 +99,6 @@ steps:
 - uses: git-commit
   config:
     path: ./out
-    message: |
+    message: | # Or task.outputs in a (Cluster)PromotionTask
       ${{ ctx.stage }}: ${{ outputs['update-image'].commitMessage }}
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -51,6 +51,15 @@ support pull request labels at all.
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 The following example demonstrates a common use case for `git-open-pr`. It

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-open-pr.md
@@ -51,15 +51,6 @@ support pull request labels at all.
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 The following example demonstrates a common use case for `git-open-pr`. It
@@ -90,7 +81,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
     targetBranch: stage/${{ ctx.stage }}
 # Wait for the PR to be merged or closed...
 ```
@@ -120,7 +111,7 @@ steps:
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
     targetBranch: stage/${{ ctx.stage }}
     title: Deploy to ${{ ctx.stage }}
     labels: ["infra", "needs-review"]
@@ -151,7 +142,7 @@ by subsequent steps to determine if a preceding step was skipped.
   as: open-pr
   config:
     repoURL: https://github.com/example/repo.git
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
     targetBranch: stage/${{ ctx.stage }}
 - if: ${{ status('open-pr') != 'Skipped' }}
   uses: git-wait-for-pr

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
@@ -52,15 +52,6 @@ system to access the git repos.
 
 ## Examples
 
-:::note
-
-This example references previous step outputs and assumes the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 In this example, a complete promotion flow is demonstrated where changes are
@@ -86,7 +77,7 @@ steps:
   config:
     repoURL: https://github.com/example/repo.git
     createTargetBranch: true
-    sourceBranch: ${{ outputs.push.branch }}
+    sourceBranch: ${{ outputs.push.branch }} # Or task.outputs in a (Cluster)PromotionTask
     targetBranch: stage/${{ ctx.stage }}
 - uses: git-wait-for-pr
   as: wait-for-pr

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-wait-for-pr.md
@@ -52,6 +52,15 @@ system to access the git repos.
 
 ## Examples
 
+:::note
+
+This example references previous step outputs and assumes the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 In this example, a complete promotion flow is demonstrated where changes are

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
@@ -44,15 +44,6 @@ The referenced `Secret` should contain the following keys:
 
 ## Evidence Management
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Create Evidence
 
 Creates cryptographically signed kargo promotion evidence for an artifact in JFrog Artifactory.
@@ -155,7 +146,7 @@ steps:
       packageRepo: ${{ vars.packageRepo }}
       packageName: ${{ vars.packageName }}
       packageVersion: ${{ imageFrom(vars.packageRegistry+"/"+vars.packageRepo+"/"+vars.packageName).Tag }}
-      evidenceName: ${{ outputs['create-test-evidence'].name }}
+      evidenceName: ${{ outputs['create-test-evidence'].name }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Process Evidence (Query and Verify)

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jfrog-evidence.md
@@ -44,6 +44,15 @@ The referenced `Secret` should contain the following keys:
 
 ## Evidence Management
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Create Evidence
 
 Creates cryptographically signed kargo promotion evidence for an artifact in JFrog Artifactory.

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
@@ -48,6 +48,15 @@ The referenced `Secret` should contain the following keys:
 
 ## Issue Management
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Create Issue
 
 Creates a new Jira issue with specified details.

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/jira.md
@@ -48,15 +48,6 @@ The referenced `Secret` should contain the following keys:
 
 ## Issue Management
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Create Issue
 
 Creates a new Jira issue with specified details.
@@ -109,7 +100,7 @@ steps:
     credentials:
       secretName: jira-credentials
     updateIssue:
-      issueKey: "${{ outputs['create-promotion-issue'].key }}"
+      issueKey: "${{ outputs['create-promotion-issue'].key }}" # Or task.outputs in a (Cluster)PromotionTask
       status: "IN PROGRESS"
 ```
 
@@ -295,7 +286,7 @@ steps:
       secretName: jira-credentials
     deleteComment:
       issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
-      commentID: "${{ quote(outputs['add-progress-comment'].commentID) }}"
+      commentID: "${{ quote(outputs['add-progress-comment'].commentID) }}" # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Delete Comment
@@ -325,7 +316,7 @@ steps:
       secretName: jira-credentials
     deleteComment:
       issueKey: "${{ freightMetadata(ctx.targetFreight.name)['jira-issue-key'] }}"
-      commentID: "${{ outputs['previous-comment-step'].commentID }}"
+      commentID: "${{ outputs['previous-comment-step'].commentID }}" # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ## Status Tracking
@@ -504,7 +495,7 @@ spec:
           credentials:
             secretName: jira
           commentOnIssue:
-            issueKey: ${{ outputs['create-promotion-issue'].key }}
+            issueKey: ${{ outputs['create-promotion-issue'].key }} # Or task.outputs in a (Cluster)PromotionTask
             body: "Release ${{ imageFrom(vars.imageRepo).Tag }} has been promoted to ${{ ctx.stage }} environment. Freight: ${{ ctx.targetFreight.name }}. Ready for testing."
 
       # Cleanup on failure

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
@@ -41,6 +41,15 @@ transfer occurs in that case.
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Retagging an Image with a Release Version
 
 In this example, a dedicated "release" Stage sits downstream from a testing

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
@@ -41,15 +41,6 @@ transfer occurs in that case.
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Retagging an Image with a Release Version
 
 In this example, a dedicated "release" Stage sits downstream from a testing
@@ -99,7 +90,7 @@ steps:
     images:
     - image: registry.example.com/widget-service
       newName: registry.example.com/widget-service/${{ ctx.stage }}
-      digest: ${{ outputs["push-to-stage"].digest }}
+      digest: ${{ outputs["push-to-stage"].digest }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Promoting an OCI Helm Chart

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
@@ -112,6 +112,15 @@ Currently SMTP messages do not return any specific outputs. This may change in f
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Sending a plain text message to Slack
 
 ```yaml

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/send-message.md
@@ -112,15 +112,6 @@ Currently SMTP messages do not return any specific outputs. This may change in f
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Sending a plain text message to Slack
 
 ```yaml
@@ -222,5 +213,5 @@ steps:
         values:
           # NOTE: Make sure to wrap this in quotes with `quote` otherwise it will get rendered
           # as a number
-          slackThreadTS: "${{ quote(outputs['send-slack']?.slack?.threadTS ?? '') }}"
+          slackThreadTS: "${{ quote(outputs['send-slack']?.slack?.threadTS ?? '') }}" # Or task.outputs in a (Cluster)PromotionTask
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
@@ -70,15 +70,6 @@ The step writes outputs to the specified file as JSON and returns an empty map.
 
 ## Examples
 
-:::note
-
-Examples that reference previous step outputs assume the steps are defined
-directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
-referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
-use `task.outputs` instead.
-
-:::
-
 ### Common Usage
 
 The most common usage of this step is to retrieve outputs from the OpenTofu
@@ -133,7 +124,7 @@ The outputs can then be referenced in subsequent steps:
 ```yaml
 - uses: http
   config:
-    url: ${{ outputs.infra.function_url.value }}
+    url: ${{ outputs.infra.function_url.value }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Retrieving a Specific Output
@@ -164,7 +155,7 @@ The output value can be referenced directly:
 ```yaml
 - uses: http
   config:
-    url: ${{ outputs.endpoint.function_url }}
+    url: ${{ outputs.endpoint.function_url }} # Or task.outputs in a (Cluster)PromotionTask
 ```
 
 ### Writing Outputs to a File

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/tf-output.md
@@ -70,6 +70,15 @@ The step writes outputs to the specified file as JSON and returns an empty map.
 
 ## Examples
 
+:::note
+
+Examples that reference previous step outputs assume the steps are defined
+directly in a `Stage`'s `spec.promotionTemplate`, where those outputs are
+referenced with `outputs`. In a `PromotionTask` or `ClusterPromotionTask`,
+use `task.outputs` instead.
+
+:::
+
 ### Common Usage
 
 The most common usage of this step is to retrieve outputs from the OpenTofu


### PR DESCRIPTION
**All pull requests must reference an existing issue with no blocking labels.**
PRs that do not meet this requirement will be automatically closed. See the
[Contributor Guide](https://docs.kargo.io/contributor-guide) for details.

## Issue Reference

Closes #6275

## Description

Clarifies that examples using previous step outputs assume the steps are defined directly in a `Stage`'s `spec.promotionTemplate`, where outputs are referenced with `outputs`.

Adds the corresponding note to promotion step reference pages that include examples relying on previous step outputs, and points readers using `PromotionTask` or `ClusterPromotionTask` to `task.outputs` instead.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

Validation: `git diff --check`; Docusaurus build completed successfully. The build reported pre-existing broken-anchor warnings outside this change.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
