### PR TITLE
fix: prevent AnalysisRun reuse across promotions of the same freight

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -1292,8 +1292,9 @@ func (r *RegularStageReconciler) recordFreightVerificationEvent(
 }
 
 // startVerification starts a new verification for the Freight that is associated
-// with the Stage. If the Freight has already been verified, then no verification
-// is started unless a re-verification is requested.
+// with the Stage. If an AnalysisRun already exists for the current promotion,
+// its status is returned without creating a new run. A re-verification request
+// always creates a new AnalysisRun.
 //
 // If there is no verification configuration for the Stage, then the verification
 // is automatically considered successful and no verification is started.
@@ -1332,14 +1333,18 @@ func (r *RegularStageReconciler) startVerification(
 
 	logger := logging.LoggerFromContext(ctx)
 
-	// If this is not a re-verification request, check if there is an existing
-	// AnalysisRun for the Stage and Freight. If there is, return the status
-	// of the existing AnalysisRun.
+	// If this is not a re-verification request, check if an AnalysisRun already
+	// exists for the current promotion. If so, return its status without
+	// creating a new run.
 	if req == nil {
+		var promotionName string
+		if stage.Status.LastPromotion != nil {
+			promotionName = stage.Status.LastPromotion.Name
+		}
 		existingAnalysisRun, err := r.findExistingAnalysisRun(ctx, types.NamespacedName{
 			Namespace: stage.Namespace,
 			Name:      stage.Name,
-		}, freight.ID)
+		}, freight.ID, promotionName)
 		if err != nil {
 			newVI.FinishTime = ptr.To(metav1.Now())
 			newVI.Phase = kargoapi.VerificationPhaseError
@@ -1414,12 +1419,10 @@ func (r *RegularStageReconciler) startVerification(
 			Reference:  types.NamespacedName{Namespace: stage.Namespace, Name: freightRef.Name},
 		})
 	}
