### PR TITLE
feat(chart): minor chart improvements

### DIFF
--- a/charts/kargo/README.md
+++ b/charts/kargo/README.md
@@ -44,9 +44,15 @@
 
 ### Data Plane
 
-| Name                | Description                                                                                                                                                                                                                                                                                                                                                            | Value  |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `dataPlane.install` | Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. | `true` |
+| Name                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                | Value  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `dataPlane.install` | Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argoCD.dataPlane.install`. | `true` |
+
+### Argo CD Data Plane
+
+| Name                       | Description                                                                                                                                                                                                                                         | Value  |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `argoCD.dataPlane.install` | Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane. | `true` |
 
 ### CRDs
 

--- a/charts/kargo/README.md
+++ b/charts/kargo/README.md
@@ -46,13 +46,13 @@
 
 | Name                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                | Value  |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `dataPlane.install` | Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argoCD.dataPlane.install`. | `true` |
+| `dataPlane.install` | Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argocd.dataPlane.install`. | `true` |
 
 ### Argo CD Data Plane
 
 | Name                       | Description                                                                                                                                                                                                                                         | Value  |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `argoCD.dataPlane.install` | Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane. | `true` |
+| `argocd.dataPlane.install` | Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane. | `true` |
 
 ### CRDs
 

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-api
+      serviceAccountName: kargo-api
       {{- with .Values.api.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/api/service-account.yaml
+++ b/charts/kargo/templates/api/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install) .Values.api.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argoCD.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.argocd.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argocd.dataPlane.install .Values.controller.enabled .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/kargo/templates/argocd/role-binding.yaml
+++ b/charts/kargo/templates/argocd/role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.argoCD.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argocd.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argoCD.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.argocd.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argocd.dataPlane.install .Values.controller.enabled .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/kargo/templates/argocd/role.yaml
+++ b/charts/kargo/templates/argocd/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.argoCD.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
+{{- if and .Values.argocd.dataPlane.install .Values.controller.argocd.integrationEnabled .Values.controller.argocd.watchArgocdNamespaceOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/kargo/templates/controller/cluster-role-bindings.yaml
+++ b/charts/kargo/templates/controller/cluster-role-bindings.yaml
@@ -35,7 +35,7 @@ subjects:
   name: kargo-controller
 {{- end }}
 {{- end }}
-{{- if and .Values.argoCD.dataPlane.install .Values.rbac.installClusterRoleBindings .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
+{{- if and .Values.argocd.dataPlane.install .Values.rbac.installClusterRoleBindings .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/kargo/templates/controller/cluster-role-bindings.yaml
+++ b/charts/kargo/templates/controller/cluster-role-bindings.yaml
@@ -15,25 +15,6 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: kargo-controller
-{{- if and .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kargo-controller-argocd
-  labels:
-    {{- include "kargo.labels" . | nindent 4 }}
-    {{- include "kargo.controller.labels" . | nindent 4 }}
-  {{- include "kargo.annotations" (dict "root" . "annotations" .Values.controller.annotations) | nindent 2 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kargo-controller-argocd
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Release.Namespace }}
-  name: kargo-controller
-{{- end }}
 {{- if .Values.controller.rollouts.integrationEnabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,4 +34,23 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: kargo-controller
 {{- end }}
+{{- end }}
+{{- if and .Values.argoCD.dataPlane.install .Values.rbac.installClusterRoleBindings .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kargo-controller-argocd
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.controller.labels" . | nindent 4 }}
+  {{- include "kargo.annotations" (dict "root" . "annotations" .Values.controller.annotations) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-controller-argocd
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: kargo-controller
 {{- end }}

--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -153,7 +153,7 @@ rules:
   - deletecollection
 {{- end }}
 {{- end }}
-{{- if and .Values.argoCD.dataPlane.install .Values.rbac.installClusterRoles .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
+{{- if and .Values.argocd.dataPlane.install .Values.rbac.installClusterRoles .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -113,27 +113,6 @@ rules:
   - list
   - watch
 {{- end }}
-{{- if and .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kargo-controller-argocd
-  labels:
-    {{- include "kargo.labels" . | nindent 4 }}
-    {{- include "kargo.controller.labels" . | nindent 4 }}
-  {{- include "kargo.annotations" (dict "root" . "annotations" .Values.controller.annotations) | nindent 2 }}
-rules:
-- apiGroups:
-  - argoproj.io
-  resources:
-  - applications
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-{{- end }}
 {{- if .Values.controller.rollouts.integrationEnabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -173,4 +152,25 @@ rules:
   - watch
   - deletecollection
 {{- end }}
+{{- end }}
+{{- if and .Values.argoCD.dataPlane.install .Values.rbac.installClusterRoles .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kargo-controller-argocd
+  labels:
+    {{- include "kargo.labels" . | nindent 4 }}
+    {{- include "kargo.controller.labels" . | nindent 4 }}
+  {{- include "kargo.annotations" (dict "root" . "annotations" .Values.controller.annotations) | nindent 2 }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
 {{- end }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-controller
+      serviceAccountName: kargo-controller
       {{- with .Values.controller.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/controller/service-account.yaml
+++ b/charts/kargo/templates/controller/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install .Values.argoCD.dataPlane.install) .Values.controller.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/controller/service-account.yaml
+++ b/charts/kargo/templates/controller/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.workloads.install .Values.dataPlane.install .Values.argoCD.dataPlane.install) .Values.controller.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install .Values.argocd.dataPlane.install) .Values.controller.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-dex-server
+      serviceAccountName: kargo-dex-server
       {{- with .Values.api.oidc.dex.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/dex-server/service-account.yaml
+++ b/charts/kargo/templates/dex-server/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.api.enabled .Values.api.oidc.enabled .Values.api.oidc.dex.enabled }}
+{{- if and .Values.workloads.install .Values.api.enabled .Values.api.oidc.enabled .Values.api.oidc.dex.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/external-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/external-webhooks-server/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-external-webhooks-server
+      serviceAccountName: kargo-external-webhooks-server
       {{- with .Values.externalWebhooksServer.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/external-webhooks-server/service-account.yaml
+++ b/charts/kargo/templates/external-webhooks-server/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalWebhooksServer.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install) .Values.externalWebhooksServer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/garbage-collector/service-account.yaml
+++ b/charts/kargo/templates/garbage-collector/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.garbageCollector.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install) .Values.garbageCollector.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-webhooks-server
+      serviceAccountName: kargo-webhooks-server
       {{- with .Values.webhooksServer.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/kubernetes-webhooks-server/service-account.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhooksServer.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install) .Values.webhooksServer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccount: kargo-management-controller
+      serviceAccountName: kargo-management-controller
       {{- with .Values.managementController.affinity | default .Values.global.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kargo/templates/management-controller/service-account.yaml
+++ b/charts/kargo/templates/management-controller/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.managementController.enabled }}
+{{- if and (or .Values.workloads.install .Values.dataPlane.install) .Values.managementController.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -81,8 +81,14 @@ workloads:
 
 ## @section Data Plane
 dataPlane:
-  ## @param dataPlane.install Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them.
+  ## @param dataPlane.install Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argoCD.dataPlane.install`.
   install: true
