### PR TITLE
fix: empty actor for promos created with kargo api tokens

### DIFF
--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -244,6 +244,10 @@ func (a *authMiddleware) authenticate(
 // account name extracted from the standard "sub" claim.
 func serviceAccountUsernameFromToken(rawToken string) (username, usernameClaim string) {
 	mapClaims := jwt.MapClaims{}
+	// #nosec G115 -- The token has already been verified by Kubernetes before
+	// this function is called; Kubernetes validates the JWT signature, so any
+	// claims present are trustworthy. The extracted username is used only for
+	// the create-actor display annotation and plays no role in authorization.
 	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).
 		ParseUnverified(rawToken, &mapClaims); err != nil {
 		return "", ""

--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -225,12 +225,43 @@ func (a *authMiddleware) authenticate(
 	}
 	logger.Debug("token recognized by Kubernetes")
 
+	username, usernameClaim := serviceAccountUsernameFromToken(rawToken)
 	return user.ContextWithInfo(
 		ctx,
 		user.Info{
-			BearerToken: rawToken,
+			BearerToken:   rawToken,
+			Username:      username,
+			UsernameClaim: usernameClaim,
 		},
 	), nil
+}
+
+// serviceAccountUsernameFromToken extracts a meaningful username from a
+// Kubernetes service account JWT. For Kargo API tokens (legacy
+// ServiceAccountToken-type Secrets), the JWT contains the secret name in the
+// "kubernetes.io/serviceaccount/secret.name" claim, which is the name the user
+// chose when running "kargo create token --name=...". Falls back to the service
+// account name extracted from the standard "sub" claim.
+func serviceAccountUsernameFromToken(rawToken string) (username, usernameClaim string) {
+	mapClaims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).
+		ParseUnverified(rawToken, &mapClaims); err != nil {
+		return "", ""
+	}
+	if secretName, ok := mapClaims["kubernetes.io/serviceaccount/secret.name"]; ok {
+		if name, ok := secretName.(string); ok && name != "" {
+			return name, "serviceaccount"
+		}
+	}
+	// Fall back to the service account name from the sub claim.
+	// Sub format: "system:serviceaccount:<namespace>:<name>"
+	sub, _ := mapClaims["sub"].(string)
+	if strings.HasPrefix(sub, "system:serviceaccount:") {
+		if parts := strings.SplitN(sub, ":", 4); len(parts) == 4 && parts[3] != "" {
+			return parts[3], "serviceaccount"
+		}
+	}
+	return "", ""
 }
 
 func (a *authMiddleware) listServiceAccounts(

--- a/pkg/server/auth_middleware_test.go
+++ b/pkg/server/auth_middleware_test.go
@@ -48,6 +48,7 @@ EZv4FqnG2KDTlXoV/Ku1ib5vzgQK5fTFfqO5dm5sLM4qQFmLadULaTcNOldyH3KG
 c1e3
 -----END CERTIFICATE-----`)
 
+
 func TestNewAuthMiddleware(t *testing.T) {
 	a := &authMiddleware{}
 	middleware := newAuthMiddleware(t.Context(), config.ServerConfig{}, nil)
@@ -167,6 +168,20 @@ func TestAuthenticate(t *testing.T) {
 		testKargoIssuer = "fake-kargo-issuer"
 		testToken       = "some-token"
 	)
+	saTokenWithSecretName, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":                                    "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/namespace": "my-project",
+		"kubernetes.io/serviceaccount/secret.name":          "my-ci-token",
+		"kubernetes.io/serviceaccount/service-account.name": "my-role",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	saTokenSubOnly, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+
 	testSets := map[string]struct {
 		path           string
 		authMiddleware *authMiddleware
@@ -401,6 +416,50 @@ func TestAuthenticate(t *testing.T) {
 				require.Equal(t, "invalid token", err.Error())
 				_, ok := user.InfoFromContext(ctx)
 				require.False(t, ok)
+			},
+		},
+		"Kubernetes SA token with secret name claim": {
+			path: testPath,
+			authMiddleware: &authMiddleware{
+				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
+					rc, ok := claims.(*jwt.RegisteredClaims)
+					require.True(t, ok)
+					rc.Issuer = "kubernetes/serviceaccount"
+					return nil, nil, nil
+				},
+				verifyKubernetesTokenFn: func(context.Context, string) error {
+					return nil
+				},
+			},
+			token: saTokenWithSecretName,
+			assertions: func(ctx context.Context, err error) {
+				require.NoError(t, err)
+				u, ok := user.InfoFromContext(ctx)
+				require.True(t, ok)
+				require.Equal(t, "my-ci-token", u.Username)
+				require.Equal(t, "serviceaccount", u.UsernameClaim)
+			},
+		},
+		"Kubernetes SA token without secret name claim falls back to SA name": {
+			path: testPath,
+			authMiddleware: &authMiddleware{
+				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
+					rc, ok := claims.(*jwt.RegisteredClaims)
+					require.True(t, ok)
+					rc.Issuer = "kubernetes/serviceaccount"
+					return nil, nil, nil
+				},
+				verifyKubernetesTokenFn: func(context.Context, string) error {
+					return nil
+				},
+			},
+			token: saTokenSubOnly,
+			assertions: func(ctx context.Context, err error) {
+				require.NoError(t, err)
+				u, ok := user.InfoFromContext(ctx)
+				require.True(t, ok)
+				require.Equal(t, "my-role", u.Username)
+				require.Equal(t, "serviceaccount", u.UsernameClaim)
 			},
 		},
 	}
@@ -736,6 +795,72 @@ func TestVerifyKubernetesToken(t *testing.T) {
 			}
 			err := authenticator.verifyKubernetesToken(t.Context(), testToken)
 			testCase.assertions(t, err)
+		})
+	}
+}
+
+func TestServiceAccountUsernameFromToken(t *testing.T) {
+	t.Parallel()
+
+	tokenWithSecretName, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":                                    "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/namespace": "my-project",
+		"kubernetes.io/serviceaccount/secret.name":          "my-ci-token",
+		"kubernetes.io/serviceaccount/service-account.name": "my-role",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenSubOnly, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenNonSASub, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "some-other-subject",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenMissingSub, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name             string
+		token            string
+		expectedUsername string
+		expectedClaim    string
+	}{
+		{
+			name:  "not a JWT",
+			token: "not-a-jwt",
+		},
+		{
+			name:             "secret name claim takes priority",
+			token:            tokenWithSecretName,
+			expectedUsername: "my-ci-token",
+			expectedClaim:    "serviceaccount",
+		},
+		{
+			name:             "fallback to SA name from sub when no secret name",
+			token:            tokenSubOnly,
+			expectedUsername: "my-role",
+			expectedClaim:    "serviceaccount",
+		},
+		{
+			name:  "non-SA sub returns empty",
+			token: tokenNonSASub,
+		},
+		{
+			name:  "missing sub returns empty",
+			token: tokenMissingSub,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			username, claim := serviceAccountUsernameFromToken(testCase.token)
+			require.Equal(t, testCase.expectedUsername, username)
+			require.Equal(t, testCase.expectedClaim, claim)
 		})
 	}
 }

--- a/pkg/server/auth_middleware_test.go
+++ b/pkg/server/auth_middleware_test.go
@@ -48,7 +48,6 @@ EZv4FqnG2KDTlXoV/Ku1ib5vzgQK5fTFfqO5dm5sLM4qQFmLadULaTcNOldyH3KG
 c1e3
 -----END CERTIFICATE-----`)
 
