### PR TITLE
feat(ui): add freight provenance card view

### DIFF
--- a/ui/src/features/project/pipelines/context/freight-timeline-controller-context.ts
+++ b/ui/src/features/project/pipelines/context/freight-timeline-controller-context.ts
@@ -22,6 +22,7 @@ export type FreightTimelineControllerContextType = {
     view: 'graph' | 'list';
     showMinimap: boolean;
     stepEdges: boolean;
+    freightCardView: 'compact' | 'provenance';
   };
   setPreferredFilter: (filter: FreightTimelineControllerContextType['preferredFilter']) => void;
 };

--- a/ui/src/features/project/pipelines/freight/freight-card.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-card.tsx
@@ -31,6 +31,7 @@ import { useManualApprovalModal } from '../promotion/use-manual-approval-modal';
 
 import { DeleteFreightModal } from './delete-freight-modal';
 import { FreightArtifact } from './freight-artifact';
+import { FreightProvenanceRows } from './freight-provenance-rows';
 import { useSoakTimeCounter } from './use-soak-time-counter';
 
 type FreightCardProps = {
@@ -107,6 +108,7 @@ export const FreightCard = (props: FreightCardProps) => {
         boxShadow: '0 4px 8px rgba(0,0,0,.1)'
       }
     : undefined;
+  const isProvenanceView = props.preferredFilter.freightCardView === 'provenance';
 
   return (
     <div
@@ -282,60 +284,72 @@ export const FreightCard = (props: FreightCardProps) => {
             </div>
           )}
 
-          {props?.preferredFilter?.showAlias && (
+          {props?.preferredFilter?.showAlias && !isProvenanceView && (
             <div className='text-[10px] text-nowrap mb-2'>{freightAlias}</div>
           )}
 
-          <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:block [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
-            {props.freight?.commits?.slice(0, 2).map((commit) => (
-              <FreightArtifact key={commit?.repoURL} artifact={commit} />
-            ))}
+          {isProvenanceView ? (
+            <FreightProvenanceRows
+              freight={props.freight}
+              showAlias={props.preferredFilter.showAlias}
+              age={creation.relative}
+            />
+          ) : (
+            <>
+              <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:block [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
+                {props.freight?.commits?.slice(0, 2).map((commit) => (
+                  <FreightArtifact key={commit?.repoURL} artifact={commit} />
+                ))}
 
-            {props.freight?.charts?.slice(0, 2).map((chart) => (
-              <FreightArtifact key={chart?.repoURL} artifact={chart} />
-            ))}
+                {props.freight?.charts?.slice(0, 2).map((chart) => (
+                  <FreightArtifact key={chart?.repoURL} artifact={chart} />
+                ))}
 
-            {props.freight?.images?.slice(0, 2).map((image) => (
-              <FreightArtifact key={image?.repoURL} artifact={image} />
-            ))}
+                {props.freight?.images?.slice(0, 2).map((image) => (
+                  <FreightArtifact key={image?.repoURL} artifact={image} />
+                ))}
 
-            {props.freight?.artifacts?.slice(0, 2).map((other) => (
-              <FreightArtifact key={other?.version} artifact={other} />
-            ))}
+                {props.freight?.artifacts?.slice(0, 2).map((other) => (
+                  <FreightArtifact key={other?.version} artifact={other} />
+                ))}
 
-            {noOfGitCommits + noOfHelmReleases + noOfContainerImages > 6 && (
-              <Typography.Text type='secondary' className='text-[10px]'>
-                +
-                {noOfGitCommits +
-                  noOfHelmReleases +
-                  noOfContainerImages -
-                  (props.freight?.charts?.slice(0, 2)?.length +
-                    props.freight?.commits?.slice(0, 2)?.length +
-                    props.freight?.images?.slice(0, 2)?.length)}{' '}
-                more
-              </Typography.Text>
-            )}
-          </div>
+                {noOfGitCommits + noOfHelmReleases + noOfContainerImages > 6 && (
+                  <Typography.Text type='secondary' className='text-[10px]'>
+                    +
+                    {noOfGitCommits +
+                      noOfHelmReleases +
+                      noOfContainerImages -
+                      (props.freight?.charts?.slice(0, 2)?.length +
+                        props.freight?.commits?.slice(0, 2)?.length +
+                        props.freight?.images?.slice(0, 2)?.length)}{' '}
+                    more
+                  </Typography.Text>
+                )}
+              </div>
 
-          <div className='flex flex-col mx-auto w-full gap-0.5 items-center justify-center text-nowrap py-1 mt-auto'>
-            {(noOfGitCommits ? 1 : 0) + (noOfHelmReleases ? 1 : 0) + (noOfContainerImages ? 1 : 0) >
-              2 && (
-              <>
-                <FreightCard.ArtifactCount icon={faGithub} count={noOfGitCommits} />
+              <div className='flex flex-col mx-auto w-full gap-0.5 items-center justify-center text-nowrap py-1 mt-auto'>
+                {(noOfGitCommits ? 1 : 0) +
+                  (noOfHelmReleases ? 1 : 0) +
+                  (noOfContainerImages ? 1 : 0) >
+                  2 && (
+                  <>
+                    <FreightCard.ArtifactCount icon={faGithub} count={noOfGitCommits} />
 
-                <FreightCard.ArtifactCount icon={faAnchor} count={noOfHelmReleases} />
+                    <FreightCard.ArtifactCount icon={faAnchor} count={noOfHelmReleases} />
 
-                <FreightCard.ArtifactCount icon={faDocker} count={noOfContainerImages} />
-              </>
-            )}
-            <Typography.Text
-              className='text-xs text-nowrap'
-              type='secondary'
-              title={creation.abs?.toString()}
-            >
-              {creation.relative}
-            </Typography.Text>
-          </div>
+                    <FreightCard.ArtifactCount icon={faDocker} count={noOfContainerImages} />
+                  </>
+                )}
+                <Typography.Text
+                  className='text-xs text-nowrap'
+                  type='secondary'
+                  title={creation.abs?.toString()}
+                >
+                  {creation.relative}
+                </Typography.Text>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/ui/src/features/project/pipelines/freight/freight-provenance-rows.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-provenance-rows.tsx
@@ -1,0 +1,39 @@
+import { Typography } from 'antd';
+
+import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
+
+import { getFreightProvenanceRows } from './freight-provenance-utils';
+
+type Props = {
+  freight: Freight;
+  showAlias: boolean;
+  age?: string;
+};
+
+export const FreightProvenanceRows = (props: Props) => {
+  const rows = getFreightProvenanceRows(props.freight, {
+    showAlias: props.showAlias,
+    age: props.age
+  });
+
+  return (
+    <div className='flex flex-col gap-0.5 text-left min-w-0 w-full py-1'>
+      {rows.map((row) => (
+        <div
+          className='grid grid-cols-[52px_minmax(0,1fr)] gap-2 min-w-0 text-[10px]'
+          key={row.key}
+        >
+          <Typography.Text type='secondary' className='uppercase text-[10px] leading-4'>
+            {row.label}
+          </Typography.Text>
+          <Typography.Text
+            className='font-mono text-[10px] leading-4 truncate'
+            title={row.title || row.value}
+          >
+            {row.value}
+          </Typography.Text>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/ui/src/features/project/pipelines/freight/freight-provenance-utils.test.ts
+++ b/ui/src/features/project/pipelines/freight/freight-provenance-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+
+import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
+
+import { artifactName, getFreightProvenanceRows } from './freight-provenance-utils';
+
+const freight = (input: Partial<Freight>) =>
+  ({
+    alias: '',
+    metadata: { name: 'fb95df6e1234567890' },
+    commits: [],
+    charts: [],
+    images: [],
+    artifacts: [],
+    ...input
+  }) as Freight;
+
+describe('artifactName', () => {
+  test('uses the last repo segment and trims .git', () => {
+    expect(artifactName('https://github.com/fixico/deployment-hub.git')).toBe('deployment-hub');
+    expect(
+      artifactName('europe-docker.pkg.dev/prj-platform-mgmt-eu/ar-platform-workload-apps/fixicore')
+    ).toBe('fixicore');
+  });
+});
+
+describe('getFreightProvenanceRows', () => {
+  test('formats alias, git commit, image tag, id, and age', () => {
+    const rows = getFreightProvenanceRows(
+      freight({
+        alias: 'release-2026.06.12-588d48a-fb95df6e',
+        commits: [
+          {
+            repoURL: 'https://github.com/fixico/deployment-hub.git',
+            id: '0423f94abcdef'
+          }
+        ],
+        images: [
+          {
+            repoURL:
+              'europe-docker.pkg.dev/prj-platform-mgmt-eu/ar-platform-workload-apps/fixicore',
+            tag: 'release-latest'
+          }
+        ]
+      }),
+      { showAlias: true, age: '18 minutes' }
+    );
+
+    expect(rows.map((row) => [row.label, row.value])).toEqual([
+      ['alias', 'release-2026.06.12-588d48a-fb95df6e'],
+      ['git', 'deployment-hub @ 0423f94'],
+      ['image', 'fixicore:release-latest'],
+      ['id', 'fb95df6'],
+      ['age', '18 minutes']
+    ]);
+  });
+
+  test('hides alias when requested', () => {
+    const rows = getFreightProvenanceRows(freight({ alias: 'release-2026.06.12-588d48a' }), {
+      showAlias: false
+    });
+
+    expect(rows.map((row) => row.label)).toEqual(['id']);
+  });
+
+  test('uses git tags before commit IDs', () => {
+    const rows = getFreightProvenanceRows(
+      freight({
+        commits: [
+          {
+            repoURL: 'https://github.com/acme/app.git',
+            id: 'abcdef123456',
+            tag: 'v1.2.3'
+          }
+        ]
+      })
+    );
+
+    expect(rows.find((row) => row.label === 'git')?.value).toBe('app @ v1.2.3');
+  });
+});

--- a/ui/src/features/project/pipelines/freight/freight-provenance-utils.ts
+++ b/ui/src/features/project/pipelines/freight/freight-provenance-utils.ts
@@ -1,0 +1,132 @@
+import {
+  ArtifactReference as GenericArtifactReference,
+  Chart,
+  Freight,
+  GitCommit,
+  Image
+} from '@ui/gen/api/v1alpha1/generated_pb';
+
+export type FreightProvenanceRow = {
+  key: string;
+  label: string;
+  value: string;
+  title?: string;
+};
+
+const shortID = (id: string = '', length = 7) => id.slice(0, length);
+
+export const artifactName = (repoURL: string = '') => {
+  const normalized = repoURL.replace(/\/+$/, '').replace(/\.git$/, '');
+  const parts = normalized.split('/').filter(Boolean);
+  return parts[parts.length - 1] || repoURL;
+};
+
+const gitRow = (commit: GitCommit, index: number): FreightProvenanceRow | null => {
+  const revision = commit.tag || shortID(commit.id);
+  if (!revision) {
+    return null;
+  }
+  const source = artifactName(commit.repoURL);
+  return {
+    key: `git-${commit.repoURL || index}-${revision}`,
+    label: 'git',
+    value: source ? `${source} @ ${revision}` : revision,
+    title: `${commit.repoURL || 'Git'}${commit.id ? ` @ ${commit.id}` : ''}`
+  };
+};
+
+const chartRow = (chart: Chart, index: number): FreightProvenanceRow | null => {
+  if (!chart.version) {
+    return null;
+  }
+  const source = chart.name || artifactName(chart.repoURL);
+  return {
+    key: `chart-${chart.repoURL || index}-${chart.name || ''}-${chart.version}`,
+    label: 'chart',
+    value: source ? `${source}:${chart.version}` : chart.version,
+    title: `${chart.repoURL || 'Chart'}${chart.name ? `/${chart.name}` : ''}:${chart.version}`
+  };
+};
+
+const imageRow = (image: Image, index: number): FreightProvenanceRow | null => {
+  if (!image.tag) {
+    return null;
+  }
+  const source = artifactName(image.repoURL);
+  return {
+    key: `image-${image.repoURL || index}-${image.tag}`,
+    label: 'image',
+    value: source ? `${source}:${image.tag}` : image.tag,
+    title: `${image.repoURL || 'Image'}:${image.tag}`
+  };
+};
+
+const genericArtifactRow = (
+  artifact: GenericArtifactReference,
+  index: number
+): FreightProvenanceRow | null => {
+  if (!artifact.version) {
+    return null;
+  }
+  return {
+    key: `artifact-${artifact.subscriptionName || index}-${artifact.version}`,
+    label: 'artifact',
+    value: artifact.subscriptionName
+      ? `${artifact.subscriptionName}:${artifact.version}`
+      : artifact.version,
+    title: `${artifact.artifactType || 'Artifact'}:${artifact.version}`
+  };
+};
+
+export const freightShortName = (freight: Freight) => shortID(freight.metadata?.name || '');
+
+export const getFreightProvenanceRows = (
+  freight: Freight,
+  options: { showAlias: boolean; age?: string } = { showAlias: true }
+): FreightProvenanceRow[] => {
+  const rows: FreightProvenanceRow[] = [];
+
+  if (options.showAlias && freight.alias) {
+    rows.push({
+      key: 'alias',
+      label: 'alias',
+      value: freight.alias,
+      title: freight.alias
+    });
+  }
+
+  rows.push(
+    ...freight.commits
+      .map((commit, index) => gitRow(commit, index))
+      .filter((row): row is FreightProvenanceRow => Boolean(row)),
+    ...freight.charts
+      .map((chart, index) => chartRow(chart, index))
+      .filter((row): row is FreightProvenanceRow => Boolean(row)),
+    ...freight.images
+      .map((image, index) => imageRow(image, index))
+      .filter((row): row is FreightProvenanceRow => Boolean(row)),
+    ...freight.artifacts
+      .map((artifact, index) => genericArtifactRow(artifact, index))
+      .filter((row): row is FreightProvenanceRow => Boolean(row))
+  );
+
+  const id = freightShortName(freight);
+  if (id) {
+    rows.push({
+      key: 'id',
+      label: 'id',
+      value: id,
+      title: freight.metadata?.name
+    });
+  }
+
+  if (options.age) {
+    rows.push({
+      key: 'age',
+      label: 'age',
+      value: options.age
+    });
+  }
+
+  return rows;
+};

--- a/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-timeline-filters.tsx
@@ -85,6 +85,24 @@ export const FreightTimelineFilters = (props: FreightTimelineFiltersProps) => {
           }
         />
       </div>
+      <div className='text-xs flex items-center gap-3 mt-2'>
+        <label>Card: </label>
+        <Select
+          className='min-w-[200px] ml-auto'
+          size='small'
+          value={props.preferredFilter?.freightCardView}
+          options={[
+            { value: 'compact', label: 'Compact' },
+            { value: 'provenance', label: 'Provenance' }
+          ]}
+          onChange={(freightCardView) =>
+            props.onPreferredFilterChange({
+              ...props.preferredFilter,
+              freightCardView
+            })
+          }
+        />
+      </div>
 
       <div className='flex mt-3 gap-2'>
         <Checkbox

--- a/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
+++ b/ui/src/features/project/pipelines/freight/use-freight-carousel.ts
@@ -4,6 +4,7 @@ import { FreightTimelineControllerContextType } from '@ui/features/project/pipel
 
 const PAGE_SIZE = 20;
 const MIN_CARD_WIDTH = 140;
+const PROVENANCE_CARD_WIDTH = 220;
 const CARD_GAP = 4;
 
 type PreferredFilter = FreightTimelineControllerContextType['preferredFilter'];
@@ -42,6 +43,8 @@ export const useFreightCarousel = (
   const [offset, setOffset] = useState(0);
   const [cardWidth, setCardWidth] = useState(MIN_CARD_WIDTH);
   const [canSlideRight, setCanSlideRight] = useState(false);
+  const minCardWidth =
+    preferredFilter.freightCardView === 'provenance' ? PROVENANCE_CARD_WIDTH : MIN_CARD_WIDTH;
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -53,7 +56,7 @@ export const useFreightCarousel = (
       // makes the next card peek through on certain resolutions.
       const W = viewport.getBoundingClientRect().width;
       if (W <= 0) return;
-      const n = Math.max(1, Math.floor((W + CARD_GAP) / (MIN_CARD_WIDTH + CARD_GAP)));
+      const n = Math.max(1, Math.floor((W + CARD_GAP) / (minCardWidth + CARD_GAP)));
       const exactW = (W - (n - 1) * CARD_GAP) / n;
       cardsPerPageRef.current = n;
       setCardWidth(exactW);
@@ -68,7 +71,7 @@ export const useFreightCarousel = (
     const ro = new ResizeObserver(compute);
     ro.observe(viewport);
     return () => ro.disconnect();
-  }, []);
+  }, [minCardWidth]);
 
   useEffect(() => {
     setVisibleCount(Math.max(PAGE_SIZE, cardsPerPageRef.current * 2));
@@ -77,7 +80,8 @@ export const useFreightCarousel = (
     preferredFilter.sources,
     preferredFilter.timerange,
     preferredFilter.warehouses,
-    preferredFilter.hideUnusedFreights
+    preferredFilter.hideUnusedFreights,
+    preferredFilter.freightCardView
   ]);
 
   const loadMore = useCallback(() => {

--- a/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
+++ b/ui/src/features/project/pipelines/url-params/use-freight-timeline-controller-store.ts
@@ -22,7 +22,8 @@ export const useFreightTimelineControllerStore = (project: string) => {
       images: false,
       view: 'graph',
       showMinimap: true,
-      stepEdges: false
+      stepEdges: false,
+      freightCardView: 'compact'
     };
 
     const hasFilterParams = Object.keys(filters).some((name) => searchParams.has(name));
@@ -49,6 +50,11 @@ export const useFreightTimelineControllerStore = (project: string) => {
     const stepEdges = searchParams.get('stepEdges');
     if (stepEdges && stepEdges !== '') {
       filters.stepEdges = stepEdges === 'true';
+    }
+
+    const freightCardView = searchParams.get('freightCardView');
+    if (freightCardView && ['compact', 'provenance'].includes(freightCardView)) {
+      filters.freightCardView = freightCardView as 'compact' | 'provenance';
     }
 
     const sourcesParam = searchParams.getAll('sources');
@@ -117,6 +123,8 @@ export const useFreightTimelineControllerStore = (project: string) => {
         currentSearchParams.set('showMinimap', `${nextPartial.showMinimap}`);
 
         currentSearchParams.set('stepEdges', `${nextPartial.stepEdges}`);
+
+        currentSearchParams.set('freightCardView', `${nextPartial.freightCardView}`);
 
         currentSearchParams.set('showColors', `${nextPartial.showColors}`);
 


### PR DESCRIPTION
Summary
- Add an opt-in provenance view for Freight cards in the pipeline timeline.
- Keep the existing compact card view as the default.

Changes
- Add a `Card` filter with `Compact` and `Provenance` modes.
- Render provenance rows for alias, Git source/revision, chart version, image tag, generic artifact, Freight ID, and age.
- Persist the selected card view in URL params/local filter state.
- Use a wider carousel card width only when provenance mode is selected.

Testing
- `pnpm test -- src/features/project/pipelines/freight/freight-provenance-utils.test.ts --run`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --cached --check`
- `gitleaks protect --staged --redact --no-banner`

Risks/Notes
- The existing compact Freight card rendering remains unchanged unless users select `Card: Provenance`.
- `pnpm build` still reports existing bundle-size/dynamic-import warnings.
