### PR TITLE
feat: add file-write promotion step

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
@@ -13,11 +13,25 @@ text file.
 Unlike [`yaml-update`](yaml-update.md), this step replaces the whole file. It
 does not preserve comments or formatting from an existing file.
 
+:::note[Restrictions]
+
+`file-write` only writes within the promotion workspace:
+
+- `path` must be relative and may not traverse outside the workspace; paths
+  containing `..` that escape the workspace are rejected.
+- Writing into the `.git` directory is forbidden.
+- Paths that resolve to a different location through a symlink are rejected.
+
+By default the step will not replace an existing file; set `overwrite` to
+`true` to allow replacement.
+
+:::
+
 ## Configuration
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `path` | `string` | Y | Path to the file to write. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `path` | `string` | Y | Path to the file to write. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. It may not traverse outside that workspace or write into the `.git` directory. |
 | `contents` | `string` | Y | Contents to write to the file. This may be an empty string. |
 | `permissions` | `string` | N | Octal file permissions to apply to the written file, for example `"0644"`. Defaults to `"0600"`. Executable, special, and world-writable modes are rejected. |
 | `overwrite` | `bool` | N | Whether an existing file may be replaced. Defaults to `false`. |

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
@@ -19,6 +19,7 @@ does not preserve comments or formatting from an existing file.
 |------|------|----------|-------------|
 | `path` | `string` | Y | Path to the file to write. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `contents` | `string` | Y | Contents to write to the file. This may be an empty string. |
