### PR TITLE
fix(ui): reconnect pipeline watch on tab visibility instead of canceling

### DIFF
--- a/ui/src/features/project/pipelines/graph/use-events-watcher.ts
+++ b/ui/src/features/project/pipelines/graph/use-events-watcher.ts
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 import { Watcher } from '@ui/features/project/pipelines/watcher';
 import { queryCache } from '@ui/features/utils/cache';
 import { Stage, Warehouse } from '@ui/gen/api/v1alpha1/generated_pb';
-import { useDocumentEvent } from '@ui/utils/document';
 
 export const useEventsWatcher = (
   project: string,
@@ -15,26 +14,42 @@ export const useEventsWatcher = (
   warehouses?: string[]
 ) => {
   const client = useQueryClient();
-  const isWindowVisible = useDocumentEvent(
-    'visibilitychange',
-    () => document.visibilityState === 'visible'
-  );
 
   useEffect(() => {
-    if (!isWindowVisible || !project) {
+    if (!project) {
       return;
     }
 
-    const watcher = new Watcher(project, client);
+    let watcher: Watcher | undefined;
 
-    watcher.watchStages(act?.onStage, warehouses);
-    watcher.watchWarehouses({
-      onWarehouseEvent: act?.onWarehouse,
-      refreshHook: queryCache.freight.refetchQueryFreight
-    });
+    // (Re)establish the watch streams. Aborts any previous watcher first so we
+    // never leak a connection.
+    const connect = () => {
+      watcher?.cancelWatch();
+      watcher = new Watcher(project, client);
+      watcher.watchStages(act?.onStage, warehouses);
+      watcher.watchWarehouses({
+        onWarehouseEvent: act?.onWarehouse,
+        refreshHook: queryCache.freight.refetchQueryFreight
+      });
+    };
+
+    connect();
+
+    // Reconnect when the tab becomes visible again. The watch is left running
+    // while the tab is hidden (we do NOT cancel on leave), but a hidden tab can
+    // be throttled/frozen and have its stream silently dropped -- reconnecting
+    // on return guarantees a live stream again.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
-      watcher.cancelWatch();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      watcher?.cancelWatch();
     };
-  }, [isWindowVisible, project, (warehouses || []).join(',')]);
+  }, [project, (warehouses || []).join(',')]);
 };

--- a/ui/src/features/project/pipelines/graph/use-events-watcher.ts
+++ b/ui/src/features/project/pipelines/graph/use-events-watcher.ts
@@ -41,7 +41,9 @@ export const useEventsWatcher = (
     // be throttled/frozen and have its stream silently dropped -- reconnecting
     // on return guarantees a live stream again.
     const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
+      // Reuse the existing connection if it is still alive; only reconnect when
+      // the stream has actually ended (e.g. dropped while the tab was hidden).
+      if (document.visibilityState === 'visible' && !watcher?.isActive()) {
         connect();
       }
     };

--- a/ui/src/features/project/pipelines/watcher.ts
+++ b/ui/src/features/project/pipelines/watcher.ts
@@ -54,6 +54,10 @@ export class Watcher {
   client: QueryClient;
   promiseClient: Client<typeof KargoService>;
   project: string;
+  // Set once either stream ends or errors for a reason other than an
+  // intentional cancel. Used by isActive() so callers can reuse a live watcher
+  // instead of needlessly reconnecting.
+  private ended = false;
 
   constructor(project: string, client: QueryClient) {
     this.cancel = new AbortController();
@@ -64,6 +68,18 @@ export class Watcher {
 
   cancelWatch() {
     this.cancel.abort();
+  }
+
+  // Whether the watch is still running: not cancelled and neither stream has
+  // ended/errored.
+  isActive() {
+    return !this.cancel.signal.aborted && !this.ended;
+  }
+
+  private markEnded() {
+    if (!this.cancel.signal.aborted) {
+      this.ended = true;
+    }
   }
 
   async watchStages(
@@ -130,7 +146,9 @@ export class Watcher {
 
         onStageEvent?.(stage);
       }
-    );
+    )
+      .catch(() => {})
+      .finally(() => this.markEnded());
   }
 
   async watchWarehouses(opts?: {
@@ -204,6 +222,8 @@ export class Watcher {
 
         opts?.onWarehouseEvent?.(warehouse);
       }
-    );
+    )
+      .catch(() => {})
+      .finally(() => this.markEnded());
   }
 }


### PR DESCRIPTION
### Summary

Keeps the pipeline Stages/Warehouses watch alive while the tab is inactive,
and reconnects when the tab becomes visible again instead of tearing the
watch down on every tab switch.

### Changes

- Do not cancel the watch when the tab loses visibility
- Reconnect the watch when the tab becomes visible again (heals a stream that
  was throttled, frozen, or silently dropped while hidden)
- Watch is still cleaned up on unmount and when project/warehouses change

Closes #6439 