### PR TITLE
test(charts): add helm-unittest suite for the kargo chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,19 @@ jobs:
       if: steps.cache-helm.outputs.cache-hit != 'true'
       run: make install-helm
     - name: Run chart unit tests
-      run: make test-chart
+      run: |
+        set -o pipefail
+        make test-chart 2>&1 | tee /tmp/chart-tests.log
+    - name: Publish chart test summary
+      if: always()
+      run: |
+        [ -f /tmp/chart-tests.log ] || exit 0
+        {
+          echo '## Chart unit tests'
+          echo '```'
+          sed -n '/^### Chart/,$p' /tmp/chart-tests.log
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
 
   lint-proto:
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,33 @@ jobs:
     - name: Run linter
       run: make lint-charts
 
+  test-chart:
+    runs-on: ubuntu-latest
+    container:
+      image: *golangImage
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Cache helm
+      id: cache-helm
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          hack/bin/helm
+          hack/bin/helm-*
+        key:
+          ${{ runner.os }}-helm-${{ hashFiles('hack/tools/go.mod') }}
+    - name: Install helm
+      if: steps.cache-helm.outputs.cache-hit != 'true'
+      run: make install-helm
+    - name: Run chart unit tests
+      run: make test-chart
+
   lint-proto:
     permissions:
       contents: read # Permissions to read the repository, required because we override the default permissions

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,17 @@ lint-charts: install-helm
 	$(HELM) dep up && \
 	$(HELM) lint .
 
+# helm-unittest plugin version used by `make test-chart`.
+HELM_UNITTEST_VERSION ?= v1.1.0
+
+.PHONY: test-chart
+test-chart: install-helm
+	$(HELM) plugin list | grep -q unittest || \
+		$(HELM) plugin install --version $(HELM_UNITTEST_VERSION) https://github.com/helm-unittest/helm-unittest
+	cd charts/kargo && \
+	$(HELM) dep up && \
+	$(HELM) unittest .
+
 .PHONY: lint-ui
 lint-ui:
 	pnpm --dir=ui install --dev
@@ -360,6 +371,10 @@ hack-lint-proto: hack-build-dev-tools
 .PHONY: hack-lint-charts
 hack-lint-charts: hack-build-dev-tools
 	$(DOCKER_CMD) make lint-charts
+
+.PHONY: hack-test-chart
+hack-test-chart: hack-build-dev-tools
+	$(DOCKER_CMD) make test-chart
 
 .PHONY: hack-lint-ui
 hack-lint-ui: hack-build-dev-tools

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,10 @@ HELM_UNITTEST_VERSION ?= v1.1.0
 
 .PHONY: test-chart
 test-chart: install-helm
+	@# stdout of the install is redirected to silence the plugin's usage
+	@# banner; errors still surface on stderr.
 	$(HELM) plugin list | grep -q unittest || \
-		$(HELM) plugin install --version $(HELM_UNITTEST_VERSION) https://github.com/helm-unittest/helm-unittest
+		$(HELM) plugin install --version $(HELM_UNITTEST_VERSION) https://github.com/helm-unittest/helm-unittest >/dev/null
 	cd charts/kargo && \
 	$(HELM) dep up && \
 	$(HELM) unittest .

--- a/charts/kargo/.helmignore
+++ b/charts/kargo/.helmignore
@@ -1,0 +1,4 @@
+# Patterns to ignore when building Helm packages.
+# Chart unit-test fixtures are not part of the released chart.
+tests/
+test/

--- a/charts/kargo/test/values-unittest.yaml
+++ b/charts/kargo/test/values-unittest.yaml
@@ -1,0 +1,12 @@
+# Minimal values required for templates to render during tests.
+# Does NOT set any feature flags or functional preconditions — those
+# belong as explicit set: blocks in individual test cases.
+#
+# The only values here are the ones the chart hard-requires (via `fail`) to
+# render at all: the API admin account password hash and token signing key,
+# which the API Secret/Deployment demand whenever api.adminAccount.enabled is
+# true (the default) and api.secret.name is unset.
+api:
+  adminAccount:
+    passwordHash: "$2a$10$unittestunittestunittestunittestunittestunittestun"
+    tokenSigningKey: unittest-token-signing-key

--- a/charts/kargo/tests/README.md
+++ b/charts/kargo/tests/README.md
@@ -1,0 +1,60 @@
+# Chart Unit Tests
+
+Uses [helm-unittest](https://github.com/helm-unittest/helm-unittest) v1.x (pinned to v1.1.0). Run with
+`make test-chart` from the repo root.
+
+All suites load `test/values-unittest.yaml` as a baseline. It contains only the values the chart
+*hard-requires* to render at all (the API admin-account `passwordHash` / `tokenSigningKey`, which the
+API Secret demands via `fail`). It sets **no feature flags** — those, and any value a test description
+explicitly names ("when OIDC is enabled", "when crds.keep is false"), are set via `set:` in the
+individual test case.
+
+## File layout
+
+One test file per component directory, named `<component>_test.yaml`. Each file holds one or more
+suites, one suite per template file.
+
+```
+tests/
+  _helpers_test.yaml                    # helpers from _helpers.tpl
+  crds_test.yaml                        # crds.yaml
+  namespaces_test.yaml                  # {system,shared,cluster-secrets}-resources-namespace
+  common_test.yaml                      # common/ (shared cluster roles, cert issuer)
+  api_test.yaml                         # api/*
+  controller_test.yaml                  # controller/*
+  management-controller_test.yaml       # management-controller/*
+  garbage-collector_test.yaml           # garbage-collector/*
+  kubernetes-webhooks-server_test.yaml  # kubernetes-webhooks-server/*
+  external-webhooks-server_test.yaml    # external-webhooks-server/*
+  dex-server_test.yaml                  # dex-server/*
+  users_test.yaml                       # users/*
+  argocd_test.yaml                      # argocd/*
+```
+
+## Suite naming
+
+Suite names mirror the template path without the `templates/` prefix:
+- Component templates: `api/deployment.yaml`
+- Helpers: `_helpers.tpl/kargo.baseURL`
+
+## Template scope: suite-level vs leaf-level
+
+**Suite-level `templates:`** — for templates that render standalone.
+
+**Leaf-level `template:`** (per-test) — required for the workload templates (api, controller,
+management-controller, kubernetes/external webhooks server Deployments and the garbage-collector
+CronJob) which `include` their sibling ConfigMap/Secret via `print $.Template.BasePath ...` to compute
+a checksum annotation. Those siblings must be listed at suite level so the include resolves; each test
+then scopes assertions with `template:`.
+
+## Common patterns
+
+| Pattern | When to use |
+|---|---|
+| `isKind` + `equal path: metadata.name` | Verify a template renders the right object |
+| `hasDocuments: count: N` | Count documents in a multi-document template |
+| `documentSelector: {path: metadata.name, value: X}` | Scope assertions to one document in a multi-doc file |
+| `notExists` / `exists` | Verify a field is absent/present per feature flag |
+| `contains` / `notContains` | List membership (RBAC rules, env, webhook operations) |
+| `matchRegex` | Image refs / derived URLs |
+| Bracket notation `metadata.annotations["helm.sh/resource-policy"]` | Keys containing dots |

--- a/charts/kargo/tests/_helpers_test.yaml
+++ b/charts/kargo/tests/_helpers_test.yaml
@@ -1,0 +1,91 @@
+suite: _helpers.tpl/kargo.image
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/deployment.yaml
+  - templates/api/configmap.yaml
+  - templates/api/secret.yaml
+tests:
+  - it: defaults the image tag to the chart appVersion
+    template: templates/api/deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":.+$"
+
+  - it: honors an explicit repository and tag override
+    template: templates/api/deployment.yaml
+    set:
+      image.repository: example.com/custom/kargo
+      image.tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/custom/kargo:v9.9.9
+
+---
+suite: _helpers.tpl/kargo.labels
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/configmap.yaml
+tests:
+  - it: emits the standard chart + managed-by labels
+    asserts:
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^kargo-"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: api
+
+  - it: merges global labels into every resource
+    set:
+      global.labels.team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+---
+suite: _helpers.tpl/kargo.baseURL
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/configmap.yaml
+tests:
+  - it: produces an https URL when direct TLS is enabled (default)
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: https://localhost
+
+  - it: produces an http URL when no TLS is in use
+    set:
+      api.tls.enabled: false
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: http://localhost
+
+  - it: produces an https URL via ingress TLS even when direct TLS is off
+    set:
+      api.tls.enabled: false
+      api.ingress.enabled: true
+      api.ingress.tls.enabled: true
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: https://localhost
+
+  - it: produces an https URL when upstream TLS termination is configured
+    set:
+      api.tls.enabled: false
+      api.tls.terminatedUpstream: true
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: https://localhost

--- a/charts/kargo/tests/api_test.yaml
+++ b/charts/kargo/tests/api_test.yaml
@@ -1,0 +1,228 @@
+suite: api/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+# configmap + secret are listed so the Deployment's checksum includes resolve;
+# each test scopes assertions to the Deployment with template:.
+templates:
+  - templates/api/deployment.yaml
+  - templates/api/configmap.yaml
+  - templates/api/secret.yaml
+tests:
+  - it: renders the API Deployment by default
+    template: templates/api/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-api
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kargo-api
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^.+/kargo:.+"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: kargo-api
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: kargo-api
+
+  - it: is not rendered when the API is disabled
+    template: templates/api/deployment.yaml
+    set:
+      api.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not rendered when workloads are not installed
+    template: templates/api/deployment.yaml
+    set:
+      workloads.install: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses an exec health probe when TLS is enabled (default)
+    template: templates/api/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.exec
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.grpc
+
+  - it: uses a gRPC health probe when TLS is disabled
+    template: templates/api/deployment.yaml
+    set:
+      api.tls.enabled: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.grpc
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.exec
+
+---
+suite: api/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/configmap.yaml
+tests:
+  - it: renders API configuration with defaults
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.LOG_LEVEL
+          value: INFO
+      - equal:
+          path: data.SECRET_MANAGEMENT_ENABLED
+          value: "true"
+      - equal:
+          path: data.ROLLOUTS_INTEGRATION_ENABLED
+          value: "true"
+      - equal:
+          path: data.ADMIN_ACCOUNT_ENABLED
+          value: "true"
+
+  - it: derives an https token issuer and TLS env when TLS is enabled (default)
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: https://localhost
+      - equal:
+          path: data.TLS_ENABLED
+          value: "true"
+
+  - it: derives an http token issuer when TLS is disabled
+    set:
+      api.tls.enabled: false
+    asserts:
+      - equal:
+          path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
+          value: http://localhost
+      - notExists:
+          path: data.TLS_ENABLED
+
+  - it: omits secret management when disabled
+    set:
+      api.secretManagementEnabled: false
+    asserts:
+      - notExists:
+          path: data.SECRET_MANAGEMENT_ENABLED
+
+  - it: enables OIDC config when OIDC is turned on
+    set:
+      api.oidc.enabled: true
+      api.oidc.issuerURL: https://idp.example.com
+      api.oidc.clientID: kargo
+    asserts:
+      - equal:
+          path: data.OIDC_ENABLED
+          value: "true"
+      - equal:
+          path: data.OIDC_ISSUER_URL
+          value: https://idp.example.com
+
+---
+suite: api/secret.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/secret.yaml
+tests:
+  - it: renders the admin account secret by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: stringData.ADMIN_ACCOUNT_PASSWORD_HASH
+          value: "$2a$10$unittestunittestunittestunittestunittestunittestun"
+      - isNotEmpty:
+          path: stringData.ADMIN_ACCOUNT_TOKEN_SIGNING_KEY
+
+  - it: is not rendered when an external secret name is provided
+    set:
+      api.secret.name: my-external-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: api/service.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/service.yaml
+tests:
+  - it: exposes port 443 over https by default (TLS enabled)
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].appProtocol
+          value: https
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+
+  - it: exposes port 80 over http when TLS is disabled
+    set:
+      api.tls.enabled: false
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].appProtocol
+          value: http
+
+---
+suite: api/ingress.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/api/ingress.yaml
+tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an Ingress for the API host when enabled
+    set:
+      api.ingress.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: localhost
+
+  - it: routes /webhooks to the external webhooks server when it has no own ingress
+    set:
+      api.ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /webhooks
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: kargo-external-webhooks-server