+| `permissions` | `string` | N | Octal file permissions to apply to the written file, for example `"0644"`. Defaults to `"0600"`. Executable, special, and world-writable modes are rejected. |
 | `overwrite` | `bool` | N | Whether an existing file may be replaced. Defaults to `false`. |
 
 ## Examples

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/file-write.md
@@ -1,0 +1,63 @@
+---
+sidebar_label: file-write
+description: Writes literal or rendered content to a file.
+---
+
+# `file-write`
+
+`file-write` writes content to a file in the temporary workspace that Kargo
+provisions for a promotion process. It is useful when previous steps have
+produced structured data that should be rendered into a new YAML, JSON, or other
+text file.
+
+Unlike [`yaml-update`](yaml-update.md), this step replaces the whole file. It
+does not preserve comments or formatting from an existing file.
+
+## Configuration
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Y | Path to the file to write. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
+| `contents` | `string` | Y | Contents to write to the file. This may be an empty string. |
+| `overwrite` | `bool` | N | Whether an existing file may be replaced. Defaults to `false`. |
+
+## Examples
+
+### Writing YAML
+
+In this example, a previous step has produced an object and `file-write` renders
+that object as YAML in a Stage-specific output branch.
+
+```yaml
+steps:
+- uses: yaml-parse
+  as: read-config
+  config:
+    path: ./src/apps.yaml
+    outputs:
+    - name: appConfig
+      fromExpression: apps[ctx.stage]
+- uses: file-write
+  config:
+    path: ./out/app-config.yaml
+    contents: ${{ asYAML(outputs['read-config'].appConfig) }}
+    overwrite: true
+# Commit, push, etc...
+```
+
+### Writing JSON
+
+Use `asJSON()` when the destination file should contain pretty-printed JSON:
+
+```yaml
+steps:
+- uses: file-write
+  config:
+    path: ./out/app-config.json
+    contents: ${{ asJSON(outputs['read-config'].appConfig) }}
+    overwrite: true
+```
+
+The [`git-commit`](git-commit.md) step will pick up files written by
+`file-write` when they are inside the Git working tree configured for
+`git-commit`.

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -353,6 +353,37 @@ config:
   rawField: ${{ unsafeQuote("string") }} # Will result in "\"string\""
 ```
 
+### `asYAML(value)`
+
+The `asYAML()` function converts any value to a YAML string. It has one required
+argument:
+
+- `value` (Required): A value of any type to be converted to YAML.
+
+This is useful with steps such as [`file-write`](./30-promotion-steps/file-write.md)
+when an object from a previous step should be rendered into a YAML file.
+
+Example:
+
+```yaml
+config:
+  contents: ${{ asYAML(outputs['read-config'].appConfig) }}
+```
+
+### `asJSON(value)`
+
+The `asJSON()` function converts any value to a pretty-printed JSON string. It
+has one required argument:
+
+- `value` (Required): A value of any type to be converted to JSON.
+
+Example:
+
+```yaml
+config:
+  contents: ${{ asJSON(outputs['read-config'].appConfig) }}
+```
+
 ### `configMap(name)`
 
 The `configMap()` function returns the `Data` field (a `map[string]string`) of a

--- a/pkg/expressions/json_templates.go
+++ b/pkg/expressions/json_templates.go
@@ -327,7 +327,7 @@ func asYAMLFunc(a ...any) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error applying asYAML() function: %w", err)
 	}
-	return string(yamlBytes), nil
+	return fmt.Sprintf("\"%s\"", yamlBytes), nil
 }
 
 func asJSONFunc(a ...any) (any, error) {

--- a/pkg/expressions/json_templates.go
+++ b/pkg/expressions/json_templates.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/expr-lang/expr"
+	"go.yaml.in/yaml/v3"
 )
 
 type supportedDelimiterSet struct {
@@ -43,10 +44,13 @@ var supportedDelimiters = []supportedDelimiterSet{
 // result in a string.
 // This behavior should be intuitive to anyone familiar with YAML.
 func EvaluateJSONTemplate(jsonBytes []byte, env map[string]any, exprOpts ...expr.Option) ([]byte, error) {
-	if _, ok := env["quote"]; ok {
-		return nil, fmt.Errorf(
-			`"quote" is a forbidden key in the environment map; it is reserved for internal use`,
-		)
+	for _, fn := range []string{"quote", "asYAML", "asJSON"} {
+		if _, ok := env[fn]; ok {
+			return nil, fmt.Errorf(
+				`%q is a forbidden key in the environment map; it is reserved for internal use`,
+				fn,
+			)
+		}
 	}
 	var parsed map[string]any
 	if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
@@ -125,7 +129,7 @@ func EvaluateTemplate(template string, env map[string]any, exprOpts ...expr.Opti
 	}
 
 	if exprOpts == nil {
-		exprOpts = make([]expr.Option, 0, 2)
+		exprOpts = make([]expr.Option, 0, 4)
 	}
 	exprOpts = append(
 		exprOpts,
@@ -137,6 +141,16 @@ func EvaluateTemplate(template string, env map[string]any, exprOpts ...expr.Opti
 		expr.Function(
 			"unsafeQuote",
 			unsafeQuoteFunc,
+			new(func(any) string),
+		),
+		expr.Function(
+			"asYAML",
+			asYAMLFunc,
+			new(func(any) string),
+		),
+		expr.Function(
+			"asJSON",
+			asJSONFunc,
 			new(func(any) string),
 		),
 	)
@@ -306,4 +320,20 @@ func unsafeQuoteFunc(a ...any) (any, error) {
 		return nil, fmt.Errorf("error applying quote() function: %w", err)
 	}
 	return fmt.Sprintf(`"%s"`, jsonBytes), nil
+}
+
+func asYAMLFunc(a ...any) (any, error) {
+	yamlBytes, err := yaml.Marshal(a[0])
+	if err != nil {
+		return nil, fmt.Errorf("error applying asYAML() function: %w", err)
+	}
+	return string(yamlBytes), nil
+}
+
+func asJSONFunc(a ...any) (any, error) {
+	jsonBytes, err := json.MarshalIndent(a[0], "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error applying asJSON() function: %w", err)
+	}
+	return fmt.Sprintf("\"%s\n\"", jsonBytes), nil
 }

--- a/pkg/expressions/json_templates.go
+++ b/pkg/expressions/json_templates.go
@@ -44,6 +44,7 @@ var supportedDelimiters = []supportedDelimiterSet{
 // result in a string.
 // This behavior should be intuitive to anyone familiar with YAML.
 func EvaluateJSONTemplate(jsonBytes []byte, env map[string]any, exprOpts ...expr.Option) ([]byte, error) {
+	// TODO: Consider reserving "unsafeQuote" in this list after confirming it's safe to do so
 	for _, fn := range []string{"quote", "asYAML", "asJSON"} {
 		if _, ok := env[fn]; ok {
 			return nil, fmt.Errorf(

--- a/pkg/expressions/json_templates_test.go
+++ b/pkg/expressions/json_templates_test.go
@@ -241,6 +241,39 @@ func TestEvaluateJSONTemplate(t *testing.T) {
 			},
 		},
 		{
+			name:         "asYAML function formats map as string",
+			jsonTemplate: `{ "AString": "${{ asYAML({ 'foo': 'bar', 'count': 2 }) }}" }`,
+			assertions: func(t *testing.T, jsonOutput []byte, err error) {
+				require.NoError(t, err)
+				parsed := testStruct{}
+				require.NoError(t, json.Unmarshal(jsonOutput, &parsed))
+				require.Contains(t, parsed.AString, "foo: bar\n")
+				require.Contains(t, parsed.AString, "count: 2\n")
+			},
+		},
+		{
+			name:         "asYAML function formats array as string",
+			jsonTemplate: `{ "AString": "${{ asYAML([ 'one', 'two' ]) }}" }`,
+			assertions: func(t *testing.T, jsonOutput []byte, err error) {
+				require.NoError(t, err)
+				parsed := testStruct{}
+				require.NoError(t, json.Unmarshal(jsonOutput, &parsed))
+				require.Equal(t, "- one\n- two\n", parsed.AString)
+			},
+		},
+		{
+			name:         "asJSON function formats object as pretty JSON string",
+			jsonTemplate: `{ "AString": "${{ asJSON({ 'foo': 'bar', 'count': 2 }) }}" }`,
+			assertions: func(t *testing.T, jsonOutput []byte, err error) {
+				require.NoError(t, err)
+				parsed := testStruct{}
+				require.NoError(t, json.Unmarshal(jsonOutput, &parsed))
+				require.JSONEq(t, `{"foo":"bar","count":2}`, parsed.AString)
+				require.Contains(t, parsed.AString, "\n")
+				require.True(t, parsed.AString[len(parsed.AString)-1:] == "\n")
+			},
+		},
+		{
 			name: "a variety of tricky cases dealing with YAML and quotes",
 			yamlTemplate: `
 value1: {"foo": "bar"} # This is a JSON object
