### PR TITLE
feat(ui): surface current freight, show aliases, drop UIDs

### DIFF
--- a/ui/src/features/common/utils.test.ts
+++ b/ui/src/features/common/utils.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, test } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { describe, expect, it, test } from 'vitest';
 
-import { Freight, FreightReference, Stage } from '@ui/gen/api/v1alpha1/generated_pb';
+import {
+  Freight,
+  FreightReference,
+  FreightSchema,
+  Stage,
+  StageSchema
+} from '@ui/gen/api/v1alpha1/generated_pb';
 
-import { getCurrentFreightForComparison } from './utils';
+import {
+  ALIAS_LABEL_KEY,
+  getCurrentFreightByWarehouse,
+  getCurrentFreightForComparison,
+  getShortFreightLabel
+} from './utils';
 
 const ref = (origin: string, image: string): FreightReference =>
   ({
@@ -61,5 +73,91 @@ describe('getCurrentFreightForComparison', () => {
     const empty = { status: { freightHistory: [] } } as unknown as Stage;
 
     expect(getCurrentFreightForComparison(empty, incoming('warehouse-a'))).toBeUndefined();
+  });
+});
+
+describe('getCurrentFreightByWarehouse', () => {
+  it('returns an empty map when the stage has no freight history', () => {
+    const stage = create(StageSchema, { metadata: { name: 'test' } });
+    expect(getCurrentFreightByWarehouse(stage)).toEqual({});
+  });
+
+  it('keys the current freight by warehouse identifier', () => {
+    const stage = create(StageSchema, {
+      status: {
+        freightHistory: [
+          {
+            items: {
+              'Warehouse/w-1': { name: 'freight-aaa' },
+              'Warehouse/w-2': { name: 'freight-bbb' }
+            }
+          },
+          // older collection -- must be ignored
+          { items: { 'Warehouse/w-1': { name: 'freight-old' } } }
+        ]
+      }
+    });
+
+    const result = getCurrentFreightByWarehouse(stage);
+
+    expect(Object.keys(result).sort()).toEqual(['Warehouse/w-1', 'Warehouse/w-2']);
+    expect(result['Warehouse/w-1'].reference.name).toBe('freight-aaa');
+    expect(result['Warehouse/w-2'].reference.name).toBe('freight-bbb');
+  });
+
+  it('resolves the alias from the freight map, preferring the alias field', () => {
+    const stage = create(StageSchema, {
+      status: {
+        freightHistory: [{ items: { 'Warehouse/w-1': { name: 'freight-aaa' } } }]
+      }
+    });
+    const freightMap: Record<string, Freight> = {
+      'freight-aaa': create(FreightSchema, { alias: 'tasty-tiger' })
+    };
+
+    expect(getCurrentFreightByWarehouse(stage, freightMap)['Warehouse/w-1'].alias).toBe(
+      'tasty-tiger'
+    );
+  });
+
+  it('falls back to the alias label when the alias field is empty', () => {
+    const stage = create(StageSchema, {
+      status: {
+        freightHistory: [{ items: { 'Warehouse/w-1': { name: 'freight-aaa' } } }]
+      }
+    });
+    const freightMap: Record<string, Freight> = {
+      'freight-aaa': create(FreightSchema, {
+        metadata: { labels: { [ALIAS_LABEL_KEY]: 'brave-bear' } }
+      })
+    };
+
+    expect(getCurrentFreightByWarehouse(stage, freightMap)['Warehouse/w-1'].alias).toBe(
+      'brave-bear'
+    );
+  });
+
+  it('leaves the alias undefined when the freight is not in the map', () => {
+    const stage = create(StageSchema, {
+      status: {
+        freightHistory: [{ items: { 'Warehouse/w-1': { name: 'freight-aaa' } } }]
+      }
+    });
+
+    expect(getCurrentFreightByWarehouse(stage, {})['Warehouse/w-1'].alias).toBeUndefined();
+  });
+});
+
+describe('getShortFreightLabel', () => {
+  it('truncates the hash to seven characters when there is no alias', () => {
+    expect(getShortFreightLabel('abcdef0123456789')).toBe('abcdef0');
+  });
+
+  it('combines the alias with the short hash when an alias is provided', () => {
+    expect(getShortFreightLabel('abcdef0123456789', 'tasty-tiger')).toBe('tasty-tiger (abcdef0)');
+  });
+
+  it('returns an empty string when the name is missing', () => {
+    expect(getShortFreightLabel()).toBe('');
   });
 });

