### PR TITLE
fix: enqueue selector-based Promotions on Argo CD Application changes

### DIFF
--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -118,6 +118,21 @@ func SetupReconcilerWithManager(
 		return fmt.Errorf("index running Promotions by Argo CD Applications: %w", err)
 	}
 
+	// Index running Promotions by Stage. This is used to enqueue Promotions when
+	// an Argo CD Application they selected by label selector changes, since such
+	// Promotions are not captured by the name-based Applications index.
+	if err := kargoMgr.GetFieldIndexer().IndexField(
+		ctx,
+		&kargoapi.Promotion{},
+		indexer.RunningPromotionsByStageField,
+		indexer.RunningPromotionsByStage(
+			cfg.ShardName,
+			cfg.IsDefaultController,
+		),
+	); err != nil {
+		return fmt.Errorf("index running Promotions by Stage: %w", err)
+	}
+
 	reconciler := newReconciler(
 		kargoMgr.GetClient(),
 		kargoMgr.GetAPIReader(),

--- a/pkg/controller/promotions/watches.go
+++ b/pkg/controller/promotions/watches.go
@@ -69,6 +69,26 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		return
 	}
 
+	// Collect the running Promotions associated with this Application, deduped by
+	// key in case a Promotion is matched by both lookups below.
+	enqueued := make(map[types.NamespacedName]struct{})
+	enqueue := func(promo kargoapi.Promotion) {
+		key := types.NamespacedName{Namespace: promo.Namespace, Name: promo.Name}
+		if _, ok := enqueued[key]; ok {
+			return
+		}
+		enqueued[key] = struct{}{}
+		wq.Add(reconcile.Request{NamespacedName: key})
+		logger.Debug(
+			"enqueued Promotion for reconciliation",
+			"namespace", promo.Namespace,
+			"promotion", promo.Name,
+			"app", newApp.Name,
+		)
+	}
+
+	// Promotions that reference this Application by name are found via the
+	// name-based index.
 	promotions := &kargoapi.PromotionList{}
 	if err := u.kargoClient.List(
 		ctx,
@@ -88,22 +108,51 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		)
 		return
 	}
-
 	for _, promotion := range promotions.Items {
-		wq.Add(
-			reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: promotion.Namespace,
-					Name:      promotion.Name,
-				},
-			},
-		)
-		logger.Debug(
-			"enqueued Promotion for reconciliation",
-			"namespace", promotion.Namespace,
-			"promotion", promotion.Name,
+		enqueue(promotion)
+	}
+
+	// Promotions that selected this Application by label selector are not
+	// captured by the name-based index. The Application's authorized-stage
+	// annotation names the Stage(s) authorized to manage it, so enqueue the
+	// running Promotions for those Stages. This is a correct superset: a
+	// spuriously enqueued Promotion simply results in an idempotent re-check.
+	annotation, ok := newApp.Annotations[kargoapi.AnnotationKeyAuthorizedStage]
+	if !ok {
+		return
+	}
+	authorizedStages, err := kargoapi.AuthorizedStages(annotation)
+	if err != nil {
+		logger.Error(
+			err, "error parsing authorized Stages for Application",
 			"app", newApp.Name,
+			"namespace", newApp.Namespace,
 		)
+		return
+	}
+	for _, stage := range authorizedStages {
+		stagePromotions := &kargoapi.PromotionList{}
+		if err := u.kargoClient.List(
+			ctx,
+			stagePromotions,
+			client.InNamespace(stage.Namespace),
+			client.MatchingFields{
+				// Note: This index only includes running Promotions assigned to
+				// this shard.
+				indexer.RunningPromotionsByStageField: stage.Name,
+			},
+		); err != nil {
+			logger.Error(
+				err, "error listing Promotions for Stage authorized by Application",
+				"app", newApp.Name,
+				"namespace", stage.Namespace,
+				"stage", stage.Name,
+			)
+			continue
+		}
+		for _, promotion := range stagePromotions.Items {
+			enqueue(promotion)
+		}
 	}
 }
 

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -29,6 +29,7 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 		name         string
 		applications []client.Object
 		indexer      client.IndexerFunc
