### PR TITLE
fix: event-driven wake-up for selector-based argocd-update/wait steps

### DIFF
--- a/pkg/controller/promotions/argocd_selector.go
+++ b/pkg/controller/promotions/argocd_selector.go
@@ -1,0 +1,196 @@
+package promotions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libargocd "github.com/akuity/kargo/pkg/argocd"
+	"github.com/akuity/kargo/pkg/expressions"
+	"github.com/akuity/kargo/pkg/logging"
+	"github.com/akuity/kargo/pkg/promotion"
+)
+
+// promotionSelectorsMatchApp reports whether any label-selector-based
+// argocd-update or argocd-wait step in the (running) Promotion targets the Argo
+// CD Application identified by appNamespace and appLabels.
+//
+// This is the forward half of the scoped-forward-scan that handles
+// label-selector targeting: the Promotion is the selector-bearing (intrinsic)
+// side, and the changed Application is the query. Selectors are evaluated
+// against the Application's labels exactly as the argocd-update/argocd-wait
+// steps would, so the result cannot go stale relative to the Stage.
+func promotionSelectorsMatchApp(
+	ctx context.Context,
+	cl client.Client,
+	promo *kargoapi.Promotion,
+	appNamespace string,
+	appLabels map[string]string,
+) bool {
+	logger := logging.LoggerFromContext(ctx).WithValues(
+		"promotion", promo.Name,
+		"namespace", promo.Namespace,
+	)
+
+	// The Stage is required to build the expression context for the step config.
+	stage := &kargoapi.Stage{}
+	if err := cl.Get(
+		ctx,
+		client.ObjectKey{Namespace: promo.Namespace, Name: promo.Spec.Stage},
+		stage,
+	); err != nil {
+		logger.Error(
+			err, "failed to get Stage for Promotion",
+			"stage", promo.Spec.Stage,
+		)
+		return false
+	}
+	promoCtx := promotion.NewContext(promo, stage)
+
+	for i, step := range promo.Spec.Steps {
+		if int64(i) > promo.Status.CurrentStep {
+			// We are only interested in steps that have already been executed or
+			// are about to be.
+			break
+		}
+		if (step.Uses != "argocd-update" && step.Uses != "argocd-wait") ||
+			step.Config == nil {
+			continue
+		}
+
+		dirStep := promotion.Step{
+			Kind:   step.Uses,
+			Alias:  step.As,
+			Vars:   step.Vars,
+			Config: step.Config.Raw,
+		}
+		evaluator := promotion.NewStepEvaluator(cl, nil)
+		vars, err := evaluator.Vars(ctx, promoCtx, dirStep)
+		if err != nil {
+			logger.Error(err, "error evaluating step vars; ignoring step", "step", i)
+			continue
+		}
+
+		// Unpack only the fields we care about. We deliberately avoid unmarshaling
+		// the entire config into a struct, both because we lack the context to
+		// evaluate every expression and because templated fields may not be
+		// strings in the struct.
+		cfgMap := map[string]any{}
+		if err = json.Unmarshal(step.Config.Raw, &cfgMap); err != nil {
+			logger.Error(err, "error unmarshaling step config; ignoring step", "step", i)
+			continue
+		}
+		appsList, ok := cfgMap["apps"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, app := range appsList {
+			appMap, ok := app.(map[string]any)
+			if !ok {
+				continue
+			}
+			selMap, ok := appMap["selector"].(map[string]any)
+			if !ok {
+				// Not a selector-based entry (or malformed); name-based entries are
+				// handled by the name index.
+				continue
+			}
+
+			env := evaluator.BuildExprEnv(
+				promoCtx,
+				promotion.ExprEnvWithOutputs(promoCtx.State),
+				promotion.ExprEnvWithTaskOutputs(dirStep.Alias, promoCtx.State),
+				promotion.ExprEnvWithVars(vars),
+			)
+
+			// The targeted namespace defaults to the Argo CD controller namespace.
+			namespace := libargocd.Namespace()
+			if nsTemplate, ok := appMap["namespace"].(string); ok {
+				evaluated, err := expressions.EvaluateTemplate(nsTemplate, env)
+				if err != nil {
+					logger.Error(err, "error evaluating app namespace; ignoring entry", "step", i)
+					continue
+				}
+				if s, ok := evaluated.(string); ok {
+					namespace = s
+				}
+			}
+			if namespace != appNamespace {
+				continue
+			}
+
+			selector, err := evaluateAppSelector(selMap, env)
+			if err != nil {
+				logger.Error(err, "error building app selector; ignoring entry", "step", i)
+				continue
+			}
+			if selector.Matches(labels.Set(appLabels)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// evaluateAppSelector converts an argocd step's selector config (as an
+// unstructured map), evaluating any expressions in its values against env, into
+// a labels.Selector. The selector config's JSON shape matches
+// metav1.LabelSelector.
+func evaluateAppSelector(
+	selMap map[string]any,
+	env map[string]any,
+) (labels.Selector, error) {
+	labelSelector := &metav1.LabelSelector{}
+
+	if matchLabels, ok := selMap["matchLabels"].(map[string]any); ok {
+		labelSelector.MatchLabels = make(map[string]string, len(matchLabels))
+		for key, value := range matchLabels {
+			tmpl, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("matchLabels value for %q is not a string", key)
+			}
+			evaluated, err := expressions.EvaluateTemplate(tmpl, env)
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating matchLabels value for %q: %w", key, err)
+			}
+			labelSelector.MatchLabels[key] = fmt.Sprintf("%v", evaluated)
+		}
+	}
+
+	if matchExpressions, ok := selMap["matchExpressions"].([]any); ok {
+		for _, expr := range matchExpressions {
+			exprMap, ok := expr.(map[string]any)
+			if !ok {
+				continue
+			}
+			key, _ := exprMap["key"].(string)
+			operator, _ := exprMap["operator"].(string)
+			req := metav1.LabelSelectorRequirement{
+				Key:      key,
+				Operator: metav1.LabelSelectorOperator(operator),
+			}
+			if values, ok := exprMap["values"].([]any); ok {
+				for _, value := range values {
+					tmpl, ok := value.(string)
+					if !ok {
+						return nil, fmt.Errorf("matchExpressions value for key %q is not a string", key)
+					}
+					evaluated, err := expressions.EvaluateTemplate(tmpl, env)
+					if err != nil {
+						return nil, fmt.Errorf("error evaluating matchExpressions value for key %q: %w", key, err)
+					}
+					req.Values = append(req.Values, fmt.Sprintf("%v", evaluated))
+				}
+			}
+			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, req)
+		}
+	}
+
+	return metav1.LabelSelectorAsSelector(labelSelector)
+}

--- a/pkg/controller/promotions/argocd_selector.go
+++ b/pkg/controller/promotions/argocd_selector.go
@@ -2,19 +2,28 @@ package promotions
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	libargocd "github.com/akuity/kargo/pkg/argocd"
-	"github.com/akuity/kargo/pkg/expressions"
 	"github.com/akuity/kargo/pkg/logging"
 	"github.com/akuity/kargo/pkg/promotion"
+	rbuiltin "github.com/akuity/kargo/pkg/promotion/runner/builtin"
+	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
+
+// argoCDSelectorStepConfig is the minimal subset of an argocd-update or
+// argocd-wait step config needed to determine whether the step targets an Argo
+// CD Application by label selector. It reuses builtin.ArgoCDAppSelector so the
+// selector shape stays in sync with the step runners.
+type argoCDSelectorStepConfig struct {
+	Apps []struct {
+		Namespace string                     `json:"namespace,omitempty"`
+		Selector  *builtin.ArgoCDAppSelector `json:"selector,omitempty"`
+	} `json:"apps"`
+}
 
 // promotionSelectorsMatchApp reports whether any label-selector-based
 // argocd-update or argocd-wait step in the (running) Promotion targets the Argo
@@ -22,9 +31,10 @@ import (
 //
 // This is the forward half of the scoped-forward-scan that handles
 // label-selector targeting: the Promotion is the selector-bearing (intrinsic)
-// side, and the changed Application is the query. Selectors are evaluated
-// against the Application's labels exactly as the argocd-update/argocd-wait
-// steps would, so the result cannot go stale relative to the Stage.
+// side, and the changed Application is the query. The step config is evaluated
+// exactly as the engine evaluates it for the step runner, and the selector is
+// built with the same helper the runner uses, so the result cannot drift
+// relative to what the step would actually match.
 func promotionSelectorsMatchApp(
 	ctx context.Context,
 	cl client.Client,
@@ -50,7 +60,9 @@ func promotionSelectorsMatchApp(
 		)
 		return false
 	}
+
 	promoCtx := promotion.NewContext(promo, stage)
+	evaluator := promotion.NewStepEvaluator(cl, nil)
 
 	for i, step := range promo.Spec.Steps {
 		if int64(i) > promo.Status.CurrentStep {
@@ -63,69 +75,42 @@ func promotionSelectorsMatchApp(
 			continue
 		}
 
+		// Evaluate the step config exactly as the engine does for the step
+		// runner, so any expressions in the selector or namespace are resolved
+		// identically.
 		dirStep := promotion.Step{
 			Kind:   step.Uses,
 			Alias:  step.As,
 			Vars:   step.Vars,
 			Config: step.Config.Raw,
 		}
-		evaluator := promotion.NewStepEvaluator(cl, nil)
-		vars, err := evaluator.Vars(ctx, promoCtx, dirStep)
+		evaledCfg, err := evaluator.Config(ctx, promoCtx, dirStep)
 		if err != nil {
-			logger.Error(err, "error evaluating step vars; ignoring step", "step", i)
+			logger.Error(err, "error evaluating step config; ignoring step", "step", i)
+			continue
+		}
+		cfg, err := promotion.ConfigToStruct[argoCDSelectorStepConfig](evaledCfg)
+		if err != nil {
+			logger.Error(err, "error converting step config; ignoring step", "step", i)
 			continue
 		}
 
-		// Unpack only the fields we care about. We deliberately avoid unmarshaling
-		// the entire config into a struct, both because we lack the context to
-		// evaluate every expression and because templated fields may not be
-		// strings in the struct.
-		cfgMap := map[string]any{}
-		if err = json.Unmarshal(step.Config.Raw, &cfgMap); err != nil {
-			logger.Error(err, "error unmarshaling step config; ignoring step", "step", i)
-			continue
-		}
-		appsList, ok := cfgMap["apps"].([]any)
-		if !ok {
-			continue
-		}
-
-		for _, app := range appsList {
-			appMap, ok := app.(map[string]any)
-			if !ok {
+		for _, app := range cfg.Apps {
+			if app.Selector == nil {
+				// Name-based entries are handled by the name index.
 				continue
 			}
-			selMap, ok := appMap["selector"].(map[string]any)
-			if !ok {
-				// Not a selector-based entry (or malformed); name-based entries are
-				// handled by the name index.
-				continue
-			}
-
-			env := evaluator.BuildExprEnv(
-				promoCtx,
-				promotion.ExprEnvWithOutputs(promoCtx.State),
-				promotion.ExprEnvWithTaskOutputs(dirStep.Alias, promoCtx.State),
-				promotion.ExprEnvWithVars(vars),
-			)
 
 			// The targeted namespace defaults to the Argo CD controller namespace.
-			namespace := libargocd.Namespace()
-			if nsTemplate, ok := appMap["namespace"].(string); ok {
-				evaluated, err := expressions.EvaluateTemplate(nsTemplate, env)
-				if err != nil {
-					logger.Error(err, "error evaluating app namespace; ignoring entry", "step", i)
-					continue
-				}
-				if s, ok := evaluated.(string); ok {
-					namespace = s
-				}
+			namespace := app.Namespace
+			if namespace == "" {
+				namespace = libargocd.Namespace()
 			}
 			if namespace != appNamespace {
 				continue
 			}
 
-			selector, err := evaluateAppSelector(selMap, env)
+			selector, err := rbuiltin.BuildArgoCDAppLabelSelector(app.Selector)
 			if err != nil {
 				logger.Error(err, "error building app selector; ignoring entry", "step", i)
 				continue
@@ -136,61 +121,4 @@ func promotionSelectorsMatchApp(
 		}
 	}
 	return false
-}
-
-// evaluateAppSelector converts an argocd step's selector config (as an
-// unstructured map), evaluating any expressions in its values against env, into
-// a labels.Selector. The selector config's JSON shape matches
-// metav1.LabelSelector.
-func evaluateAppSelector(
-	selMap map[string]any,
-	env map[string]any,
-) (labels.Selector, error) {
-	labelSelector := &metav1.LabelSelector{}
-
-	if matchLabels, ok := selMap["matchLabels"].(map[string]any); ok {
-		labelSelector.MatchLabels = make(map[string]string, len(matchLabels))
-		for key, value := range matchLabels {
-			tmpl, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("matchLabels value for %q is not a string", key)
-			}
-			evaluated, err := expressions.EvaluateTemplate(tmpl, env)
-			if err != nil {
-				return nil, fmt.Errorf("error evaluating matchLabels value for %q: %w", key, err)
-			}
-			labelSelector.MatchLabels[key] = fmt.Sprintf("%v", evaluated)
-		}
-	}
-
-	if matchExpressions, ok := selMap["matchExpressions"].([]any); ok {
-		for _, expr := range matchExpressions {
-			exprMap, ok := expr.(map[string]any)
-			if !ok {
-				continue
-			}
-			key, _ := exprMap["key"].(string)
-			operator, _ := exprMap["operator"].(string)
-			req := metav1.LabelSelectorRequirement{
-				Key:      key,
-				Operator: metav1.LabelSelectorOperator(operator),
-			}
-			if values, ok := exprMap["values"].([]any); ok {
-				for _, value := range values {
-					tmpl, ok := value.(string)
-					if !ok {
-						return nil, fmt.Errorf("matchExpressions value for key %q is not a string", key)
-					}
-					evaluated, err := expressions.EvaluateTemplate(tmpl, env)
-					if err != nil {
-						return nil, fmt.Errorf("error evaluating matchExpressions value for key %q: %w", key, err)
-					}
-					req.Values = append(req.Values, fmt.Sprintf("%v", evaluated))
-				}
-			}
-			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, req)
-		}
-	}
-
-	return metav1.LabelSelectorAsSelector(labelSelector)
 }

--- a/pkg/controller/promotions/argocd_selector_test.go
+++ b/pkg/controller/promotions/argocd_selector_test.go
@@ -1,0 +1,130 @@
+package promotions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestPromotionSelectorsMatchApp(t *testing.T) {
+	const (
+		project = "fake-project"
+		stage   = "fake-stage"
+	)
+
+	matchExprConfig := `{"apps":[{"namespace":"argocd","selector":` +
+		`{"matchExpressions":[{"key":"env","operator":"In","values":["prod"]}]}}]}`
+	templatedConfig := `{"apps":[{"namespace":"argocd","selector":` +
+		`{"matchLabels":{"stage":"${{ ctx.stage }}"}}}]}`
+
+	promoWithStep := func(config string) *kargoapi.Promotion {
+		return &kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{Name: "fake-promotion", Namespace: project},
+			Spec: kargoapi.PromotionSpec{
+				Stage: stage,
+				Steps: []kargoapi.PromotionStep{{
+					Uses:   "argocd-update",
+					Config: &apiextensionsv1.JSON{Raw: []byte(config)},
+				}},
+			},
+			Status: kargoapi.PromotionStatus{
+				Phase:       kargoapi.PromotionPhaseRunning,
+				CurrentStep: 0,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name         string
+		promo        *kargoapi.Promotion
+		appNamespace string
+		appLabels    map[string]string
+		expected     bool
+	}{
+		{
+			name:         "matchLabels match",
+			promo:        promoWithStep(`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`),
+			appNamespace: "argocd",
+			appLabels:    map[string]string{"app": "foo"},
+			expected:     true,
+		},
+		{
+			name:         "matchLabels do not match",
+			promo:        promoWithStep(`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`),
+			appNamespace: "argocd",
+			appLabels:    map[string]string{"app": "bar"},
+			expected:     false,
+		},
+		{
+			name:         "namespace does not match",
+			promo:        promoWithStep(`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`),
+			appNamespace: "other",
+			appLabels:    map[string]string{"app": "foo"},
+			expected:     false,
+		},
+		{
+			name:         "matchExpressions match",
+			promo:        promoWithStep(matchExprConfig),
+			appNamespace: "argocd",
+			appLabels:    map[string]string{"env": "prod"},
+			expected:     true,
+		},
+		{
+			name:         "templated matchLabels value resolves against context",
+			promo:        promoWithStep(templatedConfig),
+			appNamespace: "argocd",
+			appLabels:    map[string]string{"stage": stage},
+			expected:     true,
+		},
+		{
+			name:         "name-based entry is ignored",
+			promo:        promoWithStep(`{"apps":[{"namespace":"argocd","name":"some-app"}]}`),
+			appNamespace: "argocd",
+			appLabels:    map[string]string{"app": "foo"},
+			expected:     false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{Name: stage, Namespace: project},
+				}).
+				Build()
+
+			require.Equal(
+				t,
+				testCase.expected,
+				promotionSelectorsMatchApp(
+					t.Context(),
+					c,
+					testCase.promo,
+					testCase.appNamespace,
+					testCase.appLabels,
+				),
+			)
+		})
+	}
+
+	t.Run("missing Stage returns false", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		require.False(t, promotionSelectorsMatchApp(
+			t.Context(),
+			c,
+			promoWithStep(`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`),
+			"argocd",
+			map[string]string{"app": "foo"},
+		))
+	})
+}

--- a/pkg/controller/promotions/predicates.go
+++ b/pkg/controller/promotions/predicates.go
@@ -1,6 +1,8 @@
 package promotions
 
 import (
+	"maps"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
@@ -172,5 +174,62 @@ func (p ArgoCDAppReconciledAfterOperation[T]) Delete(event.TypedDeleteEvent[T]) 
 }
 
 func (p ArgoCDAppReconciledAfterOperation[T]) Generic(event.TypedGenericEvent[T]) bool {
+	return false
+}
+
+// ArgoCDAppLabelsChanged is a predicate that fires when an ArgoCD Application's
+// labels change. A label selector's match set depends on Application labels, so
+// a relabeling can move an Application into or out of a selector-based
+// Promotion's target set. This enables the Promotion reconciler to react
+// promptly to such membership changes instead of waiting for a polling
+// interval.
+type ArgoCDAppLabelsChanged[T any] struct {
+	logger *logging.Logger
+}
+
+func (p ArgoCDAppLabelsChanged[T]) Create(event.TypedCreateEvent[T]) bool {
+	return false
+}
+
+func (p ArgoCDAppLabelsChanged[T]) Update(e event.TypedUpdateEvent[T]) bool {
+	oldApp := any(e.ObjectOld).(*argocd.Application) // nolint: forcetypeassert
+	newApp := any(e.ObjectNew).(*argocd.Application) // nolint: forcetypeassert
+	if oldApp == nil || newApp == nil {
+		p.logger.Error(
+			nil, "Update event has no new or old object",
+			"event", e,
+		)
+		return false
+	}
+	return !maps.Equal(oldApp.Labels, newApp.Labels)
+}
+
+func (p ArgoCDAppLabelsChanged[T]) Delete(event.TypedDeleteEvent[T]) bool {
+	return false
+}
+
+func (p ArgoCDAppLabelsChanged[T]) Generic(event.TypedGenericEvent[T]) bool {
+	return false
+}
+
+// ArgoCDAppCreatedOrDeleted is a predicate that fires when an ArgoCD
+// Application is created or deleted. Either event can change the match set of a
+// label selector, so it enables the Promotion reconciler to react promptly when
+// an Application that a selector-based Promotion targets appears or disappears.
+type ArgoCDAppCreatedOrDeleted[T any] struct{}
+
+func (p ArgoCDAppCreatedOrDeleted[T]) Create(event.TypedCreateEvent[T]) bool {
+	return true
+}
+
+func (p ArgoCDAppCreatedOrDeleted[T]) Update(event.TypedUpdateEvent[T]) bool {
+	return false
+}
+
+func (p ArgoCDAppCreatedOrDeleted[T]) Delete(event.TypedDeleteEvent[T]) bool {
+	return true
+}
+
+func (p ArgoCDAppCreatedOrDeleted[T]) Generic(event.TypedGenericEvent[T]) bool {
 	return false
 }

--- a/pkg/controller/promotions/predicates_test.go
+++ b/pkg/controller/promotions/predicates_test.go
@@ -374,3 +374,94 @@ func TestArgoCDAppReconciledAfterOperation_Update(t *testing.T) {
 		})
 	}
 }