@@ -347,5 +380,13 @@ value13: | # This is a string
 	t.Run("quote function is forbidden", func(t *testing.T) {
 		_, err := EvaluateJSONTemplate([]byte(`{}`), map[string]any{"quote": nil})
 		require.ErrorContains(t, err, `"quote" is a forbidden key`)
+	})
+	t.Run("asYAML function is forbidden", func(t *testing.T) {
+		_, err := EvaluateJSONTemplate([]byte(`{}`), map[string]any{"asYAML": nil})
+		require.ErrorContains(t, err, `"asYAML" is a forbidden key`)
+	})
+	t.Run("asJSON function is forbidden", func(t *testing.T) {
+		_, err := EvaluateJSONTemplate([]byte(`{}`), map[string]any{"asJSON": nil})
+		require.ErrorContains(t, err, `"asJSON" is a forbidden key`)
 	})
 }

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -1147,6 +1147,66 @@ func TestStepEvaluator_Config(t *testing.T) {
 			},
 		},
 		{
+			name:     "test asYAML boolean",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asYAML(true) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "true\n",
+			},
+		},
+		{
+			name:     "test asYAML number",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asYAML(42) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "42\n",
+			},
+		},
+		{
+			name:     "test asJSON nil",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asJSON(nil) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "null\n",
+			},
+		},
+		{
+			name:     "test asJSON boolean",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asJSON(true) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "true\n",
+			},
+		},
+		{
+			name:     "test asJSON string",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asJSON('foo') }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "\"foo\"\n",
+			},
+		},
+		{
 			name: "test warehouse function",
 			// Test that the warehouse() function can be used to reference freight
 			// origins

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -1133,6 +1133,20 @@ func TestStepEvaluator_Config(t *testing.T) {
 			},
 		},
 		{
+			name:     "test asYAML keeps nil contents as a string",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"path": "out.yaml",
+					"contents": "${{ asYAML(nil) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"path":     "out.yaml",
+				"contents": "null\n",
+			},
+		},
+		{
 			name: "test warehouse function",
 			// Test that the warehouse() function can be used to reference freight
 			// origins

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -1207,6 +1207,42 @@ func TestStepEvaluator_Config(t *testing.T) {
 			},
 		},
 		{
+			name:     "test asYAML structured map",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asYAML({ 'foo': 'bar', 'count': 2 }) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "count: 2\nfoo: bar\n",
+			},
+		},
+		{
+			name:     "test asYAML structured list",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asYAML([ 'one', 'two' ]) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "- one\n- two\n",
+			},
+		},
+		{
+			name:     "test asJSON structured object",
+			promoCtx: Context{},
+			step: Step{
+				Config: []byte(`{
+					"contents": "${{ asJSON({ 'foo': 'bar', 'count': 2 }) }}"
+				}`),
+			},
+			expectedCfg: Config{
+				"contents": "{\n  \"count\": 2,\n  \"foo\": \"bar\"\n}\n",
+			},
+		},
+		{
 			name: "test warehouse function",
 			// Test that the warehouse() function can be used to reference freight
 			// origins

--- a/pkg/promotion/runner/builtin/file_writer.go
+++ b/pkg/promotion/runner/builtin/file_writer.go
@@ -115,7 +115,9 @@ func (f *fileWriter) run(
 
 	if _, err = os.Stat(absPath); err == nil && !cfg.Overwrite {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
-			&promotion.TerminalError{Err: fmt.Errorf("file %q already exists", cfg.Path)}
+			&promotion.TerminalError{Err: fmt.Errorf(
+				"file %q already exists; set overwrite to true to replace it", cfg.Path,
+			)}
 	}
 
 	if err = os.MkdirAll(filepath.Dir(absPath), 0o700); err != nil {

--- a/pkg/promotion/runner/builtin/file_writer.go
+++ b/pkg/promotion/runner/builtin/file_writer.go
@@ -64,24 +64,28 @@ func (f *fileWriter) run(
 	cfg builtin.FileWriteConfig,
 ) (promotion.StepResult, error) {
 	if filepath.IsAbs(cfg.Path) {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("path %q must be relative", cfg.Path)
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{Err: fmt.Errorf("path %q must be relative", cfg.Path)}
 	}
 	cleanPath := filepath.Clean(cfg.Path)
 	if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("path %q attempts to traverse outside the working directory", cfg.Path)
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{
+				Err: fmt.Errorf("path %q attempts to traverse outside the working directory", cfg.Path),
+			}
 	}
 
 	absPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("could not secure join path %q: %w", cfg.Path, err)
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{
+				Err: fmt.Errorf("could not secure join path %q: %w", cfg.Path, err),
+			}
 	}
 
 	if _, err = os.Stat(absPath); err == nil && !cfg.Overwrite {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("file %q already exists", cfg.Path)
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{Err: fmt.Errorf("file %q already exists", cfg.Path)}
 	}
 
 	if err = os.MkdirAll(filepath.Dir(absPath), 0o700); err != nil {

--- a/pkg/promotion/runner/builtin/file_writer.go
+++ b/pkg/promotion/runner/builtin/file_writer.go
@@ -1,0 +1,98 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/xeipuuv/gojsonschema"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/promotion"
+	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
+)
+
+const stepKindFileWrite = "file-write"
+
+func init() {
+	promotion.DefaultStepRunnerRegistry.MustRegister(
+		promotion.StepRunnerRegistration{
+			Name:  stepKindFileWrite,
+			Value: newFileWriter,
+		},
+	)
+}
+
+// fileWriter is an implementation of the promotion.StepRunner interface that
+// writes content to a file.
+type fileWriter struct {
+	schemaLoader gojsonschema.JSONLoader
+}
+
+// newFileWriter returns an implementation of the promotion.StepRunner interface
+// that writes content to a file.
+func newFileWriter(promotion.StepRunnerCapabilities) promotion.StepRunner {
+	return &fileWriter{schemaLoader: getConfigSchemaLoader(stepKindFileWrite)}
+}
+
+// Run implements the promotion.StepRunner interface.
+func (f *fileWriter) Run(
+	ctx context.Context,
+	stepCtx *promotion.StepContext,
+) (promotion.StepResult, error) {
+	cfg, err := f.convert(stepCtx.Config)
+	if err != nil {
+		return promotion.StepResult{
+			Status: kargoapi.PromotionStepStatusFailed,
+		}, &promotion.TerminalError{Err: err}
+	}
+	return f.run(ctx, stepCtx, cfg)
+}
+
+// convert validates fileWriter configuration against a JSON schema and converts
+// it into a builtin.FileWriteConfig struct.
+func (f *fileWriter) convert(cfg promotion.Config) (builtin.FileWriteConfig, error) {
+	return validateAndConvert[builtin.FileWriteConfig](f.schemaLoader, cfg, stepKindFileWrite)
+}
+
+func (f *fileWriter) run(
+	_ context.Context,
+	stepCtx *promotion.StepContext,
+	cfg builtin.FileWriteConfig,
+) (promotion.StepResult, error) {
+	if filepath.IsAbs(cfg.Path) {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("path %q must be relative", cfg.Path)
+	}
+	cleanPath := filepath.Clean(cfg.Path)
+	if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("path %q attempts to traverse outside the working directory", cfg.Path)
+	}
+
+	absPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
+	if err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("could not secure join path %q: %w", cfg.Path, err)
+	}
+
+	if _, err = os.Stat(absPath); err == nil && !cfg.Overwrite {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("file %q already exists", cfg.Path)
+	}
+
+	if err = os.MkdirAll(filepath.Dir(absPath), 0o700); err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("error creating parent directories for %q: %w", cfg.Path, err)
+	}
+
+	if err = os.WriteFile(absPath, []byte(cfg.Contents), 0o600); err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("error writing file %q: %w", cfg.Path, err)
+	}
+
+	return promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, nil
+}

