### PR TITLE
fix: allow Kubernetes namespace GC to delete replicated secrets

### DIFF
--- a/pkg/webhook/kubernetes/admission.go
+++ b/pkg/webhook/kubernetes/admission.go
@@ -2,9 +2,20 @@ package webhook
 
 import (
 	"regexp"
+	"slices"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+// kubernetesSystemControllerUsernames is the set of well-known Kubernetes
+// system identities that perform garbage collection and namespace teardown.
+// These must be allowed to delete replicated secrets when a namespace is
+// removed so that namespaces do not become stuck in Terminating.
+var kubernetesSystemControllerUsernames = map[string]struct{}{
+	"system:serviceaccount:kube-system:namespace-controller":      {},
+	"system:serviceaccount:kube-system:generic-garbage-collector": {},
+	"system:kube-controller-manager":                              {},
+}
 
 type IsRequestFromKargoControlplaneFn func(admission.Request) bool
 
@@ -16,4 +27,19 @@ func IsRequestFromKargoControlplane(regex *regexp.Regexp) IsRequestFromKargoCont
 		}
 		return regex.Match([]byte(req.UserInfo.Username))
 	}
+}
+
+// IsRequestFromKubernetesSystemController returns true when the admission
+// request originates from one of the well-known Kubernetes system controllers
+// responsible for garbage collection and namespace teardown.
+func IsRequestFromKubernetesSystemController(req admission.Request) bool {
+	_, ok := kubernetesSystemControllerUsernames[req.UserInfo.Username]
+	return ok
+}
+
+// IsRequestFromClusterAdmin returns true when the admission request originates
+// from a member of the system:masters group, which maps to cluster-admin
+// privileges and is used for break-glass operations.
+func IsRequestFromClusterAdmin(req admission.Request) bool {
+	return slices.Contains(req.UserInfo.Groups, "system:masters")
 }

--- a/pkg/webhook/kubernetes/admission.go
+++ b/pkg/webhook/kubernetes/admission.go
@@ -7,14 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// kubernetesSystemControllerUsernames is the set of well-known Kubernetes
+// kubernetesGarbageCollectorUsernames is the set of well-known Kubernetes
 // system identities that perform garbage collection and namespace teardown.
 // These must be allowed to delete replicated secrets when a namespace is
 // removed so that namespaces do not become stuck in Terminating.
-var kubernetesSystemControllerUsernames = map[string]struct{}{
+var kubernetesGarbageCollectorUsernames = map[string]struct{}{
 	"system:serviceaccount:kube-system:namespace-controller":      {},
 	"system:serviceaccount:kube-system:generic-garbage-collector": {},
-	"system:kube-controller-manager":                              {},
+	// when --use-service-account-credentials=false or unset
+	"system:kube-controller-manager": {},
 }
 
 type IsRequestFromKargoControlplaneFn func(admission.Request) bool
@@ -29,11 +30,11 @@ func IsRequestFromKargoControlplane(regex *regexp.Regexp) IsRequestFromKargoCont
 	}
 }
 
-// IsRequestFromKubernetesSystemController returns true when the admission
+// IsRequestFromKubernetesGarbageCollector returns true when the admission
 // request originates from one of the well-known Kubernetes system controllers
 // responsible for garbage collection and namespace teardown.