+
+func TestArgoCDAppLabelsChanged_Update(t *testing.T) {
+	testCases := []struct {
+		name string
+		e    event.TypedUpdateEvent[*argocd.Application]
+		want bool
+	}{
+		{
+			name: "ObjectOld is nil",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectNew: &argocd.Application{},
+			},
+			want: false,
+		},
+		{
+			name: "ObjectNew is nil",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+			},
+			want: false,
+		},
+		{
+			name: "labels unchanged",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
+				},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "both nil labels unchanged",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{},
+			},
+			want: false,
+		},
+		{
+			name: "label value changed",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
+				},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "dev"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "label added",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "label removed",
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod"}},
+				},
+				ObjectNew: &argocd.Application{},
+			},
+			want: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			p := ArgoCDAppLabelsChanged[*argocd.Application]{
+				logger: logging.NewDiscardLoggerOrDie(),
+			}
+			require.Equal(t, testCase.want, p.Update(testCase.e))
+		})
+	}
+}
+
+func TestArgoCDAppCreatedOrDeleted(t *testing.T) {
+	p := ArgoCDAppCreatedOrDeleted[*argocd.Application]{}
+	require.True(t, p.Create(event.TypedCreateEvent[*argocd.Application]{}))
+	require.True(t, p.Delete(event.TypedDeleteEvent[*argocd.Application]{}))
+	require.False(t, p.Update(event.TypedUpdateEvent[*argocd.Application]{}))
+	require.False(t, p.Generic(event.TypedGenericEvent[*argocd.Application]{}))
+}

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -118,6 +118,22 @@ func SetupReconcilerWithManager(
 		return fmt.Errorf("index running Promotions by Argo CD Applications: %w", err)
 	}
 