-	if curVI == nil || (req.ForID(curVI.ID) && req.ControlPlane && req.Actor != "") {
-		if stage.Status.LastPromotion != nil {
-			builderOpts = append(builderOpts, rollouts.WithExtraAnnotations{
-				kargoapi.AnnotationKeyPromotion: stage.Status.LastPromotion.Name,
-			})
-		}
+	if stage.Status.LastPromotion != nil {
+		builderOpts = append(builderOpts, rollouts.WithExtraAnnotations{
+			kargoapi.AnnotationKeyPromotion: stage.Status.LastPromotion.Name,
+		})
 	}
 	ar, err := builder.Build(ctx, stage.Namespace, stage.Spec.Verification, builderOpts...)
 	if err != nil {
@@ -1628,13 +1631,16 @@ func (r *RegularStageReconciler) abortVerification(
 	}, nil
 }
 
-// findExistingAnalysisRun finds the most recent AnalysisRun for a Stage and
-// Freight collection in the namespace of the Stage. If no AnalysisRun is found,
-// it returns nil.
+// findExistingAnalysisRun finds the most recent AnalysisRun for a Stage,
+// Freight collection, and Promotion in the namespace of the Stage. The
+// promotionName is matched against the kargo.akuity.io/promotion annotation on
+// the AnalysisRun; when empty the annotation filter is skipped. Returns nil if
+// no matching AnalysisRun is found.
 func (r *RegularStageReconciler) findExistingAnalysisRun(
 	ctx context.Context,
 	stage types.NamespacedName,
 	freightColID string,
+	promotionName string,
 ) (*rolloutsapi.AnalysisRun, error) {
 	analysisRuns := &rolloutsapi.AnalysisRunList{}
 	if err := r.client.List(
@@ -1658,12 +1664,25 @@ func (r *RegularStageReconciler) findExistingAnalysisRun(
 		return nil, nil
 	}
 
+	// Filter by the promotion annotation so that AnalysisRuns belonging to a
+	// previous promotion of the same freight are not reused.
+	items := analysisRuns.Items
+	if promotionName != "" {
+		items = slices.DeleteFunc(items, func(ar rolloutsapi.AnalysisRun) bool {
+			return ar.Annotations[kargoapi.AnnotationKeyPromotion] != promotionName
+		})
+	}
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+
 	// Sort the AnalysisRuns by creation timestamp, so that the most recent
 	// one is first.
-	slices.SortFunc(analysisRuns.Items, func(lhs, rhs rolloutsapi.AnalysisRun) int {
+	slices.SortFunc(items, func(lhs, rhs rolloutsapi.AnalysisRun) int {
 		return rhs.CreationTimestamp.Compare(lhs.CreationTimestamp.Time)
 	})
-	return &analysisRuns.Items[0], nil
+	return &items[0], nil
 }
 
 // autoPromoteFreight automatically promotes the latest promotable (i.e.

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -4723,12 +4723,13 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 	twoHoursAgo := now.Add(-2 * time.Hour)
 
 	tests := []struct {
-		name         string
-		stage        types.NamespacedName
-		freightColID string
-		objects      []client.Object
-		interceptor  interceptor.Funcs
-		assertions   func(*testing.T, *rolloutsapi.AnalysisRun, error)
+		name          string
+		stage         types.NamespacedName
+		freightColID  string
+		promotionName string
+		objects       []client.Object
+		interceptor   interceptor.Funcs
+		assertions    func(*testing.T, *rolloutsapi.AnalysisRun, error)
 	}{
 		{
 			name: "no analysis runs found",
@@ -4770,7 +4771,8 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 				Namespace: "fake-project",
 				Name:      "test-stage",
 			},
-			freightColID: "test-collection",
+			freightColID:  "test-collection",
+			promotionName: "test-promotion",
 			objects: []client.Object{
 				&rolloutsapi.AnalysisRun{
 					ObjectMeta: metav1.ObjectMeta{
@@ -4780,6 +4782,9 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 						Labels: map[string]string{
 							kargoapi.LabelKeyStage:             "test-stage",
 							kargoapi.LabelKeyFreightCollection: "test-collection",
+						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyPromotion: "test-promotion",
 						},
 					},
 					Status: rolloutsapi.AnalysisRunStatus{
@@ -4795,6 +4800,9 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 							kargoapi.LabelKeyStage:             "test-stage",
 							kargoapi.LabelKeyFreightCollection: "test-collection",
 						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyPromotion: "test-promotion",
+						},
 					},
 					Status: rolloutsapi.AnalysisRunStatus{
 						Phase: "Failed",
@@ -4807,6 +4815,106 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 				require.NotNil(t, ar)
 				assert.Equal(t, "newer-analysis", ar.Name)
 				assert.Equal(t, hourAgo.Unix(), ar.CreationTimestamp.Unix())
+			},
+		},
+		{
+			name: "filters by promotion annotation",
+			stage: types.NamespacedName{
+				Namespace: "fake-project",
+				Name:      "test-stage",
+			},
+			freightColID:  "test-collection",
+			promotionName: "current-promotion",
+			objects: []client.Object{
+				&rolloutsapi.AnalysisRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "previous-promotion-analysis",
+						Namespace:         "fake-project",
+						CreationTimestamp: metav1.Time{Time: hourAgo},
+						Labels: map[string]string{
+							kargoapi.LabelKeyStage:             "test-stage",
+							kargoapi.LabelKeyFreightCollection: "test-collection",
+						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyPromotion: "previous-promotion",
+						},
+					},
+				},
+				&rolloutsapi.AnalysisRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "current-promotion-analysis",
+						Namespace:         "fake-project",
+						CreationTimestamp: metav1.Time{Time: twoHoursAgo},
+						Labels: map[string]string{
+							kargoapi.LabelKeyStage:             "test-stage",
+							kargoapi.LabelKeyFreightCollection: "test-collection",
+						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyPromotion: "current-promotion",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, ar *rolloutsapi.AnalysisRun, err error) {
+				require.NoError(t, err)
+
+				require.NotNil(t, ar)
+				assert.Equal(t, "current-promotion-analysis", ar.Name)
+			},
+		},
+		{
+			name: "returns nil when all runs belong to a different promotion",
+			stage: types.NamespacedName{
+				Namespace: "fake-project",
+				Name:      "test-stage",
+			},
+			freightColID:  "test-collection",
+			promotionName: "current-promotion",
+			objects: []client.Object{
+				&rolloutsapi.AnalysisRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "previous-promotion-analysis",
+						Namespace: "fake-project",
+						Labels: map[string]string{
+							kargoapi.LabelKeyStage:             "test-stage",
+							kargoapi.LabelKeyFreightCollection: "test-collection",
+						},
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyPromotion: "previous-promotion",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, ar *rolloutsapi.AnalysisRun, err error) {
+				require.NoError(t, err)
+				assert.Nil(t, ar)
+			},
+		},
+		{
+			name: "skips promotion filter when promotionName is empty",
+			stage: types.NamespacedName{
+				Namespace: "fake-project",
+				Name:      "test-stage",
+			},
+			freightColID:  "test-collection",
+			promotionName: "",
+			objects: []client.Object{
+				&rolloutsapi.AnalysisRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-analysis",
+						Namespace: "fake-project",
+						Labels: map[string]string{
+							kargoapi.LabelKeyStage:             "test-stage",
+							kargoapi.LabelKeyFreightCollection: "test-collection",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, ar *rolloutsapi.AnalysisRun, err error) {
+				require.NoError(t, err)
+
+				require.NotNil(t, ar)
+				assert.Equal(t, "test-analysis", ar.Name)
 			},
 		},
 		{
@@ -4969,7 +5077,7 @@ func TestRegularStageReconciler_findExistingAnalysisRun(t *testing.T) {
 				client: c,
 			}
 
-			ar, err := r.findExistingAnalysisRun(t.Context(), tt.stage, tt.freightColID)
+			ar, err := r.findExistingAnalysisRun(t.Context(), tt.stage, tt.freightColID, tt.promotionName)
 			tt.assertions(t, ar, err)
 		})
 	}


### PR DESCRIPTION
## Description

Closes https://github.com/akuity/kargo/issues/6372

When the same freight was promoted a second time, `findExistingAnalysisRun` would find the AnalysisRun from the first promotion (matching on stage + freight collection labels) and return it as already-existing — so `startVerification` returned early and never created a new AnalysisRun for the second promotion.

The fix adds the `kargo.akuity.io/promotion` annotation as an additional filter in `findExistingAnalysisRun`. An AnalysisRun from a prior promotion of the same freight is therefore invisible to the check, and a new run is created as expected.

The promotion annotation is now always set when creating a new AnalysisRun, ensuring the filter is reliably populated on every run.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [X] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