-
 func TestNewAuthMiddleware(t *testing.T) {
 	a := &authMiddleware{}
 	middleware := newAuthMiddleware(t.Context(), config.ServerConfig{}, nil)

--- a/pkg/server/option/auth.go
+++ b/pkg/server/option/auth.go
@@ -454,12 +454,43 @@ func (a *authInterceptor) authenticate(
 	}
 	logger.Debug("token recognized by Kubernetes")
 
+	username, usernameClaim := serviceAccountUsernameFromToken(rawToken)
 	return user.ContextWithInfo(
 		ctx,
 		user.Info{
-			BearerToken: rawToken,
+			BearerToken:   rawToken,
+			Username:      username,
+			UsernameClaim: usernameClaim,
 		},
 	), nil
+}
+
+// serviceAccountUsernameFromToken extracts a meaningful username from a
+// Kubernetes service account JWT. For Kargo API tokens (legacy
+// ServiceAccountToken-type Secrets), the JWT contains the secret name in the
+// "kubernetes.io/serviceaccount/secret.name" claim, which is the name the user
+// chose when running "kargo create token --name=...". Falls back to the service
+// account name extracted from the standard "sub" claim.
+func serviceAccountUsernameFromToken(rawToken string) (username, usernameClaim string) {
+	mapClaims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).
+		ParseUnverified(rawToken, &mapClaims); err != nil {
+		return "", ""
+	}
+	if secretName, ok := mapClaims["kubernetes.io/serviceaccount/secret.name"]; ok {
+		if name, ok := secretName.(string); ok && name != "" {
+			return name, "serviceaccount"
+		}
+	}
+	// Fall back to the service account name from the sub claim.
+	// Sub format: "system:serviceaccount:<namespace>:<name>"
+	sub, _ := mapClaims["sub"].(string)
+	if strings.HasPrefix(sub, "system:serviceaccount:") {
+		if parts := strings.SplitN(sub, ":", 4); len(parts) == 4 && parts[3] != "" {
+			return parts[3], "serviceaccount"
+		}
+	}
+	return "", ""
 }
 
 var verifierMu = sync.Mutex{}