+		stageIndexer client.IndexerFunc
 		interceptor  interceptor.Funcs
 		e            event.TypedUpdateEvent[*argocd.Application]
 		assertions   func(*testing.T, workqueue.TypedRateLimitingInterface[reconcile.Request])
@@ -217,11 +218,123 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 				require.Equal(t, 0, wq.Len())
 			},
 		},
+		{
+			name: "Application authorizes a Stage with a selector-based Promotion",
+			applications: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "selector-promotion",
+						Namespace: "fake-namespace",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "fake-stage"},
+				},
+			},
+			// Name-based index finds nothing (selector-based step).
+			indexer: func(client.Object) []string { return nil },
+			stageIndexer: func(obj client.Object) []string {
+				if obj.GetName() == "selector-promotion" {
+					return []string{"fake-stage"}
+				}
+				return nil
+			},
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-application-name",
+						Namespace: "fake-application-namespace",
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyAuthorizedStage: "fake-namespace:fake-stage",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 1, wq.Len())
+				item, _ := wq.Get()
+				require.Equal(t, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "fake-namespace",
+						Name:      "selector-promotion",
+					},
+				}, item)
+			},
+		},
+		{
+			name: "name-based and Stage-based lookups are deduplicated",
+			applications: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "matching-promotion",
+						Namespace: "fake-namespace",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "fake-stage"},
+				},
+			},
+			indexer: func(obj client.Object) []string {
+				if obj.GetName() == "matching-promotion" {
+					return []string{"fake-application-namespace:fake-application-name"}
+				}
+				return nil
+			},
+			stageIndexer: func(obj client.Object) []string {
+				if obj.GetName() == "matching-promotion" {
+					return []string{"fake-stage"}
+				}
+				return nil
+			},
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-application-name",
+						Namespace: "fake-application-namespace",
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyAuthorizedStage: "fake-namespace:fake-stage",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 1, wq.Len())
+				item, _ := wq.Get()
+				require.Equal(t, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "fake-namespace",
+						Name:      "matching-promotion",
+					},
+				}, item)
+			},
+		},
+		{
+			name:    "malformed authorized-stage annotation enqueues nothing",
+			indexer: func(client.Object) []string { return nil },
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-application-name",
+						Namespace: "fake-application-namespace",
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyAuthorizedStage: "bogus",
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 0, wq.Len())
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 			require.NoError(t, kargoapi.AddToScheme(scheme))
+
+			stageIndexer := tt.stageIndexer
+			if stageIndexer == nil {
+				stageIndexer = func(client.Object) []string { return nil }
+			}
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -230,6 +343,11 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 					&kargoapi.Promotion{},
 					indexer.RunningPromotionsByArgoCDApplicationsField,
 					tt.indexer,
+				).
+				WithIndex(
+					&kargoapi.Promotion{},
+					indexer.RunningPromotionsByStageField,
+					stageIndexer,
 				).
 				WithInterceptorFuncs(tt.interceptor)
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -35,6 +35,7 @@ const (
 
 	RunningPromotionsByArgoCDApplicationsField = "applications"
 	RunningPromotionsByPullRequestURLField     = "pullRequestURL"
+	RunningPromotionsByStageField              = "runningStage"
 
 	StagesByAnalysisRunField    = "analysisRun"
 	StagesByFreightField        = "freight"
@@ -298,6 +299,47 @@ func RunningPromotionsByArgoCDApplications(
 			}
 		}
 		return res
