### PR TITLE
feat(ui): add Azure DevOps support to getGitCommitURL

### DIFF
--- a/ui/src/features/freight-timeline/open-container-initiative-utils.test.ts
+++ b/ui/src/features/freight-timeline/open-container-initiative-utils.test.ts
@@ -56,6 +56,12 @@ describe('getGitCommitURL', () => {
       url: 'git@bitbucket.org:akuity/kargo.git',
       expected: 'https://bitbucket.org/akuity/kargo/commits/abc1234'
     },
+    // Azure DevOps
+    {
+      name: 'azure devops HTTPS',
+      url: 'https://dev.azure.com/akuity/kargo-project/_git/kargo',
+      expected: 'https://dev.azure.com/akuity/kargo-project/_git/kargo/commit/abc1234'
+    },
     // Unknown provider — fall back to original url
     {
       name: 'unknown provider returns original url',

--- a/ui/src/features/freight-timeline/open-container-initiative-utils.ts
+++ b/ui/src/features/freight-timeline/open-container-initiative-utils.ts
@@ -40,6 +40,8 @@ export const getGitCommitURL = (url: string, revision: string) => {
       return `${baseUrl}/-/commit/${revision}`;
     } else if (resource.includes('bitbucket')) {
       return `${baseUrl}/commits/${revision}`;
+    } else if (resource.includes('dev.azure.com')) {
+      return `${url}/commit/${revision}`;
     }
   } catch {
     // fall through to return original url


### PR DESCRIPTION
Closes #6515

## Summary

The `getGitCommitURL` utility in `open-container-initiative-utils.ts` builds deeplink URLs from `org.opencontainers.image.source` + `org.opencontainers.image.revision` annotations. It currently handles GitHub, GitLab, and Bitbucket but falls through to returning the raw source URL for Azure DevOps, meaning the commit hash on a Freight card never becomes a clickable `/commit/<sha>` link.

## Changes

- **`open-container-initiative-utils.ts`**: adds an `else if (resource.includes('dev.azure.com'))` branch that returns `\`${url}/commit/${revision}\`` directly against the original source URL (rather than the reconstructed `baseUrl`) because ADO's four-segment path form — `https://dev.azure.com/{org}/{project}/_git/{repo}` — doesn't compose cleanly from `gitUrlParse`'s `owner` + `name` fields.

- **`open-container-initiative-utils.test.ts`**: adds one test case mirroring the existing GitHub/GitLab/Bitbucket patterns.

## Test

```
pnpm vitest run src/features/freight-timeline/open-container-initiative-utils.test.ts
# 13 passed (13)
```

## ADO URL anatomy

```
https://dev.azure.com/{org}/{project}/_git/{repo}
                                           ↑ commit deeplink appended here
→ https://dev.azure.com/{org}/{project}/_git/{repo}/commit/{sha}
```