--- a/pkg/promotion/runner/builtin/file_writer.go
+++ b/pkg/promotion/runner/builtin/file_writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -16,6 +17,8 @@ import (
 )
 
 const stepKindFileWrite = "file-write"
+
+const defaultFileWritePermissions os.FileMode = 0o600
 
 func init() {
 	promotion.DefaultStepRunnerRegistry.MustRegister(
@@ -75,6 +78,13 @@ func (f *fileWriter) run(
 			}
 	}
 
+	if cleanPath == ".git" || strings.HasPrefix(cleanPath, ".git"+string(filepath.Separator)) {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{
+				Err: fmt.Errorf("writing to the .git directory is forbidden: %q", cfg.Path),
+			}
+	}
+
 	absPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
@@ -93,10 +103,56 @@ func (f *fileWriter) run(
 			fmt.Errorf("error creating parent directories for %q: %w", cfg.Path, err)
 	}
 
-	if err = os.WriteFile(absPath, []byte(cfg.Contents), 0o600); err != nil {
+	permissions, err := parseFileWritePermissions(cfg.Permissions)
+	if err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{Err: err}
+	}
+
+	if err = os.WriteFile(absPath, []byte(cfg.Contents), permissions); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error writing file %q: %w", cfg.Path, err)
 	}
 