+	}
+}
+
+// RunningPromotionsByStage returns a client.IndexerFunc that indexes running
+// Promotions by the name of the Stage they target.
+//
+// This index complements RunningPromotionsByArgoCDApplications: when an Argo CD
+// Application changes, a Promotion that selected it by label selector (rather
+// than by name) cannot be found via the name-based index. The Application's
+// authorized-stage annotation, however, names the Stage(s) authorized to manage
+// it, so this index allows those Stages' running Promotions to be enqueued
+// directly.
+//
+// When the provided shardName is non-empty, only Promotions labeled with the
+// provided shardName are indexed. When the provided shardName is empty, only
+// Promotions not labeled with a shardName are indexed.
+func RunningPromotionsByStage(
+	shardName string,
+	isDefaultController bool,
+) client.IndexerFunc {
+	return func(obj client.Object) []string {
+		// Return early if the Promotion is not the responsibility of this
+		// controller.
+		objShard := obj.GetLabels()[kargoapi.LabelKeyShard]
+		// Note(krancour): staticcheck wants us to apply De Morgan's law here, but
+		// this logic feels more readable as is. i.e. NOT (responsible for).
+		if !(objShard == shardName || (objShard == "" && isDefaultController)) { // nolint: staticcheck
+			return nil
+		}
+
+		promo, ok := obj.(*kargoapi.Promotion)
+		if !ok {
+			return nil
+		}
+
+		// We are only interested in running Promotions.
+		if promo.Status.Phase != kargoapi.PromotionPhaseRunning {
+			return nil
+		}
+
+		return []string{promo.Spec.Stage}
 	}
 }
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -585,6 +585,77 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 	}
 }
 
+func TestRunningPromotionsByStage(t *testing.T) {
+	t.Parallel()
+	const testShardName = "test-shard"
+
+	testCases := []struct {
+		name      string
+		obj       client.Object
+		shardName string
+		expected  []string
+	}{
+		{
+			name:     "Object is not a Promotion",
+			obj:      &kargoapi.Stage{},
+			expected: nil,
+		},
+		{
+			name: "Promotion is not running",
+			obj: &kargoapi.Promotion{
+				Spec:   kargoapi.PromotionSpec{Stage: "fake-stage"},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseSucceeded},
+			},
+			expected: nil,
+		},
+		{
+			name: "Promotion belongs to another shard",
+			obj: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{kargoapi.LabelKeyShard: "another"},
+				},
+				Spec:   kargoapi.PromotionSpec{Stage: "fake-stage"},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			shardName: testShardName,
+			expected:  nil,
+		},
+		{
+			name: "running Promotion belongs to this shard",
+			obj: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{kargoapi.LabelKeyShard: testShardName},
+				},
+				Spec:   kargoapi.PromotionSpec{Stage: "fake-stage"},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			shardName: testShardName,
+			expected:  []string{"fake-stage"},
+		},
+		{
+			name: "running Promotion for default controller",
+			obj: &kargoapi.Promotion{
+				Spec:   kargoapi.PromotionSpec{Stage: "fake-stage"},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			expected: []string{"fake-stage"},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t,
+				testCase.expected,
+				RunningPromotionsByStage(
+					testCase.shardName,
+					testCase.shardName == "",
+				)(testCase.obj),
+			)
+		})
+	}
+}
+
 func TestRunningPromotionsByPullRequestURL(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
## Description

Closes #6176

_Update: This approach is flawed because it assumes that argocd-wait operates only on authorized applications._ 

When an `argocd-update` or `argocd-wait` step selects `Application`s by label `selector` rather than by `name`, the affected `Promotion` was not captured by the name-based Applications index. As a result, `Application` state changes did not promptly wake the `Promotion`, which only progressed on the regular reconciliation interval (~5 minutes) — whereas `name`-based steps finished promptly.

This PR keys the wake-up trigger on the **authorization relationship**, which every updated `Application` carries via its `authorized-stage` annotation and which is a correct superset for both name- and selector-based steps:

- Adds a `RunningPromotionsByStage` index (shard-aware, running-only).
- Registers it in the promotions controller's manager cache.
- On `Application` changes, in addition to the existing name-based lookup, enqueues the running `Promotion`s of every Stage named in the `Application`'s `authorized-stage` annotation, deduplicated.

Because authorization is explicit and intrinsic to the `Application`, this avoids any "reverse selector" evaluation at event time. A spuriously enqueued `Promotion` results only in an idempotent re-check, while the previous behavior risked a multi-minute stall.

> **Stacked PR.** Base is `EronWright/issue-6027` (it depends on `kargoapi.AuthorizedStages` introduced there). Draft until #6027 merges; GitHub will retarget the base to `main` automatically.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

<!-- Internal indexing/enqueue fix; no user-facing configuration change. -->

### AI Use Disclosure

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**