-func IsRequestFromKubernetesSystemController(req admission.Request) bool {
-	_, ok := kubernetesSystemControllerUsernames[req.UserInfo.Username]
+func IsRequestFromKubernetesGarbageCollector(req admission.Request) bool {
+	_, ok := kubernetesGarbageCollectorUsernames[req.UserInfo.Username]
 	return ok
 }
 

--- a/pkg/webhook/kubernetes/admission_test.go
+++ b/pkg/webhook/kubernetes/admission_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func TestIsRequestFromKubernetesSystemController(t *testing.T) {
+func TestIsRequestFromKubernetesGarbageCollector(t *testing.T) {
 	testCases := []struct {
 		name     string
 		username string
@@ -46,7 +46,7 @@ func TestIsRequestFromKubernetesSystemController(t *testing.T) {
 					UserInfo: authnv1.UserInfo{Username: testCase.username},
 				},
 			}
-			require.Equal(t, testCase.expected, IsRequestFromKubernetesSystemController(req))
+			require.Equal(t, testCase.expected, IsRequestFromKubernetesGarbageCollector(req))
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/admission_test.go
+++ b/pkg/webhook/kubernetes/admission_test.go
@@ -11,6 +11,85 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+func TestIsRequestFromKubernetesSystemController(t *testing.T) {
+	testCases := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "namespace-controller is allowed",
+			username: "system:serviceaccount:kube-system:namespace-controller",
+			expected: true,
+		},
+		{
+			name:     "generic-garbage-collector is allowed",
+			username: "system:serviceaccount:kube-system:generic-garbage-collector",
+			expected: true,
+		},
+		{
+			name:     "kube-controller-manager is allowed",
+			username: "system:kube-controller-manager",
+			expected: true,
+		},
+		{
+			name:     "other user is not allowed",
+			username: "some-user",
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authnv1.UserInfo{Username: testCase.username},
+				},
+			}
+			require.Equal(t, testCase.expected, IsRequestFromKubernetesSystemController(req))
+		})
+	}
+}
+
+func TestIsRequestFromClusterAdmin(t *testing.T) {
+	testCases := []struct {
+		name     string
+		groups   []string
+		expected bool
+	}{
+		{
+			name:     "system:masters group member is allowed",
+			groups:   []string{"system:masters"},
+			expected: true,
+		},
+		{
+			name:     "system:masters among multiple groups is allowed",
+			groups:   []string{"some-group", "system:masters"},
+			expected: true,
+		},
+		{
+			name:     "no groups is not allowed",
+			expected: false,
+		},
+		{
+			name:     "other groups only is not allowed",
+			groups:   []string{"some-group"},
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authnv1.UserInfo{Groups: testCase.groups},
+				},
+			}
+			require.Equal(t, testCase.expected, IsRequestFromClusterAdmin(req))
+		})
+	}
+}
+
 func TestIsRequestFromKargoControlplane(t *testing.T) {
 	testCases := map[string]struct {
 		regex    *regexp.Regexp

--- a/pkg/webhook/kubernetes/replicatedresource/webhook.go
+++ b/pkg/webhook/kubernetes/replicatedresource/webhook.go
@@ -38,6 +38,12 @@ func (w *webhook) Handle(
 	if req.UserInfo.Username == w.cfg.ManagementControllerUsername {
 		return admission.Allowed("request from Kargo management controller")
 	}
+	if libWebhook.IsRequestFromKubernetesSystemController(req) {
+		return admission.Allowed("request from Kubernetes system controller")
+	}
+	if libWebhook.IsRequestFromClusterAdmin(req) {
+		return admission.Allowed("request from cluster administrator")
+	}
 	return admission.Denied(
 		"replicated resources are managed by Kargo" +
 			" and cannot be created, modified, or deleted by end users",

--- a/pkg/webhook/kubernetes/replicatedresource/webhook.go
+++ b/pkg/webhook/kubernetes/replicatedresource/webhook.go
@@ -3,6 +3,7 @@ package replicatedresource
 import (
 	"context"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -38,9 +39,12 @@ func (w *webhook) Handle(
 	if req.UserInfo.Username == w.cfg.ManagementControllerUsername {
 		return admission.Allowed("request from Kargo management controller")
 	}
-	if libWebhook.IsRequestFromKubernetesSystemController(req) {
+	// Namespace and GC controller are allowed to delete replicated resources
+	if req.Operation == admissionv1.Delete &&
+		libWebhook.IsRequestFromKubernetesGarbageCollector(req) {
 		return admission.Allowed("request from Kubernetes system controller")
 	}
+	// Cluster administrators are allowed to perform any operation
 	if libWebhook.IsRequestFromClusterAdmin(req) {
 		return admission.Allowed("request from cluster administrator")
 	}

--- a/pkg/webhook/kubernetes/replicatedresource/webhook_test.go
+++ b/pkg/webhook/kubernetes/replicatedresource/webhook_test.go
@@ -118,7 +118,7 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
-			name: "system:masters group member is allowed",
+			name: "system:masters group member DELETE is allowed",
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
@@ -130,6 +130,35 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(t *testing.T, resp admission.Response) {
 				require.True(t, resp.Allowed)
+			},
+		},
+		{
+			name: "system:masters group member UPDATE is allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					UserInfo: authnv1.UserInfo{
+						Username: "cluster-admin",
+						Groups:   []string{"system:masters"},
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+			},
+		},
+		{
+			name: "garbage collector non-DELETE is denied",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					UserInfo: authnv1.UserInfo{
+						Username: "system:serviceaccount:kube-system:namespace-controller",
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.False(t, resp.Allowed)
 			},
 		},
 		{

--- a/pkg/webhook/kubernetes/replicatedresource/webhook_test.go
+++ b/pkg/webhook/kubernetes/replicatedresource/webhook_test.go
@@ -76,6 +76,63 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			name: "namespace-controller DELETE is allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					UserInfo: authnv1.UserInfo{
+						Username: "system:serviceaccount:kube-system:namespace-controller",
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+			},
+		},
+		{
+			name: "generic-garbage-collector DELETE is allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					UserInfo: authnv1.UserInfo{
+						Username: "system:serviceaccount:kube-system:generic-garbage-collector",
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+			},
+		},
+		{
+			name: "kube-controller-manager DELETE is allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					UserInfo: authnv1.UserInfo{
+						Username: "system:kube-controller-manager",
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+			},
+		},
+		{
+			name: "system:masters group member is allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					UserInfo: authnv1.UserInfo{
+						Username: "cluster-admin",
+						Groups:   []string{"system:masters"},
+					},
+				},
+			},
+			assert: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+			},
+		},
+		{
 			name: "other controlplane component is denied",
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
## Description

Fixes https://github.com/akuity/kargo/issues/6443

## Summary

- When a Project is deleted, Kubernetes garbage collection controllers (`namespace-controller`, `generic-garbage-collector`, `kube-controller-manager`) attempt to delete the replicated secrets inside the terminating namespace. The replicated-resource-delete admission webhook was denying these requests, leaving namespaces permanently stuck in Terminating.
- The webhook's Handle function now also allows requests from well-known Kubernetes system controller identities and from members of the `system:masters` group (for break-glass scenarios).

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).

### Quality

- [x] Adds or updates corresponding tests.

### AI Use Disclosure

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