+	// Index running Promotions that target Argo CD Applications by label
+	// selector. This coarsely narrows the candidate set when an Application
+	// changes, so the watch handler can evaluate each selector forward against
+	// the changed Application rather than scanning every running Promotion.
+	if err := kargoMgr.GetFieldIndexer().IndexField(
+		ctx,
+		&kargoapi.Promotion{},
+		indexer.RunningPromotionsByArgoCDSelectorsField,
+		indexer.RunningPromotionsByArgoCDSelectors(
+			cfg.ShardName,
+			cfg.IsDefaultController,
+		),
+	); err != nil {
+		return fmt.Errorf("index running Promotions by Argo CD selectors: %w", err)
+	}
+
 	reconciler := newReconciler(
 		kargoMgr.GetClient(),
 		kargoMgr.GetAPIReader(),

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -210,6 +210,10 @@ func SetupReconcilerWithManager(
 					ArgoCDAppReconciledAfterOperation[*argocd.Application]{
 						logger: logger,
 					},
+					ArgoCDAppLabelsChanged[*argocd.Application]{
+						logger: logger,
+					},
+					ArgoCDAppCreatedOrDeleted[*argocd.Application]{},
 				),
 			),
 		); err != nil {

--- a/pkg/controller/promotions/watches.go
+++ b/pkg/controller/promotions/watches.go
@@ -26,20 +26,40 @@ type UpdatedArgoCDAppHandler[T any] struct {
 
 // Create implements TypedEventHandler.
 func (u *UpdatedArgoCDAppHandler[T]) Create(
-	context.Context,
-	event.TypedCreateEvent[T],
-	workqueue.TypedRateLimitingInterface[reconcile.Request],
+	ctx context.Context,
+	e event.TypedCreateEvent[T],
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
 ) {
-	// No-op
+	logger := logging.LoggerFromContext(ctx)
+	app := any(e.Object).(*argocd.Application) // nolint: forcetypeassert
+	if app == nil {
+		logger.Error(nil, "Create event has no object", "event", e)
+		return
+	}
+	// A newly-created Application can enter a label selector's match set. Name-
+	// based targeting is unaffected by creation (such a Promotion already
+	// references the Application by name and will be reconciled when the
+	// Application is next updated), so only selector-based Promotions are woken.
+	enqueued, enqueue := newEnqueuer(logger, wq, app.Name)
+	u.enqueueSelectorMatches(ctx, enqueued, enqueue, app)
 }
 
 // Delete implements TypedEventHandler.
 func (u *UpdatedArgoCDAppHandler[T]) Delete(
-	context.Context,
-	event.TypedDeleteEvent[T],
-	workqueue.TypedRateLimitingInterface[reconcile.Request],
+	ctx context.Context,
+	e event.TypedDeleteEvent[T],
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
 ) {
-	// No-op
+	logger := logging.LoggerFromContext(ctx)
+	app := any(e.Object).(*argocd.Application) // nolint: forcetypeassert
+	if app == nil {
+		logger.Error(nil, "Delete event has no object", "event", e)
+		return
+	}
+	// A deleted Application leaves a label selector's match set. The deleted
+	// object still carries its labels, so we can evaluate selectors against it.
+	enqueued, enqueue := newEnqueuer(logger, wq, app.Name)
+	u.enqueueSelectorMatches(ctx, enqueued, enqueue, app)
 }
 
 // Generic implements TypedEventHandler.
@@ -71,21 +91,7 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 
 	// Collect the running Promotions to enqueue, deduped by key in case a
 	// Promotion is matched by both the name- and selector-based lookups below.
-	enqueued := make(map[types.NamespacedName]struct{})
-	enqueue := func(promo kargoapi.Promotion) {
-		key := types.NamespacedName{Namespace: promo.Namespace, Name: promo.Name}
-		if _, ok := enqueued[key]; ok {
-			return
-		}
-		enqueued[key] = struct{}{}
-		wq.Add(reconcile.Request{NamespacedName: key})
-		logger.Debug(
-			"enqueued Promotion for reconciliation",
-			"namespace", promo.Namespace,
-			"promotion", promo.Name,
-			"app", newApp.Name,
-		)
-	}
+	enqueued, enqueue := newEnqueuer(logger, wq, newApp.Name)
 
 	// Promotions that target this Application by name are found directly via the
 	// name-based index.
@@ -114,11 +120,51 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 
 	// Promotions that target this Application by label selector cannot be found
 	// via the name-based index, because a selector's match set depends on the
-	// Application's labels. Instead, narrow to the (small) set of running
-	// Promotions that use selectors via a coarse index, then evaluate each
-	// selector forward against the changed Application. We test both the old and
-	// new label sets so a Promotion is still woken when an Application's labels
-	// change such that it stops matching.
+	// Application's labels. We test both the old and new label sets so a
+	// Promotion is still woken when an Application's labels change such that it
+	// enters or stops matching the selector.
+	u.enqueueSelectorMatches(ctx, enqueued, enqueue, newApp, oldApp)
+}
+
+// newEnqueuer returns a dedupe set and an enqueue function that adds a Promotion
+// to the workqueue at most once, logging the Application that triggered it.
+func newEnqueuer(
+	logger *logging.Logger,
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+	appName string,
+) (map[types.NamespacedName]struct{}, func(kargoapi.Promotion)) {
+	enqueued := make(map[types.NamespacedName]struct{})
+	enqueue := func(promo kargoapi.Promotion) {
+		key := types.NamespacedName{Namespace: promo.Namespace, Name: promo.Name}
+		if _, ok := enqueued[key]; ok {
+			return
+		}
+		enqueued[key] = struct{}{}
+		wq.Add(reconcile.Request{NamespacedName: key})
+		logger.Debug(
+			"enqueued Promotion for reconciliation",
+			"namespace", promo.Namespace,
+			"promotion", promo.Name,
+			"app", appName,
+		)
+	}
+	return enqueued, enqueue
+}
+
+// enqueueSelectorMatches enqueues every running, selector-based Promotion in
+// this shard whose argocd-update/argocd-wait selectors match any of the given
+// Applications. The candidate set is narrowed via a coarse index
+// (RunningPromotionsByArgoCDSelectorsField) before each selector is evaluated
+// forward against the Applications. Passing multiple Applications (e.g. an
+// Update event's old and new states) wakes a Promotion both when an Application
+// enters and when it leaves a selector's match set.
+func (u *UpdatedArgoCDAppHandler[T]) enqueueSelectorMatches(
+	ctx context.Context,
+	enqueued map[types.NamespacedName]struct{},
+	enqueue func(kargoapi.Promotion),
+	apps ...*argocd.Application,
+) {
+	logger := logging.LoggerFromContext(ctx)
 	selectorPromotions := &kargoapi.PromotionList{}
 	if err := u.kargoClient.List(
 		ctx,
@@ -131,11 +177,7 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 			),
 		},
 	); err != nil {
-		logger.Error(
-			err, "error listing selector-based Promotions for Application",
-			"app", newApp.Name,
-			"namespace", newApp.Namespace,
-		)
+		logger.Error(err, "error listing selector-based Promotions for Application")
 		return
 	}
 	for i := range selectorPromotions.Items {
@@ -146,9 +188,14 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		}]; ok {
 			continue
 		}