+	if cfg.Permissions != "" {
+		if err = os.Chmod(absPath, permissions); err != nil {
+			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+				fmt.Errorf("error setting permissions on file %q: %w", cfg.Path, err)
+		}
+	}
+
 	return promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, nil
+}
+
+func parseFileWritePermissions(permissions string) (os.FileMode, error) {
+	if permissions == "" {
+		return defaultFileWritePermissions, nil
+	}
+
+	parsed, err := strconv.ParseUint(permissions, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid permissions %q: must be an octal file mode", permissions)
+	}
+
+	mode := os.FileMode(parsed)
+	// Only ordinary permission bits are allowed through. os.FileMode.Perm()
+	// strips away special bits such as setuid, setgid, and sticky; if stripping
+	// would change the requested mode, reject it instead of applying a surprising
+	// permission set.
+	if mode != mode.Perm() {
+		return 0, fmt.Errorf("permissions %q must not include special mode bits", permissions)
+	}
+	// Do not allow file-write to create executable files. Promotion steps can
+	// still write scripts as text, but another explicit step should be required
+	// before they become executable.
+	if mode&0o111 != 0 {
+		return 0, fmt.Errorf("permissions %q must not include executable bits", permissions)
+	}
+	// World-writable files are unnecessarily broad for generated promotion
+	// artifacts, so keep the writable surface limited to owner and group.
+	if mode&0o002 != 0 {
+		return 0, fmt.Errorf("permissions %q must not be world-writable", permissions)
+	}
+
+	return mode, nil
 }

--- a/pkg/promotion/runner/builtin/file_writer.go
+++ b/pkg/promotion/runner/builtin/file_writer.go
@@ -85,11 +85,31 @@ func (f *fileWriter) run(
 			}
 	}
 
+	permissions, err := parseFileWritePermissions(cfg.Permissions)
+	if err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{Err: err}
+	}
+
 	absPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.Path)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
 			&promotion.TerminalError{
 				Err: fmt.Errorf("could not secure join path %q: %w", cfg.Path, err),
+			}
+	}
+
+	relPath, err := filepath.Rel(stepCtx.WorkDir, absPath)
+	if err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{
+				Err: fmt.Errorf("could not get relative path for %q: %w", absPath, err),
+			}
+	}
+	if relPath != cleanPath {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
+			&promotion.TerminalError{
+				Err: fmt.Errorf("path %q resolves to a different path %q (symlinks are forbidden)", cfg.Path, relPath),
 			}
 	}
 
@@ -103,22 +123,14 @@ func (f *fileWriter) run(
 			fmt.Errorf("error creating parent directories for %q: %w", cfg.Path, err)
 	}
 
-	permissions, err := parseFileWritePermissions(cfg.Permissions)
-	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
-			&promotion.TerminalError{Err: err}
-	}
-
 	if err = os.WriteFile(absPath, []byte(cfg.Contents), permissions); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error writing file %q: %w", cfg.Path, err)
 	}
 
-	if cfg.Permissions != "" {
-		if err = os.Chmod(absPath, permissions); err != nil {
-			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-				fmt.Errorf("error setting permissions on file %q: %w", cfg.Path, err)
-		}
+	if err = os.Chmod(absPath, permissions); err != nil {
+		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+			fmt.Errorf("error setting permissions on file %q: %w", cfg.Path, err)
 	}
 
 	return promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, nil

--- a/pkg/promotion/runner/builtin/file_writer_test.go
+++ b/pkg/promotion/runner/builtin/file_writer_test.go
@@ -127,7 +127,7 @@ func Test_fileWriter_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
 				require.ErrorContains(t, err, "already exists")
-				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, result)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
 
 				content, readErr := os.ReadFile(filepath.Join(workDir, "config.yaml"))
 				require.NoError(t, readErr)
@@ -161,7 +161,7 @@ func Test_fileWriter_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
 				require.Error(t, err)
