### PR TITLE
fix(api): Adds in missing role name validation

### DIFF
--- a/pkg/server/rbac/policy_rules.go
+++ b/pkg/server/rbac/policy_rules.go
@@ -182,7 +182,7 @@ func validateResourceTypeName(resource string) error {
 	switch resource {
 	case "analysisruns", "analysistemplates", "configmaps", "events", "freights",
 		"freights/status", "projectconfigs", "promotions", "rolebindings", "roles",
-		"secrets", "serviceaccounts", "stages", "warehouses":
+		"secrets", "serviceaccounts", "stages", "warehouses", "promotiontasks":
 		return nil
 	case "analysisrun", "analysistemplate", "configmap", "event", "freight",
 		"projectconfig", "promotion", "role", "rolebinding", "secret",


### PR DESCRIPTION
This is a follow up to #6335 which correctly added the promotiontasks resource to the admin role, but it forgot to add the resource name to the validation function on the back end

Closes #6415