--- a/ui/src/features/common/utils.ts
+++ b/ui/src/features/common/utils.ts
@@ -46,6 +46,34 @@ export function getCurrentFreightForComparison(
   return getCurrentFreight(stage).find((freight) => freight?.origin?.name === originName);
 }
 
+export interface CurrentFreightItem {
+  reference: FreightReference;
+  alias?: string;
+}
+
+export function getCurrentFreightByWarehouse(
+  stage: Stage,
+  freightMap?: Record<string, Freight>
+): Record<string, CurrentFreightItem> {
+  const items = stage?.status?.freightHistory?.[0]?.items || {};
+
+  const result: Record<string, CurrentFreightItem> = {};
+  for (const [warehouseIdentifier, reference] of Object.entries(items)) {
+    const fullFreight = reference.name ? freightMap?.[reference.name] : undefined;
+    result[warehouseIdentifier] = {
+      reference,
+      alias: fullFreight ? getAlias(fullFreight) : undefined
+    };
+  }
+
+  return result;
+}
+
+export function getShortFreightLabel(name?: string, alias?: string): string {
+  const shortID = (name || '').slice(0, 7);
+  return alias ? `${alias} (${shortID})` : shortID;
+}
+
 export function getCurrentFreightWarehouse(stage: Stage) {
   const freightRef = getCurrentFreight(stage);
   const isWarehouseKind = freightRef.some((freight) => freight?.origin?.kind === 'Warehouse');

--- a/ui/src/features/freight/freight-details.tsx
+++ b/ui/src/features/freight/freight-details.tsx
@@ -1,10 +1,9 @@
 import { toJson } from '@bufbuild/protobuf';
 import { faFile, faInfoCircle, faPencil } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Drawer, Space, Tabs, Typography } from 'antd';
-import classNames from 'classnames';
+import { Button, Descriptions, Drawer, Space, Tabs, Typography } from 'antd';
 import { useEffect, useState } from 'react';
-import { generatePath, useNavigate, useParams } from 'react-router-dom';
+import { Link, generatePath, useNavigate, useParams } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
 import { useExtensionsContext } from '@ui/extensions/extensions-context';
@@ -22,12 +21,6 @@ import { FreightMetadata } from './freight-metadata';
 import { FreightStatusList } from './freight-status-list';
 import { UpdateFreightAliasModal } from './update-freight-alias-modal';
 