-				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, result)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
 			},
 		},
 		{

--- a/pkg/promotion/runner/builtin/file_writer_test.go
+++ b/pkg/promotion/runner/builtin/file_writer_test.go
@@ -1,0 +1,204 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/promotion"
+	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
+)
+
+func Test_fileWriter_convert(t *testing.T) {
+	tests := []validationTestCase{
+		{
+			name: "path not specified",
+			config: promotion.Config{
+				"contents": "test content",
+			},
+			expectedProblems: []string{
+				"invalid file-write config: (root): path is required",
+			},
+		},
+		{
+			name: "path is empty string",
+			config: promotion.Config{
+				"path":     "",
+				"contents": "test content",
+			},
+			expectedProblems: []string{
+				"invalid file-write config: path: String length must be greater than or equal to 1",
+			},
+		},
+		{
+			name: "contents not specified",
+			config: promotion.Config{
+				"path": "test.txt",
+			},
+			expectedProblems: []string{
+				"invalid file-write config: (root): contents is required",
+			},
+		},
+		{
+			name: "contents may be empty",
+			config: promotion.Config{
+				"path":     "test.txt",
+				"contents": "",
+			},
+		},
+		{
+			name: "unknown field",
+			config: promotion.Config{
+				"path":     "test.txt",
+				"contents": "test content",
+				"unknown":  true,
+			},
+			expectedProblems: []string{
+				"invalid file-write config: (root): Additional property unknown is not allowed",
+			},
+		},
+		{
+			name: "valid configuration",
+			config: promotion.Config{
+				"path":      "test.txt",
+				"contents":  "test content",
+				"overwrite": true,
+			},
+		},
+	}
+
+	r := newFileWriter(promotion.StepRunnerCapabilities{})
+	runner, ok := r.(*fileWriter)
+	require.True(t, ok)
+
+	runValidationTests(t, runner.convert, tests)
+}
+
+func Test_fileWriter_run(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		dirs       []string
+		cfg        builtin.FileWriteConfig
+		assertions func(*testing.T, string, promotion.StepResult, error)
+	}{
+		{
+			name: "writes new file",
+			cfg: builtin.FileWriteConfig{
+				Path:     "out/config.yaml",
+				Contents: "key: value\n",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				content, readErr := os.ReadFile(filepath.Join(workDir, "out/config.yaml"))
+				require.NoError(t, readErr)
+				assert.Equal(t, "key: value\n", string(content))
+			},
+		},
+		{
+			name: "writes empty file",
+			cfg: builtin.FileWriteConfig{
+				Path:     "empty.txt",
+				Contents: "",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				content, readErr := os.ReadFile(filepath.Join(workDir, "empty.txt"))
+				require.NoError(t, readErr)
+				assert.Empty(t, content)
+			},
+		},
+		{
+			name: "fails when file exists without overwrite",
+			files: map[string]string{
+				"config.yaml": "existing: true\n",
+			},
+			cfg: builtin.FileWriteConfig{
+				Path:     "config.yaml",
+				Contents: "existing: false\n",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "already exists")
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, result)
+
+				content, readErr := os.ReadFile(filepath.Join(workDir, "config.yaml"))
+				require.NoError(t, readErr)
+				assert.Equal(t, "existing: true\n", string(content))
+			},
+		},
+		{
+			name: "overwrites existing file",
+			files: map[string]string{
+				"config.yaml": "existing: true\n",
+			},
+			cfg: builtin.FileWriteConfig{
+				Path:      "config.yaml",
+				Contents:  "existing: false\n",
+				Overwrite: true,
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				content, readErr := os.ReadFile(filepath.Join(workDir, "config.yaml"))
+				require.NoError(t, readErr)
+				assert.Equal(t, "existing: false\n", string(content))
+			},
+		},
+		{
+			name: "fails when path escapes work dir",
+			cfg: builtin.FileWriteConfig{
+				Path:     "../escape.txt",
+				Contents: "test content",
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.Error(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, result)
+			},
+		},
+		{
+			name: "fails when destination is directory",
+			dirs: []string{"config.yaml"},
+			cfg: builtin.FileWriteConfig{
+				Path:      "config.yaml",
+				Contents:  "test content",
+				Overwrite: true,
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.Error(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, result)
+			},
+		},
+	}
+
+	runner := &fileWriter{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			for _, dir := range tt.dirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(workDir, dir), 0o700))
+			}
+			for path, content := range tt.files {
+				absPath := filepath.Join(workDir, path)
+				require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o700))
+				require.NoError(t, os.WriteFile(absPath, []byte(content), 0o600))
+			}
+
+			result, err := runner.run(
+				t.Context(),
+				&promotion.StepContext{WorkDir: workDir},
+				tt.cfg,
+			)
+			tt.assertions(t, workDir, result, err)
+		})
+	}
+}

