### PR TITLE
fix: Use ECR provider only if repo URL regex matches

### DIFF
--- a/pkg/credentials/ecr/managed_identity.go
+++ b/pkg/credentials/ecr/managed_identity.go
@@ -106,7 +106,7 @@ func (p *ManagedIdentityProvider) Supports(
 	if req.Type != credentials.TypeImage && req.Type != credentials.TypeHelm {
 		return false, nil
 	}
-	return true, nil
+	return ecrURLRegex.MatchString(req.RepoURL), nil
 }
 
 func (p *ManagedIdentityProvider) GetCredentials(

--- a/pkg/credentials/ecr/managed_identity_test.go
+++ b/pkg/credentials/ecr/managed_identity_test.go
@@ -62,6 +62,24 @@ func TestManagedIdentityProvider_Supports(t *testing.T) {
 			repoURL:  fakeRepoURL,
 			expected: false,
 		},
+		{
+			name: "non-ECR image URL not supported",
+			provider: &ManagedIdentityProvider{
+				accountID: fakeAccountID,
+			},
+			credType: credentials.TypeImage,
+			repoURL:  "us-docker.pkg.dev/project/repo/image",
+			expected: false,
+		},
+		{
+			name: "non-ECR helm URL not supported",
+			provider: &ManagedIdentityProvider{
+				accountID: fakeAccountID,
+			},
+			credType: credentials.TypeHelm,
+			repoURL:  "us-docker.pkg.dev/project/repo/chart",
+			expected: false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Description

Closes #6332

Fixes a bug to update the ECR `Support()` function such that the ECR provider is only selected if the repo URL matches the expected ECR url format. Otherwise, this ends up returning `true` for all repo URLs, including non-ECR repos. 

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [x] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [x] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
