### PR TITLE
ci: scan the kargo image for CVEs with Grype at build and release time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,10 +266,15 @@ jobs:
       uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       with:
         cache-db: true
+    # cve-scan.sh re-stamps the VEX product @id to the scanned digest, which it
+    # resolves from the job-local registry tag via crane.
+    - name: Install Crane
+      uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
     - name: Scan image for CVEs
       env:
         GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
         GRYPE_REGISTRY_INSECURE_USE_HTTP: "true" # job-local registry service
+        CRANE_INSECURE: "true" # job-local registry is plain HTTP
         FAIL_ON: "" # report-only; set to "high" to enforce
       # VEX lookups use the canonical published repo path.
       run: ./hack/cve-scan.sh "registry:localhost:5000/kargo:scan" "ghcr.io/akuity/kargo"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,9 +255,24 @@ jobs:
         platforms: linux/amd64,linux/arm64
         build-args: |
           BASE_IMAGE=localhost:5000/kargo-base
-        push: false
+        # Push to the job-local registry service (nothing leaves the runner)
+        # so the built image can be scanned for CVEs below.
+        tags: localhost:5000/kargo:scan
+        push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+    - name: Install Grype
+      id: grype
+      uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+      with:
+        cache-db: true
+    - name: Scan image for CVEs
+      env:
+        GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+        GRYPE_REGISTRY_INSECURE_USE_HTTP: "true" # job-local registry service
+        FAIL_ON: "" # report-only; set to "high" to enforce
+      # VEX lookups use the canonical published repo path.
+      run: ./hack/cve-scan.sh "registry:localhost:5000/kargo:scan" "ghcr.io/akuity/kargo"
 
   build-cli:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,18 @@ jobs:
           -a "sha=${{ github.sha }}" \
           --yes \
           ${{ steps.repo.outputs.repo}}@${{ steps.image.outputs.digest}}
