### PR TITLE
fix(chart): quote OIDC_ADDITIONAL_SCOPES to avoid null in ConfigMap

### DIFF
--- a/charts/kargo/templates/api/configmap.yaml
+++ b/charts/kargo/templates/api/configmap.yaml
@@ -38,7 +38,7 @@ data:
   {{- end }}
   {{- if .Values.api.oidc.enabled }}
   OIDC_ENABLED: "true"
-  OIDC_ADDITIONAL_SCOPES: {{ join "," .Values.api.oidc.additionalScopes }}
+  OIDC_ADDITIONAL_SCOPES: {{ join "," .Values.api.oidc.additionalScopes | quote }}
   {{- if .Values.api.oidc.globalServiceAccounts.namespaces }}
   GLOBAL_SERVICE_ACCOUNT_NAMESPACES: {{ .Release.Namespace }},{{ join "," .Values.api.oidc.globalServiceAccounts.namespaces }}
   {{- else }}


### PR DESCRIPTION
## Description

When `api.oidc.additionalScopes` is empty, the api ConfigMap renders `OIDC_ADDITIONAL_SCOPES:` with an empty value, which YAML parses as `null`. ConfigMap `data` is string-typed, so the API server drops the key entirely. GitOps tools such as Argo CD then report a permanent, unreconcilable diff between the desired manifest (key present and `null`) and the live ConfigMap (key absent).

Quoting the value renders it as an empty string, which is preserved as-is and eliminates the drift. Non-empty scope lists are unaffected, and this matches the quoting already used by the surrounding keys in the same ConfigMap (e.g. `PERMISSIVE_CORS_POLICY_ENABLED`, `LOG_LEVEL`).

## Checklist

### Eligibility

- [x] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
