### PR TITLE
fix: use flagset when initializing klog

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -71,14 +71,16 @@ func init() {
 		panic(err)
 	}
 
+	fs := flag.NewFlagSet("kargo_logger", flag.ExitOnError)
+
 	// Configure klog to use the same writer
-	klog.InitFlags(nil)
+	klog.InitFlags(fs)
 	klog.SetOutput(writer)
 	klogLevel := "0"
 	if k := os.Getenv("KLOG_LEVEL"); k != "" {
 		klogLevel = k
 	}
-	if err = flag.Set("v", klogLevel); err != nil {
+	if err = fs.Set("v", klogLevel); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## Issue Reference

NA

## Description

When using kargo as a library, logger will initialize klog in the init() function with default flagset. This means that if any other tool initializes the klog with default flagset in the main() function, that will panic with `flag redefined` error.

klog recommends calling `InitFlags` in `main()` or using a flagset. This PR uses a "kargo_logger" flagset for `InitFlags`

## Checklist

- [ ] The PR is linked to an existing issue.
- [ ] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [x] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