-		if promotionSelectorsMatchApp(ctx, u.kargoClient, &promotion, newApp.Namespace, newApp.Labels) ||
-			promotionSelectorsMatchApp(ctx, u.kargoClient, &promotion, oldApp.Namespace, oldApp.Labels) {
-			enqueue(promotion)
+		for _, app := range apps {
+			if app == nil {
+				continue
+			}
+			if promotionSelectorsMatchApp(ctx, u.kargoClient, &promotion, app.Namespace, app.Labels) {
+				enqueue(promotion)
+				break
+			}
 		}
 	}
 }

--- a/pkg/controller/promotions/watches.go
+++ b/pkg/controller/promotions/watches.go
@@ -69,6 +69,26 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		return
 	}
 
+	// Collect the running Promotions to enqueue, deduped by key in case a
+	// Promotion is matched by both the name- and selector-based lookups below.
+	enqueued := make(map[types.NamespacedName]struct{})
+	enqueue := func(promo kargoapi.Promotion) {
+		key := types.NamespacedName{Namespace: promo.Namespace, Name: promo.Name}
+		if _, ok := enqueued[key]; ok {
+			return
+		}
+		enqueued[key] = struct{}{}
+		wq.Add(reconcile.Request{NamespacedName: key})
+		logger.Debug(
+			"enqueued Promotion for reconciliation",
+			"namespace", promo.Namespace,
+			"promotion", promo.Name,
+			"app", newApp.Name,
+		)
+	}
+
+	// Promotions that target this Application by name are found directly via the
+	// name-based index.
 	promotions := &kargoapi.PromotionList{}
 	if err := u.kargoClient.List(
 		ctx,
@@ -88,22 +108,48 @@ func (u *UpdatedArgoCDAppHandler[T]) Update(
 		)
 		return
 	}
