### PR TITLE
feat: record `FreightCreated` events

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -27,6 +27,7 @@ const (
 	EventTypePromotionFailed                 EventType = "PromotionFailed"
 	EventTypePromotionErrored                EventType = "PromotionErrored"
 	EventTypePromotionAborted                EventType = "PromotionAborted"
+	EventTypeFreightCreated                  EventType = "FreightCreated"
 	EventTypeFreightApproved                 EventType = "FreightApproved"
 	EventTypeFreightVerificationSucceeded    EventType = "FreightVerificationSucceeded"
 	EventTypeFreightVerificationFailed       EventType = "FreightVerificationFailed"

--- a/pkg/controller/warehouses/warehouses.go
+++ b/pkg/controller/warehouses/warehouses.go
@@ -102,13 +102,15 @@ func SetupReconcilerWithManager(
 			),
 		).
 		WithOptions(controller.CommonOptions(cfg.MaxConcurrentReconciles)).
-		Complete(func() *reconciler {
-			r := newReconciler(mgr.GetClient(), credentialsDB, subscriberRegistry, cfg)
-			r.eventSender = k8sevent.NewEventSender(
+		Complete(newReconciler(
+			mgr.GetClient(),
+			credentialsDB,
+			subscriberRegistry,
+			cfg,
+			k8sevent.NewEventSender(
 				libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), cfg.Name()),
-			)
-			return r
-		}()); err != nil {
+			),
+		)); err != nil {
 		return fmt.Errorf("error building Warehouse reconciler: %w", err)
 	}
 
@@ -125,12 +127,14 @@ func newReconciler(
 	credentialsDB credentials.Database,
 	subscriberRegistry subscription.SubscriberRegistry,
 	cfg ReconcilerConfig,
+	eventSender kargoEvent.Sender,
 ) *reconciler {
 	r := &reconciler{
 		client:             kubeClient,
 		credentialsDB:      credentialsDB,
 		subscriberRegistry: subscriberRegistry,
 		cfg:                cfg,
+		eventSender:        eventSender,
 		shardPredicate: controller.ResponsibleFor[kargoapi.Warehouse]{
 			IsDefaultController: cfg.IsDefaultController,
 			ShardName:           cfg.ShardName,

--- a/pkg/controller/warehouses/warehouses.go
+++ b/pkg/controller/warehouses/warehouses.go
@@ -496,7 +496,7 @@ func (r *reconciler) syncWarehouse(
 				)
 				if r.eventSender != nil {
 					evt := kargoEvent.NewFreightCreated(
-						"Freight created from discovered artifacts",
+						"",
 						api.FormatEventControllerActor(r.cfg.Name()),
 						freight,
 					)

--- a/pkg/controller/warehouses/warehouses.go
+++ b/pkg/controller/warehouses/warehouses.go
@@ -500,7 +500,7 @@ func (r *reconciler) syncWarehouse(
 				)
 				if r.eventSender != nil {
 					evt := kargoEvent.NewFreightCreated(
-						"",
+						"Freight created from discovered artifacts",
 						api.FormatEventControllerActor(r.cfg.Name()),
 						freight,
 					)

--- a/pkg/controller/warehouses/warehouses.go
+++ b/pkg/controller/warehouses/warehouses.go
@@ -22,9 +22,12 @@ import (
 	"github.com/akuity/kargo/pkg/conditions"
 	"github.com/akuity/kargo/pkg/controller"
 	"github.com/akuity/kargo/pkg/credentials"
+	kargoEvent "github.com/akuity/kargo/pkg/event"
+	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	"github.com/akuity/kargo/pkg/expressions/function"
 	"github.com/akuity/kargo/pkg/kargo"
 	"github.com/akuity/kargo/pkg/kubeclient"
+	libEvent "github.com/akuity/kargo/pkg/kubernetes/event"
 	"github.com/akuity/kargo/pkg/logging"
 	intpredicate "github.com/akuity/kargo/pkg/predicate"
 	"github.com/akuity/kargo/pkg/subscription"
@@ -43,6 +46,15 @@ func ReconcilerConfigFromEnv() ReconcilerConfig {
 	return cfg
 }
 
+// Name returns the name of the Warehouse controller.
+func (c ReconcilerConfig) Name() string {
+	const name = "warehouse-controller"
+	if c.ShardName != "" {
+		return name + "-" + c.ShardName
+	}
+	return name
+}
+
 // reconciler reconciles Warehouse resources.
 type reconciler struct {
 	client             client.Client
@@ -50,6 +62,7 @@ type reconciler struct {
 	subscriberRegistry subscription.SubscriberRegistry
 	cfg                ReconcilerConfig
 	shardPredicate     controller.ResponsibleFor[kargoapi.Warehouse]
+	eventSender        kargoEvent.Sender
 
 	// The following behaviors are overridable for testing purposes:
 
@@ -89,12 +102,13 @@ func SetupReconcilerWithManager(
 			),
 		).
 		WithOptions(controller.CommonOptions(cfg.MaxConcurrentReconciles)).
-		Complete(newReconciler(
-			mgr.GetClient(),
-			credentialsDB,
-			subscriberRegistry,
-			cfg,
-		)); err != nil {
+		Complete(func() *reconciler {
+			r := newReconciler(mgr.GetClient(), credentialsDB, subscriberRegistry, cfg)
+			r.eventSender = k8sevent.NewEventSender(
+				libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), cfg.Name()),
+			)
+			return r
+		}()); err != nil {
 		return fmt.Errorf("error building Warehouse reconciler: %w", err)
 	}
 
@@ -480,6 +494,17 @@ func (r *reconciler) syncWarehouse(
 						ObservedGeneration: warehouse.GetGeneration(),
 					},
 				)
+				if r.eventSender != nil {
+					evt := kargoEvent.NewFreightCreated(
+						"Freight created from discovered artifacts",
+						api.FormatEventControllerActor(r.cfg.Name()),
+						freight,
+					)
+					if err := r.eventSender.Send(ctx, evt); err != nil {
+						logger.Error(err, "failed to send FreightCreated event",
+							"freight", freight.Name)
+					}
+				}
 			}
 
 			status.LastFreightID = freight.Name

--- a/pkg/controller/warehouses/warehouses_test.go
+++ b/pkg/controller/warehouses/warehouses_test.go
@@ -64,6 +64,31 @@ func TestNewReconciler(t *testing.T) {
 	require.NotNil(t, e.patchStatusFn)
 }
 
+func TestReconcilerConfigName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cfg      ReconcilerConfig
+		expected string
+	}{
+		{
+			name:     "no shard name",
+			cfg:      ReconcilerConfig{},
+			expected: "warehouse-controller",
+		},
+		{
+			name:     "with shard name",
+			cfg:      ReconcilerConfig{ShardName: "my-shard"},
+			expected: "warehouse-controller-my-shard",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.cfg.Name())
+		})
+	}
+}
+
 func TestSyncWarehouse(t *testing.T) {
 	fakeRecorder := fakeevent.NewEventRecorder(1)
 
@@ -548,6 +573,58 @@ func TestSyncWarehouse(t *testing.T) {
 						return errors.New("failed to send event")
 					},
 				},