--- a/pkg/promotion/runner/builtin/file_writer_test.go
+++ b/pkg/promotion/runner/builtin/file_writer_test.go
@@ -51,6 +51,18 @@ func Test_fileWriter_convert(t *testing.T) {
 			},
 		},
 		{
+			name: "contents must be a string",
+			config: promotion.Config{
+				"path": "test.txt",
+				"contents": map[string]any{
+					"key": "value",
+				},
+			},
+			expectedProblems: []string{
+				"invalid file-write config: contents: Invalid type. Expected: string",
+			},
+		},
+		{
 			name: "unknown field",
 			config: promotion.Config{
 				"path":     "test.txt",
@@ -64,9 +76,32 @@ func Test_fileWriter_convert(t *testing.T) {
 		{
 			name: "valid configuration",
 			config: promotion.Config{
-				"path":      "test.txt",
-				"contents":  "test content",
-				"overwrite": true,
+				"path":        "test.txt",
+				"contents":    "test content",
+				"overwrite":   true,
+				"permissions": "0644",
+			},
+		},
+		{
+			name: "permissions must be a string",
+			config: promotion.Config{
+				"path":        "test.txt",
+				"contents":    "test content",
+				"permissions": 0o644,
+			},
+			expectedProblems: []string{
+				"invalid file-write config: permissions: Invalid type. Expected: string",
+			},
+		},
+		{
+			name: "permissions must be octal",
+			config: promotion.Config{
+				"path":        "test.txt",
+				"contents":    "test content",
+				"permissions": "invalid",
+			},
+			expectedProblems: []string{
+				"invalid file-write config: permissions: Does not match pattern",
 			},
 		},
 	}
@@ -102,6 +137,21 @@ func Test_fileWriter_run(t *testing.T) {
 			},
 		},
 		{
+			name: "writes contents exactly as provided",
+			cfg: builtin.FileWriteConfig{
+				Path:     "out/config.yaml",
+				Contents: "key: value",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				content, readErr := os.ReadFile(filepath.Join(workDir, "out/config.yaml"))
+				require.NoError(t, readErr)
+				assert.Equal(t, "key: value", string(content))
+			},
+		},
+		{
 			name: "writes empty file",
 			cfg: builtin.FileWriteConfig{
 				Path:     "empty.txt",
@@ -114,6 +164,78 @@ func Test_fileWriter_run(t *testing.T) {
 				content, readErr := os.ReadFile(filepath.Join(workDir, "empty.txt"))
 				require.NoError(t, readErr)
 				assert.Empty(t, content)
+			},
+		},
+		{
+			name: "writes file with custom permissions",
+			cfg: builtin.FileWriteConfig{
+				Path:        "public.txt",
+				Contents:    "test content",
+				Permissions: "0644",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				info, statErr := os.Stat(filepath.Join(workDir, "public.txt"))
+				require.NoError(t, statErr)
+				assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+			},
+		},
+		{
+			name: "changes permissions when overwriting existing file",
+			files: map[string]string{
+				"public.txt": "existing content",
+			},
+			cfg: builtin.FileWriteConfig{
+				Path:        "public.txt",
+				Contents:    "new content",
+				Overwrite:   true,
+				Permissions: "0644",
+			},
+			assertions: func(t *testing.T, workDir string, result promotion.StepResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusSucceeded}, result)
+
+				info, statErr := os.Stat(filepath.Join(workDir, "public.txt"))
+				require.NoError(t, statErr)
+				assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+			},
+		},
+		{
+			name: "rejects executable permissions",
+			cfg: builtin.FileWriteConfig{
+				Path:        "script.sh",
+				Contents:    "echo test",
+				Permissions: "0755",
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "must not include executable bits")
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
+			},
+		},
+		{
+			name: "rejects special mode bits",
+			cfg: builtin.FileWriteConfig{
+				Path:        "public.txt",
+				Contents:    "test content",
+				Permissions: "1777",
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "must not include special mode bits")
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
+			},
+		},
+		{
+			name: "rejects world-writable permissions",
+			cfg: builtin.FileWriteConfig{
+				Path:        "public.txt",
+				Contents:    "test content",
+				Permissions: "0666",
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "must not be world-writable")
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
 			},
 		},
 		{
@@ -161,6 +283,17 @@ func Test_fileWriter_run(t *testing.T) {
 			},
 			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
 				require.Error(t, err)
+				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
+			},
+		},
+		{
+			name: "fails when path targets .git directory",
+			cfg: builtin.FileWriteConfig{
+				Path:     ".git/config",
+				Contents: "malicious content",
+			},
+			assertions: func(t *testing.T, _ string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "writing to the .git directory is forbidden")
 				assert.Equal(t, promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed}, result)
 			},
 		},