-const CopyValue = (props: { value: string; label: string; className?: string }) => (
-  <div className={classNames('flex items-center text-gray-500 font-mono', props.className)}>
-    <span className='text-gray-400 mr-2 text-xs'>{props.label}</span>
-    <Typography.Text copyable>{props.value}</Typography.Text>
-  </div>
-);
 export const FreightDetails = ({
   freight,
   refetchFreight
@@ -108,9 +101,45 @@ export const FreightDetails = ({
                   children: (
                     <>
                       <div className='mb-8'>
-                        {alias && freight?.metadata?.name && (
-                          <CopyValue label='NAME:' value={freight.metadata?.name} />
-                        )}
+                        <Descriptions
+                          className='mb-5 max-w-4xl'
+                          column={1}
+                          bordered
+                          size='small'
+                          items={[
+                            ...(alias && freight?.metadata?.name
+                              ? [
+                                  {
+                                    key: 'name',
+                                    label: 'Name',
+                                    children: (
+                                      <Typography.Text copyable>
+                                        {freight.metadata.name}
+                                      </Typography.Text>
+                                    )
+                                  }
+                                ]
+                              : []),
+                            ...(freight?.origin?.name
+                              ? [
+                                  {
+                                    key: 'origin',
+                                    label: 'Origin',
+                                    children: (
+                                      <Link
+                                        to={generatePath(paths.warehouse, {
+                                          name: projectName,
+                                          warehouseName: freight.origin.name
+                                        })}
+                                      >
+                                        {freight.origin.name}
+                                      </Link>
+                                    )
+                                  }
+                                ]
+                              : [])
+                          ]}
+                        />
                         <br />
                         <FreightMetadata freight={freight} className='mb-5' />
                         <FreightTable freight={freight} />

--- a/ui/src/features/freight/freight-details.tsx
+++ b/ui/src/features/freight/freight-details.tsx
@@ -111,9 +111,6 @@ export const FreightDetails = ({
                         {alias && freight?.metadata?.name && (
                           <CopyValue label='NAME:' value={freight.metadata?.name} />
                         )}
-                        {freight?.metadata?.uid && (
-                          <CopyValue label='UID:' value={freight?.metadata?.uid} />
-                        )}
                         <br />
                         <FreightMetadata freight={freight} className='mb-5' />
                         <FreightTable freight={freight} />

--- a/ui/src/features/project/pipelines/freight/freight-artifact-list-utils.ts
+++ b/ui/src/features/project/pipelines/freight/freight-artifact-list-utils.ts
@@ -1,0 +1,25 @@
+import {
+  ArtifactReference,
+  Chart,
+  Freight,
+  FreightReference,
+  GitCommit,
+  Image
+} from '@ui/gen/api/v1alpha1/generated_pb';
+
+// DEFAULT_MAX_ARTIFACTS is the number of artifact tags rendered before the
+// remainder is collapsed into a "+N more" indicator.
+export const DEFAULT_MAX_ARTIFACTS = 3;
+
+export type FreightArtifactItem = GitCommit | Chart | Image | ArtifactReference;
+
+// getFreightArtifacts flattens a Freight's (or FreightReference's) commits,
+// charts, images, and other artifacts into a single ordered list.
+export const getFreightArtifacts = (
+  freight?: Freight | FreightReference
+): FreightArtifactItem[] => [
+  ...(freight?.commits || []),
+  ...(freight?.charts || []),
+  ...(freight?.images || []),
+  ...(freight?.artifacts || [])
+];

--- a/ui/src/features/project/pipelines/freight/freight-artifact-list.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-artifact-list.tsx
@@ -1,0 +1,40 @@
+import { Typography } from 'antd';
+
+import { Freight, FreightReference } from '@ui/gen/api/v1alpha1/generated_pb';
+
+import { FreightArtifact } from './freight-artifact';
+import { DEFAULT_MAX_ARTIFACTS, getFreightArtifacts } from './freight-artifact-list-utils';
+
+type FreightArtifactListProps = {
+  freight?: Freight | FreightReference;
+  // max is the number of artifacts to render before collapsing the rest into a
+  // "+N more" indicator.
+  max?: number;
+  expand?: boolean;
+};
+
+// FreightArtifactList renders up to `max` artifact tags for a piece of Freight,
+// collapsing any overflow into a "+N more" indicator. Shared by the freight
+// timeline card and the Stage drawer's current-freight panel. It renders a flat
+// fragment so callers control the surrounding layout.
+export const FreightArtifactList = ({
+  freight,
+  max = DEFAULT_MAX_ARTIFACTS,
+  expand
+}: FreightArtifactListProps) => {
+  const artifacts = getFreightArtifacts(freight);
+  const overflow = artifacts.length - max;
+
+  return (
+    <>
+      {artifacts.slice(0, max).map((artifact, i) => (
+        <FreightArtifact key={i} artifact={artifact} expand={expand} />
+      ))}
+      {overflow > 0 && (
+        <Typography.Text type='secondary' className='text-[10px]'>
+          +{overflow} more
+        </Typography.Text>
+      )}
+    </>
+  );
+};

--- a/ui/src/features/project/pipelines/freight/freight-card.tsx
+++ b/ui/src/features/project/pipelines/freight/freight-card.tsx
@@ -30,7 +30,7 @@ import { timestampDate } from '@ui/utils/connectrpc-utils';
 import { useManualApprovalModal } from '../promotion/use-manual-approval-modal';
 
 import { DeleteFreightModal } from './delete-freight-modal';
-import { FreightArtifact } from './freight-artifact';
+import { FreightArtifactList } from './freight-artifact-list';
 import { useSoakTimeCounter } from './use-soak-time-counter';
 
 type FreightCardProps = {
@@ -287,34 +287,7 @@ export const FreightCard = (props: FreightCardProps) => {
           )}
 
           <div className='flex flex-col gap-1 justify-center items-center min-w-0 max-w-full [&_.ant-tag]:block [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate'>
-            {props.freight?.commits?.slice(0, 2).map((commit) => (
-              <FreightArtifact key={commit?.repoURL} artifact={commit} />
-            ))}
-
-            {props.freight?.charts?.slice(0, 2).map((chart) => (
-              <FreightArtifact key={chart?.repoURL} artifact={chart} />
-            ))}
-
-            {props.freight?.images?.slice(0, 2).map((image) => (
-              <FreightArtifact key={image?.repoURL} artifact={image} />
-            ))}
-
-            {props.freight?.artifacts?.slice(0, 2).map((other) => (
-              <FreightArtifact key={other?.version} artifact={other} />
-            ))}
-
-            {noOfGitCommits + noOfHelmReleases + noOfContainerImages > 6 && (
-              <Typography.Text type='secondary' className='text-[10px]'>
-                +
-                {noOfGitCommits +
-                  noOfHelmReleases +
-                  noOfContainerImages -
-                  (props.freight?.charts?.slice(0, 2)?.length +
-                    props.freight?.commits?.slice(0, 2)?.length +
-                    props.freight?.images?.slice(0, 2)?.length)}{' '}
-                more
-              </Typography.Text>
-            )}
+            <FreightArtifactList freight={props.freight} />
           </div>
 
           <div className='flex flex-col mx-auto w-full gap-0.5 items-center justify-center text-nowrap py-1 mt-auto'>

--- a/ui/src/features/project/pipelines/promotion/freight-details.tsx
+++ b/ui/src/features/project/pipelines/promotion/freight-details.tsx
@@ -66,10 +66,6 @@ export const FreightDetails = (props: FreightDetailsProps) => {
                       )
                     },
                     {
-                      label: 'uid',
-                      children: props.freight?.metadata?.uid
-                    },
-                    {
                       label: 'created',
                       children: `${freightCreatedAt.relative}${freightCreatedAt.relative && ' , on'} ${freightCreatedAt.abs}`
                     }

--- a/ui/src/features/stage/promotions.tsx
+++ b/ui/src/features/stage/promotions.tsx
@@ -3,7 +3,7 @@ import { createConnectQueryKey, useMutation, useQuery } from '@connectrpc/connec
 import { faUndo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useQueryClient } from '@tanstack/react-query';
-import { Flex, Spin, Table, Tooltip } from 'antd';
+import { Flex, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import { format } from 'date-fns';
 import React, { useEffect, useState } from 'react';
@@ -17,21 +17,22 @@ import {
   isPromotionPhaseTerminal,
   isPromotionRetryable
 } from '@ui/features/common/promotion-status/utils';
+import { getAlias, getShortFreightLabel } from '@ui/features/common/utils';
 import {
-  getFreight,
   listPromotions,
   promoteToStage
 } from '@ui/gen/api/service/v1alpha1/service-KargoService_connectquery';
 import { ListPromotionsResponse } from '@ui/gen/api/service/v1alpha1/service_pb';
 import { KargoService } from '@ui/gen/api/service/v1alpha1/service_pb';
 import { ArgoCDShard } from '@ui/gen/api/service/v1alpha1/service_pb';
-import { Freight, Promotion } from '@ui/gen/api/v1alpha1/generated_pb';
+import { Promotion } from '@ui/gen/api/v1alpha1/generated_pb';
 import uiPlugins from '@ui/plugins';
 import { UiPluginHoles } from '@ui/plugins/atoms/ui-plugin-hole/ui-plugin-holes';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
 
 import { Promotion as PromotionComponent } from '../project/pipelines/promotion/promotion';
 
+import { useGetFreightMap } from './tabs/freight-history/use-get-freight-map';
 import { hasAbortRequest, promotionCompareFn } from './utils/promotion';
 
 export const Promotions = ({ argocdShard }: { argocdShard?: ArgoCDShard }) => {
@@ -44,15 +45,7 @@ export const Promotions = ({ argocdShard }: { argocdShard?: ArgoCDShard }) => {
     { enabled: !!stageName }
   );
 
-  const [curFreight, setCurFreight] = useState<string | undefined>();
-
-  const { data: freightData, isLoading: isLoadingFreight } = useQuery(
-    getFreight,
-    { project: projectName, name: curFreight },
-    {
-      enabled: !!curFreight
-    }
-  );
+  const freightMap = useGetFreightMap(projectName || '');
 
   const promotionMutation = useMutation(promoteToStage);
 
@@ -192,29 +185,20 @@ export const Promotions = ({ argocdShard }: { argocdShard?: ArgoCDShard }) => {
     },
     {
       title: 'Freight',
-      render: (_, promotion) => (
-        <Tooltip
-          overlay={
-            <Spin spinning={isLoadingFreight}>
-              <div className='w-40 text-center truncate'>
-                {(freightData?.result?.value as Freight)?.alias}
-              </div>
-            </Spin>
-          }
-          onOpenChange={() => {
-            setCurFreight(promotion.spec?.freight);
-          }}
-        >
+      render: (_, promotion) => {
+        const freightName = promotion.spec?.freight || '';
+
+        return (
           <Link
             to={generatePath(paths.freight, {
               name: projectName,
-              freightName: promotion.spec?.freight
+              freightName
             })}
           >
-            {promotion.spec?.freight?.substring(0, 7)}
+            {getShortFreightLabel(freightName, getAlias(freightMap[freightName]))}
           </Link>
-        </Tooltip>
-      )
+        );
+      }
     },
     {
       title: '',

--- a/ui/src/features/stage/requested-freight.tsx
+++ b/ui/src/features/stage/requested-freight.tsx
@@ -131,7 +131,7 @@ export const RequestedFreight = ({
                       wrap
                       gap={4}
                       align='center'
-                      className='[&_.ant-tag]:m-0 [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate [&_a_.ant-tag]:cursor-pointer'
+                      className='[&_.ant-tag]:m-0 [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate [&>a]:flex [&>a]:items-center [&_a_.ant-tag]:cursor-pointer'
                     >
                       <FreightArtifactList freight={current.reference} />
                     </Flex>

--- a/ui/src/features/stage/requested-freight.tsx
+++ b/ui/src/features/stage/requested-freight.tsx
@@ -10,6 +10,9 @@ import { Stage } from '@ui/gen/api/v1alpha1/generated_pb';
 
 import { SmallLabel } from '../common/small-label';
 import { StageTag } from '../common/stage-tag';
+import { CurrentFreightItem } from '../common/utils';
+import { FreightArtifactList } from '../project/pipelines/freight/freight-artifact-list';
+import { shortVersion } from '../project/pipelines/freight/short-version-utils';
 
 export const RequestedFreight = ({
   projectName,
@@ -17,7 +20,8 @@ export const RequestedFreight = ({
   onDelete,
   className,
   itemStyle,
-  hideTitle
+  hideTitle,
+  currentFreight
 }: {
   projectName?: string;
   requestedFreight?: {
@@ -28,6 +32,7 @@ export const RequestedFreight = ({
   className?: string;
   itemStyle?: React.CSSProperties;
   hideTitle?: boolean;
+  currentFreight?: Record<string, CurrentFreightItem>;
 }) => {
   const { stageColorMap } = useContext(ColorContext);
 
@@ -49,58 +54,89 @@ export const RequestedFreight = ({
 
       <div className='flex gap-5 flex-wrap'>
         {requestedFreight?.map((freight, i) => {
+          const current = currentFreight?.[`${freight.origin?.kind}/${freight.origin?.name}`];
+          const currentFreightName = current?.reference?.name || '';
+
           return (
             <div
               key={i}
               className='bg-gray-50 rounded-md p-3 border-2 border-solid border-gray-200'
               style={itemStyle}
             >
-              <Flex>
-                <div>
-                  <SmallLabel className='mb-1'>
-                    {(freight.origin?.kind || 'Unknown').toUpperCase()}
-                  </SmallLabel>
+              <Flex gap={16} align='stretch'>
+                <div className='flex-1 min-w-0'>
+                  <Flex>
+                    <div>
+                      <SmallLabel className='mb-1'>
+                        {(freight.origin?.kind || 'Unknown').toUpperCase()}
+                      </SmallLabel>
 
-                  <div className='text-base mb-3 font-semibold'>{freight.origin?.name}</div>
+                      <div className='mb-3 font-semibold'>{freight.origin?.name}</div>
+                    </div>
+                    {onDelete && (
+                      <div className='ml-auto cursor-pointer'>
+                        <FontAwesomeIcon icon={faTimes} onClick={() => onDelete(i)} />
+                      </div>
+                    )}
+                  </Flex>
+
+                  <SmallLabel className='mb-1'>SOURCE</SmallLabel>
+                  <Flex gap={6}>
+                    {freight.sources?.direct && (
+                      <Link
+                        to={generatePath(paths.warehouse, {
+                          name: projectName,
+                          warehouseName: freight.origin?.name
+                        })}
+                      >
+                        <Flex
+                          align='center'
+                          justify='center'
+                          className='bg-gray-600 text-white py-1 px-2 rounded font-semibold cursor-pointer'
+                        >
+                          <FontAwesomeIcon icon={faArrowRightToBracket} className='mr-2' />
+                          DIRECT
+                        </Flex>
+                      </Link>
+                    )}
+                    {freight.sources?.stages?.map((stage) => (
+                      <Link
+                        key={stage}
+                        to={generatePath(paths.stage, { name: projectName, stageName: stage })}
+                      >
+                        <StageTag
+                          stage={{ metadata: { name: stage } } as Stage}
+                          projectName={projectName || ''}
+                          stageColorMap={stageColorMap}
+                        />
+                      </Link>
+                    ))}
+                  </Flex>
                 </div>
-                {onDelete && (
-                  <div className='ml-auto cursor-pointer'>
-                    <FontAwesomeIcon icon={faTimes} onClick={() => onDelete(i)} />
+
+                {current && (
+                  <div className='w-48 shrink-0 border-0 border-l border-solid border-gray-200 pl-4'>
+                    <SmallLabel className='mb-1'>CURRENT FREIGHT</SmallLabel>
+                    <Link
+                      to={generatePath(paths.freight, {
+                        name: projectName,
+                        freightName: currentFreightName
+                      })}
+                      className='font-semibold truncate block mb-3'
+                    >
+                      {current.alias || shortVersion(currentFreightName, 12)}
+                    </Link>
+                    <SmallLabel className='mb-1'>ARTIFACTS</SmallLabel>
+                    <Flex
+                      wrap
+                      gap={4}
+                      align='center'
+                      className='[&_.ant-tag]:m-0 [&_.ant-tag]:max-w-full [&_.ant-tag]:truncate [&_a_.ant-tag]:cursor-pointer'
+                    >
+                      <FreightArtifactList freight={current.reference} />
+                    </Flex>
                   </div>
                 )}
-              </Flex>
-
-              <SmallLabel className='mb-1'>SOURCE</SmallLabel>
-              <Flex gap={6}>
-                {freight.sources?.direct && (
-                  <Link
-                    to={generatePath(paths.warehouse, {
-                      name: projectName,
-                      warehouseName: freight.origin?.name
-                    })}
-                  >
-                    <Flex
-                      align='center'
-                      justify='center'
-                      className='bg-gray-600 text-white py-1 px-2 rounded font-semibold cursor-pointer'
-                    >
-                      <FontAwesomeIcon icon={faArrowRightToBracket} className='mr-2' />
-                      DIRECT
-                    </Flex>
-                  </Link>
-                )}
-                {freight.sources?.stages?.map((stage) => (
-                  <Link
-                    key={stage}
-                    to={generatePath(paths.stage, { name: projectName, stageName: stage })}
-                  >
-                    <StageTag
-                      stage={{ metadata: { name: stage } } as Stage}
-                      projectName={projectName || ''}
-                      stageColorMap={stageColorMap}
-                    />
-                  </Link>
-                ))}
               </Flex>
             </div>
           );

--- a/ui/src/features/stage/stage-details.tsx
+++ b/ui/src/features/stage/stage-details.tsx
@@ -18,6 +18,7 @@ import { useExtensionsContext } from '@ui/extensions/extensions-context';
 import { Description } from '@ui/features/common/description';
 import { HealthStatusIcon } from '@ui/features/common/health-status/health-status-icon';
 import { useStageControllerStatus } from '@ui/features/common/stage-status/use-stage-controller-status';
+import { getCurrentFreightByWarehouse } from '@ui/features/common/utils';
 import {
   getConfig,
   getStage
@@ -34,6 +35,7 @@ import { Promotions } from './promotions';
 import { RequestedFreight } from './requested-freight';
 import { StageActions } from './stage-actions';
 import { FreightHistory } from './tabs/freight-history/freight-history';
+import { useGetFreightMap } from './tabs/freight-history/use-get-freight-map';
 import { StageSettings } from './tabs/settings/stage-settings';
 import { useImages } from './use-images';
 import { Verifications } from './verifications';
@@ -51,6 +53,12 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
   const navigate = useNavigate();
 
   const images = useImages([stage]);
+
+  const freightMap = useGetFreightMap(projectName || '');
+  const currentFreight = useMemo(
+    () => getCurrentFreightByWarehouse(stage, freightMap),
+    [stage, freightMap]
+  );
 
   const onClose = () => navigate(generatePath(paths.project, { name: projectName }));
   const [isVerificationRunning, setIsVerificationRunning] = useState(false);
@@ -144,8 +152,9 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
             <RequestedFreight
               requestedFreight={stage?.spec?.requestedFreight || []}
               projectName={projectName}
-              itemStyle={{ width: '250px' }}
+              itemStyle={{ minWidth: '250px', maxWidth: '480px' }}
               className='space-y-5'
+              currentFreight={currentFreight}
             />
             <Tabs
               className='flex-1'

--- a/ui/src/features/stage/tabs/freight-history/use-get-freight-map.ts
+++ b/ui/src/features/stage/tabs/freight-history/use-get-freight-map.ts
@@ -1,19 +1,34 @@
 import { useQuery } from '@connectrpc/connect-query';
 import { useMemo } from 'react';
 
+import { useDictionaryContext } from '@ui/features/project/pipelines/context/dictionary-context';
+import { useFreightTimelineControllerStore } from '@ui/features/project/pipelines/url-params/use-freight-timeline-controller-store';
 import { queryFreight } from '@ui/gen/api/service/v1alpha1/service-KargoService_connectquery';
 import { Freight } from '@ui/gen/api/v1alpha1/generated_pb';
 
 export const useGetFreightMap = (project: string) => {
-  const freightQuery = useQuery(queryFreight, { project });
+  const dictionaryContext = useDictionaryContext();
+  const [preferredFilter] = useFreightTimelineControllerStore(project);
+
+  // Stage details is rendered by the pipeline view, which already loads the
+  // project's Freight into DictionaryContext. Reuse that map instead of issuing
+  // a duplicate queryFreight request. This is only safe when no warehouse filter
+  // is active: a filtered context map omits Freight that Stage details still
+  // needs to resolve (e.g. aliases in the promotions/verifications tables), so
+  // in that case we fall back to our own unfiltered fetch.
+  const canReuseContext = !!dictionaryContext && preferredFilter.warehouses.length === 0;
+
+  const freightQuery = useQuery(queryFreight, { project }, { enabled: !canReuseContext });
 
   return useMemo(() => {
-    const freightData = freightQuery.data;
+    if (canReuseContext) {
+      return dictionaryContext.freightById;
+    }
 
     // generate metadata.name -> full freight data (because history doesn't have it all) to show in freight history
     const freightMap: Record<string, Freight> = {};
 
-    for (const freight of freightData?.groups?.['']?.freight || []) {
+    for (const freight of freightQuery.data?.groups?.['']?.freight || []) {
       const freightId = freight?.metadata?.name;
       if (freightId) {
         freightMap[freightId] = freight;
@@ -21,5 +36,5 @@ export const useGetFreightMap = (project: string) => {
     }
 
     return freightMap;
-  }, [freightQuery.data]);
+  }, [canReuseContext, dictionaryContext, freightQuery.data]);
 };

--- a/ui/src/features/stage/verifications.tsx
+++ b/ui/src/features/stage/verifications.tsx
@@ -4,15 +4,17 @@ import { format } from 'date-fns';
 import moment from 'moment';
 import { useMemo, useState } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
-import { generatePath } from 'react-router-dom';
+import { generatePath, useParams } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
+import { getAlias, getShortFreightLabel } from '@ui/features/common/utils';
 import { FreightCollection, VerificationInfo } from '@ui/gen/api/v1alpha1/generated_pb';
 import { timestampDate } from '@ui/utils/connectrpc-utils';
 
 import { AnalysisModal } from '../common/analysis-modal/analysis-modal';
 import { useModal } from '../common/modal/use-modal';
 
+import { useGetFreightMap } from './tabs/freight-history/use-get-freight-map';
 import { verificationPhaseIsTerminal } from './utils/verification-phase';
 import { VerificationIcon } from './verification-icon';
 
@@ -23,6 +25,8 @@ type Props = {
 
 export const Verifications = ({ verifications, images }: Props) => {
   const { show } = useModal();
+  const { name: projectName } = useParams();
+  const freightMap = useGetFreightMap(projectName || '');
 
   const [showImplicitVerifications, setShowImplicitVerifications] = useState(false);
 
@@ -144,11 +148,10 @@ export const Verifications = ({ verifications, images }: Props) => {
                   freightName: freight?.name
                 })}
               >
-                {freight?.name?.slice(0, 7)}
+                {getShortFreightLabel(freight.name, getAlias(freightMap[freight.name]))}
               </ReactRouterLink>
             );
           }}
-          width={120}
         />
       </Table>
     </>


### PR DESCRIPTION
fixes #6465, fixes #6308

- Stage drawer: show currently-running freight (alias + artifacts) in each
  requested-freight card
- Promotions and Verifications tabs: show alias alongside the hash
- Remove UID display from the freight and promotion drawers
- Extract shared FreightArtifactList ("show N + X more") used by the
  freightline card and the current-freight panel
  
  
<img width="1340" height="741" alt="image" src="https://github.com/user-attachments/assets/01d7cc9a-a9d3-4cc9-b144-afdb3cb0f49f" />