-
 	for _, promotion := range promotions.Items {
-		wq.Add(
-			reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: promotion.Namespace,
-					Name:      promotion.Name,
-				},
-			},
-		)
-		logger.Debug(
-			"enqueued Promotion for reconciliation",
-			"namespace", promotion.Namespace,
-			"promotion", promotion.Name,
+		enqueue(promotion)
+	}
+
+	// Promotions that target this Application by label selector cannot be found
+	// via the name-based index, because a selector's match set depends on the
+	// Application's labels. Instead, narrow to the (small) set of running
+	// Promotions that use selectors via a coarse index, then evaluate each
+	// selector forward against the changed Application. We test both the old and
+	// new label sets so a Promotion is still woken when an Application's labels
+	// change such that it stops matching.
+	selectorPromotions := &kargoapi.PromotionList{}
+	if err := u.kargoClient.List(
+		ctx,
+		selectorPromotions,
+		&client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(
+				// Note: This index only includes Promotions assigned to this shard.
+				indexer.RunningPromotionsByArgoCDSelectorsField,
+				indexer.RunningPromotionsByArgoCDSelectorsValue,
+			),
+		},
+	); err != nil {
+		logger.Error(
+			err, "error listing selector-based Promotions for Application",
 			"app", newApp.Name,
+			"namespace", newApp.Namespace,
 		)
+		return
+	}
+	for i := range selectorPromotions.Items {
+		promotion := selectorPromotions.Items[i]
+		if _, ok := enqueued[types.NamespacedName{
+			Namespace: promotion.Namespace,
+			Name:      promotion.Name,
+		}]; ok {
+			continue
+		}
+		if promotionSelectorsMatchApp(ctx, u.kargoClient, &promotion, newApp.Namespace, newApp.Labels) ||
+			promotionSelectorsMatchApp(ctx, u.kargoClient, &promotion, oldApp.Namespace, oldApp.Labels) {
+			enqueue(promotion)
+		}
 	}
 }
 

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -331,6 +331,33 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 				require.Equal(t, 0, wq.Len())
 			},
 		},
+		{
+			name:         "Application relabeled out of selector still enqueues (old labels matched)",
+			applications: selectorTestObjects(),
+			indexer:      func(client.Object) []string { return nil },
+			selectorIndexer: func(obj client.Object) []string {
+				if obj.GetName() == "selector-promotion" {
+					return []string{indexer.RunningPromotionsByArgoCDSelectorsValue}
+				}
+				return nil
+			},
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				// Old labels match the selector; new labels do not. The Promotion
+				// must still be woken so it re-evaluates the shrunken match set.
+				ObjectOld: matchingSelectorApp(),
+				ObjectNew: nonMatchingSelectorApp(),
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 1, wq.Len())
+				item, _ := wq.Get()
+				require.Equal(t, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "fake-project",
+						Name:      "selector-promotion",
+					},
+				}, item)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -505,4 +532,168 @@ func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
 			testCase.assertions(t, wq)
 		})
 	}
