### PR TITLE
chore: upgrade ci to golang from 1.26.4-trixie

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: &golangImage golang:1.26.3-trixie
+      image: &golangImage golang:1.26.4-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,7 +243,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: &golangImage golang:1.26.3-trixie
+      image: &golangImage golang:1.26.4-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]


### PR DESCRIPTION
Follow up to #6418

Dependabot isn't smart enough to know that CI needs it's Go version bumped along with the bumps in the Dockerfiles.

I typically amend dependabot's Go version bump PRs accordingly.

Looks like #6418 was merged without that.

This fixes it.