### PR TITLE
docs(security): scan released images with grype + Akuity's VEX attestation

### DIFF
--- a/docs/docs/40-operator-guide/40-security/45-verifying-images.md
+++ b/docs/docs/40-operator-guide/40-security/45-verifying-images.md
@@ -1,0 +1,66 @@
+---
+sidebar_label: Verifying Images
+---
+
+# Verifying Images
+
+Akuity continuously scans the official Kargo image
+(`ghcr.io/akuity/kargo`) for known vulnerabilities (CVEs) and publishes the
+results of that triage as [OpenVEX](https://openvex.dev/) documents. VEX
+("Vulnerability Exploitability eXchange") records, for each CVE a scanner might
+flag, whether the image is actually affected — and when it is not, _why_ (for
+example, the vulnerable code is present in a bundled OS library but never in an
+execute path).
+
+This lets you cut false-positive noise from your own image scans: a CVE that
+Akuity has assessed as `not_affected` carries a machine-readable justification
+you can fold into your scanner's output instead of triaging it by hand.
+
+There are two ways to consume these assessments.
+
+## Apply VEX during scanning
+
+The assessments are published as OpenVEX documents at `vex.akuity.io`, keyed by
+image repository. This path works with any scanner that supports VEX and needs
+no additional tooling. For example, with
+[Grype](https://github.com/anchore/grype):
+
+```bash
+# Fetch Akuity's VEX document for the Kargo image.
+curl -fsSL https://vex.akuity.io/pkg/oci/ghcr.io/akuity/kargo/vex.json -o kargo-vex.json
+
+# Scan, applying the assessments. CVEs assessed as not_affected are
+# suppressed (and annotated with their justification).
+grype ghcr.io/akuity/kargo:<version> --vex kargo-vex.json
+```
+
+The published document carries assessments for the latest patch of each
+supported release line.
+
+## Verify the signed attestation
+
+Akuity also attaches the same OpenVEX assessment to each image **digest** as a
+[cosign](https://github.com/sigstore/cosign) attestation, signed keylessly via
+Sigstore (GitHub OIDC / Fulcio). This gives you cryptographic provenance: proof
+that the assessment was produced by Akuity and pertains to exactly the image you
+are running.
+
+```bash
+cosign verify-attestation --type openvex \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity https://github.com/akuityio/cve-triage/.github/workflows/attest-vex.yml@refs/heads/main \
+  ghcr.io/akuity/kargo:<version>
+```
+
+A successful verification prints the signer identity and the attestation
+payload. To inspect the assessment without verifying the signature, use
+`cosign download attestation <image> | jq -r '.payload | @base64d | fromjson'`.
+
+:::info
+
+The attestation is signed by Akuity's vulnerability-triage workflow, which is a
+distinct identity from the workflow that builds and signs the Kargo release
+image itself. The assessments are appended on change — a digest keeps its
+attestation until Akuity re-authors a disposition for it.
+
+:::

--- a/docs/docs/40-operator-guide/40-security/45-verifying-images.md
+++ b/docs/docs/40-operator-guide/40-security/45-verifying-images.md
@@ -22,16 +22,25 @@ There are two ways to consume these assessments.
 
 The assessments are published as OpenVEX documents at `vex.akuity.io`, keyed by
 image repository. This path works with any scanner that supports VEX and needs
-no additional tooling. For example, with
-[Grype](https://github.com/anchore/grype):
+no additional tooling. Fetch the document once, then pass it to your scanner —
+CVEs that Akuity has assessed as `not_affected` are suppressed (and annotated
+with their justification).
 
 ```bash
 # Fetch Akuity's VEX document for the Kargo image.
 curl -fsSL https://vex.akuity.io/pkg/oci/ghcr.io/akuity/kargo/vex.json -o kargo-vex.json
+```
 
-# Scan, applying the assessments. CVEs assessed as not_affected are
-# suppressed (and annotated with their justification).
+With [Grype](https://github.com/anchore/grype):
+
+```bash
 grype ghcr.io/akuity/kargo:<version> --vex kargo-vex.json
+```
+
+With [Trivy](https://github.com/aquasecurity/trivy):
+
+```bash
+trivy image --vex kargo-vex.json ghcr.io/akuity/kargo:<version>
 ```
 
 The published document carries assessments for the latest patch of each

--- a/docs/docs/40-operator-guide/40-security/45-verifying-images.md
+++ b/docs/docs/40-operator-guide/40-security/45-verifying-images.md
@@ -29,11 +29,13 @@ you only apply assessments whose Akuity signature checks out:
 IMAGE=ghcr.io/akuity/kargo:<version>
 
 # Verify Akuity's signature and extract the OpenVEX document in one step.
+# A digest may carry more than one attestation (assessments are appended as
+# dispositions change), so take the most recent by timestamp.
 cosign verify-attestation --type openvex \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity https://github.com/akuityio/cve-triage/.github/workflows/attest-vex.yml@refs/heads/main \
   "$IMAGE" \
-  | jq -r '.payload | @base64d | fromjson | .predicate' > kargo-vex.json
+  | jq -s 'map(.payload | @base64d | fromjson | .predicate) | max_by(.timestamp)' > kargo-vex.json
 
 # Scan, applying the assessments. CVEs Akuity has marked not_affected are
 # suppressed (Grype lists them under its ignored set with vex-status

--- a/docs/docs/40-operator-guide/40-security/45-verifying-images.md
+++ b/docs/docs/40-operator-guide/40-security/45-verifying-images.md
@@ -4,55 +4,52 @@ sidebar_label: Verifying Images
 
 # Verifying Images
 
-Akuity continuously scans the official Kargo image
-(`ghcr.io/akuity/kargo`) for known vulnerabilities (CVEs) and publishes the
-results of that triage as [OpenVEX](https://openvex.dev/) documents. VEX
-("Vulnerability Exploitability eXchange") records, for each CVE a scanner might
-flag, whether the image is actually affected — and when it is not, _why_ (for
-example, the vulnerable code is present in a bundled OS library but never in an
-execute path).
+Akuity continuously scans the official Kargo image (`ghcr.io/akuity/kargo`) for
+known vulnerabilities (CVEs) and publishes the results of that triage as
+[OpenVEX](https://openvex.dev/) assessments. VEX ("Vulnerability Exploitability
+eXchange") records, for each CVE a scanner might flag, whether the image is
+actually affected — and when it is not, _why_ (for example, a vulnerable
+function is present in a bundled library but is never reachable in this image).
+Folding these assessments into your own scans drops the false positives Akuity
+has already triaged.
 
-This lets you cut false-positive noise from your own image scans: a CVE that
-Akuity has assessed as `not_affected` carries a machine-readable justification
-you can fold into your scanner's output instead of triaging it by hand.
+The assessments are attached to **each image digest** as a signed
+[cosign](https://github.com/sigstore/cosign) attestation (keyless, via Sigstore
+/ GitHub OIDC), so they travel with the image — there is no extra endpoint to
+configure, and the signature proves Akuity authored the assessment for exactly
+the image you are running.
 
-There are two ways to consume these assessments.
+## Apply the assessments with Grype
 
-## Apply VEX during scanning
-
-The assessments are published as OpenVEX documents at `vex.akuity.io`, keyed by
-image repository. This path works with any scanner that supports VEX and needs
-no additional tooling. Fetch the document once, then pass it to your scanner —
-CVEs that Akuity has assessed as `not_affected` are suppressed (and annotated
-with their justification).
-
-```bash
-# Fetch Akuity's VEX document for the Kargo image.
-curl -fsSL https://vex.akuity.io/pkg/oci/ghcr.io/akuity/kargo/vex.json -o kargo-vex.json
-```
-
-With [Grype](https://github.com/anchore/grype):
+Verify and extract the attestation, then pass it to
+[Grype](https://github.com/anchore/grype) with `--vex`. Verifying first means
+you only apply assessments whose Akuity signature checks out:
 
 ```bash
-grype ghcr.io/akuity/kargo:<version> --vex kargo-vex.json
+IMAGE=ghcr.io/akuity/kargo:<version>
+
+# Verify Akuity's signature and extract the OpenVEX document in one step.
+cosign verify-attestation --type openvex \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity https://github.com/akuityio/cve-triage/.github/workflows/attest-vex.yml@refs/heads/main \
+  "$IMAGE" \
+  | jq -r '.payload | @base64d | fromjson | .predicate' > kargo-vex.json
+
+# Scan, applying the assessments. CVEs Akuity has marked not_affected are
+# suppressed (Grype lists them under its ignored set with vex-status
+# not_affected) and annotated with the justification.
+grype "$IMAGE" --vex kargo-vex.json
 ```
 
-With [Trivy](https://github.com/aquasecurity/trivy):
+A CVE is suppressed only when Akuity has dispositioned it **and** your scanner
+still reports it — assessments are added as CVEs are triaged, so a freshly built
+image may surface findings that are not yet dispositioned.
 
-```bash
-trivy image --vex kargo-vex.json ghcr.io/akuity/kargo:<version>
-```
+## Verify provenance only
 
-The published document carries assessments for the latest patch of each
-supported release line.
-
-## Verify the signed attestation
-
-Akuity also attaches the same OpenVEX assessment to each image **digest** as a
-[cosign](https://github.com/sigstore/cosign) attestation, signed keylessly via
-Sigstore (GitHub OIDC / Fulcio). This gives you cryptographic provenance: proof
-that the assessment was produced by Akuity and pertains to exactly the image you
-are running.
+To simply confirm that an image carries an authentic Akuity assessment (for
+example, as a release gate), run the `verify-attestation` step on its own; it
+exits non-zero if the signature or signer identity does not match:
 
 ```bash
 cosign verify-attestation --type openvex \
@@ -61,15 +58,16 @@ cosign verify-attestation --type openvex \
   ghcr.io/akuity/kargo:<version>
 ```
 
-A successful verification prints the signer identity and the attestation
-payload. To inspect the assessment without verifying the signature, use
-`cosign download attestation <image> | jq -r '.payload | @base64d | fromjson'`.
+:::info Scope of the assessments
 
-:::info
+Akuity attaches an assessment to the **latest patch of each supported release
+line** (e.g. the newest `1.10.x`). An assessment pertains to that specific
+digest; older patches keep the assessment they received while they were current.
+Suppression is keyed to the exact package versions present in the image, so an
+assessment authored for one patch will not mis-apply to an image built from
+different package versions.
 
-The attestation is signed by Akuity's vulnerability-triage workflow, which is a
-distinct identity from the workflow that builds and signs the Kargo release
-image itself. The assessments are appended on change — a digest keeps its
-attestation until Akuity re-authors a disposition for it.
+The attestation is signed by Akuity's vulnerability-triage workflow, a distinct
+identity from the workflow that builds and signs the Kargo release image itself.
 
 :::


### PR DESCRIPTION
Adds an operator-guide / Security page documenting how to consume Akuity's OpenVEX assessments for the Kargo image, scoped to **grype + cosign**.

Akuity attaches the assessments as a **signed cosign attestation on each image digest** (keyless, Sigstore/OIDC) — that's the authoritative, portable source (it travels with the image). The recipe:

```bash
cosign verify-attestation --type openvex \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity https://github.com/akuityio/cve-triage/.github/workflows/attest-vex.yml@refs/heads/main \
  $IMAGE | jq -r '.payload | @base64d | fromjson | .predicate' > kargo-vex.json
grype $IMAGE --vex kargo-vex.json
```

Verify-first means only signature-checked VEX is applied. Includes a provenance-only variant and a version-scope note.

**Changed from the earlier revision:** dropped the `vex.akuity.io` website fetch and the Trivy example. The website is now internal pre-release-CI infra, not an end-user surface; and Trivy/Scout need a *reified* product `@id` (grype matches the attestation's `repo@digest` as-is, but trivy/scout don't) — that's tracked as a separate multi-tool follow-up. Scoped here to grype, which is Akuity's own CI scanner.

Verified end-to-end against `ghcr.io/akuity/kargo` (verify+extract+grype runs clean; suppression confirmed where a dispositioned CVE is live).