+				discoverArtifactsFn: func(
+					context.Context, string,
+					[]kargoapi.RepoSubscription,
+				) (*kargoapi.DiscoveredArtifacts, error) {
+					return &kargoapi.DiscoveredArtifacts{
+						Git: []kargoapi.GitDiscoveryResult{
+							{
+								RepoURL: "fake-repo",
+								Commits: []kargoapi.DiscoveredCommit{{ID: "fake-commit"}},
+							},
+						},
+					}, nil
+				},
+				buildFreightFromLatestArtifactsFn: func(
+					string,
+					*kargoapi.DiscoveredArtifacts,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-freight",
+							Namespace: "fake-namespace",
+						},
+					}, nil
+				},
+				createFreightFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return nil
+				},
+				patchStatusFn: func(context.Context, *kargoapi.Warehouse, func(*kargoapi.WarehouseStatus)) error {
+					return nil
+				},
+			},
+			warehouse: &kargoapi.Warehouse{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: kargoapi.WarehouseSpec{
+					FreightCreationPolicy: kargoapi.FreightCreationPolicyAutomatic,
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.WarehouseStatus, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, status.LastFreightID)
+			},
+		},
+
+		{
+			name: "successful freight creation with nil event sender",
+			reconciler: &reconciler{
+				cfg:         ReconcilerConfig{},
+				eventSender: nil,
 				discoverArtifactsFn: func(
 					context.Context, string,
 					[]kargoapi.RepoSubscription,

--- a/pkg/controller/warehouses/warehouses_test.go
+++ b/pkg/controller/warehouses/warehouses_test.go
@@ -21,9 +21,25 @@ import (
 	"github.com/akuity/kargo/pkg/conditions"
 	"github.com/akuity/kargo/pkg/controller"
 	"github.com/akuity/kargo/pkg/credentials"
+	kargoEvent "github.com/akuity/kargo/pkg/event"
+	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
+	fakeevent "github.com/akuity/kargo/pkg/kubernetes/event/fake"
 	"github.com/akuity/kargo/pkg/logging"
 	"github.com/akuity/kargo/pkg/subscription"
 )
+
+type testEventSender struct {
+	sendFn func(context.Context, kargoEvent.Meta) error
+}
+
+func (s *testEventSender) Send(ctx context.Context, evt kargoEvent.Meta) error {
+	if s.sendFn != nil {
+		return s.sendFn(ctx, evt)
+	}
+	return nil
+}
+
+func (s *testEventSender) Shutdown() {}
 
 func TestNewReconciler(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
@@ -48,6 +64,8 @@ func TestNewReconciler(t *testing.T) {
 }
 
 func TestSyncWarehouse(t *testing.T) {
+	fakeRecorder := fakeevent.NewEventRecorder(1)
+
 	testCases := []struct {
 		name       string
 		reconciler *reconciler
@@ -383,6 +401,8 @@ func TestSyncWarehouse(t *testing.T) {
 		{
 			name: "automatic Freight creation",
 			reconciler: &reconciler{
+				cfg:         ReconcilerConfig{},
+				eventSender: k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
 				discoverArtifactsFn: func(
 					context.Context, string,
 					[]kargoapi.RepoSubscription,
@@ -458,6 +478,119 @@ func TestSyncWarehouse(t *testing.T) {
 				require.Equal(t, metav1.ConditionTrue, freightCreatedCondition.Status)
 				require.Equal(t, "NewFreight", freightCreatedCondition.Reason)
 				require.Equal(t, int64(1), freightCreatedCondition.ObservedGeneration)
+			},
+		},
+
+		{
+			name: "sends FreightCreated event on successful freight creation",
+			reconciler: &reconciler{
+				cfg:         ReconcilerConfig{},
+				eventSender: k8sevent.NewEventSender(fakeRecorder),
+				discoverArtifactsFn: func(
+					context.Context, string,
+					[]kargoapi.RepoSubscription,
+				) (*kargoapi.DiscoveredArtifacts, error) {
+					return &kargoapi.DiscoveredArtifacts{
+						Git: []kargoapi.GitDiscoveryResult{
+							{
+								RepoURL: "fake-repo",
+								Commits: []kargoapi.DiscoveredCommit{{ID: "fake-commit"}},
+							},
+						},
+					}, nil
+				},
+				buildFreightFromLatestArtifactsFn: func(
+					string,
+					*kargoapi.DiscoveredArtifacts,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-freight",
+							Namespace: "fake-namespace",
+						},
+					}, nil
+				},
+				createFreightFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return nil
+				},
+				patchStatusFn: func(context.Context, *kargoapi.Warehouse, func(*kargoapi.WarehouseStatus)) error {
+					return nil
+				},
+			},
+			warehouse: &kargoapi.Warehouse{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: kargoapi.WarehouseSpec{
+					FreightCreationPolicy: kargoapi.FreightCreationPolicyAutomatic,
+				},
+			},
+			assertions: func(t *testing.T, _ kargoapi.WarehouseStatus, err error) {
+				require.NoError(t, err)
+				select {
+				case evt := <-fakeRecorder.Events:
+					require.Equal(t, string(kargoapi.EventTypeFreightCreated), evt.Reason)
+				default:
+					t.Fatal("expected FreightCreated event to be sent but got none")
+				}
+			},
+		},
+
+		{
+			name: "event send error does not fail reconciliation",
+			reconciler: &reconciler{
+				cfg: ReconcilerConfig{},
+				eventSender: &testEventSender{
+					sendFn: func(context.Context, kargoEvent.Meta) error {
+						return errors.New("failed to send event")
+					},
+				},
+				discoverArtifactsFn: func(
+					context.Context, string,
+					[]kargoapi.RepoSubscription,
+				) (*kargoapi.DiscoveredArtifacts, error) {
+					return &kargoapi.DiscoveredArtifacts{
+						Git: []kargoapi.GitDiscoveryResult{
+							{
+								RepoURL: "fake-repo",
+								Commits: []kargoapi.DiscoveredCommit{{ID: "fake-commit"}},
+							},
+						},
+					}, nil
+				},
+				buildFreightFromLatestArtifactsFn: func(
+					string,
+					*kargoapi.DiscoveredArtifacts,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-freight",
+							Namespace: "fake-namespace",
+						},
+					}, nil
+				},
+				createFreightFn: func(
+					context.Context,
+					client.Object,
+					...client.CreateOption,
+				) error {
+					return nil
+				},
+				patchStatusFn: func(context.Context, *kargoapi.Warehouse, func(*kargoapi.WarehouseStatus)) error {
+					return nil
+				},
+			},
+			warehouse: &kargoapi.Warehouse{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: kargoapi.WarehouseSpec{
+					FreightCreationPolicy: kargoapi.FreightCreationPolicyAutomatic,
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.WarehouseStatus, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, status.LastFreightID)
 			},
 		},
 

--- a/pkg/controller/warehouses/warehouses_test.go
+++ b/pkg/controller/warehouses/warehouses_test.go
@@ -50,6 +50,7 @@ func TestNewReconciler(t *testing.T) {
 		&credentials.FakeDB{},
 		subscription.MustNewSubscriberRegistry(),
 		ReconcilerConfig{MinReconciliationInterval: minReconciliationInterval},
+		nil,
 	)
 	require.NotNil(t, e.client)
 	require.NotNil(t, e.credentialsDB)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -14,6 +14,7 @@ var KnownEventTypes = []kargoapi.EventType{
 	kargoapi.EventTypePromotionFailed,
 	kargoapi.EventTypePromotionErrored,
 	kargoapi.EventTypePromotionAborted,
+	kargoapi.EventTypeFreightCreated,
 	kargoapi.EventTypeFreightApproved,
 	kargoapi.EventTypeFreightVerificationSucceeded,
 	kargoapi.EventTypeFreightVerificationFailed,

--- a/pkg/event/freight.go
+++ b/pkg/event/freight.go
@@ -189,6 +189,17 @@ func (f *FreightVerificationUnknown) Type() kargoapi.EventType {
 	return kargoapi.EventTypeFreightVerificationUnknown
 }
 
+// FreightCreated is an event fired when a new piece of Freight is created by
+// a Warehouse or API server
+type FreightCreated struct {
+	Common
+	Freight
+}
+
+func (f *FreightCreated) Type() kargoapi.EventType {
+	return kargoapi.EventTypeFreightCreated
+}
+
 type FreightApproved struct {
 	Common
 	Freight
@@ -290,6 +301,16 @@ func NewFreightVerificationInconclusive(actor, stageName string, freight *kargoa
 	}
 }
 
+// NewFreightCreated creates a new `FreightCreated` event.
+func NewFreightCreated(message, actor string, freight *kargoapi.Freight) *FreightCreated {
+	common := newCommonFromFreight(message, actor, freight)
+	freightEvent := newFreight(freight, "")
+	return &FreightCreated{
+		Common:  common,
+		Freight: freightEvent,
+	}
+}
+
 // NewFreightApproved creates a new `FreightApproved` event.
 func NewFreightApproved(message, actor, stageName string, freight *kargoapi.Freight,
 ) *FreightApproved {
@@ -374,6 +395,13 @@ func (f *FreightVerificationInconclusive) MarshalAnnotations() map[string]string
 	f.Common.MarshalAnnotationsTo(annotations)
 	f.Freight.MarshalAnnotationsTo(annotations)
 	f.FreightVerification.MarshalAnnotationsTo(annotations)
+	return annotations
+}
+
+func (f *FreightCreated) MarshalAnnotations() map[string]string {
+	annotations := map[string]string{}
+	f.Common.MarshalAnnotationsTo(annotations)
+	f.Freight.MarshalAnnotationsTo(annotations)
 	return annotations
 }
 
@@ -596,6 +624,27 @@ func UnmarshalFreightVerificationAbortedAnnotations(
 		FreightVerification: verification,
 	}
 	return &evt, nil
+}
+
+// UnmarshalFreightCreatedAnnotations converts the given annotations into a
+// FreightCreated event. This is used by the main event handler to convert the data
+// into a normal structured event, but is exposed for convenience.
+func UnmarshalFreightCreatedAnnotations(
+	eventID string,
+	annotations map[string]string,
+) (*FreightCreated, error) {
+	freight, err := UnmarshalFreightAnnotations(annotations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal freight annotations: %w", err)
+	}
+	common, err := UnmarshalCommonAnnotations(eventID, annotations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal common annotations: %w", err)
+	}
+	return &FreightCreated{
+		Common:  common,
+		Freight: freight,
+	}, nil
 }
 
 // UnmarshalFreightApprovedAnnotations converts the given annotations into a

--- a/pkg/event/freight_test.go
+++ b/pkg/event/freight_test.go
@@ -511,6 +511,17 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 			expectError:  true,
 			errorMessage: "failed to parse freight create time",
 		},
+		"freight created - invalid freight annotations": {
+			annotations: map[string]string{
+				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime: "invalid-time",
+			},
+			unmarshalFunc: func(annotations map[string]string) (Meta, error) {
+				return UnmarshalFreightCreatedAnnotations("event-id", annotations)
+			},
+			expectError:  true,
+			errorMessage: "failed to unmarshal freight annotations",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/event/freight_test.go
+++ b/pkg/event/freight_test.go
@@ -131,6 +131,11 @@ func TestFreightApproved(t *testing.T) {
 	require.Equal(t, kargoapi.EventTypeFreightApproved, evt.Type())
 }
 
+func TestFreightCreated(t *testing.T) {
+	evt := &FreightCreated{}
+	require.Equal(t, kargoapi.EventTypeFreightCreated, evt.Type())
+}
+
 func TestNewFreightCommon(t *testing.T) {
 	testCases := map[string]struct {
 		message         string
@@ -279,6 +284,24 @@ func TestNewFreightApproved(t *testing.T) {
 	require.Equal(t, "Freight approved", event.GetMessage())
 }
 
+func TestNewFreightCreated(t *testing.T) {
+	freight := &kargoapi.Freight{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-freight",
+			Namespace:         "test-project",
+			CreationTimestamp: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	evt := NewFreightCreated("Freight created", "test-actor", freight)
+
+	require.Equal(t, kargoapi.EventTypeFreightCreated, evt.Type())
+	require.Equal(t, "test-project", evt.GetProject())
+	require.Equal(t, "test-freight", evt.GetName())
+	require.Equal(t, "Freight", evt.Kind())
+	require.Equal(t, "Freight created", evt.GetMessage())
+}
+
 func TestFreightEventMarshalAnnotations(t *testing.T) {
 	freight := &kargoapi.Freight{
 		ObjectMeta: metav1.ObjectMeta{
@@ -318,6 +341,17 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
 				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
 				kargoapi.AnnotationKeyEventStageName:         "test-stage",
+				kargoapi.AnnotationKeyEventFreightAlias:      "v1.0.0",
+			},
+		},
+		"freight created": {
+			event: NewFreightCreated("Freight created", "test-actor", freight),
+			expected: map[string]string{
+				kargoapi.AnnotationKeyEventProject:           "test-project",
+				kargoapi.AnnotationKeyEventActor:             "test-actor",
+				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventStageName:         "",
 				kargoapi.AnnotationKeyEventFreightAlias:      "v1.0.0",
 			},
 		},
@@ -442,6 +476,26 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 				Freight: Freight{
 					Name:       "test-freight",
 					StageName:  "test-stage",
+					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+		"freight created": {
+			annotations: map[string]string{
+				kargoapi.AnnotationKeyEventProject:           "test-project",
+				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+			},
+			unmarshalFunc: func(annotations map[string]string) (Meta, error) {
+				return UnmarshalFreightCreatedAnnotations("event-id", annotations)
+			},
+			expectedType: &FreightCreated{
+				Common: Common{
+					Project: "test-project",
+					ID:      "event-id",
+				},
+				Freight: Freight{
+					Name:       "test-freight",
 					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 			},

--- a/pkg/event/kubernetes/kubernetes.go
+++ b/pkg/event/kubernetes/kubernetes.go
@@ -27,6 +27,8 @@ func FromKubernetesEvent(evt corev1.Event) (event.Meta, error) {
 		parsedEvent, err = event.UnmarshalPromotionErroredAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypePromotionAborted:
 		parsedEvent, err = event.UnmarshalPromotionAbortedAnnotations(id, evt.Annotations)
+	case kargoapi.EventTypeFreightCreated:
+		parsedEvent, err = event.UnmarshalFreightCreatedAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypeFreightApproved:
 		parsedEvent, err = event.UnmarshalFreightApprovedAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypeFreightVerificationSucceeded:

--- a/pkg/event/kubernetes/kubernetes_test.go
+++ b/pkg/event/kubernetes/kubernetes_test.go
@@ -94,6 +94,27 @@ func TestFromKubernetesEvent(t *testing.T) {
 			},
 			expectedType: kargoapi.EventTypeFreightVerificationSucceeded,
 		},
+		"freight created event": {
+			k8sEvent: corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "test-uid",
+					Annotations: map[string]string{
+						kargoapi.AnnotationKeyEventProject:           "test-project",
+						kargoapi.AnnotationKeyEventFreightName:       "test-freight",
+						kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+					},
+				},
+				Reason:  string(kargoapi.EventTypeFreightCreated),
+				Message: "Freight created",
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Freight",
+					Name:      "test-freight",
+					Namespace: "test-project",
+				},
+				LastTimestamp: metav1.Time{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+			},
+			expectedType: kargoapi.EventTypeFreightCreated,
+		},
 		"freight approved event": {
 			k8sEvent: corev1.Event{
 				ObjectMeta: metav1.ObjectMeta{
@@ -215,6 +236,7 @@ func TestFromKubernetesEvent_AllEventTypes(t *testing.T) {
 		kargoapi.EventTypeFreightVerificationAborted,
 		kargoapi.EventTypeFreightVerificationInconclusive,
 		kargoapi.EventTypeFreightVerificationUnknown,
+		kargoapi.EventTypeFreightCreated,
 		kargoapi.EventTypeFreightApproved,
 	}
 
@@ -319,6 +341,20 @@ func TestEventSender_Send(t *testing.T) {
 				Freight: event.Freight{
 					Name:       "test-freight",
 					StageName:  "test-stage",
+					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expectedCalls: 1,
+		},
+		"freight created event": {
+			event: &event.FreightCreated{
+				Common: event.Common{
+					Project: "test-project",
+					Message: "Freight created",
+					Actor:   stringPtr("test-actor"),
+				},
+				Freight: event.Freight{
+					Name:       "test-freight",
 					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 			},

--- a/pkg/server/common.go
+++ b/pkg/server/common.go
@@ -37,6 +37,12 @@ var (
 		Kind:    "Secret",
 	}
 
+	freightGVK = schema.GroupVersionKind{
+		Group:   kargoapi.GroupVersion.Group,
+		Version: kargoapi.GroupVersion.Version,
+		Kind:    "Freight",
+	}
+
 	errSecretManagementDisabled = libhttp.ErrorStr(
 		"secret management is not enabled",
 		http.StatusNotImplemented,

--- a/pkg/server/create_resource_v1alpha1.go
+++ b/pkg/server/create_resource_v1alpha1.go
@@ -12,12 +12,18 @@ import (
 	"github.com/gin-gonic/gin"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigyaml "sigs.k8s.io/yaml"
 
 	svcv1alpha1 "github.com/akuity/kargo/api/service/v1alpha1"
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
+	"github.com/akuity/kargo/pkg/event"
 	libhttp "github.com/akuity/kargo/pkg/http"
+	"github.com/akuity/kargo/pkg/logging"
+	"github.com/akuity/kargo/pkg/server/user"
 )
 
 // createResourceResponse is the response for creating resources
@@ -214,6 +220,26 @@ func (s *server) createResource(
 		return createResourceResult{
 			Error: fmt.Errorf("create resource: %w", err).Error(),
 		}, err
+	}
+
+	if obj.GroupVersionKind() == freightGVK && s.sender != nil {
+		var freight kargoapi.Freight
+		if convertErr := runtime.DefaultUnstructuredConverter.FromUnstructured(
+			obj.Object,
+			&freight,
+		); convertErr == nil {
+			var actor string
+			eventMsg := "Freight created"
+			if u, ok := user.InfoFromContext(ctx); ok {
+				actor = api.FormatEventUserActor(u)
+				eventMsg += fmt.Sprintf(" by %q", actor)
+			}
+			evt := event.NewFreightCreated(eventMsg, actor, &freight)
+			if sendErr := s.sender.Send(ctx, evt); sendErr != nil {
+				logging.LoggerFromContext(ctx).Error(
+					sendErr, "error sending FreightCreated event")
+			}
+		}
 	}
 
 	// Convert the created object to a map for the response

--- a/pkg/server/create_resource_v1alpha1_test.go
+++ b/pkg/server/create_resource_v1alpha1_test.go
@@ -209,7 +209,7 @@ func Test_server_createResources(t *testing.T) {
 type errSender struct{ err error }
 
 func (s *errSender) Send(_ context.Context, _ event.Meta) error { return s.err }
-func (s *errSender) Shutdown()                                   {}
+func (s *errSender) Shutdown()                                  {}
 
 func Test_server_createResources_freightEvent(t *testing.T) {
 	testFreight := &kargoapi.Freight{

--- a/pkg/server/create_resource_v1alpha1_test.go
+++ b/pkg/server/create_resource_v1alpha1_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/event"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	fakeevent "github.com/akuity/kargo/pkg/kubernetes/event/fake"
 	"github.com/akuity/kargo/pkg/server/user"
@@ -204,6 +206,11 @@ func Test_server_createResources(t *testing.T) {
 	)
 }
 
+type errSender struct{ err error }
+
+func (s *errSender) Send(_ context.Context, _ event.Meta) error { return s.err }
+func (s *errSender) Shutdown()                                   {}
+
 func Test_server_createResources_freightEvent(t *testing.T) {
 	testFreight := &kargoapi.Freight{
 		TypeMeta: metav1.TypeMeta{
@@ -266,6 +273,16 @@ func Test_server_createResources_freightEvent(t *testing.T) {
 					require.Equal(t, corev1.EventTypeNormal, evt.EventType)
 					require.Equal(t, string(kargoapi.EventTypeFreightCreated), evt.Reason)
 					require.Equal(t, "Freight created", evt.Message)
+				},
+			},
+			{
+				name: "Freight with sender error still succeeds",
+				serverSetup: func(_ *testing.T, s *server) {
+					s.sender = &errSender{err: errors.New("send failed")}
+				},
+				body: mustJSONBody(testFreight),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
 				},
 			},
 			{

--- a/pkg/server/create_resource_v1alpha1_test.go
+++ b/pkg/server/create_resource_v1alpha1_test.go
@@ -2,17 +2,22 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
+	fakeevent "github.com/akuity/kargo/pkg/kubernetes/event/fake"
+	"github.com/akuity/kargo/pkg/server/user"
 )
 
 func Test_server_createResources(t *testing.T) {
@@ -193,6 +198,92 @@ func Test_server_createResources(t *testing.T) {
 						warehouse,
 					)
 					require.NoError(t, err)
+				},
+			},
+		},
+	)
+}
+
+func Test_server_createResources_freightEvent(t *testing.T) {
+	testFreight := &kargoapi.Freight{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kargoapi.GroupVersion.String(),
+			Kind:       "Freight",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-freight",
+			Namespace: "fake-project",
+		},
+	}
+
+	// recorder is reassigned by each serverSetup before assertions reads it.
+	// Test cases are run sequentially so this is safe.
+	var recorder *fakeevent.EventRecorder
+
+	testRESTEndpoint(
+		t, nil,
+		http.MethodPost, "/v1beta1/resources",
+		[]restTestCase{
+			{
+				name: "non-Freight resource does not send event",
+				serverSetup: func(_ *testing.T, s *server) {
+					recorder = fakeevent.NewEventRecorder(1)
+					s.sender = k8sevent.NewEventSender(recorder)
+				},
+				body: mustJSONBody(&kargoapi.Warehouse{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: kargoapi.GroupVersion.String(),
+						Kind:       "Warehouse",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-warehouse",
+						Namespace: "fake-project",
+					},
+				}),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+					require.Empty(t, recorder.Events)
+				},
+			},
+			{
+				name: "Freight without sender succeeds without event",
+				body: mustJSONBody(testFreight),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+				},
+			},
+			{
+				name: "Freight with sender sends FreightCreated event",
+				serverSetup: func(_ *testing.T, s *server) {
+					recorder = fakeevent.NewEventRecorder(1)
+					s.sender = k8sevent.NewEventSender(recorder)
+				},
+				body: mustJSONBody(testFreight),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+					require.Len(t, recorder.Events, 1)
+					evt := <-recorder.Events
+					require.Equal(t, corev1.EventTypeNormal, evt.EventType)
+					require.Equal(t, string(kargoapi.EventTypeFreightCreated), evt.Reason)
+					require.Equal(t, "Freight created", evt.Message)
+				},
+			},
+			{
+				name: "Freight with user context includes actor in event message",
+				serverSetup: func(_ *testing.T, s *server) {
+					recorder = fakeevent.NewEventRecorder(1)
+					s.sender = k8sevent.NewEventSender(recorder)
+				},
+				ctxSetup: func(ctx context.Context) context.Context {
+					return user.ContextWithInfo(ctx, user.Info{IsAdmin: true})
+				},
+				body: mustJSONBody(testFreight),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+					require.Len(t, recorder.Events, 1)
+					evt := <-recorder.Events
+					require.Equal(t, string(kargoapi.EventTypeFreightCreated), evt.Reason)
+					require.Contains(t, evt.Message, kargoapi.EventActorAdmin)
 				},
 			},
 		},


### PR DESCRIPTION
**All pull requests must reference an existing issue with no blocking labels.**
PRs that do not meet this requirement will be automatically closed. See the
[Contributor Guide](https://docs.kargo.io/contributor-guide) for details.

## Issue Reference

Closes https://github.com/akuity/kargo/issues/6322

## Description

Records `FreightCreated` event at warehouse controller and `create_resource` API when creating manually

```yaml
Name:             a9240a508444b6b16ab10397273136639d219b11.18b1432306fc931f
Namespace:        kargo-demo-3
Labels:           <none>
Annotations:      event.kargo.akuity.io/actor: controller:warehouse-controller
                  event.kargo.akuity.io/freight-alias: inky-sloth
                  event.kargo.akuity.io/freight-commits:
                    [{"repoURL":"https://github.com/akuity/kargo","id":"4a704c6dbee1410f0255ca4e90b0ecb1deb4bebf","message":"chore(deps): bump @babel/plugin-t...
                  event.kargo.akuity.io/freight-create-time: 2026-05-20T11:39:05Z
                  event.kargo.akuity.io/freight-name: a9240a508444b6b16ab10397273136639d219b11
                  event.kargo.akuity.io/project: kargo-demo-3
                  event.kargo.akuity.io/stage-name:
API Version:      v1
Count:            1
Event Time:       <nil>
First Timestamp:  2026-05-20T11:39:05Z
Involved Object:
  API Version:   kargo.akuity.io/v1alpha1
  Kind:          Freight
  Name:          a9240a508444b6b16ab10397273136639d219b11
  Namespace:     kargo-demo-3
Kind:            Event
Last Timestamp:  2026-05-20T11:39:05Z
Message:         Freight created from discovered artifacts
Metadata:
  Creation Timestamp:  2026-05-20T11:39:05Z
  Resource Version:    13813
  UID:                 a1000cc3-9146-48e4-b4c4-75dee8976f60
Reason:                FreightCreated
Reporting Component:   warehouse-controller
Reporting Instance:
Source:
  Component:  warehouse-controller
Type:         Normal
Events:       <none>


Name:             f0e5209cf56bc1926e72fcb67286858494d81434.18b14325d679c275
Namespace:        kargo-demo-3
Labels:           <none>
Annotations:      event.kargo.akuity.io/actor: email:kilgore@kilgore.trout
                  event.kargo.akuity.io/freight-alias: existing-squirrel
                  event.kargo.akuity.io/freight-commits:
                    [{"repoURL":"https://github.com/akuity/kargo","id":"c6cec22b240fad644085729b9ba02f3d21ef7229","message":"chore(deps): bump github.com/go-g...
                  event.kargo.akuity.io/freight-create-time: 2026-05-20T11:39:17Z
                  event.kargo.akuity.io/freight-name: f0e5209cf56bc1926e72fcb67286858494d81434
                  event.kargo.akuity.io/project: kargo-demo-3
                  event.kargo.akuity.io/stage-name:
API Version:      v1
Count:            1
Event Time:       <nil>
First Timestamp:  2026-05-20T11:39:17Z
Involved Object:
  API Version:   kargo.akuity.io/v1alpha1
  Kind:          Freight
  Name:          f0e5209cf56bc1926e72fcb67286858494d81434
  Namespace:     kargo-demo-3
Kind:            Event
Last Timestamp:  2026-05-20T11:39:17Z
Message:         Freight created by "email:kilgore@kilgore.trout"
Metadata:
  Creation Timestamp:  2026-05-20T11:39:17Z
  Resource Version:    13827
  UID:                 b98fe307-4aeb-4f7c-964e-fa6344506cbd
Reason:                FreightCreated
Reporting Component:   api
Reporting Instance:
Source:
  Component:  api
Type:         Normal
Events:       <none>
```

<img width="1512" height="831" alt="Screenshot 2026-05-20 at 5 11 04 PM" src="https://github.com/user-attachments/assets/9ddb5810-cd44-4e22-8a0c-cc34890906f0" />


## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [x] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