+}
+
+// selectorTestObjects returns a Stage and a running, selector-based Promotion
+// (argocd-update with matchLabels app=foo, namespace argocd) for exercising the
+// selector-driven enqueue paths.
+func selectorTestObjects() []client.Object {
+	return []client.Object{
+		&kargoapi.Stage{
+			ObjectMeta: metav1.ObjectMeta{Name: "fake-stage", Namespace: "fake-project"},
+		},
+		&kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-promotion", Namespace: "fake-project"},
+			Spec: kargoapi.PromotionSpec{
+				Stage: "fake-stage",
+				Steps: []kargoapi.PromotionStep{{
+					Uses: "argocd-update",
+					Config: &apiextensionsv1.JSON{
+						Raw: []byte(
+							`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`,
+						),
+					},
+				}},
+			},
+			Status: kargoapi.PromotionStatus{
+				Phase:       kargoapi.PromotionPhaseRunning,
+				CurrentStep: 0,
+			},
+		},
+	}
+}
+
+func matchingSelectorApp() *argocd.Application {
+	return &argocd.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-application-name",
+			Namespace: "argocd",
+			Labels:    map[string]string{"app": "foo"},
+		},
+	}
+}
+
+func nonMatchingSelectorApp() *argocd.Application {
+	return &argocd.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-application-name",
+			Namespace: "argocd",
+			Labels:    map[string]string{"app": "bar"},
+		},
+	}
+}
+
+// newSelectorAppHandler builds an UpdatedArgoCDAppHandler whose client indexes
+// "selector-promotion" into the coarse selector index and finds nothing in the
+// name-based index.
+func newSelectorAppHandler(
+	t *testing.T,
+	objs ...client.Object,
+) *UpdatedArgoCDAppHandler[*argocd.Application] {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(
+			&kargoapi.Promotion{},
+			indexer.RunningPromotionsByArgoCDApplicationsField,
+			func(client.Object) []string { return nil },
+		).
+		WithIndex(
+			&kargoapi.Promotion{},
+			indexer.RunningPromotionsByArgoCDSelectorsField,
+			func(obj client.Object) []string {
+				if obj.GetName() == "selector-promotion" {
+					return []string{indexer.RunningPromotionsByArgoCDSelectorsValue}
+				}
+				return nil
+			},
+		).
+		Build()
+	return &UpdatedArgoCDAppHandler[*argocd.Application]{kargoClient: c}
+}
+
+func newTestWorkqueue() workqueue.TypedRateLimitingInterface[reconcile.Request] {
+	return workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[reconcile.Request](),
+	)
+}
+
+func requireSelectorPromotionEnqueued(
+	t *testing.T,
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	t.Helper()
+	require.Equal(t, 1, wq.Len())
+	item, _ := wq.Get()
+	require.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "fake-project",
+			Name:      "selector-promotion",
+		},
+	}, item)
+}
+
+func TestUpdatedArgoCDAppHandler_Create(t *testing.T) {
+	t.Run("matching Application enqueues selector Promotion", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Create(
+			t.Context(),
+			event.TypedCreateEvent[*argocd.Application]{Object: matchingSelectorApp()},
+			wq,
+		)
+		requireSelectorPromotionEnqueued(t, wq)
+	})
+
+	t.Run("non-matching Application does not enqueue", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Create(
+			t.Context(),
+			event.TypedCreateEvent[*argocd.Application]{Object: nonMatchingSelectorApp()},
+			wq,
+		)
+		require.Equal(t, 0, wq.Len())
+	})
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Create(t.Context(), event.TypedCreateEvent[*argocd.Application]{}, wq)
+		require.Equal(t, 0, wq.Len())
+	})
+}
+
+func TestUpdatedArgoCDAppHandler_Delete(t *testing.T) {
+	t.Run("matching Application enqueues selector Promotion", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Delete(
+			t.Context(),
+			event.TypedDeleteEvent[*argocd.Application]{Object: matchingSelectorApp()},
+			wq,
+		)
+		requireSelectorPromotionEnqueued(t, wq)
+	})
+
+	t.Run("non-matching Application does not enqueue", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Delete(
+			t.Context(),
+			event.TypedDeleteEvent[*argocd.Application]{Object: nonMatchingSelectorApp()},
+			wq,
+		)
+		require.Equal(t, 0, wq.Len())
+	})
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		u := newSelectorAppHandler(t, selectorTestObjects()...)
+		wq := newTestWorkqueue()
+		u.Delete(t.Context(), event.TypedDeleteEvent[*argocd.Application]{}, wq)
+		require.Equal(t, 0, wq.Len())
+	})
 }

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,12 +27,13 @@ import (
 
 func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 	tests := []struct {
-		name         string
-		applications []client.Object
-		indexer      client.IndexerFunc
-		interceptor  interceptor.Funcs
-		e            event.TypedUpdateEvent[*argocd.Application]
-		assertions   func(*testing.T, workqueue.TypedRateLimitingInterface[reconcile.Request])
+		name            string
+		applications    []client.Object
+		indexer         client.IndexerFunc
+		selectorIndexer client.IndexerFunc
+		interceptor     interceptor.Funcs
+		e               event.TypedUpdateEvent[*argocd.Application]
+		assertions      func(*testing.T, workqueue.TypedRateLimitingInterface[reconcile.Request])
 	}{
 		{
 			name: "Event without new object",
@@ -217,11 +219,128 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 				require.Equal(t, 0, wq.Len())
 			},
 		},
+		{
+			name: "Application matched by label selector enqueues the Promotion",
+			applications: []client.Object{
+				&kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-stage",
+						Namespace: "fake-project",
+					},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "selector-promotion",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage: "fake-stage",
+						Steps: []kargoapi.PromotionStep{{
+							Uses: "argocd-update",
+							Config: &apiextensionsv1.JSON{
+								Raw: []byte(
+									`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`,
+								),
+							},
+						}},
+					},
+					Status: kargoapi.PromotionStatus{
+						Phase:       kargoapi.PromotionPhaseRunning,
+						CurrentStep: 0,
+					},
+				},
+			},
+			// Name-based index finds nothing for a selector-based step.
+			indexer: func(client.Object) []string { return nil },
+			selectorIndexer: func(obj client.Object) []string {
+				if obj.GetName() == "selector-promotion" {
+					return []string{indexer.RunningPromotionsByArgoCDSelectorsValue}
+				}
+				return nil
+			},
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-application-name",
+						Namespace: "argocd",
+						Labels:    map[string]string{"app": "foo"},
+					},
+				},
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 1, wq.Len())
+				item, _ := wq.Get()
+				require.Equal(t, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "fake-project",
+						Name:      "selector-promotion",
+					},
+				}, item)
+			},
+		},
+		{
+			name: "Application not matching label selector is not enqueued",
+			applications: []client.Object{
+				&kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-stage",
+						Namespace: "fake-project",
+					},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "selector-promotion",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage: "fake-stage",
+						Steps: []kargoapi.PromotionStep{{
+							Uses: "argocd-update",
+							Config: &apiextensionsv1.JSON{
+								Raw: []byte(
+									`{"apps":[{"namespace":"argocd","selector":{"matchLabels":{"app":"foo"}}}]}`,
+								),
+							},
+						}},
+					},
+					Status: kargoapi.PromotionStatus{
+						Phase:       kargoapi.PromotionPhaseRunning,
+						CurrentStep: 0,
+					},
+				},
+			},
+			indexer: func(client.Object) []string { return nil },
+			selectorIndexer: func(obj client.Object) []string {
+				if obj.GetName() == "selector-promotion" {
+					return []string{indexer.RunningPromotionsByArgoCDSelectorsValue}
+				}
+				return nil
+			},
+			e: event.TypedUpdateEvent[*argocd.Application]{
+				ObjectOld: &argocd.Application{},
+				ObjectNew: &argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-application-name",
+						Namespace: "argocd",
+						Labels:    map[string]string{"app": "bar"},
+					},
+				},
+			},
+			assertions: func(t *testing.T, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				require.Equal(t, 0, wq.Len())
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
 			require.NoError(t, kargoapi.AddToScheme(scheme))
+
+			selectorIndexer := tt.selectorIndexer
+			if selectorIndexer == nil {
+				selectorIndexer = func(client.Object) []string { return nil }
+			}
 
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -230,6 +349,11 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 					&kargoapi.Promotion{},
 					indexer.RunningPromotionsByArgoCDApplicationsField,
 					tt.indexer,
+				).
+				WithIndex(
+					&kargoapi.Promotion{},
+					indexer.RunningPromotionsByArgoCDSelectorsField,
+					selectorIndexer,
 				).
 				WithInterceptorFuncs(tt.interceptor)
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -34,6 +34,7 @@ const (
 	PromotionsByTerminalField        = "terminal"
 
 	RunningPromotionsByArgoCDApplicationsField = "applications"
+	RunningPromotionsByArgoCDSelectorsField    = "argoCDSelectors"
 	RunningPromotionsByPullRequestURLField     = "pullRequestURL"
 
 	StagesByAnalysisRunField    = "analysisRun"
@@ -298,6 +299,89 @@ func RunningPromotionsByArgoCDApplications(
 			}
 		}
 		return res
