### PR TITLE
fix(management-controller): skip Role normalization when create-actor annotation is absent

### DIFF
--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -1000,6 +1000,10 @@ func (r *reconciler) ensureDefaultUserRoles(
 			}
 		}
 	}
+	// Only normalize Roles and RoleBindings when the create-actor annotation
+	// is present. Without it, the Project's kargo-* Roles are self-managed
+	// (e.g. via GitOps) and the controller should not overwrite them.
+	if _, ok := project.Annotations[kargoapi.AnnotationKeyCreateActor]; ok {
 	for _, role := range roles {
 		roleLogger := logger.WithValues(
 			"name", role.Name,
@@ -1038,6 +1042,7 @@ func (r *reconciler) ensureDefaultUserRoles(
 		}
 		roleLogger.Debug("updated Role in project namespace")
 	}
+	} // end create-actor annotation check
 
 	for _, rbName := range allRoles {
 		rbLogger := logger.WithValues(


### PR DESCRIPTION
## What this fixes

The management-controller unconditionally normalizes kargo-* Roles (kargo-admin, kargo-viewer, kargo-promoter) on every Project reconciliation. When a Project does not have the `kargo.akuity.io/create-actor` annotation, these Roles are self-managed (e.g. via GitOps), and the controller overwriting them causes:
- Loss of custom scope on the Roles
- Thrashing with GitOps tooling that provisioned the Roles

## What I changed

In `pkg/controller/management/projects/projects.go`, the Role normalization loop in `ensureDefaultUserRoles` now checks for the `create-actor` annotation before running. When the annotation is absent, Role creation/update is skipped entirely.

## How to test

1. Create a Project without the `kargo.akuity.io/create-actor` annotation
2. Manually create a kargo-admin Role with custom rules
3. Trigger a reconciliation (e.g. update the Project)
4. Verify the custom Role rules are preserved (not overwritten)

Fixes #6409