### PR TITLE
fix: reject path traversal in rendered resource filenames

### DIFF
--- a/pkg/promotion/runner/builtin/helm_template_runner.go
+++ b/pkg/promotion/runner/builtin/helm_template_runner.go
@@ -397,6 +397,13 @@ func (h *helmTemplateRunner) writeResourcesFlat(outPath, manifest string) error 
 			fileName = fmt.Sprintf("resource-%d.yaml", i)
 		}
 
+		// Filenames are derived from rendered resource metadata, which is
+		// untrusted input. Reject anything that isn't a plain filename so a
+		// malicious or malformed manifest cannot write outside outPath.
+		if err = validateGeneratedResourceFilename(fileName); err != nil {
+			return err
+		}
+
 		// Write the resource to the output directory.
 		//
 		// #nosec G703 -- Contextually, if this was constructed from a

--- a/pkg/promotion/runner/builtin/helm_template_runner_test.go
+++ b/pkg/promotion/runner/builtin/helm_template_runner_test.go
@@ -1281,6 +1281,34 @@ spec:
 			},
 		},
 		{
+			name: "flat layout rejects manifest metadata that would escape output dir",
+			cfg: builtin.HelmTemplateConfig{
+				OutPath:   "output",
+				OutLayout: ptr.To(builtin.Flat),
+			},
+			rls: &release.Release{
+				Manifest: `---
+apiVersion: v1
+kind: ../outside/marker
+metadata:
+  name: written
+data:
+  key: value`,
+			},
+			setup: func(t *testing.T) (workDir string) {
+				workDir = t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(workDir, "outside"), 0o700))
+				return workDir
+			},
+			assertions: func(t *testing.T, workDir string, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+				assert.NoFileExists(
+					t,
+					filepath.Join(workDir, "outside", "marker-written.yaml"),
+				)
+			},
+		},
+		{
 			name: "skip test hooks",
 			cfg: builtin.HelmTemplateConfig{
 				OutPath:   "output",

--- a/pkg/promotion/runner/builtin/kustomize_builder.go
+++ b/pkg/promotion/runner/builtin/kustomize_builder.go
@@ -213,6 +213,12 @@ func (k *kustomizeBuilder) writeIndividualFiles(dirPath string, m resmap.ResMap,
 }
 
 func (k *kustomizeBuilder) writeResource(path, fName string, res *resource.Resource) error {
+	// Filenames are derived from rendered resource metadata, which is untrusted
+	// input. Reject anything that isn't a plain filename so a malicious or
+	// malformed resource cannot write outside path.
+	if err := validateGeneratedResourceFilename(fName); err != nil {
+		return err
+	}
 	m, err := res.Map()
 	if err != nil {
 		return err

--- a/pkg/promotion/runner/builtin/kustomize_builder_test.go
+++ b/pkg/promotion/runner/builtin/kustomize_builder_test.go
@@ -396,6 +396,37 @@ metadata:
 			},
 		},
 		{
+			name: "output directory rejects resource metadata that would escape it",
+			setupFiles: func(t *testing.T, dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(`---
+apiVersion: v1
+kind: ../owned/marker
+metadata:
+  name: written
+`), 0o600))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "owned"), 0o700))
+			},
+			config: builtin.KustomizeBuildConfig{
+				Path:    ".",
+				OutPath: "output/",
+			},
+			assertions: func(t *testing.T, dir string, result promotion.StepResult, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+				assert.Equal(
+					t,
+					promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
+					result,
+				)
+				assert.NoFileExists(t, filepath.Join(dir, "owned", "marker-written.yaml"))
+			},
+		},
+		{
 			name:       "kustomization file not found",
 			setupFiles: func(*testing.T, string) {},
 			config: builtin.KustomizeBuildConfig{

--- a/pkg/promotion/runner/builtin/resource_filename.go
+++ b/pkg/promotion/runner/builtin/resource_filename.go
@@ -1,0 +1,33 @@
+package builtin
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// validateGeneratedResourceFilename rejects filenames derived from rendered
+// Kubernetes resource metadata that contain path separators, parent-directory
+// segments, or other components that could cause a write to escape the
+// configured output directory when joined to it.
+//
+// The flat layout for helm-template and the per-resource directory output for
+// kustomize-build both contract to write each resource as a single file at the
+// top level of the configured output directory. Any generated name that is not
+// a plain filename violates that contract -- whether or not it would actually
+// escape the directory after joining.
+func validateGeneratedResourceFilename(fileName string) error {
+	if fileName == "" {
+		return fmt.Errorf("generated resource filename is empty")
+	}
+	// "." and ".." are their own clean forms, so the Clean check below does not
+	// reject them. They must be excluded explicitly: "." would target outPath
+	// itself, and ".." would escape it.
+	if fileName == "." || fileName == ".." ||
+		filepath.IsAbs(fileName) ||
+		strings.ContainsAny(fileName, `/\`) ||
+		filepath.Clean(fileName) != fileName {
+		return fmt.Errorf("unsafe generated resource filename %q", fileName)
+	}
+	return nil
+}

--- a/pkg/promotion/runner/builtin/resource_filename_test.go
+++ b/pkg/promotion/runner/builtin/resource_filename_test.go
@@ -1,0 +1,85 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateGeneratedResourceFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		assert   func(*testing.T, error)
+	}{
+		{
+			name:     "empty",
+			fileName: "",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "generated resource filename is empty")
+			},
+		},
+		{
+			name:     "plain filename",
+			fileName: "configmap-test-ns-test-configmap.yaml",
+			assert: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:     "absolute path",
+			fileName: "/etc/passwd",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "forward slash separator",
+			fileName: "subdir/file.yaml",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "backslash separator",
+			fileName: `subdir\file.yaml`,
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "current segment alone",
+			fileName: ".",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "parent segment",
+			fileName: "..",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "parent traversal",
+			fileName: "../owned-marker.yaml",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+		{
+			name:     "current-dir prefix",
+			fileName: "./file.yaml",
+			assert: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "unsafe generated resource filename")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.assert(t, validateGeneratedResourceFilename(tt.fileName))
+		})
+	}
+}


### PR DESCRIPTION
The helm-template `outLayout: flat` and kustomize-build directory output paths derive per-resource filenames from rendered Kubernetes resource metadata (kind, namespace, name) and pass them straight to filepath.Join. A rendered resource whose metadata contains path separators or parent-directory segments can escape the configured output directory.

Add a validator that rejects empty names, ".", "..", absolute paths, names containing path separators, and anything filepath.Clean rewrites. Wire it into writeResourcesFlat (helm) and writeResource (kustomize) before the os.WriteFile call.

There will be a forthcoming security advisory related to this. Severity is extremely low and deemed not to necessitate immediate action. For this reason, I also do not intend on backporting this to 1.9.x and earlier. The fix will be included in v1.10.5 only.