--- a/pkg/server/option/auth.go
+++ b/pkg/server/option/auth.go
@@ -473,6 +473,10 @@ func (a *authInterceptor) authenticate(
 // account name extracted from the standard "sub" claim.
 func serviceAccountUsernameFromToken(rawToken string) (username, usernameClaim string) {
 	mapClaims := jwt.MapClaims{}
+	// #nosec G115 -- The token has already been verified by Kubernetes before
+	// this function is called; Kubernetes validates the JWT signature, so any
+	// claims present are trustworthy. The extracted username is used only for
+	// the create-actor display annotation and plays no role in authorization.
 	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).
 		ParseUnverified(rawToken, &mapClaims); err != nil {
 		return "", ""

--- a/pkg/server/option/auth_test.go
+++ b/pkg/server/option/auth_test.go
@@ -47,6 +47,7 @@ EZv4FqnG2KDTlXoV/Ku1ib5vzgQK5fTFfqO5dm5sLM4qQFmLadULaTcNOldyH3KG
 c1e3
 -----END CERTIFICATE-----`)
 
+
 func TestNewAuthInterceptor(t *testing.T) {
 	a := newAuthInterceptor(t.Context(), config.ServerConfig{}, nil)
 	require.NotNil(t, a)
@@ -163,6 +164,20 @@ func TestAuthenticate(t *testing.T) {
 		testKargoIssuer = "fake-kargo-issuer"
 		testToken       = "some-token"
 	)
+	saTokenWithSecretName, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":                                    "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/namespace": "my-project",
+		"kubernetes.io/serviceaccount/secret.name":          "my-ci-token",
+		"kubernetes.io/serviceaccount/service-account.name": "my-role",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	saTokenSubOnly, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+
 	testSets := map[string]struct {
 		procedure       string
 		authInterceptor *authInterceptor
@@ -397,6 +412,50 @@ func TestAuthenticate(t *testing.T) {
 				require.Equal(t, "invalid token", err.Error())
 				_, ok := user.InfoFromContext(ctx)
 				require.False(t, ok)
+			},
+		},
+		"Kubernetes SA token with secret name claim": {
+			procedure: testProcedure,
+			authInterceptor: &authInterceptor{
+				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
+					rc, ok := claims.(*jwt.RegisteredClaims)
+					require.True(t, ok)
+					rc.Issuer = "kubernetes/serviceaccount"
+					return nil, nil, nil
+				},
+				verifyKubernetesTokenFn: func(context.Context, string) error {
+					return nil
+				},
+			},
+			token: saTokenWithSecretName,
+			assertions: func(ctx context.Context, err error) {
+				require.NoError(t, err)
+				u, ok := user.InfoFromContext(ctx)
+				require.True(t, ok)
+				require.Equal(t, "my-ci-token", u.Username)
+				require.Equal(t, "serviceaccount", u.UsernameClaim)
+			},
+		},
+		"Kubernetes SA token without secret name claim falls back to SA name": {
+			procedure: testProcedure,
+			authInterceptor: &authInterceptor{
+				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
+					rc, ok := claims.(*jwt.RegisteredClaims)
+					require.True(t, ok)
+					rc.Issuer = "kubernetes/serviceaccount"
+					return nil, nil, nil
+				},
+				verifyKubernetesTokenFn: func(context.Context, string) error {
+					return nil
+				},
+			},
+			token: saTokenSubOnly,
+			assertions: func(ctx context.Context, err error) {
+				require.NoError(t, err)
+				u, ok := user.InfoFromContext(ctx)
+				require.True(t, ok)
+				require.Equal(t, "my-role", u.Username)
+				require.Equal(t, "serviceaccount", u.UsernameClaim)
 			},
 		},
 	}
@@ -658,6 +717,72 @@ func TestVerifyKubernetesToken(t *testing.T) {
 			}
 			err := authenticator.verifyKubernetesToken(t.Context(), testToken)
 			testCase.assertions(t, err)
+		})
+	}
+}
+
+func TestServiceAccountUsernameFromToken(t *testing.T) {
+	t.Parallel()
+
+	tokenWithSecretName, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":                                    "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/namespace": "my-project",
+		"kubernetes.io/serviceaccount/secret.name":          "my-ci-token",
+		"kubernetes.io/serviceaccount/service-account.name": "my-role",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenSubOnly, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+		"sub": "system:serviceaccount:my-project:my-role",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenNonSASub, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "some-other-subject",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	tokenMissingSub, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name             string
+		token            string
+		expectedUsername string
+		expectedClaim    string
+	}{
+		{
+			name:  "not a JWT",
+			token: "not-a-jwt",
+		},
+		{
+			name:             "secret name claim takes priority",
+			token:            tokenWithSecretName,
+			expectedUsername: "my-ci-token",
+			expectedClaim:    "serviceaccount",
+		},
+		{
+			name:             "fallback to SA name from sub when no secret name",
+			token:            tokenSubOnly,
+			expectedUsername: "my-role",
+			expectedClaim:    "serviceaccount",
+		},
+		{
+			name:  "non-SA sub returns empty",
+			token: tokenNonSASub,
+		},
+		{
+			name:  "missing sub returns empty",
+			token: tokenMissingSub,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			username, claim := serviceAccountUsernameFromToken(testCase.token)
+			require.Equal(t, testCase.expectedUsername, username)
+			require.Equal(t, testCase.expectedClaim, claim)
 		})
 	}
 }

--- a/pkg/server/option/auth_test.go
+++ b/pkg/server/option/auth_test.go
@@ -47,7 +47,6 @@ EZv4FqnG2KDTlXoV/Ku1ib5vzgQK5fTFfqO5dm5sLM4qQFmLadULaTcNOldyH3KG
 c1e3
 -----END CERTIFICATE-----`)
 
-
 func TestNewAuthInterceptor(t *testing.T) {
 	a := newAuthInterceptor(t.Context(), config.ServerConfig{}, nil)
 	require.NotNil(t, a)


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/6201

### Before

To reproduce the issue I:
1. created a new test token.
2. added it to my kargo config
3. created a promotion with an http step that sends a POST request to webhook site to check the actor.
4. verified it was empty.

https://github.com/user-attachments/assets/e1e8b157-bd0b-4fe6-8f2f-bcfa30e8eed3


### After

Verified the actor was populated after adding parsing for service account username from the token.

https://github.com/user-attachments/assets/5b530aff-aac2-4db0-9d8e-27537507e1fc

