### PR TITLE
feat(chart): per-controller argocd ClusterRole; tpl env + envFrom values

### DIFF
--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.api.resources) }}
         {{- with (concat .Values.global.env .Values.api.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- if and .Values.api.rollouts.integrationEnabled .Values.api.rollouts.logs.enabled .Values.api.rollouts.logs.tokenSecret.name .Values.api.rollouts.logs.tokenSecret.key }}
         - name: ANALYSIS_RUN_LOG_TOKEN
@@ -96,7 +96,7 @@ spec:
         - secretRef:
             name: {{ .Values.api.secret.name | default "kargo-api" }}
         {{- with (concat .Values.global.envFrom .Values.api.envFrom) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         ports:
         - name: h2c

--- a/charts/kargo/templates/controller/cluster-role-bindings.yaml
+++ b/charts/kargo/templates/controller/cluster-role-bindings.yaml
@@ -51,7 +51,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kargo-controller-argocd
+  name: {{ include "kargo.controller.fullname" . }}-argocd
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}

--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -153,15 +153,16 @@ rules:
   - deletecollection
 {{- end }}
 {{- end }}
-{{- if and .Values.argocd.dataPlane.install .Values.rbac.installClusterRoles .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
+{{- if and .Values.argocd.dataPlane.kargoController.install .Values.rbac.installClusterRoles .Values.controller.enabled .Values.controller.argocd.integrationEnabled (not .Values.controller.argocd.watchArgocdNamespaceOnly) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kargo-controller-argocd
+  name: {{ include "kargo.controller.fullname" . }}-argocd
   labels:
     {{- include "kargo.labels" . | nindent 4 }}
     {{- include "kargo.controller.labels" . | nindent 4 }}
+    {{- include "kargo.controller.idLabel" . | nindent 4 }}
   {{- include "kargo.annotations" (dict "root" . "annotations" .Values.controller.annotations) | nindent 2 }}
 rules:
 - apiGroups:

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -77,13 +77,13 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.controller.resources) }}
         {{- with (concat .Values.global.env .Values.controller.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "kargo.controller.fullname" . }}
         {{- with (concat .Values.global.envFrom .Values.controller.envFrom) }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         volumeMounts:
         - mountPath: /tmp

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -66,11 +66,11 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.api.oidc.dex.resources) }}
         {{- with (concat .Values.global.env .Values.api.oidc.dex.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- with (concat .Values.global.envFrom .Values.api.oidc.dex.envFrom) }}
         envFrom:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         volumeMounts:
         - mountPath: /etc/dex

--- a/charts/kargo/templates/external-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/external-webhooks-server/deployment.yaml
@@ -81,13 +81,13 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.externalWebhooksServer.resources) }}
         {{- with (concat .Values.global.env .Values.externalWebhooksServer.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         envFrom:
         - configMapRef:
             name: kargo-external-webhooks-server
         {{- with (concat .Values.global.envFrom .Values.externalWebhooksServer.envFrom) }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         ports:
         - containerPort: 8080

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -83,13 +83,13 @@ spec:
                   divisor: "1"
                   resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.garbageCollector.resources) }}
             {{- with (concat .Values.global.env .Values.garbageCollector.env) }}
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
             envFrom:
             - configMapRef:
                 name: kargo-garbage-collector
             {{- with (concat .Values.global.envFrom .Values.garbageCollector.envFrom) }}
-              {{- toYaml . | nindent 12 }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
             {{- if or $kc .Values.garbageCollector.volumeMounts }}
             volumeMounts:

--- a/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
@@ -81,13 +81,13 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.webhooksServer.resources) }}
         {{- with (concat .Values.global.env .Values.webhooksServer.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         envFrom:
         - configMapRef:
             name: kargo-webhooks-server
         {{- with (concat .Values.global.envFrom .Values.webhooksServer.envFrom) }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         ports:
         - containerPort: 9443

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -73,13 +73,13 @@ spec:
               divisor: "1"
               resource: {{ include "kargo.selectCpuResourceField" (dict "resources" .Values.managementController.resources) }}
         {{- with (concat .Values.global.env .Values.managementController.env) }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         envFrom:
         - configMapRef:
             name: kargo-management-controller
         {{- with (concat .Values.global.envFrom .Values.managementController.envFrom) }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- if or $kc .Values.managementController.volumeMounts }}
         volumeMounts:


### PR DESCRIPTION
Intended for use downstream:

* The `kargo-controller-argocd` ClusterRole is now per-controller — name suffixed via the controller fullname helper, gated on `argocd.dataPlane.kargoController.install` rather than the data-plane-wide `argocd.dataPlane.install`. With no `controller.id` set the rendered name remains `kargo-controller-argocd`, preserving today's shape; the per-controller CRB's `roleRef` updates accordingly.

* `tpl` applied to the rendered `env` and `envFrom` lists across api, controller, management-controller, kubernetes-webhooks-server, external-webhooks-server, dex-server, and garbage-collector. Operators can now reference helper output (e.g., `kargo.controller.fullname`) in injected `env`/`envFrom` entries; previously those rendered as literal text.