--- a/charts/kargo/tests/api_test.yaml
+++ b/charts/kargo/tests/api_test.yaml
@@ -92,7 +92,7 @@ tests:
           path: data.ADMIN_ACCOUNT_ENABLED
           value: "true"
 
-  - it: derives an https token issuer and TLS env when TLS is enabled (default)
+  - it: token issuer URL uses the https scheme when TLS is enabled (default)
     asserts:
       - equal:
           path: data.ADMIN_ACCOUNT_TOKEN_ISSUER
@@ -101,7 +101,7 @@ tests:
           path: data.TLS_ENABLED
           value: "true"
 
-  - it: derives an http token issuer when TLS is disabled
+  - it: token issuer URL uses the http scheme when TLS is disabled
     set:
       api.tls.enabled: false
     asserts:

--- a/charts/kargo/tests/argocd_test.yaml
+++ b/charts/kargo/tests/argocd_test.yaml
@@ -1,0 +1,69 @@
+suite: argocd/role.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/argocd/role.yaml
+tests:
+  - it: is not rendered by default (watchArgocdNamespaceOnly is false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a namespaced Argo CD Role when watching only the Argo CD namespace
+    set:
+      controller.argocd.watchArgocdNamespaceOnly: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: kargo-controller
+      - equal:
+          path: metadata.namespace
+          value: argocd
+      - contains:
+          path: rules[0].resources
+          content: applications
+
+  - it: honors a custom Argo CD namespace
+    set:
+      controller.argocd.watchArgocdNamespaceOnly: true
+      controller.argocd.namespace: my-argocd
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-argocd
+
+  - it: is not rendered when Argo CD integration is disabled
+    set:
+      controller.argocd.watchArgocdNamespaceOnly: true
+      controller.argocd.integrationEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: argocd/role-binding.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/argocd/role-binding.yaml
+tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: binds the controller in the Argo CD namespace when watching it only
+    set:
+      controller.argocd.watchArgocdNamespaceOnly: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: roleRef.name
+          value: kargo-controller

--- a/charts/kargo/tests/common_test.yaml
+++ b/charts/kargo/tests/common_test.yaml
@@ -1,0 +1,56 @@
+suite: common/cluster-roles.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/common/cluster-roles.yaml
+tests:
+  - it: renders the shared project-scoped cluster roles by default
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: kargo-project-admin
+        isKind:
+          of: ClusterRole
+      - documentSelector:
+          path: metadata.name
+          value: kargo-project-secrets-reader
+        isKind:
+          of: ClusterRole
+
+  - it: grants the project admin access to secrets when secret management is enabled
+    set:
+      api.secretManagementEnabled: true
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-project-admin
+        contains:
+          path: rules[0].resources
+          content: secrets
+
+  - it: omits secret access for the project admin when secret management is disabled
+    set:
+      api.secretManagementEnabled: false
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-project-admin
+        notContains:
+          path: rules[0].resources
+          content: secrets
+
+  - it: is not rendered when cluster roles are disabled
+    set:
+      rbac.installClusterRoles: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not rendered when the data plane is not installed
+    set:
+      dataPlane.install: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kargo/tests/controller_test.yaml
+++ b/charts/kargo/tests/controller_test.yaml
@@ -1,0 +1,126 @@
+suite: controller/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/controller/deployment.yaml
+  - templates/controller/configmap.yaml
+tests:
+  - it: renders the controller Deployment by default
+    template: templates/controller/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-controller
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kargo-controller
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: kargo-controller
+
+  - it: is not rendered when the controller is disabled
+    template: templates/controller/deployment.yaml
+    set:
+      controller.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: controller/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/controller/configmap.yaml
+tests:
+  - it: marks the controller as default when no shard name is set
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.IS_DEFAULT_CONTROLLER
+          value: "true"
+      - notExists:
+          path: data.SHARD_NAME
+
+  - it: sets the shard name and is not default when a shard is named
+    set:
+      controller.shardName: shard-a
+    asserts:
+      - equal:
+          path: data.SHARD_NAME
+          value: shard-a
+      - notExists:
+          path: data.IS_DEFAULT_CONTROLLER
+
+  - it: is both sharded and default when isDefault is set with a shard name
+    set:
+      controller.shardName: shard-a
+      controller.isDefault: true
+    asserts:
+      - equal:
+          path: data.SHARD_NAME
+          value: shard-a
+      - equal:
+          path: data.IS_DEFAULT_CONTROLLER
+          value: "true"
+
+  - it: includes the API server base URL when the API is enabled
+    asserts:
+      - equal:
+          path: data.API_SERVER_BASE_URL
+          value: https://localhost
+
+  - it: omits the API server base URL when the API is disabled
+    set:
+      api.enabled: false
+    asserts:
+      - notExists:
+          path: data.API_SERVER_BASE_URL
+
+---
+suite: controller/cluster-role-bindings.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/controller/cluster-role-bindings.yaml
+tests:
+  - it: binds the controller and its integration roles by default
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-controller
+        equal:
+          path: roleRef.name
+          value: kargo-controller
+      - documentSelector:
+          path: metadata.name
+          value: kargo-controller-rollouts
+        isKind:
+          of: ClusterRoleBinding
+
+  - it: drops the rollouts binding when rollouts integration is disabled
+    set:
+      controller.rollouts.integrationEnabled: false
+      controller.argocd.integrationEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: kargo-controller
+
+  - it: is not rendered when cluster role bindings are disabled
+    set:
+      rbac.installClusterRoleBindings: false
+      argocd.dataPlane.install: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kargo/tests/crds_test.yaml
+++ b/charts/kargo/tests/crds_test.yaml
@@ -1,0 +1,44 @@
+suite: crds.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/crds.yaml
+tests:
+  - it: installs all CRDs by default
+    asserts:
+      - hasDocuments:
+          count: 9
+      - documentSelector:
+          path: metadata.name
+          value: stages.kargo.akuity.io
+        isKind:
+          of: CustomResourceDefinition
+
+  - it: keeps CRDs on uninstall by default
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+          documentIndex: 0
+
+  - it: does not annotate CRDs to keep when crds.keep is false
+    set:
+      crds.keep: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          documentIndex: 0
+
+  - it: installs no CRDs when crds.install is false
+    set:
+      crds.install: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: installs no CRDs when the data plane is not installed
+    set:
+      dataPlane.install: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kargo/tests/dex-server_test.yaml
+++ b/charts/kargo/tests/dex-server_test.yaml
@@ -1,0 +1,82 @@
+suite: dex-server/service.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/dex-server/service.yaml
+tests:
+  - it: is not rendered when Dex is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the Dex Service when OIDC + Dex are enabled
+    set:
+      api.oidc.enabled: true
+      api.oidc.dex.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: kargo-dex-server
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 5556
+
+---
+suite: dex-server/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/dex-server/deployment.yaml
+  - templates/dex-server/secret.yaml
+tests:
+  - it: is not rendered when Dex is disabled (default)
+    template: templates/dex-server/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the Dex Deployment when OIDC + Dex are enabled
+    template: templates/dex-server/deployment.yaml
+    set:
+      api.oidc.enabled: true
+      api.oidc.dex.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-dex-server
+
+---
+suite: dex-server/secret.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/dex-server/secret.yaml
+tests:
+  - it: is not rendered when Dex is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the Dex config Secret when OIDC + Dex are enabled
+    set:
+      api.oidc.enabled: true
+      api.oidc.dex.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: kargo-dex-server

--- a/charts/kargo/tests/external-webhooks-server_test.yaml
+++ b/charts/kargo/tests/external-webhooks-server_test.yaml
@@ -1,0 +1,79 @@
+suite: external-webhooks-server/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/external-webhooks-server/deployment.yaml
+  - templates/external-webhooks-server/configmap.yaml
+tests:
+  - it: renders the external webhooks server Deployment by default
+    template: templates/external-webhooks-server/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-external-webhooks-server
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kargo-external-webhooks-server
+
+  - it: is not rendered when the external webhooks server is disabled
+    template: templates/external-webhooks-server/deployment.yaml
+    set:
+      externalWebhooksServer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: external-webhooks-server/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/external-webhooks-server/configmap.yaml
+tests:
+  - it: renders configuration with defaults
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.LOG_LEVEL
+          value: INFO
+      - equal:
+          path: data.SYSTEM_RESOURCES_NAMESPACE
+          value: kargo-system-resources
+      - equal:
+          path: data.TLS_ENABLED
+          value: "true"
+
+  - it: derives the external webhooks server base URL (https by default)
+    asserts:
+      - equal:
+          path: data.EXTERNAL_WEBHOOK_SERVER_BASE_URL
+          value: https://localhost
+
+  - it: omits TLS env when direct TLS is disabled
+    set:
+      externalWebhooksServer.tls.enabled: false
+    asserts:
+      - notExists:
+          path: data.TLS_ENABLED
+
+---
+suite: external-webhooks-server/service.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/external-webhooks-server/service.yaml
+tests:
+  - it: renders the external webhooks Service
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: kargo-external-webhooks-server

--- a/charts/kargo/tests/garbage-collector_test.yaml
+++ b/charts/kargo/tests/garbage-collector_test.yaml
@@ -1,0 +1,75 @@
+suite: garbage-collector/cron-job.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/garbage-collector/cron-job.yaml
+  - templates/garbage-collector/configmap.yaml
+tests:
+  - it: renders the garbage collector CronJob by default
+    template: templates/garbage-collector/cron-job.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: kargo-garbage-collector
+      - equal:
+          path: spec.schedule
+          value: "0 * * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: kargo-garbage-collector
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
+          content: garbage-collector
+
+  - it: honors a custom schedule
+    template: templates/garbage-collector/cron-job.yaml
+    set:
+      garbageCollector.schedule: "*/30 * * * *"
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "*/30 * * * *"
+
+  - it: is not rendered when the garbage collector is disabled
+    template: templates/garbage-collector/cron-job.yaml
+    set:
+      garbageCollector.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: garbage-collector/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/garbage-collector/configmap.yaml
+tests:
+  - it: renders retention configuration with defaults
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.LOG_LEVEL
+          value: INFO
+      - isNotEmpty:
+          path: data.NUM_WORKERS
+      - isNotEmpty:
+          path: data.MAX_RETAINED_PROMOTIONS
+      - isNotEmpty:
+          path: data.MAX_RETAINED_FREIGHT
+
+  - it: reflects an overridden worker count
+    set:
+      garbageCollector.workers: 8
+    asserts:
+      - equal:
+          path: data.NUM_WORKERS
+          value: "8"

--- a/charts/kargo/tests/kubernetes-webhooks-server_test.yaml
+++ b/charts/kargo/tests/kubernetes-webhooks-server_test.yaml
@@ -1,0 +1,102 @@
+suite: kubernetes-webhooks-server/webhooks.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/kubernetes-webhooks-server/webhooks.yaml
+tests:
+  - it: registers the mutating and validating webhook configurations by default
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: kind
+          value: MutatingWebhookConfiguration
+        lengthEqual:
+          path: webhooks
+          count: 4
+
+  - it: is not rendered when webhook registration is disabled
+    set:
+      webhooks.register: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not rendered when the data plane is not installed
+    set:
+      dataPlane.install: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits the CA bundle when a self-signed cert is used (default)
+    documentSelector:
+      path: kind
+      value: MutatingWebhookConfiguration
+    asserts:
+      - notExists:
+          path: webhooks[0].clientConfig.caBundle
+
+  - it: injects the CA bundle when provided and not self-signed
+    documentSelector:
+      path: kind
+      value: MutatingWebhookConfiguration
+    set:
+      webhooksServer.tls.selfSignedCert: false
+      webhooksServer.tls.caBundle: test-ca-bundle
+    asserts:
+      - isNotEmpty:
+          path: webhooks[0].clientConfig.caBundle
+
+---
+suite: kubernetes-webhooks-server/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/kubernetes-webhooks-server/configmap.yaml
+tests:
+  - it: derives the control-plane user regex from enabled components by default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.CONTROLPLANE_USER_REGEX
+          pattern: "kargo-controller"
+
+  - it: honors an explicit control-plane user regex
+    set:
+      webhooksServer.controlplaneUserRegex: "^my-custom-regex$"
+    asserts:
+      - equal:
+          path: data.CONTROLPLANE_USER_REGEX
+          value: "^my-custom-regex$"
+
+---
+suite: kubernetes-webhooks-server/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/kubernetes-webhooks-server/deployment.yaml
+  - templates/kubernetes-webhooks-server/configmap.yaml
+tests:
+  - it: renders the webhooks server Deployment by default
+    template: templates/kubernetes-webhooks-server/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-webhooks-server
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kargo-webhooks-server
+
+  - it: is not rendered when the webhooks server is disabled
+    template: templates/kubernetes-webhooks-server/deployment.yaml
+    set:
+      webhooksServer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kargo/tests/management-controller_test.yaml
+++ b/charts/kargo/tests/management-controller_test.yaml
@@ -1,0 +1,66 @@
+suite: management-controller/deployment.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/management-controller/deployment.yaml
+  - templates/management-controller/configmap.yaml
+tests:
+  - it: renders the management controller Deployment by default
+    template: templates/management-controller/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: kargo-management-controller
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kargo-management-controller
+
+  - it: is not rendered when the management controller is disabled
+    template: templates/management-controller/deployment.yaml
+    set:
+      managementController.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: management-controller/configmap.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/management-controller/configmap.yaml
+tests:
+  - it: renders management controller configuration with defaults
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.LOG_LEVEL
+          value: INFO
+      - equal:
+          path: data.SYSTEM_RESOURCES_NAMESPACE
+          value: kargo-system-resources
+      - equal:
+          path: data.SHARED_RESOURCES_NAMESPACE
+          value: kargo-shared-resources
+      - equal:
+          path: data.MAX_CONCURRENT_PROJECT_RECONCILES
+          value: "4"
+
+  - it: derives the external webhooks server base URL (https by default)
+    asserts:
+      - equal:
+          path: data.EXTERNAL_WEBHOOK_SERVER_BASE_URL
+          value: https://localhost
+
+  - it: stops managing controller role bindings when cluster-wide secret reading is enabled
+    set:
+      controller.serviceAccount.clusterWideSecretReadingEnabled: true
+    asserts:
+      - equal:
+          path: data.MANAGE_CONTROLLER_ROLE_BINDINGS
+          value: "false"

--- a/charts/kargo/tests/namespaces_test.yaml
+++ b/charts/kargo/tests/namespaces_test.yaml
@@ -1,0 +1,85 @@
+suite: system-resources-namespace/namespace.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/system-resources-namespace/namespace.yaml
+tests:
+  - it: creates the system resources namespace by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: kargo-system-resources
+
+  - it: honors a custom system resources namespace name
+    set:
+      global.systemResources.namespace: custom-system
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-system
+
+  - it: is not created when namespace creation is disabled
+    set:
+      global.systemResources.createNamespace: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not created when the data plane is not installed
+    set:
+      dataPlane.install: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: shared-resources-namespace/namespace.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/shared-resources-namespace/namespace.yaml
+tests:
+  - it: creates the shared resources namespace by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: kargo-shared-resources
+
+  - it: is not created when namespace creation is disabled
+    set:
+      global.sharedResources.createNamespace: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: cluster-secrets-namespace/namespace.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/cluster-secrets-namespace/namespace.yaml
+tests:
+  - it: creates the (deprecated) cluster secrets namespace by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: kargo-cluster-secrets
+
+  - it: is not created when namespace creation is disabled
+    set:
+      global.createClusterSecretsNamespace: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kargo/tests/users_test.yaml
+++ b/charts/kargo/tests/users_test.yaml
@@ -1,0 +1,99 @@
+suite: users/service-accounts.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/users/service-accounts.yaml
+tests:
+  - it: renders the four system role service accounts by default
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentSelector:
+          path: metadata.name
+          value: kargo-admin
+        equal:
+          path: metadata.labels["rbac.kargo.akuity.io/system-role"]
+          value: "true"
+
+  - it: does not annotate service accounts with claims by default
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-admin
+        notExists:
+          path: metadata.annotations["rbac.kargo.akuity.io/claims"]
+
+  - it: annotates the admin service account with OIDC claims when configured
+    set:
+      api.oidc.admins.claims:
+        groups:
+          - kargo-admins
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-admin
+        isNotEmpty:
+          path: metadata.annotations["rbac.kargo.akuity.io/claims"]
+
+  - it: is not rendered when the API is disabled
+    set:
+      api.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: users/cluster-roles.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/users/cluster-roles.yaml
+tests:
+  - it: renders the four system cluster roles by default
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-admin
+        isKind:
+          of: ClusterRole
+      - documentSelector:
+          path: metadata.name
+          value: kargo-viewer
+        isKind:
+          of: ClusterRole
+
+  - it: is not rendered when cluster roles are disabled
+    set:
+      rbac.installClusterRoles: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is not rendered when the API is disabled
+    set:
+      api.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+---
+suite: users/cluster-role-bindings.yaml
+values:
+  - ../test/values-unittest.yaml
+templates:
+  - templates/users/cluster-role-bindings.yaml
+tests:
+  - it: binds the system cluster roles to their service accounts by default
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: kargo-admin
+        isKind:
+          of: ClusterRoleBinding
+
+  - it: is not rendered when cluster role bindings are disabled
+    set:
+      rbac.installClusterRoleBindings: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Context

The `charts/kargo` chart has **no unit tests** today — only `make lint-charts` (`helm lint`), which
catches YAML/schema errors but not rendering logic. The chart carries a lot of conditional behavior
that can regress silently: per-component `enabled` flags, the `dataPlane.install` / `workloads.install`
master gates, RBAC scope toggles (`rbac.installClusterRoles/Bindings`), TLS-aware URLs / probes /
service ports, CRD keep-policy annotations, controller sharding, webhook CA-bundle injection, and
OIDC/Dex wiring.

This adds a [`helm-unittest`](https://github.com/helm-unittest/helm-unittest) suite covering that
logic, mirroring the style used in Akuity's internal `akuity-platform` chart tests.

## What's here

**Test suites** (`charts/kargo/tests/`) — **99 tests / 34 suites**, one suite per template file:

| File | Coverage |
|---|---|
| `_helpers_test.yaml` | `kargo.image` tag defaulting/override, `kargo.labels` + `global.labels` merge, `kargo.baseURL`/`useTLS` (http vs https across direct/ingress/upstream TLS) |
| `crds_test.yaml` | 9 CRDs, `helm.sh/resource-policy: keep` toggle, `crds.install` / `dataPlane.install` gating |
| `namespaces_test.yaml` | system / shared / cluster-secrets namespace creation + `createNamespace` toggles |
| `common_test.yaml` | `kargo-project-admin` / `-secrets-reader` cluster roles; secret-rule gating on `api.secretManagementEnabled` |
| `users_test.yaml` | the four system SAs/cluster roles/bindings; OIDC claim annotations |
| `argocd_test.yaml` | namespaced Argo CD role/binding gated on `watchArgocdNamespaceOnly` |
| `api_test.yaml` | Deployment/ConfigMap/Secret/Service/Ingress; TLS-aware issuer/probes/ports; OIDC; `/webhooks` ingress path |
| `controller_test.yaml` | Deployment, sharding (`IS_DEFAULT_CONTROLLER`/`SHARD_NAME`), API base URL, integration ClusterRoleBindings |
| `management-controller_test.yaml` | Deployment + ConfigMap (namespaces, reconciler concurrency, webhook base URL) |
| `garbage-collector_test.yaml` | CronJob (schedule, `Forbid`, args) + retention ConfigMap |
| `kubernetes-webhooks-server_test.yaml` | Mutating/Validating webhook configs, CA-bundle injection, control-plane user regex |
| `external-webhooks-server_test.yaml` | Deployment + ConfigMap (TLS env, base URL) + Service |
| `dex-server_test.yaml` | Deployment/Secret/Service gated on `api.oidc.dex.enabled` |

Plus `tests/README.md` (conventions) and `test/values-unittest.yaml` (baseline = only the API
admin-account `passwordHash`/`tokenSigningKey` the chart `fail`s without).

**Runner & packaging**
- `make test-chart` / `hack-test-chart` — installs helm-unittest v1.1.0, then `helm unittest`.
- `charts/kargo/.helmignore` — keeps `tests/` and `test/` out of the packaged chart.

**CI**
- New `test-chart` job in `.github/workflows/ci.yaml`, mirroring the existing `lint-charts` job.

## Notes for reviewers

- Workload Deployments (api, controller, management-controller, both webhook servers) and the GC CronJob
  `include` their sibling ConfigMap/Secret for a checksum annotation, so those suites list both
  templates and scope each test with leaf-level `template:` (documented in `tests/README.md`).
- The baseline reflects chart defaults — note TLS is **on** by default, so default assertions expect
  https/443/exec-probes and flip via `api.tls.enabled: false`.

## Verification

- `make test-chart` → 99 passed / 34 suites.
- `make lint-charts` passes.
- Confirmed non-vacuous: a deliberately-wrong assertion fails as expected.