+    - name: Install Grype
+      id: grype
+      uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+      with:
+        cache-db: true
+    - name: Scan image for CVEs
+      env:
+        GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+        FAIL_ON: "" # report-only; set to "high" to enforce
+      # Scan the just-pushed digest; VEX lookups always use the canonical
+      # (non-unstable) repo path.
+      run: ./hack/cve-scan.sh "registry:${{ steps.repo.outputs.repo }}@${{ steps.image.outputs.digest }}" "ghcr.io/akuity/kargo"
     - name: Publish SBOM
       if: github.event_name == 'release'
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/hack/cve-scan.sh
+++ b/hack/cve-scan.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Scan a container image for CVEs with Grype, applying Akuity's published VEX
+# (Vulnerability Exploitability eXchange) statements so that findings already
+# assessed as not-affected are suppressed.
+#
+# Report-only by default: findings are written to the job log and the GitHub
+# step summary, and a warning annotation is emitted when Critical/High CVEs
+# are present. Set FAIL_ON to a severity (e.g. "high") to make the scan fail
+# the build instead.
+#
+# This is the canonical scan recipe used across Akuity image pipelines.
+#
+# Usage: cve-scan.sh <image-ref> [<vex-repo>]
+#
+#   <image-ref>  Image to scan, with an explicit grype scheme, e.g.:
+#                  docker:us-docker.pkg.dev/akuity/akp/akuity-platform:1.2.3
+#                    (image in the local docker daemon, typical for PR builds)
+#                  registry:us-docker.pkg.dev/akuity/akp/akuity-platform@sha256:...
+#                    (image in a remote registry, typical for pushed images;
+#                     prefer scanning by digest)
+#   <vex-repo>   Repository path used to look up VEX statements at
+#                ${VEX_BASE_URL}/pkg/oci/<vex-repo>/vex.json. Defaults to the
+#                repository derived from <image-ref> (scheme/tag/digest
+#                stripped). A missing VEX document is not an error: VEX
+#                publishing may not yet cover this image.
+#
+# Environment:
+#   GRYPE_CMD     Path to the grype binary (default: "grype" on PATH)
+#   FAIL_ON       Severity threshold to fail on ("critical", "high", ...).
+#                 Empty (default) = report only, never fail.
+#   VEX_BASE_URL  Base URL of the VEX repository (default: https://vex.akuity.io)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <image-ref> [<vex-repo>]" >&2
+    exit 2
+fi
+
+IMAGE_REF="$1"
+GRYPE_CMD="${GRYPE_CMD:-grype}"
+FAIL_ON="${FAIL_ON:-}"
+VEX_BASE_URL="${VEX_BASE_URL:-https://vex.akuity.io}"
+
+# Derive the repository from the image ref: strip the grype scheme prefix,
+# any digest, and any tag (a colon after the last slash).
+repo="${IMAGE_REF#docker:}"
+repo="${repo#registry:}"
+repo="${repo#oci-archive:}"
+repo="${repo#docker-archive:}"
+repo="${repo%%@*}"
+base="${repo##*/}"
+if [[ "$base" == *:* ]]; then
+    repo="${repo%:*}"
+fi
+VEX_REPO="${2:-$repo}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+# --- Fetch VEX statements (tolerate absence) --------------------------------
+vex_args=()
+vex_url="${VEX_BASE_URL}/pkg/oci/${VEX_REPO}/vex.json"
+if curl -fsSL --retry 3 --max-time 30 "$vex_url" -o "$workdir/vex.json" 2>/dev/null \
+    && jq -e .statements "$workdir/vex.json" >/dev/null 2>&1; then
+    echo "Applying VEX statements from $vex_url"
+    vex_args=(--vex "$workdir/vex.json")
+else
+    echo "::notice::No VEX statements published for ${VEX_REPO} (${vex_url}); scanning without VEX."
+fi
+
+# --- Scan --------------------------------------------------------------------
+fail_args=()
+if [[ -n "$FAIL_ON" ]]; then
+    fail_args=(--fail-on "$FAIL_ON")
+fi
+
+echo "Scanning ${IMAGE_REF} ..."
+rc=0
+"$GRYPE_CMD" "$IMAGE_REF" \
+    ${vex_args[0]+"${vex_args[@]}"} \
+    ${fail_args[0]+"${fail_args[@]}"} \
+    -o "table=$workdir/table.txt" \
+    -o "json=$workdir/report.json" \
+    || rc=$?
+
+cat "$workdir/table.txt"
+
+# Distinguish "grype failed to scan" (no usable report) from "the FAIL_ON
+# severity gate was breached" (scan completed, non-zero exit).
+if ! jq -e '.matches' "$workdir/report.json" >/dev/null 2>&1; then
+    echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc})"
+    exit "$((rc == 0 ? 1 : rc))"
+fi
+
+# --- Report ------------------------------------------------------------------
+critical=$(jq '[.matches[] | select(.vulnerability.severity == "Critical")] | length' "$workdir/report.json")
+high=$(jq '[.matches[] | select(.vulnerability.severity == "High")] | length' "$workdir/report.json")
+total=$(jq '.matches | length' "$workdir/report.json")
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "## CVE scan: \`${IMAGE_REF}\`"
+        echo
+        echo "| Critical | High | Total |"
+        echo "|---|---|---|"
+        echo "| ${critical} | ${high} | ${total} |"
+        echo
+        echo '```'
+        head -n 300 "$workdir/table.txt"
+        echo '```'
+    } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "$critical" -gt 0 || "$high" -gt 0 ]]; then
+    echo "::warning::CVE scan of ${IMAGE_REF}: ${critical} critical, ${high} high (see job summary)"
+fi
+
+if [[ "$rc" -ne 0 ]]; then
+    echo "::error::CVE scan of ${IMAGE_REF} failed the '${FAIL_ON}' severity gate"
+fi
+exit "$rc"

--- a/hack/cve-scan.sh
+++ b/hack/cve-scan.sh
@@ -85,19 +85,38 @@ rc=0
     -o "json=$workdir/report.json" \
     || rc=$?
 
-cat "$workdir/table.txt"
+cat "$workdir/table.txt" 2>/dev/null || true
 
-# Distinguish "grype failed to scan" (no usable report) from "the FAIL_ON
-# severity gate was breached" (scan completed, non-zero exit).
+# Grype failed to produce a usable report (e.g. the image could not be fetched).
+# This is distinct from the FAIL_ON severity gate being breached. In report-only
+# mode (FAIL_ON empty) we never block the build on it — a scan that can't run is
+# a warning, not a regression in the change under review. When enforcing, we
+# fail closed: an image we cannot scan must not pass a gate.
 if ! jq -e '.matches' "$workdir/report.json" >/dev/null 2>&1; then
-    echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc})" >&2
-    exit "$((rc == 0 ? 1 : rc))"
+    if [[ -n "$FAIL_ON" ]]; then
+        echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc}); failing because the '${FAIL_ON}' gate is enforced" >&2
+        exit "$((rc == 0 ? 1 : rc))"
+    fi
+    echo "::warning::CVE scan of ${IMAGE_REF} could not be completed (grype produced no report, exit ${rc}); not blocking during report-only burn-in" >&2
+    exit 0
 fi
 
 # --- Report ------------------------------------------------------------------
 critical=$(jq '[.matches[] | select(.vulnerability.severity == "Critical")] | length' "$workdir/report.json")
 high=$(jq '[.matches[] | select(.vulnerability.severity == "High")] | length' "$workdir/report.json")
 total=$(jq '.matches | length' "$workdir/report.json")