--- a/pkg/promotion/runner/builtin/schemas/file-write-config.json
+++ b/pkg/promotion/runner/builtin/schemas/file-write-config.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FileWriteConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["path", "contents"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path is the destination file path to write.",
+      "minLength": 1
+    },
+    "contents": {
+      "type": "string",
+      "description": "Contents is the file content to write."
+    },
+    "overwrite": {
+      "type": "boolean",
+      "description": "Overwrite allows an existing file to be replaced.",
+      "default": false
+    }
+  }
+}

--- a/pkg/promotion/runner/builtin/schemas/file-write-config.json
+++ b/pkg/promotion/runner/builtin/schemas/file-write-config.json
@@ -14,6 +14,11 @@
       "type": "string",
       "description": "Contents is the file content to write."
     },
+    "permissions": {
+      "type": "string",
+      "description": "Permissions is an optional octal file mode to apply to the written file. Defaults to 0600.",
+      "pattern": "^0[0-7]{3}$"
+    },
     "overwrite": {
       "type": "boolean",
       "description": "Overwrite allows an existing file to be replaced.",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -166,8 +166,7 @@ type FileWriteConfig struct {
 	Overwrite bool `json:"overwrite,omitempty"`
 	// Path is the destination file path to write.
 	Path string `json:"path"`
-	// Permissions is an optional octal file mode to apply to the written file. Defaults to
-	// 0600.
+	// Permissions is an optional octal file mode to apply to the written file. Defaults to 0600.
 	Permissions string `json:"permissions,omitempty"`
 }
 

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -159,6 +159,15 @@ type FailConfig struct {
 	Message string `json:"message,omitempty"`
 }
 
+type FileWriteConfig struct {
+	// Contents is the file content to write.
+	Contents string `json:"contents"`
+	// Overwrite allows an existing file to be replaced.
+	Overwrite bool `json:"overwrite,omitempty"`
+	// Path is the destination file path to write.
+	Path string `json:"path"`
+}
+
 type GitClearConfig struct {
 	// Path to a working directory of a local repository from which to remove all files,
 	// excluding the .git/ directory.

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -166,6 +166,9 @@ type FileWriteConfig struct {
 	Overwrite bool `json:"overwrite,omitempty"`
 	// Path is the destination file path to write.
 	Path string `json:"path"`
+	// Permissions is an optional octal file mode to apply to the written file. Defaults to
+	// 0600.
+	Permissions string `json:"permissions,omitempty"`
 }
 
 type GitClearConfig struct {

--- a/ui/src/features/promotion-directives/registry/use-discover-registries.ts
+++ b/ui/src/features/promotion-directives/registry/use-discover-registries.ts
@@ -5,6 +5,7 @@ import argocdUpdateConfig from '@ui/gen/directives/argocd-update-config.json';
 import copyConfig from '@ui/gen/directives/copy-config.json';
 import deleteConfig from '@ui/gen/directives/delete-config.json';
 import failConfig from '@ui/gen/directives/fail-config.json';
+import fileWriteConfig from '@ui/gen/directives/file-write-config.json';
 import gitOverwriteConfig from '@ui/gen/directives/git-clear-config.json';
 import gitCloneConfig from '@ui/gen/directives/git-clone-config.json';
 import gitCommitConfig from '@ui/gen/directives/git-commit-config.json';
@@ -44,6 +45,10 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
         identifier: 'delete',
         unstable_icons: [],
         config: deleteConfig as JSONSchema7
+      },
+      {
+        identifier: 'file-write',
+        config: fileWriteConfig as JSONSchema7
       },
       {
         identifier: 'git-clone',

--- a/ui/src/gen/directives/file-write-config.json
+++ b/ui/src/gen/directives/file-write-config.json
@@ -1,0 +1,22 @@
+{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "title": "FileWriteConfig",
+ "type": "object",
+ "additionalProperties": false,
+ "properties": {
+  "path": {
+   "type": "string",
+   "description": "Path is the destination file path to write.",
+   "minLength": 1
+  },
+  "contents": {
+   "type": "string",
+   "description": "Contents is the file content to write."
+  },
+  "overwrite": {
+   "type": "boolean",
+   "description": "Overwrite allows an existing file to be replaced.",
+   "default": false
+  }
+ }
+}

--- a/ui/src/gen/directives/file-write-config.json
+++ b/ui/src/gen/directives/file-write-config.json
@@ -13,6 +13,11 @@
    "type": "string",
    "description": "Contents is the file content to write."
   },
+  "permissions": {
+   "type": "string",
+   "description": "Permissions is an optional octal file mode to apply to the written file. Defaults to 0600.",
+   "pattern": "^0[0-7]{3}$"
+  },
   "overwrite": {
    "type": "boolean",
    "description": "Overwrite allows an existing file to be replaced.",


### PR DESCRIPTION
## Issue Reference

Closes #6245 

## Description

Add a generic file-write step for rendering evaluated content into files, plus YAML and pretty JSON expression helpers for structured step outputs.


## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
