### PR TITLE
build: bump Go builder image to golang:1.26.3-trixie (release-1.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.26.1-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Direct `release-1.10` change (not a backport — `main` already runs `golang:1.26.3`, reached via #6066 / #6256).

## Why

`release-1.10` builds the kargo binary with **`golang:1.26.1-trixie`**, whose Go stdlib carries several Critical/High CVEs (e.g. `CVE-2026-27143`). Once the stale Helm binary is addressed (#6378 / #6379), these stdlib findings account for **nearly all** of the remaining Critical/High against the v1.10.x image.

This bumps the builder to **`golang:1.26.3-trixie`** — a Go *patch* bump (not a new minor), matching `main`.

## CVE impact (grype, linux/arm64), measured on combined images

| Build | Critical | High | Total |
|---|---|---|---|
| v1.10.4 (shipped) | 15 | 68 | 155 |
| release-1.10 + Helm fix only (#6379) | 2 | 26 | 45 |
| **+ this Go bump (the real v1.10.5)** | **0** | **2** | **3** |

The 2 residual Highs are both the vendored `containerd` advisory `GHSA-fqw6-gf59-qr4w`, for which no fixed Helm/containerd release is available yet.

## Relationship to #6379

Independent change, but together with the Helm-binary backport (#6379) this is what brings **v1.10.5** to 0 Critical / 2 High. Held as draft pending coordination of the v1.10.5 set.