+
+# Per-location breakdown of Critical/High findings. Grype records the file a
+# vulnerable package was found in (a bundled binary, or "" for OS packages),
+# which is the key signal for "vulnerable code not in execute path" triage:
+# a CVE that lives only in a build/scan tool is a strong not_affected case.
+by_location=$(jq -r '
+    [.matches[]
+     | select(.vulnerability.severity == "Critical" or .vulnerability.severity == "High")
+     | {loc: (.artifact.locations[0].path // "(os/image metadata)"), sev: .vulnerability.severity}]
+    | group_by(.loc)[]
+    | "| `\(.[0].loc)` | \(map(select(.sev == "Critical")) | length) | \(map(select(.sev == "High")) | length) |"
+' "$workdir/report.json")
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
@@ -106,6 +125,14 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
         echo "| Critical | High | Total |"
         echo "|---|---|---|"
         echo "| ${critical} | ${high} | ${total} |"
+        if [[ -n "$by_location" ]]; then
+            echo
+            echo "### Critical/High by location"
+            echo
+            echo "| Location | Critical | High |"
+            echo "|---|---|---|"
+            echo "$by_location"
+        fi
         echo
         echo '```'
         head -n 300 "$workdir/table.txt"

--- a/hack/cve-scan.sh
+++ b/hack/cve-scan.sh
@@ -90,7 +90,7 @@ cat "$workdir/table.txt"
 # Distinguish "grype failed to scan" (no usable report) from "the FAIL_ON
 # severity gate was breached" (scan completed, non-zero exit).
 if ! jq -e '.matches' "$workdir/report.json" >/dev/null 2>&1; then
-    echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc})"
+    echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc})" >&2
     exit "$((rc == 0 ? 1 : rc))"
 fi
 
@@ -118,6 +118,6 @@ if [[ "$critical" -gt 0 || "$high" -gt 0 ]]; then
 fi
 
 if [[ "$rc" -ne 0 ]]; then
-    echo "::error::CVE scan of ${IMAGE_REF} failed the '${FAIL_ON}' severity gate"
+    echo "::error::CVE scan of ${IMAGE_REF} failed the '${FAIL_ON}' severity gate" >&2
 fi
 exit "$rc"

--- a/hack/cve-scan.sh
+++ b/hack/cve-scan.sh
@@ -51,7 +51,9 @@ repo="${repo#oci-archive:}"
 repo="${repo#docker-archive:}"
 repo="${repo%%@*}"
 base="${repo##*/}"
+tag=""
 if [[ "$base" == *:* ]]; then
+    tag="${base##*:}"
     repo="${repo%:*}"
 fi
 VEX_REPO="${2:-$repo}"
@@ -59,13 +61,63 @@ VEX_REPO="${2:-$repo}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
+# grype matches a VEX product @id only against the image's repo digest
+# (<repo>@sha256:...) -- never the bare repo or <repo>:<tag>. The published doc
+# carries the logical repo @id (it can't know each patch's digest), so we must
+# re-stamp it to the digest of the image we are about to scan before applying.
+# We stamp to the SCANNED image's repo@digest (not VEX_REPO): the statements
+# come from VEX_REPO's published doc, but must carry the scanned image's
+# identity to match. The package-level suppression is driven by the version-
+# pinned subcomponent purls, which we leave untouched.
+resolve_stamp_ref() {
+    # Already digest-pinned: reuse the digest directly.
+    if [[ "$IMAGE_REF" == *@sha256:* ]]; then
+        printf '%s@%s\n' "$repo" "${IMAGE_REF##*@}"
+        return
+    fi
+    # Tag ref -> resolve the digest grype will compute for this image.
+    case "$IMAGE_REF" in
+        docker:*)
+            # Local daemon: first RepoDigest (empty for --load builds never
+            # pushed -> no digest to match, so VEX is skipped below).
+            docker inspect --format \
+                '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' \
+                "${IMAGE_REF#docker:}" 2>/dev/null || true
+            ;;
+        registry:*)
+            # Remote / job-local registry tag: ask for the digest via crane.
+            # ${CRANE_INSECURE:+--insecure} mirrors GRYPE_REGISTRY_INSECURE_USE_HTTP
+            # for the job-local registry:2 service.
+            if command -v crane >/dev/null 2>&1; then
+                local d
+                d="$(crane digest ${CRANE_INSECURE:+--insecure} \
+                    "${repo}:${tag:-latest}" 2>/dev/null || true)"
+                [[ -n "$d" ]] && printf '%s@%s\n' "$repo" "$d"
+            fi
+            ;;
+    esac
+    # Best-effort: empty stdout means "couldn't resolve a digest" (the caller
+    # then scans without VEX). Never return non-zero — under `set -e` a
+    # non-zero return here would kill the script before that graceful path.
+    return 0
+}
+
 # --- Fetch VEX statements (tolerate absence) --------------------------------
 vex_args=()
 vex_url="${VEX_BASE_URL}/pkg/oci/${VEX_REPO}/vex.json"
 if curl -fsSL --retry 3 --max-time 30 "$vex_url" -o "$workdir/vex.json" 2>/dev/null \
     && jq -e .statements "$workdir/vex.json" >/dev/null 2>&1; then