+
+## @section Argo CD Data Plane
+argoCD:
+  ## @param argoCD.dataPlane.install Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane.
+  dataPlane:
+    install: true
 
 ## @section CRDs
 crds:

--- a/charts/kargo/values.yaml
+++ b/charts/kargo/values.yaml
@@ -81,12 +81,12 @@ workloads:
 
 ## @section Data Plane
 dataPlane:
-  ## @param dataPlane.install Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argoCD.dataPlane.install`.
+  ## @param dataPlane.install Coarse switch that, when `false`, suppresses every data-plane resource — even where finer-grained flags (`crds.install`, `rbac.installClusterRoles`, `rbac.installClusterRoleBindings`, `webhooks.register`, `global.createClusterSecretsNamespace`, `global.sharedResources.createNamespace`, `global.systemResources.createNamespace`) would otherwise install them. Note: Argo CD data-plane RBAC is governed separately by `argocd.dataPlane.install`.
   install: true
 
 ## @section Argo CD Data Plane
-argoCD:
-  ## @param argoCD.dataPlane.install Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane.
+argocd:
+  ## @param argocd.dataPlane.install Coarse switch governing Argo CD data-plane resources — the RBAC granting the controller access to Argo CD `Application` resources. Separate from `dataPlane.install` because Argo CD may reside in a different cluster than Kargo's own data plane.
   dataPlane:
     install: true
 


### PR DESCRIPTION
Follow-up to #6318:

* Introduces one more coarse-grained switch -- `argocd.dataPlane.install` -- to make it easier, downstream, to include or not include, in the results of `helm template`, the Kargo resources that are to be installed into a complementary Argo CD control plane's cluster.

* Limits installation of the Dex ServiceAccount to the cluster in which Dex runs -- unlike other components, if the data plane were elsewhere, Dex doesn't need any footprint in that other cluster.

* Swaps `serviceAccount` in workload definitions (deprecated since k8s 1.8) for canonical field name `serviceAccountName`.