### PR TITLE
fix: verificationHistory entry finishTime was incorrectly set

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -1350,14 +1350,13 @@ func (r *RegularStageReconciler) startVerification(
 		if existingAnalysisRun != nil {
 			logger.Debug("AnalysisRun already exists for FreightCollection")
 
-			newVI.FinishTime = existingAnalysisRun.Status.CompletedAt()
+			newVI.FinishTime = ptr.To(metav1.Now())
 			newVI.Phase = kargoapi.VerificationPhase(existingAnalysisRun.Status.Phase)
 			newVI.AnalysisRun = &kargoapi.AnalysisRunReference{
 				Name:      existingAnalysisRun.Name,
 				Namespace: existingAnalysisRun.Namespace,
 				Phase:     string(existingAnalysisRun.Status.Phase),
 			}
-			newVI.FinishTime = existingAnalysisRun.Status.CompletedAt()
 			return newVI, nil
 		}
 	}

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -3692,6 +3692,13 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.NotEmpty(t, vi.ID)
 				assert.Equal(t, kargoapi.VerificationPhaseSuccessful, vi.Phase)
 				assert.Equal(t, "existing-analysis", vi.AnalysisRun.Name)
+				// Both timestamps should be the reconciliation time so that
+				// startTime <= finishTime always holds regardless of when the
+				// AnalysisRun internally ran.
+				require.NotNil(t, vi.StartTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, now.Unix(), vi.StartTime.Unix())
+				assert.Equal(t, now.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -3737,6 +3744,10 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.NotEmpty(t, vi.ID)
 				assert.Equal(t, kargoapi.VerificationPhaseSuccessful, vi.Phase)
 				assert.Equal(t, "existing-analysis", vi.AnalysisRun.Name)
+				require.NotNil(t, vi.StartTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, now.Unix(), vi.StartTime.Unix())
+				assert.Equal(t, now.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{


### PR DESCRIPTION
## Description

When testing Kargo, my Stage's verification history resulted in the following entry, which has incorrect bookkeeping:

```yaml
      verificationHistory:
        - analysisRun:
            name: staging.01ksre8aw2tv0h8qtsrrysgn22.628ebf7
            namespace: auto-rollback
            phase: Successful
          startTime: 2026-05-28T23:22:10Z
          finishTime: 2026-05-28T23:21:17Z # <<<< finishTime is *before* startTime
          id: 818fcf1e-bcf3-40ca-ac63-b976d3add50e
          phase: Successful
```

When looking at the code, it seems that we would use the **_existing_** AnalysisRun's timestamp to set verification info. However, VerificationInfo timestamps should represent Kargo's processing of the verification, not the AnalysisRun's internal clock. This fix uses time.Now(), which is already the established pattern in other parts of this function.


## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [x] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
