### PR TITLE
fix(git-merge-pr): treat merge errors as transient when wait=true

### DIFF
--- a/pkg/promotion/runner/builtin/git_pr_merger.go
+++ b/pkg/promotion/runner/builtin/git_pr_merger.go
@@ -127,8 +127,12 @@ func (g *gitPRMerger) run(
 			cfg.PRNumber,
 			&gitprovider.MergePullRequestOpts{MergeMethod: cfg.MergeMethod},
 		); err != nil {
-			// Only actual errors (auth, network, invalid PR, closed but not merged,
-			// etc.) reach here
+			// When wait is enabled, treat merge errors as transient (e.g. 405
+			// "Required status check is expected") so the step retries on the
+			// next reconciliation instead of failing permanently.
+			if cfg.Wait {
+				return promotion.StepResult{Status: kargoapi.PromotionStepStatusRunning}, nil
+			}
 			return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
 				&promotion.TerminalError{
 					Err: fmt.Errorf("error merging pull request %d: %w", cfg.PRNumber, err),

--- a/pkg/promotion/runner/builtin/git_pr_merger_test.go
+++ b/pkg/promotion/runner/builtin/git_pr_merger_test.go
@@ -113,7 +113,7 @@ func Test_gitPRMerger_run(t *testing.T) {
 		assertions func(*testing.T, promotion.StepResult, error)
 	}{
 		{
-			name: "error during merge attempt",
+			name: "error during merge attempt with wait disabled",
 			provider: &gitprovider.Fake{
 				MergePullRequestFn: func(
 					context.Context,
@@ -131,6 +131,26 @@ func Test_gitPRMerger_run(t *testing.T) {
 				require.ErrorContains(t, err, "authentication failed")
 				require.True(t, promotion.IsTerminal(err))
 				require.Equal(t, kargoapi.PromotionStepStatusFailed, res.Status)
+			},
+		},
+		{
+			name: "error during merge attempt with wait enabled returns running",
+			provider: &gitprovider.Fake{
+				MergePullRequestFn: func(
+					context.Context,
+					int64,
+					*gitprovider.MergePullRequestOpts,
+				) (*gitprovider.PullRequest, bool, error) {
+					return nil, false, errors.New("405 Repository rule violations found: Required status check is expected")
+				},
+			},
+			config: builtin.GitMergePRConfig{
+				PRNumber: 42,
+				Wait:     true,
+			},
+			assertions: func(t *testing.T, res promotion.StepResult, err error) {
+				require.NoError(t, err)
+				require.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
 			},
 		},
 		{


### PR DESCRIPTION
When `git-merge-pr` is configured with `wait: true` and the GitHub merge API returns a 405 (e.g. "Required status check is expected"), the step now returns `Running` status instead of `Failed`. The 405 means the merge is blocked by a status check that hasn't completed yet -- it's transient, not a permanent failure.

Previously, a single 405 would terminate the entire wait loop. Now it keeps polling until the merge succeeds or a non-transient error occurs.

Fixes #5761