### PR TITLE
feat: label Promotions with their Stage name

### DIFF
--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -207,14 +207,17 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 	}
 
 	// Make sure the Promotion has the same shard as the Stage
+	if promo.Labels == nil {
+		promo.Labels = make(map[string]string, 2)
+	}
 	if stage.Spec.Shard != "" {
-		if promo.Labels == nil {
-			promo.Labels = make(map[string]string, 1)
-		}
 		promo.Labels[kargoapi.LabelKeyShard] = stage.Spec.Shard
 	} else {
 		delete(promo.Labels, kargoapi.LabelKeyShard)
 	}
+
+	// Always label the Promotion with the Stage name for easy filtering.
+	promo.Labels[kargoapi.LabelKeyStage] = promo.Spec.Stage
 
 	ownerRef := metav1.NewControllerRef(stage, kargoapi.GroupVersion.WithKind("Stage"))
 	promo.OwnerReferences = []metav1.OwnerReference{*ownerRef}

--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -23,6 +23,7 @@ import (
 	kargoEvent "github.com/akuity/kargo/pkg/event"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	"github.com/akuity/kargo/pkg/kargo"
+	"github.com/akuity/kargo/pkg/kubernetes"
 	libEvent "github.com/akuity/kargo/pkg/kubernetes/event"
 	"github.com/akuity/kargo/pkg/logging"
 	libWebhook "github.com/akuity/kargo/pkg/webhook/kubernetes"
@@ -144,7 +145,7 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 	}
 
 	if promo.Annotations == nil {
-		promo.Annotations = make(map[string]string, 1)
+		promo.Annotations = make(map[string]string, 2)
 	}
 
 	switch req.Operation {
@@ -216,8 +217,9 @@ func (w *webhook) Default(ctx context.Context, obj runtime.Object) error {
 		delete(promo.Labels, kargoapi.LabelKeyShard)
 	}
 
-	// Always label the Promotion with the Stage name for easy filtering.
-	promo.Labels[kargoapi.LabelKeyStage] = promo.Spec.Stage
+	// Always label/annotate the Promotion with the Stage name for easy filtering.
+	promo.Labels[kargoapi.LabelKeyStage] = kubernetes.ShortenLabelValue(promo.Spec.Stage)
+	promo.Annotations[kargoapi.AnnotationKeyStage] = promo.Spec.Stage
 
 	ownerRef := metav1.NewControllerRef(stage, kargoapi.GroupVersion.WithKind("Stage"))
 	promo.OwnerReferences = []metav1.OwnerReference{*ownerRef}

--- a/pkg/webhook/kubernetes/promotion/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotion/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,7 +168,51 @@ func Test_webhook_Default(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "fake-shard", promo.Labels[kargoapi.LabelKeyShard])
 				require.Equal(t, "fake-stage", promo.Labels[kargoapi.LabelKeyStage])
+				require.Equal(t, "fake-stage", promo.Annotations[kargoapi.AnnotationKeyStage])
 				require.NotEmpty(t, promo.OwnerReferences)
+			},
+		},
+		{
+			name: "long stage name: label is shortened, annotation preserves full name",
+			webhook: &webhook{
+				admissionRequestFromContextFn: admission.RequestFromContext,
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: strings.Repeat("a", 64),
+						},
+						Spec: kargoapi.StageSpec{},
+					}, nil
+				},
+				isRequestFromKargoControlplaneFn: func(admission.Request) bool {
+					return false
+				},
+			},
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
+			},
+			promotion: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Stage: strings.Repeat("a", 64),
+					Steps: []kargoapi.PromotionStep{
+						{},
+					},
+				},
+			},
+			assertions: func(t *testing.T, promo *kargoapi.Promotion, err error) {
+				require.NoError(t, err)
+				fullName := strings.Repeat("a", 64)
+				// Label value must be within the 63-character Kubernetes limit.
+				require.LessOrEqual(t, len(promo.Labels[kargoapi.LabelKeyStage]), 63)
+				require.NotEqual(t, fullName, promo.Labels[kargoapi.LabelKeyStage])
+				// Annotation preserves the full, untruncated stage name.
+				require.Equal(t, fullName, promo.Annotations[kargoapi.AnnotationKeyStage])
 			},
 		},
 		{

--- a/pkg/webhook/kubernetes/promotion/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotion/webhook_test.go
@@ -166,6 +166,7 @@ func Test_webhook_Default(t *testing.T) {
 			assertions: func(t *testing.T, promo *kargoapi.Promotion, err error) {
 				require.NoError(t, err)
 				require.Equal(t, "fake-shard", promo.Labels[kargoapi.LabelKeyShard])
+				require.Equal(t, "fake-stage", promo.Labels[kargoapi.LabelKeyStage])
 				require.NotEmpty(t, promo.OwnerReferences)
 			},
 		},


### PR DESCRIPTION
## Description

The Promotion mutating webhook now sets `kargo.akuity.io/stage: <stage-name>` on every Promotion. `kargo.akuity.io/stage` already existed as a label key used on other resources (e.g., AnalysisRuns). This makes it straightforward to list or watch all Promotions for a given Stage without a field selector or client-side filter:

```
kubectl get promotions -l kargo.akuity.io/stage=my-stage
```

## Checklist

### Eligibility
- [x] Changes ten lines or fewer.

### Quality
- [x] Adds or updates corresponding tests.

### AI Use Disclosure
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off
- [x] Are signed off by their author (`git commit -s`) **(required)**
