### PR TITLE
feat(ui): add freightTab extension hook

### DIFF
--- a/ui/src/extensions/extensions-context.ts
+++ b/ui/src/extensions/extensions-context.ts
@@ -13,6 +13,7 @@ export const useExtensionsContext = () => {
 
   return {
     stageTabs: ctx?.extensions.filter((extension) => extension.type === 'stageTab') || [],
+    freightTabs: ctx?.extensions.filter((extension) => extension.type === 'freightTab') || [],
     layoutExtensions:
       ctx?.extensions.filter((extension) => extension.type === 'layoutExtension') || [],
     projectSubpages:

--- a/ui/src/extensions/types.ts
+++ b/ui/src/extensions/types.ts
@@ -22,6 +22,18 @@ export type StageTab = {
   icon?: React.ReactNode;
 };
 
+export type FreightTabComponentProps = {
+  projectName: string;
+  freightId: string;
+};
+
+export type FreightTab = {
+  type: 'freightTab';
+  component: (props: FreightTabComponentProps) => React.ReactNode;
+  label: string;
+  icon?: React.ReactNode;
+};
+
 export type LayoutExtension = {
   type: 'layoutExtension';
   component: () => React.ReactNode;
@@ -78,6 +90,7 @@ export type ArgoCDExtension = {
 
 export type Extension =
   | StageTab
+  | FreightTab
   | LayoutExtension
   | ProjectSubpage
   | AppSubpage

--- a/ui/src/features/freight/freight-details.tsx
+++ b/ui/src/features/freight/freight-details.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
+import { useExtensionsContext } from '@ui/extensions/extensions-context';
 import { Freight, FreightSchema } from '@ui/gen/api/v1alpha1/generated_pb';
 import { useGetFreightLinks } from '@ui/gen/api/v2/core/core';
 
@@ -46,6 +47,7 @@ export const FreightDetails = ({
 
   const onClose = () => navigate(generatePath(paths.project, { name: projectName }));
   const { show } = useModal();
+  const { freightTabs } = useExtensionsContext();
 
   const freightNameOrAlias = alias || freight?.metadata?.name;
   const { data: freightLinksData } = useGetFreightLinks(
@@ -128,7 +130,18 @@ export const FreightDetails = ({
                   children: (
                     <ManifestPreview object={toJson(FreightSchema, freight)} height='900px' />
                   )
-                }
+                },
+                ...freightTabs.map((data, index) => ({
+                  children: (
+                    <data.component
+                      projectName={projectName || ''}
+                      freightId={freight?.metadata?.uid || ''}
+                    />
+                  ),
+                  key: String(data.label + index),
+                  label: data.label,
+                  icon: data.icon
+                }))
               ]}
             />
           </div>


### PR DESCRIPTION
fixes #6324 
Introduces a new `freightTab` extension type, mirroring `stageTab`, that lets extensions register additional tabs in the freight details drawer. The tab component receives the project name and freight ID as primitive string params.