+	}
+}
+
+// RunningPromotionsByArgoCDSelectorsValue is the sentinel value indexed for
+// running Promotions that have at least one label-selector-based argocd-update
+// or argocd-wait step. It is the value with which to query the
+// RunningPromotionsByArgoCDSelectorsField index.
+const RunningPromotionsByArgoCDSelectorsValue = "true"
+
+// RunningPromotionsByArgoCDSelectors returns a client.IndexerFunc that indexes
+// running Promotions that have at least one label-selector-based argocd-update
+// or argocd-wait step (as opposed to one that targets an Argo CD Application by
+// name).
+//
+// Unlike RunningPromotionsByArgoCDApplications, this index cannot key on the
+// matched Application(s): a selector's match set depends on Application labels,
+// which change independently of the Promotion, so it cannot be derived from the
+// Promotion alone. Instead this is a coarse index whose only value is a
+// sentinel. It exists so that, on an Application event, the watch handler can
+// cheaply narrow the candidate set to the (small) population of running
+// Promotions that use selectors before evaluating each selector forward against
+// the changed Application.
+//
+// When the provided shardName is non-empty, only Promotions labeled with the
+// provided shardName are indexed. When the provided shardName is empty, only
+// Promotions not labeled with a shardName are indexed.
+func RunningPromotionsByArgoCDSelectors(
+	shardName string,
+	isDefaultController bool,
+) client.IndexerFunc {
+	return func(obj client.Object) []string {
+		// Return early if the Promotion is not the responsibility of this
+		// controller.
+		objShard := obj.GetLabels()[kargoapi.LabelKeyShard]
+		// Note(krancour): staticcheck wants us to apply De Morgan's law here, but
+		// this logic feels more readable as is. i.e. NOT (responsible for).
+		if !(objShard == shardName || (objShard == "" && isDefaultController)) { // nolint: staticcheck
+			return nil
+		}
+
+		promo, ok := obj.(*kargoapi.Promotion)
+		if !ok {
+			return nil
+		}
+
+		// We are only interested in running Promotions.
+		if promo.Status.Phase != kargoapi.PromotionPhaseRunning {
+			return nil
+		}
+
+		for i, step := range promo.Spec.Steps {
+			if int64(i) > promo.Status.CurrentStep {
+				// We are only interested in steps that have already been executed or
+				// are about to be.
+				break
+			}
+			if (step.Uses != "argocd-update" && step.Uses != "argocd-wait") ||
+				step.Config == nil {
+				continue
+			}
+			// A cheap structural check for the presence of a selector. No
+			// expression evaluation is required to know whether this Promotion
+			// belongs in the candidate set; the watch handler does the precise
+			// matching.
+			cfgMap := map[string]any{}
+			if err := json.Unmarshal(step.Config.Raw, &cfgMap); err != nil {
+				continue
+			}
+			apps, ok := cfgMap["apps"].([]any)
+			if !ok {
+				continue
+			}
+			for _, app := range apps {
+				appMap, ok := app.(map[string]any)
+				if !ok {
+					continue
+				}
+				if selector, ok := appMap["selector"]; ok && selector != nil {
+					return []string{RunningPromotionsByArgoCDSelectorsValue}
+				}
+			}
+		}
+		return nil
 	}
 }
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -585,6 +585,99 @@ func TestRunningPromotionsByArgoCDApplications(t *testing.T) {
 	}
 }
 
