### PR TITLE
fix: Allow specifying name of resources in argocd namespace

### DIFF
--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kargo-controller
+  name: {{ .Values.controller.argocd.resourceName | default "kargo-controller" }}
   namespace: {{ .Values.controller.argocd.namespace | default "argocd" }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kargo-controller
+  name: {{ .Values.controller.argocd.resourceName | default "kargo-controller" }}
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kargo-controller
+  name: {{ .Values.controller.argocd.resourceName | default "kargo-controller" }}
   namespace: {{ .Values.controller.argocd.namespace | default "argocd" }}
   labels:
     {{- include "kargo.labels" . | nindent 4 }}

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -592,6 +592,8 @@ controller:
     namespace: argocd
     ## @param controller.argocd.watchArgocdNamespaceOnly Specifies whether the reconciler that watches Argo CD Applications for the sake of forcing related Stages to reconcile should only watch Argo CD Application resources residing in Argo CD's own namespace. Note: Older versions of Argo CD only supported Argo CD Application resources in Argo CD's own namespace, but newer versions support Argo CD Application resources in any namespace. This should usually be left as `false`.
     watchArgocdNamespaceOnly: false
+    ## @param controller.argocd.resourceName The name of the role and rolebinding that will be created in the Argo CD namespace. Override in case of conflict with existing roles/rolebindings.
+    resourceName: kargo-controller
 
   ## All settings relating to the use of Argo Rollouts AnalysisTemplates and
   ## AnalysisRuns as a means of verifying Stages after a Promotion.


### PR DESCRIPTION
…espace

**All pull requests must reference an existing issue with no blocking labels.**
PRs that do not meet this requirement will be automatically closed. See the
[Contributor Guide](https://docs.kargo.io/contributor-guide) for details.

## Issue Reference

Closes #6295

## Description

This PR fixes the resource name clash that occurs when installing Kargo in the same namespace as Argo.

Rationale:

* Although considered in the issue description, refrained from changing anything to the resources in Kargo namespace (the majority). Consistent hard-coded resource names remain 'as-is'
* Opted for a mechanism that by default changes nothing to existing installations
* Users now have the option to specify the resource names in Argo. This is a niche use-case. If done so, chart will replace the role and rolebinding by counterparts with a different name. A quick and non-destructive change.

Rebased on v1.10.4 to properly test (couldn't find helm chart e2e tests). See comment.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [x] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
