### PR TITLE
fix(cli): correct --username flag typo in repo-credentials usage string

### DIFF
--- a/pkg/cli/cmd/create/repo_credentials.go
+++ b/pkg/cli/cmd/create/repo_credentials.go
@@ -58,7 +58,7 @@ func newRepoCredentialsCommand(cfg config.CLIConfig, streams genericiooptions.IO
     (--git | --helm | --image) \
     [--description=description] \
     --repo-url=repo-url [--regex] \
-    -username=username \
+    --username=username \
     [--password=password]`,
 		Aliases: []string{
 			"repo-credential",


### PR DESCRIPTION
## Issue Reference

Closes #6351

## Description

The `Use` string for `kargo create repo-credentials` had a single-dash typo (`-username=username`) instead of the correct double-dash form (`--username=username`). This caused the `--help` output to display incorrect flag syntax, which could mislead users trying to follow the usage example.

One-character fix: `-username` -> `--username` in the `Use` template.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate. _(No test change needed — this is a string literal in a `cobra.Command.Use` field, covered by manual `--help` verification.)_
- [x] I have added or updated documentation as appropriate. _(No doc change needed — the `Use` field itself is the user-facing documentation.)_

### AI Use Disclosure

- [x] This PR was written by a human _without_ AI assistance.
- [ ] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**