+func TestRunningPromotionsByArgoCDSelectors(t *testing.T) {
+	t.Parallel()
+	const testShardName = "test-shard"
+
+	selectorStep := kargoapi.PromotionStep{
+		Uses: "argocd-update",
+		Config: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apps":[{"selector":{"matchLabels":{"app":"foo"}}}]}`),
+		},
+	}
+	nameStep := kargoapi.PromotionStep{
+		Uses: "argocd-update",
+		Config: &apiextensionsv1.JSON{
+			Raw: []byte(`{"apps":[{"name":"some-app"}]}`),
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		obj       client.Object
+		shardName string
+		expected  []string
+	}{
+		{
+			name:     "Object is not a Promotion",
+			obj:      &kargoapi.Stage{},
+			expected: nil,
+		},
+		{
+			name: "Promotion is not running",
+			obj: &kargoapi.Promotion{
+				Spec:   kargoapi.PromotionSpec{Steps: []kargoapi.PromotionStep{selectorStep}},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseSucceeded},
+			},
+			expected: nil,
+		},
+		{
+			name: "Promotion belongs to another shard",
+			obj: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{kargoapi.LabelKeyShard: "another"},
+				},
+				Spec:   kargoapi.PromotionSpec{Steps: []kargoapi.PromotionStep{selectorStep}},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			shardName: testShardName,
+			expected:  nil,
+		},
+		{
+			name: "running Promotion with a selector-based step",
+			obj: &kargoapi.Promotion{
+				Spec:   kargoapi.PromotionSpec{Steps: []kargoapi.PromotionStep{selectorStep}},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			expected: []string{RunningPromotionsByArgoCDSelectorsValue},
+		},
+		{
+			name: "running Promotion with only a name-based step",
+			obj: &kargoapi.Promotion{
+				Spec:   kargoapi.PromotionSpec{Steps: []kargoapi.PromotionStep{nameStep}},
+				Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+			},
+			expected: nil,
+		},
+		{
+			name: "selector-based step beyond CurrentStep is ignored",
+			obj: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{nameStep, selectorStep},
+				},
+				Status: kargoapi.PromotionStatus{
+					Phase:       kargoapi.PromotionPhaseRunning,
+					CurrentStep: 0,
+				},
+			},
+			expected: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t,
+				testCase.expected,
+				RunningPromotionsByArgoCDSelectors(
+					testCase.shardName,
+					testCase.shardName == "",
+				)(testCase.obj),
+			)
+		})
+	}
+}
+
 func TestRunningPromotionsByPullRequestURL(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/pkg/promotion/runner/builtin/argocd_common.go
+++ b/pkg/promotion/runner/builtin/argocd_common.go
@@ -9,9 +9,9 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-// buildArgoCDAppLabelSelector converts an ArgoCDAppSelector into a Kubernetes
+// BuildArgoCDAppLabelSelector converts an ArgoCDAppSelector into a Kubernetes
 // labels.Selector.
-func buildArgoCDAppLabelSelector(
+func BuildArgoCDAppLabelSelector(
 	selector *builtin.ArgoCDAppSelector,
 ) (labels.Selector, error) {
 	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {

--- a/pkg/promotion/runner/builtin/argocd_common_test.go
+++ b/pkg/promotion/runner/builtin/argocd_common_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
 )
 
-func Test_buildArgoCDAppLabelSelector(t *testing.T) {
+func Test_BuildArgoCDAppLabelSelector(t *testing.T) {
 	testCases := []struct {
 		name      string
 		selector  *builtin.ArgoCDAppSelector
@@ -48,7 +48,7 @@ func Test_buildArgoCDAppLabelSelector(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			sel, err := buildArgoCDAppLabelSelector(tc.selector)
+			sel, err := BuildArgoCDAppLabelSelector(tc.selector)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/promotion/runner/builtin/argocd_updater.go
+++ b/pkg/promotion/runner/builtin/argocd_updater.go
@@ -114,7 +114,7 @@ func newArgocdUpdater(caps promotion.StepRunnerCapabilities) promotion.StepRunne
 	r := &argocdUpdater{argocdClient: caps.ArgoCDClient}
 	r.schemaLoader = getConfigSchemaLoader(stepKindArgoCDUpdate)
 	r.getAuthorizedApplicationsFn = r.getAuthorizedApplications
-	r.buildLabelSelectorFn = buildArgoCDAppLabelSelector
+	r.buildLabelSelectorFn = BuildArgoCDAppLabelSelector
 	r.buildDesiredSourcesFn = r.buildDesiredSources
 	r.mustPerformUpdateFn = r.mustPerformUpdate
 	r.syncApplicationFn = r.syncApplication

--- a/pkg/promotion/runner/builtin/argocd_updater_test.go
+++ b/pkg/promotion/runner/builtin/argocd_updater_test.go
@@ -2671,7 +2671,7 @@ func Test_argoCDUpdater_getAuthorizedApplications(t *testing.T) {
 			runner := &argocdUpdater{
 				argocdClient: c.Build(),
 			}
-			runner.buildLabelSelectorFn = buildArgoCDAppLabelSelector
+			runner.buildLabelSelectorFn = BuildArgoCDAppLabelSelector
 
 			apps, err := runner.getAuthorizedApplications(
 				t.Context(),

--- a/pkg/promotion/runner/builtin/argocd_waiter.go
+++ b/pkg/promotion/runner/builtin/argocd_waiter.go
@@ -379,7 +379,7 @@ func getArgoCDApplications(
 	}
 
 	if selector != nil {
-		labelSelector, err := buildArgoCDAppLabelSelector(selector)
+		labelSelector, err := BuildArgoCDAppLabelSelector(selector)
 		if err != nil {
 			return nil, fmt.Errorf("error building label selector: %w", err)
 		}


### PR DESCRIPTION
## Description

Closes #6176

When an `argocd-update` or `argocd-wait` step targets Argo CD `Application`s by **label selector** rather than by name, the running `Promotion` is not captured by the name-based Applications index. `Application` state changes therefore never wake the `Promotion` through the event-driven path, and it only progresses on the periodic reconciliation interval (~5 minutes) — while name-based steps complete in seconds.

### Why not "just index it the other way"?

controller-runtime's `FieldIndexer` stays fresh only when the indexed key is **intrinsic** to the indexed object — derivable from that object alone, recomputed whenever *it* is written. A name in step config is intrinsic to the `Promotion`. A selector's *match set* is not: it depends on the labels of `Application`s that change independently, and nothing re-runs the `Promotion`'s index function when an `Application`'s labels change. A reverse index keyed on `Application`s ("which Promotions select me?") has the same flaw inverted — that fact is not a function of the `Application` alone. Any such index goes stale silently. This is the same wall described in #2971 when wildcard `authorized-stage` support was removed.

### The precedent: how core Kubernetes solves this exact problem

Core Kubernetes never maintains a reverse-selector index. The EndpointSlice controller faces the identical shape — a `Pod` (label-bearing object) changes, and the controller must find the `Service`s (selector-bearing objects) that select it. Its answer, in `GetPodServiceMemberships`, is a **scoped forward scan**: list the candidate `Service`s, test each `Service`'s selector forward against the `Pod`'s labels, and enqueue the matches. Freshness is automatic because the selector-bearing side remains the source of truth and the `Pod` event is a pure query — nothing about a `Pod` write needs to update an index. The same pattern appears in the NetworkPolicy controller and in admission webhook `objectSelector` matching. On label *changes*, the EndpointSlice controller enqueues the union of old- and new-matching `Service`s (`determineNeededServiceUpdates`), so a `Service` that *stopped* matching still reconciles once to notice.

The pattern's cost is bounded by scoping the candidate set. Upstream the scope is the namespace (a `Service` only selects `Pod`s in its own namespace).

### Adapting the pattern here

Translation: changed `Application` = `Pod`; running `Promotion`s with selector-mode argocd steps = `Service`s; selector match → enqueue the `Promotion`.

Two Kargo-specific adjustments:

1. **The scope cannot be the namespace.** `apps[].namespace` permits targeting `Application`s in *arbitrary* namespaces (defaulting to the Argo CD control namespace), so the upstream namespace trick is unavailable. Instead, a new coarse, shard-aware field index — `RunningPromotionsByArgoCDSelectors` — flags running `Promotion`s having at least one selector-mode argocd step. The flag *is* intrinsic to the `Promotion` (a cheap structural check of its own step config, no expression evaluation), so the index stays fresh, and it bounds the per-event scan to the small population of running selector-`Promotion`s rather than every `Promotion` in the system.
2. **Selector resolution mirrors the existing name index.** For each candidate, the watch handler resolves the step's target namespace and selector — including expression/template evaluation in `matchLabels`/`matchExpressions` values, with the same expression environment the name-based index uses — then tests `Selector.Matches(app.Labels)` against **both the old and new** label sets (the `determineNeededServiceUpdates` union), enqueueing matches deduplicated with the name-based path.

### Reacting to membership changes, not just status

A selector's match set changes whenever a matching `Application` is **relabeled**, **created**, or **deleted** — not only when its status changes. The handler's old∪new union (above) is written to handle a relabel, but the `Application` watch predicates originally fired only on status transitions (health/sync/operation/reconciledAt), so a label-only change, a create, or a delete never reached the handler — leaving the union path unreachable for exactly the cases it was meant to cover.

This wires the missing triggers so every way a selector's membership can change wakes a running selector-`Promotion`:

- `ArgoCDAppLabelsChanged` — fires on a label diff, activating the old∪new union so a `Promotion` is woken when an `Application` enters *or* leaves its selector.
- `ArgoCDAppCreatedOrDeleted` — fires on create/delete; the handler's `Create`/`Delete` run the same coarse-index-narrowed forward scan (a deleted object still carries its labels for evaluation).

The forward-scan logic is shared across `Update`/`Create`/`Delete`. Create/Delete are selector-only — name-based targeting is unaffected by an `Application` merely appearing or disappearing. Cost stays bounded: these events are infrequent and the scan is still filtered to the small running-selector-`Promotion` set.

### What this preserves / changes

- Name-based targeting: unchanged (existing index and lookup untouched).
- Selector-based `argocd-update` *and* `argocd-wait` now wake event-driven, in seconds. Notably this works for `argocd-wait` against `Application`s carrying no `authorized-stage` annotation — waiting is read-only and requires no authorization, which is why an annotation-keyed trigger (explored previously in #6399) was unsound.
- Editing a `Stage`'s selector takes effect on the next `Application` event with no staleness — the selector is read from the running `Promotion` at event time.
- The watch now reacts to the full set of selector-membership events — status changes, label changes, creations, and deletions — rather than status changes alone.

### Deferred (deliberately)

Upstream pairs this pattern with a parsed-selector cache (`ServiceSelectorCache`, kubernetes/kubernetes#84280), worthwhile when `Pod` events fan out across many `Service`s. Here the coarse index already bounds candidates to the handful of running selector-`Promotion`s, so per-event parsing is cheap; a generation-keyed cache can be added later if profiling warrants.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

<!-- Internal indexing/enqueue fix; no user-facing configuration change. -->

### AI Use Disclosure

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
