### PR TITLE
fix: add warehouse name to freight created events

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -9,6 +9,7 @@ const (
 	AnnotationKeyEventFreightAlias           = AnnotationKeyEventPrefix + "freight-alias"
 	AnnotationKeyEventFreightName            = AnnotationKeyEventPrefix + "freight-name"
 	AnnotationKeyEventFreightCreateTime      = AnnotationKeyEventPrefix + "freight-create-time"
+	AnnotationKeyEventFreightWarehouseName   = AnnotationKeyEventPrefix + "freight-warehouse-name"
 	AnnotationKeyEventFreightCommits         = AnnotationKeyEventPrefix + "freight-commits"
 	AnnotationKeyEventFreightImages          = AnnotationKeyEventPrefix + "freight-images"
 	AnnotationKeyEventFreightCharts          = AnnotationKeyEventPrefix + "freight-charts"

--- a/pkg/event/freight.go
+++ b/pkg/event/freight.go
@@ -12,14 +12,15 @@ import (
 
 // Freight is a struct that contains common fields for freight-related events.
 type Freight struct {
-	Name       string                       `json:"name"`
-	StageName  string                       `json:"stageName"`
-	CreateTime time.Time                    `json:"createTime"`
-	Alias      *string                      `json:"alias,omitempty"`
-	Commits    []kargoapi.GitCommit         `json:"commits,omitempty"`
-	Images     []kargoapi.Image             `json:"images,omitempty"`
-	Charts     []kargoapi.Chart             `json:"charts,omitempty"`
-	Artifacts  []kargoapi.ArtifactReference `json:"artifacts,omitempty"`
+	Name          string                       `json:"name"`
+	StageName     string                       `json:"stageName"`
+	WarehouseName string                       `json:"warehouseName,omitempty"`
+	CreateTime    time.Time                    `json:"createTime"`
+	Alias         *string                      `json:"alias,omitempty"`
+	Commits       []kargoapi.GitCommit         `json:"commits,omitempty"`
+	Images        []kargoapi.Image             `json:"images,omitempty"`
+	Charts        []kargoapi.Chart             `json:"charts,omitempty"`
+	Artifacts     []kargoapi.ArtifactReference `json:"artifacts,omitempty"`
 }
 
 func (f Freight) GetName() string {
@@ -325,6 +326,9 @@ func (f *Freight) MarshalAnnotationsTo(annotations map[string]string) {
 	annotations[kargoapi.AnnotationKeyEventFreightName] = f.Name
 	annotations[kargoapi.AnnotationKeyEventFreightCreateTime] = f.CreateTime.Format(time.RFC3339)
 	annotations[kargoapi.AnnotationKeyEventStageName] = f.StageName
+	if f.WarehouseName != "" {
+		annotations[kargoapi.AnnotationKeyEventFreightWarehouseName] = f.WarehouseName
+	}
 	if f.Alias != nil {
 		annotations[kargoapi.AnnotationKeyEventFreightAlias] = *f.Alias
 	}
@@ -420,6 +424,7 @@ func UnmarshalFreightAnnotations(annotations map[string]string) (Freight, error)
 	if name, ok := annotations[kargoapi.AnnotationKeyEventFreightName]; ok && name != "" {
 		evt.Name = name
 		evt.StageName = annotations[kargoapi.AnnotationKeyEventStageName]
+		evt.WarehouseName = annotations[kargoapi.AnnotationKeyEventFreightWarehouseName]
 
 		if createTimeStr, ok := annotations[kargoapi.AnnotationKeyEventFreightCreateTime]; ok && createTimeStr != "" {
 			createTime, err := parseTime(createTimeStr)
@@ -677,6 +682,9 @@ func newFreight(freight *kargoapi.Freight, stageName string) Freight {
 		CreateTime: freight.CreationTimestamp.Time,
 		Name:       freight.Name,
 		StageName:  stageName,
+	}
+	if freight.Origin.Name != "" {
+		evt.WarehouseName = freight.Origin.Name
 	}
 	if freight.Alias != "" {
 		evt.Alias = &freight.Alias

--- a/pkg/event/freight_test.go
+++ b/pkg/event/freight_test.go
@@ -291,6 +291,10 @@ func TestNewFreightCreated(t *testing.T) {
 			Namespace:         "test-project",
 			CreationTimestamp: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 		},
+		Origin: kargoapi.FreightOrigin{
+			Kind: kargoapi.FreightOriginKindWarehouse,
+			Name: "test-warehouse",
+		},
 	}
 
 	evt := NewFreightCreated("Freight created", "test-actor", freight)
@@ -300,6 +304,7 @@ func TestNewFreightCreated(t *testing.T) {
 	require.Equal(t, "test-freight", evt.GetName())
 	require.Equal(t, "Freight", evt.Kind())
 	require.Equal(t, "Freight created", evt.GetMessage())
+	require.Equal(t, "test-warehouse", evt.WarehouseName)
 }
 
 func TestFreightEventMarshalAnnotations(t *testing.T) {
@@ -310,6 +315,10 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 			CreationTimestamp: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 		},
 		Alias: "v1.0.0",
+		Origin: kargoapi.FreightOrigin{
+			Kind: kargoapi.FreightOriginKindWarehouse,
+			Name: "test-warehouse",
+		},
 	}
 	verification := &kargoapi.VerificationInfo{
 		StartTime:  &metav1.Time{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
@@ -327,6 +336,7 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 				kargoapi.AnnotationKeyEventActor:                  "test-actor",
 				kargoapi.AnnotationKeyEventFreightName:            "test-freight",
 				kargoapi.AnnotationKeyEventFreightCreateTime:      "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName:   "test-warehouse",
 				kargoapi.AnnotationKeyEventStageName:              "test-stage",
 				kargoapi.AnnotationKeyEventFreightAlias:           "v1.0.0",
 				kargoapi.AnnotationKeyEventVerificationStartTime:  "2024-01-01T10:00:00Z",
@@ -340,6 +350,7 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 				kargoapi.AnnotationKeyEventActor:             "test-actor",
 				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
 				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName: "test-warehouse",
 				kargoapi.AnnotationKeyEventStageName:         "test-stage",
 				kargoapi.AnnotationKeyEventFreightAlias:      "v1.0.0",
 			},
@@ -347,12 +358,13 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 		"freight created": {
 			event: NewFreightCreated("Freight created", "test-actor", freight),
 			expected: map[string]string{
-				kargoapi.AnnotationKeyEventProject:           "test-project",
-				kargoapi.AnnotationKeyEventActor:             "test-actor",
-				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
-				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
-				kargoapi.AnnotationKeyEventStageName:         "",
-				kargoapi.AnnotationKeyEventFreightAlias:      "v1.0.0",
+				kargoapi.AnnotationKeyEventProject:              "test-project",
+				kargoapi.AnnotationKeyEventActor:                "test-actor",
+				kargoapi.AnnotationKeyEventFreightName:          "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime:    "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName: "test-warehouse",
+				kargoapi.AnnotationKeyEventStageName:            "",
+				kargoapi.AnnotationKeyEventFreightAlias:         "v1.0.0",
 			},
 		},
 	}
@@ -435,6 +447,7 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 				kargoapi.AnnotationKeyEventProject:                "test-project",
 				kargoapi.AnnotationKeyEventFreightName:            "test-freight",
 				kargoapi.AnnotationKeyEventFreightCreateTime:      "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName:   "test-warehouse",
 				kargoapi.AnnotationKeyEventStageName:              "test-stage",
 				kargoapi.AnnotationKeyEventVerificationStartTime:  "2024-01-01T10:00:00Z",
 				kargoapi.AnnotationKeyEventVerificationFinishTime: "2024-01-01T11:00:00Z",
@@ -448,9 +461,10 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 					ID:      "event-id",
 				},
 				Freight: Freight{
-					Name:       "test-freight",
-					StageName:  "test-stage",
-					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Name:          "test-freight",
+					StageName:     "test-stage",
+					WarehouseName: "test-warehouse",
+					CreateTime:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 				FreightVerification: FreightVerification{
 					StartTime:  ptr.To(time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)),
@@ -460,10 +474,11 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 		},
 		"freight approved": {
 			annotations: map[string]string{
-				kargoapi.AnnotationKeyEventProject:           "test-project",
-				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
-				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
-				kargoapi.AnnotationKeyEventStageName:         "test-stage",
+				kargoapi.AnnotationKeyEventProject:              "test-project",
+				kargoapi.AnnotationKeyEventFreightName:          "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime:    "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName: "test-warehouse",
+				kargoapi.AnnotationKeyEventStageName:            "test-stage",
 			},
 			unmarshalFunc: func(annotations map[string]string) (Meta, error) {
 				return UnmarshalFreightApprovedAnnotations("event-id", annotations)
@@ -474,17 +489,19 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 					ID:      "event-id",
 				},
 				Freight: Freight{
-					Name:       "test-freight",
-					StageName:  "test-stage",
-					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Name:          "test-freight",
+					StageName:     "test-stage",
+					WarehouseName: "test-warehouse",
+					CreateTime:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 			},
 		},
 		"freight created": {
 			annotations: map[string]string{
-				kargoapi.AnnotationKeyEventProject:           "test-project",
-				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
-				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventProject:              "test-project",
+				kargoapi.AnnotationKeyEventFreightName:          "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime:    "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventFreightWarehouseName: "test-warehouse",
 			},
 			unmarshalFunc: func(annotations map[string]string) (Meta, error) {
 				return UnmarshalFreightCreatedAnnotations("event-id", annotations)
@@ -495,8 +512,9 @@ func TestFreightEventUnmarshalAnnotations(t *testing.T) {
 					ID:      "event-id",
 				},
 				Freight: Freight{
-					Name:       "test-freight",
-					CreateTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Name:          "test-freight",
+					CreateTime:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					WarehouseName: "test-warehouse",
 				},
 			},
 		},

--- a/pkg/event/freight_test.go
+++ b/pkg/event/freight_test.go
@@ -346,13 +346,13 @@ func TestFreightEventMarshalAnnotations(t *testing.T) {
 		"freight approved": {
 			event: NewFreightApproved("Freight approved", "test-actor", "test-stage", freight),
 			expected: map[string]string{
-				kargoapi.AnnotationKeyEventProject:           "test-project",
-				kargoapi.AnnotationKeyEventActor:             "test-actor",
-				kargoapi.AnnotationKeyEventFreightName:       "test-freight",
-				kargoapi.AnnotationKeyEventFreightCreateTime: "2024-01-01T00:00:00Z",
+				kargoapi.AnnotationKeyEventProject:              "test-project",
+				kargoapi.AnnotationKeyEventActor:                "test-actor",
+				kargoapi.AnnotationKeyEventFreightName:          "test-freight",
+				kargoapi.AnnotationKeyEventFreightCreateTime:    "2024-01-01T00:00:00Z",
 				kargoapi.AnnotationKeyEventFreightWarehouseName: "test-warehouse",
-				kargoapi.AnnotationKeyEventStageName:         "test-stage",
-				kargoapi.AnnotationKeyEventFreightAlias:      "v1.0.0",
+				kargoapi.AnnotationKeyEventStageName:            "test-stage",
+				kargoapi.AnnotationKeyEventFreightAlias:         "v1.0.0",
 			},
 		},
 		"freight created": {


### PR DESCRIPTION
## Description

Add warehouse name in freight created events

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
