### PR TITLE
feat(ui): render promotion step output and config as YAML

### DIFF
--- a/ui/src/features/stage/promotion-step.tsx
+++ b/ui/src/features/stage/promotion-step.tsx
@@ -21,6 +21,8 @@ import uiPlugins from '@ui/plugins';
 import { UiPluginHoles } from '@ui/plugins/atoms/ui-plugin-hole/ui-plugin-holes';
 import { decodeRawData } from '@ui/utils/decode-raw-data';
 
+import { objectToYAML } from './utils/promotion';
+
 export const Step = ({
   step,
   result,
@@ -43,14 +45,12 @@ export const Step = ({
 
     let userConfig = '';
     if (step?.config?.raw) {
-      userConfig = JSON.stringify(
+      userConfig = objectToYAML(
         JSON.parse(
           decodeRawData({
             result: { case: 'raw', value: step?.config?.raw || new Uint8Array() }
           })
-        ),
-        null,
-        ' '
+        )
       );
     }
 
@@ -92,7 +92,7 @@ export const Step = ({
 
   const yamlView = {
     config: meta?.config,
-    output: output ? JSON.stringify(output || {}, null, ' ') : ''
+    output: objectToYAML(output)
   };
 
   const filteredUiPlugins = uiPlugins

--- a/ui/src/features/stage/utils/promotion.test.ts
+++ b/ui/src/features/stage/utils/promotion.test.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck cannot use class as "new Promotion" because they are being deprecated in new protobuf version, using those would mean tech debt
 
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-import { promotionCompareFn } from './promotion';
+import { objectToYAML, promotionCompareFn } from './promotion';
 
 test('promotionCompareFn', () => {
   expect(
@@ -106,4 +106,33 @@ test('promotionCompareFn', () => {
       .sort(promotionCompareFn)
       .map((p) => p.name)
   ).toStrictEqual(['c', 'd', 'a', 'b']);
+});
+
+describe('objectToYAML', () => {
+  test('returns an empty string when there is no value', () => {
+    expect(objectToYAML(undefined)).toBe('');
+  });
+
+  test('renders multi-line string values with real line breaks', () => {
+    const output = {
+      plan: 'line one\nline two\nline three'
+    };
+
+    const result = objectToYAML(output);
+
+    // block scalar, not an escaped single line
+    expect(result).not.toContain('\\n');
+    expect(result).toContain('plan: |-');
+    expect(result).toContain('  line one\n  line two\n  line three');
+  });
+
+  test('does not fold long single lines', () => {
+    const longLine = 'a'.repeat(200);
+
+    expect(objectToYAML({ value: longLine })).toBe(`value: ${longLine}\n`);
+  });
+
+  test('preserves scalar values', () => {
+    expect(objectToYAML({ commit: 'abc123', count: 3 })).toBe('commit: abc123\ncount: 3\n');
+  });
 });

--- a/ui/src/features/stage/utils/promotion.ts
+++ b/ui/src/features/stage/utils/promotion.ts
@@ -1,5 +1,7 @@
 // action, reaction and behaviour of everything related to promotion
 
+import yaml from 'yaml';
+
 import {
   getPromotionStatusPhase,
   isPromotionPhaseTerminal
@@ -64,3 +66,10 @@ export const getPromotionOutputsByStepAlias = (promotion: Promotion) => {
 
   return {};
 };
+
+// Renders a value (a promotion step's output or config) as YAML so that
+// multi-line string values (e.g. Terraform plan output) are displayed with real
+// line breaks instead of a single escaped JSON line. lineWidth: 0 disables line
+// folding so long lines are preserved verbatim.
+export const objectToYAML = (value?: object): string =>
+  value ? yaml.stringify(value, { lineWidth: 0 }) : '';


### PR DESCRIPTION
fixes #6462
<img width="1377" height="1133" alt="image" src="https://github.com/user-attachments/assets/f2e48dbc-bf4f-4ec1-8b12-aed52aecb761" />
