### PR TITLE
feat(git-tag): add force config option

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
@@ -15,6 +15,15 @@ referencing the current `HEAD` of a checked-out branch.
 | `path` | `string` | Y        | Path to a working directory of a local repository. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `tag`  | `string` | Y        | The tag to create. |
 | `message` | `string` | Y | The message with which to annotate the tag. |
+| `force` | `boolean` | N | Whether to overwrite an existing tag of the same name. Defaults to `false`. |
+
+:::caution
+Force overwriting a tag is an unconventional use of tags. Tags are conventionally
+immutable references to a specific commit, and many tools and workflows assume
+they never change. Enable `force` only when you fully understand the
+consequences and have a deliberate reason to move an existing tag to a new
+commit.
+:::
 
 ## Output
 
@@ -66,4 +75,25 @@ steps:
   config:
     path: ./out
     tag: v1.0.0
+```
+
+### Overwriting an Existing Tag
+
+In this example, the `git-tag` step moves an existing tag to the current `HEAD`
+by setting `force` to `true`. Without `force`, the step fails if the tag already
+exists.
+
+:::caution
+Force overwriting a tag is an unconventional use of tags. Use it only with
+extreme caution and a deliberate reason. See the warning under
+[Configuration](#configuration).
+:::
+
+```yaml
+steps:
+- uses: git-tag
+  config:
+    path: ./out
+    tag: dev-team-a
+    force: true
 ```

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-tag.md
@@ -15,15 +15,7 @@ referencing the current `HEAD` of a checked-out branch.
 | `path` | `string` | Y        | Path to a working directory of a local repository. This path is relative to the temporary workspace that Kargo provisions for use by the promotion process. |
 | `tag`  | `string` | Y        | The tag to create. |
 | `message` | `string` | Y | The message with which to annotate the tag. |
-| `force` | `boolean` | N | Whether to overwrite an existing tag of the same name. Defaults to `false`. |
-
-:::caution
-Force overwriting a tag is an unconventional use of tags. Tags are conventionally
-immutable references to a specific commit, and many tools and workflows assume
-they never change. Enable `force` only when you fully understand the
-consequences and have a deliberate reason to move an existing tag to a new
-commit.
-:::
+| `force` | `boolean` | N | Whether to overwrite an existing tag of the same name. Defaults to `false`. **Caution:** Overwriting a tag is unconventional—tags are normally immutable references to a specific commit—so enable this only with a deliberate reason. |
 
 ## Output
 

--- a/pkg/controller/git/ls_remote_test.go
+++ b/pkg/controller/git/ls_remote_test.go
@@ -13,7 +13,7 @@ func Test_LsRemote(t *testing.T) {
 		func(t *testing.T, rep WorkTree) {
 			// Create and push an annotated tag so we can verify that its peeled
 			// "^{}" entry is dropped and only the tag object is reported.
-			require.NoError(t, rep.CreateTag("v1.0.0", "release v1.0.0"))
+			require.NoError(t, rep.CreateTag("v1.0.0", "release v1.0.0", false))
 			require.NoError(t, rep.Push(&PushOptions{Tag: "v1.0.0"}))
 		},
 	)

--- a/pkg/controller/git/ls_remote_test.go
+++ b/pkg/controller/git/ls_remote_test.go
@@ -13,7 +13,7 @@ func Test_LsRemote(t *testing.T) {
 		func(t *testing.T, rep WorkTree) {
 			// Create and push an annotated tag so we can verify that its peeled
 			// "^{}" entry is dropped and only the tag object is reported.
-			require.NoError(t, rep.CreateTag("v1.0.0", "release v1.0.0", false))
+			require.NoError(t, rep.CreateTag("v1.0.0", "release v1.0.0", nil))
 			require.NoError(t, rep.Push(&PushOptions{Tag: "v1.0.0"}))
 		},
 	)

--- a/pkg/controller/git/mock_repo.go
+++ b/pkg/controller/git/mock_repo.go
@@ -13,7 +13,7 @@ type MockRepo struct {
 	CommitFn                  func(message string, opts *CommitOptions) error
 	CreateChildBranchFn       func(branch string) error
 	CreateOrphanedBranchFn    func(branch string) error
-	CreateTagFn               func(tag, msg string, force bool) error
+	CreateTagFn               func(tag, msg string, opts *CreateTagOptions) error
 	CurrentBranchFn           func() (string, error)
 	DeleteBranchFn            func(branch string) error
 	DirFn                     func() string
@@ -80,8 +80,8 @@ func (m *MockRepo) CreateOrphanedBranch(branch string) error {
 	return m.CreateOrphanedBranchFn(branch)
 }
 
-func (m *MockRepo) CreateTag(tag, msg string, force bool) error {
-	return m.CreateTagFn(tag, msg, force)
+func (m *MockRepo) CreateTag(tag, msg string, opts *CreateTagOptions) error {
+	return m.CreateTagFn(tag, msg, opts)
 }
 
 func (m *MockRepo) CurrentBranch() (string, error) {

--- a/pkg/controller/git/mock_repo.go
+++ b/pkg/controller/git/mock_repo.go
@@ -13,7 +13,7 @@ type MockRepo struct {
 	CommitFn                  func(message string, opts *CommitOptions) error
 	CreateChildBranchFn       func(branch string) error
 	CreateOrphanedBranchFn    func(branch string) error
-	CreateTagFn               func(tag, msg string) error
+	CreateTagFn               func(tag, msg string, force bool) error
 	CurrentBranchFn           func() (string, error)
 	DeleteBranchFn            func(branch string) error
 	DirFn                     func() string
@@ -80,8 +80,8 @@ func (m *MockRepo) CreateOrphanedBranch(branch string) error {
 	return m.CreateOrphanedBranchFn(branch)
 }
 
-func (m *MockRepo) CreateTag(tag, msg string) error {
-	return m.CreateTagFn(tag, msg)
+func (m *MockRepo) CreateTag(tag, msg string, force bool) error {
+	return m.CreateTagFn(tag, msg, force)
 }
 
 func (m *MockRepo) CurrentBranch() (string, error) {

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -42,9 +42,8 @@ type WorkTree interface {
 	// CreateOrphanedBranch creates a new branch that shares no commit history
 	// with any other branch.
 	CreateOrphanedBranch(branch string) error
-	// CreateTag creates a new tag with the specified name. If force is true,
-	// an existing tag with the same name is overwritten.
-	CreateTag(name, msg string, force bool) error
+	// CreateTag creates a new annotated tag with the specified name and message.
+	CreateTag(name, msg string, opts *CreateTagOptions) error
 	// CurrentBranch returns the current branch
 	CurrentBranch() (string, error)
 	// DeleteBranch deletes the specified branch
@@ -335,9 +334,18 @@ func (w *workTree) CreateOrphanedBranch(branch string) error {
 	return w.Clean()
 }
 
-func (w *workTree) CreateTag(tag, msg string, force bool) error {
+// CreateTagOptions represents options for creating a tag.
+type CreateTagOptions struct {
+	// Force indicates whether to overwrite an existing tag of the same name.
+	Force bool
+}
+
+func (w *workTree) CreateTag(tag, msg string, opts *CreateTagOptions) error {
+	if opts == nil {
+		opts = &CreateTagOptions{}
+	}
 	args := []string{"tag", "-a", tag, "-m", msg}
-	if force {
+	if opts.Force {
 		args = append(args, "--force")
 	}
 	cmd := w.buildGitCommand(args...)

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -42,8 +42,9 @@ type WorkTree interface {
 	// CreateOrphanedBranch creates a new branch that shares no commit history
 	// with any other branch.
 	CreateOrphanedBranch(branch string) error
-	// CreateTag creates a new tag with the specified name.
-	CreateTag(name, msg string) error
+	// CreateTag creates a new tag with the specified name. If force is true,
+	// an existing tag with the same name is overwritten.
+	CreateTag(name, msg string, force bool) error
 	// CurrentBranch returns the current branch
 	CurrentBranch() (string, error)
 	// DeleteBranch deletes the specified branch
@@ -334,8 +335,12 @@ func (w *workTree) CreateOrphanedBranch(branch string) error {
 	return w.Clean()
 }
 
-func (w *workTree) CreateTag(tag, msg string) error {
-	cmd := w.buildGitCommand("tag", "-a", tag, "-m", msg)
+func (w *workTree) CreateTag(tag, msg string, force bool) error {
+	args := []string{"tag", "-a", tag, "-m", msg}
+	if force {
+		args = append(args, "--force")
+	}
+	cmd := w.buildGitCommand(args...)
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf("error creating annotated tag %q: %w", tag, err)
 	}

--- a/pkg/promotion/runner/builtin/git_pusher_test.go
+++ b/pkg/promotion/runner/builtin/git_pusher_test.go
@@ -224,7 +224,7 @@ func Test_gitPusher_run(t *testing.T) {
 	require.NoError(t, err)
 
 	// Tag the commit so we can also test pushing tags later.
-	require.NoError(t, workTree.CreateTag("v1.0.0", "hello"))
+	require.NoError(t, workTree.CreateTag("v1.0.0", "hello", false))
 
 	// Set up a fake git provider
 	// Cannot register multiple providers with the same name, so this takes

--- a/pkg/promotion/runner/builtin/git_pusher_test.go
+++ b/pkg/promotion/runner/builtin/git_pusher_test.go
@@ -224,7 +224,7 @@ func Test_gitPusher_run(t *testing.T) {
 	require.NoError(t, err)
 
 	// Tag the commit so we can also test pushing tags later.
-	require.NoError(t, workTree.CreateTag("v1.0.0", "hello", false))
+	require.NoError(t, workTree.CreateTag("v1.0.0", "hello", nil))
 
 	// Set up a fake git provider
 	// Cannot register multiple providers with the same name, so this takes

--- a/pkg/promotion/runner/builtin/git_tagger.go
+++ b/pkg/promotion/runner/builtin/git_tagger.go
@@ -73,7 +73,7 @@ func (g *gitTagTagger) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
-	if err = workTree.CreateTag(cfg.Tag, cfg.Message); err != nil {
+	if err = workTree.CreateTag(cfg.Tag, cfg.Message, cfg.Force); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error creating tag %s: %w", cfg.Tag, err)
 	}

--- a/pkg/promotion/runner/builtin/git_tagger.go
+++ b/pkg/promotion/runner/builtin/git_tagger.go
@@ -73,7 +73,11 @@ func (g *gitTagTagger) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
-	if err = workTree.CreateTag(cfg.Tag, cfg.Message, cfg.Force); err != nil {
+	if err = workTree.CreateTag(
+		cfg.Tag,
+		cfg.Message,
+		&git.CreateTagOptions{Force: cfg.Force},
+	); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error creating tag %s: %w", cfg.Tag, err)
 	}

--- a/pkg/promotion/runner/builtin/git_tagger_test.go
+++ b/pkg/promotion/runner/builtin/git_tagger_test.go
@@ -88,6 +88,15 @@ func Test_gitTagger_convert(t *testing.T) {
 				"message": "hello",
 			},
 		},
+		{
+			name: "valid config with force",
+			config: promotion.Config{
+				"path":    "/tmp/foo",
+				"tag":     "v1.0.0",
+				"message": "hello",
+				"force":   true,
+			},
+		},
 	}
 
 	r := newGitTagger(promotion.StepRunnerCapabilities{})
@@ -176,6 +185,47 @@ func Test_gitTagger_run(t *testing.T) {
 	expectedCommit, err := workTree.LastCommitID()
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[stateKeyCommit]
+	require.True(t, ok)
+	require.Equal(t, expectedCommit, actualCommit)
+
+	// Switch back to the branch and add another commit so the tag would need to
+	// move to a different commit.
+	require.NoError(t, workTree.Checkout("master"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workTree.Dir(), "test.txt"),
+		[]byte("bar"), 0600,
+	))
+	require.NoError(t, workTree.AddAll())
+	require.NoError(t, workTree.Commit("Second commit", nil))
+
+	// Re-tagging without force should fail because the tag already exists.
+	res, err = runner.run(
+		t.Context(),
+		&promotion.StepContext{WorkDir: workDir},
+		builtin.GitTagConfig{
+			Path: "master",
+			Tag:  "v1.0.0",
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, kargoapi.PromotionStepStatusErrored, res.Status)
+
+	// Re-tagging with force should succeed and move the tag to the new commit.
+	res, err = runner.run(
+		t.Context(),
+		&promotion.StepContext{WorkDir: workDir},
+		builtin.GitTagConfig{
+			Path:  "master",
+			Tag:   "v1.0.0",
+			Force: true,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
+	require.NoError(t, workTree.Checkout("v1.0.0"))
+	expectedCommit, err = workTree.LastCommitID()
+	require.NoError(t, err)
+	actualCommit, ok = res.Output[stateKeyCommit]
 	require.True(t, ok)
 	require.Equal(t, expectedCommit, actualCommit)
 }

--- a/pkg/promotion/runner/builtin/schemas/git-tag-config.json
+++ b/pkg/promotion/runner/builtin/schemas/git-tag-config.json
@@ -3,6 +3,11 @@
   "title": "GitTagConfig",
   "type": "object",
   "properties": {
+    "force": {
+      "type": "boolean",
+      "description": "Indicates whether to overwrite an existing tag of the same name. WARNING: Force overwriting tags is an unconventional use of tags and should be utilized only with extreme caution. Default is false.",
+      "default": false
+    },
     "message": {
       "type": "string",
       "description": "The annotation message for the tag.",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -336,6 +336,10 @@ type GitPushConfig struct {
 }
 
 type GitTagConfig struct {
+	// Indicates whether to overwrite an existing tag of the same name. WARNING: Force
+	// overwriting tags is an unconventional use of tags and should be utilized only with
+	// extreme caution. Default is false.
+	Force bool `json:"force,omitempty"`
 	// The annotation message for the tag.
 	Message string `json:"message"`
 	// The path to a working directory of a local repository.

--- a/ui/src/gen/directives/git-tag-config.json
+++ b/ui/src/gen/directives/git-tag-config.json
@@ -3,6 +3,11 @@
  "title": "GitTagConfig",
  "type": "object",
  "properties": {
+  "force": {
+   "type": "boolean",
+   "description": "Indicates whether to overwrite an existing tag of the same name. WARNING: Force overwriting tags is an unconventional use of tags and should be utilized only with extreme caution. Default is false.",
+   "default": false
+  },
   "message": {
    "type": "string",
    "description": "The annotation message for the tag.",


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #6407

Adds an optional `force` configuration field to the `git-tag` promotion step. When set to `true`, the step passes `--force` to `git tag`, allowing an existing tag to be moved to the current `HEAD`. This supports workflows where a tag (for example `dev-team-a`) tracks the commit from which Argo CD syncs a team's resources and must be updated on each promotion.

Changes include:
- New `force` boolean in the `git-tag` JSON schema and generated config types (defaults to `false`)
- `WorkTree.CreateTag` updated to accept a `force` parameter and pass `--force` when enabled
- Unit tests for force and non-force behavior
- Documentation with caution admonitions about the unconventional nature of overwriting tags

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [x] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [ ] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**