### PR TITLE
feat: make Kubernetes webhook server port configurable

### DIFF
--- a/cmd/controlplane/kubernetes_webhooks.go
+++ b/cmd/controlplane/kubernetes_webhooks.go
@@ -39,6 +39,8 @@ type kubernetesWebhooksServerOptions struct {
 	QPS        float32
 	Burst      int
 
+	WebhookServerPort int
+
 	MetricsBindAddress string
 	PprofBindAddress   string
 
@@ -81,6 +83,8 @@ func (o *kubernetesWebhooksServerOptions) complete() {
 	o.QPS = types.MustParseFloat32(os.GetEnv("KUBE_API_QPS", "50.0"))
 	o.Burst = types.MustParseInt(os.GetEnv("KUBE_API_BURST", "300"))
 
+	o.WebhookServerPort = types.MustParseInt(os.GetEnv("WEBHOOK_SERVER_PORT", "9443"))
+
 	o.MetricsBindAddress = os.GetEnv("METRICS_BIND_ADDRESS", "0")
 	o.PprofBindAddress = os.GetEnv("PPROF_BIND_ADDRESS", "")
 
@@ -118,7 +122,7 @@ func (o *kubernetesWebhooksServerOptions) run(ctx context.Context) error {
 			Scheme: scheme,
 			WebhookServer: webhook.NewServer(
 				webhook.Options{
-					Port: 9443,
+					Port: o.WebhookServerPort,
 				},
 			),
 			Metrics: server.Options{


### PR DESCRIPTION
Closes #5768
Supersedes #5769

## Summary

The webhook server port is hardcoded to `9443` in the Go binary, making it impossible to change without forking when running in environments where port 9443 conflicts with other services (e.g. `hostNetwork: true` with Cilium CNI).

This PR adds a `WEBHOOK_SERVER_PORT` environment variable (default `"9443"`) to make the port configurable, following the same pattern used for `KUBE_API_QPS`, `KUBE_API_BURST`, and `METRICS_BIND_ADDRESS`.

### Changes

- **`cmd/controlplane/kubernetes_webhooks.go`**: Added `WebhookServerPort` field to the options struct. Reads `WEBHOOK_SERVER_PORT` env var (default `"9443"`) in `complete()`. Uses the field in `webhook.Options{Port: ...}` instead of the hardcoded value.

**No Helm chart changes** — per maintainer feedback in #5769, this is Go-code-only. Users who need a non-default port can set the env var via Kustomize or other last-mile config management.

### Motivation

When running Kargo alongside other operators that also bind their webhook servers to port 9443 under `hostNetwork: true` (common with Cilium in kube-proxy replacement mode on EKS), there is no way to resolve the conflict without forking. This change lets operators set a custom port via environment variable while remaining fully backward compatible — existing installations default to `9443` with no change in behavior.

## Test plan

- [x] Verify `go build ./cmd/controlplane/` compiles cleanly
- [ ] Deploy with default values and confirm webhook server listens on 9443 (no behavioral change)
- [ ] Set `WEBHOOK_SERVER_PORT=10288` env var and confirm webhook server listens on 10288

Made with [Cursor](https://cursor.com)