-    echo "Applying VEX statements from $vex_url"
-    vex_args=(--vex "$workdir/vex.json")
+    stamp_ref="$(resolve_stamp_ref)"
+    if [[ -n "$stamp_ref" ]]; then
+        # Re-stamp every statement's product @id to the scanned digest.
+        jq --arg ref "$stamp_ref" \
+            '.statements[].products[]."@id" = $ref' \
+            "$workdir/vex.json" > "$workdir/vex.stamped.json"
+        echo "Applying VEX from $vex_url (re-stamped to $stamp_ref)"
+        vex_args=(--vex "$workdir/vex.stamped.json")
+    else
+        echo "::notice::VEX found at ${vex_url} but ${IMAGE_REF} is not digest-pinned and no repo digest could be resolved; scanning without VEX. Scan a registry:<repo>@<digest> ref (or install crane) to enable suppression."
+    fi
 else
     echo "::notice::No VEX statements published for ${VEX_REPO} (${vex_url}); scanning without VEX."
 fi
@@ -87,18 +139,14 @@ rc=0
 
 cat "$workdir/table.txt" 2>/dev/null || true
 
-# Grype failed to produce a usable report (e.g. the image could not be fetched).
-# This is distinct from the FAIL_ON severity gate being breached. In report-only
-# mode (FAIL_ON empty) we never block the build on it — a scan that can't run is
-# a warning, not a regression in the change under review. When enforcing, we
-# fail closed: an image we cannot scan must not pass a gate.
+# Grype failed to produce a usable report (e.g. the image could not be fetched
+# or scanned). This is a scan error, not a CVE finding — only the *assessment*
+# (findings vs FAIL_ON) is report-only, so a scan that can't run always fails,
+# loudly, regardless of FAIL_ON. (VEX-resolution failures are handled earlier by
+# scanning without VEX; this is the grype-can't-scan case.)
 if ! jq -e '.matches' "$workdir/report.json" >/dev/null 2>&1; then
-    if [[ -n "$FAIL_ON" ]]; then
-        echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc}); failing because the '${FAIL_ON}' gate is enforced" >&2
-        exit "$((rc == 0 ? 1 : rc))"
-    fi
-    echo "::warning::CVE scan of ${IMAGE_REF} could not be completed (grype produced no report, exit ${rc}); not blocking during report-only burn-in" >&2
-    exit 0
+    echo "::error::CVE scan of ${IMAGE_REF} failed: grype did not produce a report (exit ${rc})" >&2
+    exit "$((rc == 0 ? 1 : rc))"
 fi
 
 # --- Report ------------------------------------------------------------------


### PR DESCRIPTION
Adds `hack/cve-scan.sh` — the CVE scan recipe used across Akuity image pipelines — and wires it into the two places the kargo image is built:

| Workflow / job | Scan source |
|---|---|
| `ci.yaml` / `build-image` | job-local registry service (the multi-platform build previously stayed only in buildx cache with `push: false`; it now also pushes to the job's `registry:3.0.0` service — nothing leaves the runner) |
| `release.yaml` / `publish-image` | the just-pushed digest, right after signing |

Behavior:

- **Report-only**: findings table in the job step summary + a `::warning::` annotation with Critical/High counts. `FAIL_ON: ""` at each call site; setting it to `high` later turns the scan into a hard gate (one-line diff).
- Fetches and applies Akuity's published VEX statements (OpenVEX) from `https://vex.akuity.io/pkg/oci/ghcr.io/akuity/kargo/vex.json` via `grype --vex`, so findings assessed as not-affected are suppressed. A 404 is tolerated until VEX publishing goes live — scans tighten automatically once it does.
- `-unstable` builds use the canonical `ghcr.io/akuity/kargo` path for VEX lookups, sharing the release dispositions.
- `download-grype` is pinned to a full commit SHA (v7.4.0) with DB caching.

The same recipe is live in Akuity's other image repos; this PR's own `build-image` job exercises the CI scan path end-to-end.