### PR TITLE
fix: no freight created for moved files

### DIFF
--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -60,8 +60,10 @@ type WorkTree interface {
 	// who cloned the repo associated with this working tree.
 	HomeDir() string
 	// GetDiffPathsForCommitID returns a string slice indicating the paths,
-	// relative to the root of the repository, of any files that are new or
-	// modified in the commit with the given ID.
+	// relative to the root of the repository, of any files that are added,
+	// modified, deleted, or renamed/moved in the commit with the given ID. For
+	// renamed or moved files, both the old and new paths are included so that
+	// path-based filters can match on either side of the move.
 	GetDiffPathsForCommitID(commitID string) ([]string, error)
 	// IsAncestor returns true if parent branch is an ancestor of child
 	IsAncestor(parent string, child string) (bool, error)
@@ -399,18 +401,30 @@ func (w *workTree) Fetch(opts *FetchOptions) error {
 }
 
 func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(w.buildGitCommand("show", "--pretty=", "--name-only", "--first-parent", commitID))
+	resBytes, err := libExec.Exec(w.buildGitCommand("show", "--pretty=", "--name-status", "--first-parent", commitID))
 	if err != nil {
 		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}
 	var paths []string
 	scanner := bufio.NewScanner(bytes.NewReader(resBytes))
-	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		paths = append(
-			paths,
-			scanner.Text(),
-		)
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		// --name-status output is tab-separated: <status>\t<path> for most
+		// changes, or <status>\t<old-path>\t<new-path> for renames and copies.
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		// For renames (R) and copies (C), include both old and new paths so
+		// that a path filter matching the source directory detects the removal.
+		if len(parts) == 3 && len(parts[0]) > 0 && (parts[0][0] == 'R' || parts[0][0] == 'C') {
+			paths = append(paths, parts[1], parts[2])
+		} else {
+			paths = append(paths, parts[1])
+		}
 	}
 	return paths, nil
 }

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -60,10 +60,10 @@ type WorkTree interface {
 	// who cloned the repo associated with this working tree.
 	HomeDir() string
 	// GetDiffPathsForCommitID returns a string slice indicating the paths,
-	// relative to the root of the repository, of any files that are added,
-	// modified, deleted, or renamed/moved in the commit with the given ID. For
-	// renamed or moved files, both the old and new paths are included so that
-	// path-based filters can match on either side of the move.
+	// relative to the root of the repository, of any files changed in the
+	// commit with the given ID. For renamed or moved files, both the old and
+	// new paths are included so that path-based filters can match on either
+	// side of the move.
 	GetDiffPathsForCommitID(commitID string) ([]string, error)
 	// IsAncestor returns true if parent branch is an ancestor of child
 	IsAncestor(parent string, child string) (bool, error)
@@ -414,13 +414,19 @@ func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
 		}
 		// --name-status output is tab-separated: <status>\t<path> for most
 		// changes, or <status>\t<old-path>\t<new-path> for renames and copies.
+		// The status field for renames and copies includes a similarity score
+		// (e.g. R100, C85), so we use HasPrefix rather than exact equality.
 		parts := strings.SplitN(line, "\t", 3)
 		if len(parts) < 2 {
-			continue
+			return nil, fmt.Errorf(
+				"unexpected output from git show for commit %q: %q",
+				commitID, line,
+			)
 		}
-		// For renames (R) and copies (C), include both old and new paths so
-		// that a path filter matching the source directory detects the removal.
-		if len(parts) == 3 && len(parts[0]) > 0 && (parts[0][0] == 'R' || parts[0][0] == 'C') {
+		// For renames (R), include both old and new paths so that a path filter
+		// matching the source directory detects the removal. Copies (C) leave
+		// the source unchanged, so only the destination path is relevant.
+		if len(parts) == 3 && strings.HasPrefix(parts[0], "R") {
 			paths = append(paths, parts[1], parts[2])
 		} else {
 			paths = append(paths, parts[1])

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -426,7 +426,7 @@ func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
 		// For renames (R), include both old and new paths so that a path filter
 		// matching the source directory detects the removal. Copies (C) leave
 		// the source unchanged, so only the destination path is relevant.
-		if len(parts) == 3 && (parts[0] == "R" || parts[0] == "C") {
+		if len(parts) == 3 && strings.HasPrefix(parts[0], "R") {
 			paths = append(paths, parts[1], parts[2])
 		} else {
 			paths = append(paths, parts[1])

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -426,7 +426,7 @@ func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
 		// For renames (R), include both old and new paths so that a path filter
 		// matching the source directory detects the removal. Copies (C) leave
 		// the source unchanged, so only the destination path is relevant.
-		if len(parts) == 3 && strings.HasPrefix(parts[0], "R") {
+		if len(parts) == 3 && (parts[0] == "R" || parts[0] == "C") {
 			paths = append(paths, parts[1], parts[2])
 		} else {
 			paths = append(paths, parts[1])

--- a/pkg/controller/git/work_tree_test.go
+++ b/pkg/controller/git/work_tree_test.go
@@ -400,3 +400,45 @@ func TestGetDiffPathsForMergeCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"foo/file1.txt"}, paths)
 }
+
+func TestGetDiffPathsForMovedFile(t *testing.T) {
+	testServer, testRepoURL, testRepoCreds := setupRemoteRepo(t)
+	defer testServer.Close()
+
+	rep, err := Clone(
+		testRepoURL,
+		&ClientOptions{Credentials: &testRepoCreds},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rep)
+	defer rep.Close()
+
+	wt := internalWorkTree(t, rep)
+
+	// Create initial commit with a file in app/
+	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/app", rep.Dir()), 0o755))
+	require.NoError(t, os.WriteFile(
+		fmt.Sprintf("%s/app/pod.yaml", rep.Dir()),
+		[]byte("kind: Pod"),
+		0o600,
+	))
+	require.NoError(t, rep.AddAllAndCommit("initial commit", nil))
+
+	// Move the file to a different directory
+	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/different-app", rep.Dir()), 0o755))
+	_, err = libExec.Exec(wt.buildGitCommand(
+		"mv", "app/pod.yaml", "different-app/pod.yaml",
+	))
+	require.NoError(t, err)
+	require.NoError(t, rep.AddAllAndCommit("move pod.yaml to different-app/", nil))
+
+	moveCommitID, err := rep.LastCommitID()
+	require.NoError(t, err)
+
+	// GetDiffPathsForCommitID should return both the old and new paths so
+	// that a warehouse watching app/ detects the removal.
+	paths, err := rep.GetDiffPathsForCommitID(moveCommitID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"app/pod.yaml", "different-app/pod.yaml"}, paths)
+}


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/5751

### Before

No freight created for commit with moved file on manual refresh


https://github.com/user-attachments/assets/8798306a-49aa-4a85-b547-5c51197df84a


### After

Freight created for commit with moved file on manual refresh

https://github.com/user-attachments/assets/6771abb5-ff90-45f9-9cdc-91dc6ecf9836

### Manifest used

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: ProjectConfig
metadata:
  name: kargo-demo
  namespace: kargo-demo
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Warehouse
metadata:
  name: my-warehouse
  namespace: kargo-demo
spec:
  interval: 30m
  subscriptions:
  - git:
      repoURL: git@github.com:fuskovic/testrepo.git
      branch: main
      strictSemvers: false
      includePaths:
      - app/
---
apiVersion: v1
kind: Secret
metadata:
  name: warehouse-secret
  namespace: kargo-shared-resources
  labels:
    kargo.akuity.io/cred-type: git
stringData:
  repoURL: git@github.com:fuskovic/testrepo.git
  sshPrivateKey: redacted
 
