### PR TITLE
fix: replace unbounded CEL rules on AutoRollbackConfig with enum item validation

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -201,9 +201,6 @@ message AutoPromotionOptions {
 
 // AutoRollbackConfig describes the conditions under which a Stage should
 // automatically roll back to the last known-good (verified) Freight.
-//
-// +kubebuilder:validation:XValidation:message="onPromotion items must be Failed or Errored",rule="!has(self.onPromotion) || self.onPromotion.all(p, p == 'Failed' || p == 'Errored')"
-// +kubebuilder:validation:XValidation:message="onVerification items must be Failed or Error",rule="!has(self.onVerification) || self.onVerification.all(p, p == 'Failed' || p == 'Error')"
 message AutoRollbackConfig {
   // OnPromotion is the list of terminal Promotion phases that should trigger
   // an automated rollback. Only Failed and Errored are accepted. Note that
@@ -214,6 +211,8 @@ message AutoRollbackConfig {
   //
   // +optional
   // +listType=set
+  // +kubebuilder:validation:MaxItems=2
+  // +kubebuilder:validation:Enum=Failed;Errored
   repeated string onPromotion = 1;
 
   // OnVerification is the list of terminal verification phases that should
@@ -223,6 +222,8 @@ message AutoRollbackConfig {
   //
   // +optional
   // +listType=set
+  // +kubebuilder:validation:MaxItems=2
+  // +kubebuilder:validation:Enum=Failed;Error
   repeated string onVerification = 2;
 }
 

--- a/api/v1alpha1/project_config_types.go
+++ b/api/v1alpha1/project_config_types.go
@@ -109,9 +109,6 @@ type DeepLink struct {
 
 // AutoRollbackConfig describes the conditions under which a Stage should
 // automatically roll back to the last known-good (verified) Freight.
-//
-// +kubebuilder:validation:XValidation:message="onPromotion items must be Failed or Errored",rule="!has(self.onPromotion) || self.onPromotion.all(p, p == 'Failed' || p == 'Errored')"
-// +kubebuilder:validation:XValidation:message="onVerification items must be Failed or Error",rule="!has(self.onVerification) || self.onVerification.all(p, p == 'Failed' || p == 'Error')"
 type AutoRollbackConfig struct {
 	// OnPromotion is the list of terminal Promotion phases that should trigger
 	// an automated rollback. Only Failed and Errored are accepted. Note that
@@ -122,6 +119,8 @@ type AutoRollbackConfig struct {
 	//
 	// +optional
 	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:Enum=Failed;Errored
 	OnPromotion []PromotionPhase `json:"onPromotion,omitempty" protobuf:"bytes,1,rep,name=onPromotion"`
 	// OnVerification is the list of terminal verification phases that should
 	// trigger an automated rollback. Only Failed and Error are accepted (note:
@@ -130,6 +129,8 @@ type AutoRollbackConfig struct {
 	//
 	// +optional
 	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:Enum=Failed;Error
 	OnVerification []VerificationPhase `json:"onVerification,omitempty" protobuf:"bytes,2,rep,name=onVerification"`
 }
 

--- a/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
@@ -122,10 +122,14 @@ spec:
                             necessarily indicate a problem with the Freight, since promotions might fail
                             due to transient issues with the deployment itself (network, credential
                             expirations, etc...). Defaults to [].
+                          enum:
+                          - Failed
+                          - Errored
                           items:
                             description: PromotionPhase is a high-level summary of
                               the current state of a Promotion.
                             type: string
+                          maxItems: 2
                           type: array
                           x-kubernetes-list-type: set
                         onVerification:
@@ -134,18 +138,15 @@ spec:
                             trigger an automated rollback. Only Failed and Error are accepted (note:
                             "Error", not "Errored" as in onPromotion). When absent or empty,
                             defaults to [Failed].
+                          enum:
+                          - Failed
+                          - Error
                           items:
                             type: string
+                          maxItems: 2
                           type: array
                           x-kubernetes-list-type: set
                       type: object
-                      x-kubernetes-validations:
-                      - message: onPromotion items must be Failed or Errored
-                        rule: '!has(self.onPromotion) || self.onPromotion.all(p, p
-                          == ''Failed'' || p == ''Errored'')'
-                      - message: onVerification items must be Failed or Error
-                        rule: '!has(self.onVerification) || self.onVerification.all(p,
-                          p == ''Failed'' || p == ''Error'')'
                     stage:
                       description: |-
                         Stage is the name of the Stage to which this policy applies.

--- a/docs/docs/90-api-documentation.md
+++ b/docs/docs/90-api-documentation.md
@@ -1629,11 +1629,11 @@ RawFormat specifies the format for raw resource representation.
 
 
 ### AutoRollbackConfig {#github-com-akuity-kargo-api-v1alpha1-AutoRollbackConfig}
- AutoRollbackConfig describes the conditions under which a Stage should automatically roll back to the last known-good (verified) Freight.   
+ AutoRollbackConfig describes the conditions under which a Stage should automatically roll back to the last known-good (verified) Freight.
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| onPromotion | string |  OnPromotion is the list of terminal Promotion phases that should trigger an automated rollback. Only Failed and Errored are accepted. Note that unsuccessful promotions (as opposed to unsuccessful verifications) may not necessarily indicate a problem with the Freight, since promotions might fail due to transient issues with the deployment itself (network, credential expirations, etc...). Defaults to [].  +optional +listType=set |
-| onVerification | string |  OnVerification is the list of terminal verification phases that should trigger an automated rollback. Only Failed and Error are accepted (note: "Error", not "Errored" as in onPromotion). When absent or empty, defaults to [Failed].  +optional +listType=set |
+| onPromotion | string |  OnPromotion is the list of terminal Promotion phases that should trigger an automated rollback. Only Failed and Errored are accepted. Note that unsuccessful promotions (as opposed to unsuccessful verifications) may not necessarily indicate a problem with the Freight, since promotions might fail due to transient issues with the deployment itself (network, credential expirations, etc...). Defaults to [].  +optional +listType=set   |
+| onVerification | string |  OnVerification is the list of terminal verification phases that should trigger an automated rollback. Only Failed and Error are accepted (note: "Error", not "Errored" as in onPromotion). When absent or empty, defaults to [Failed].  +optional +listType=set   |
 
 
 ### AzureWebhookReceiverConfig {#github-com-akuity-kargo-api-v1alpha1-AzureWebhookReceiverConfig}

--- a/pkg/client/generated/models/auto_rollback_config.go
+++ b/pkg/client/generated/models/auto_rollback_config.go
@@ -23,6 +23,8 @@ type AutoRollbackConfig struct {
 	//
 	// +optional
 	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:Enum=Failed;Errored
 	OnPromotion []string `json:"onPromotion"`
 
 	// OnVerification is the list of terminal verification phases that should
@@ -32,6 +34,8 @@ type AutoRollbackConfig struct {
 	//
 	// +optional
 	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:Enum=Failed;Error
 	OnVerification []string `json:"onVerification"`
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -6428,14 +6428,14 @@
       "type": "object",
       "properties": {
         "onPromotion": {
-          "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].\n\n+optional\n+listType=set",
+          "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:Enum=Failed;Errored",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "onVerification": {
-          "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].\n\n+optional\n+listType=set",
+          "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:Enum=Failed;Error",
           "type": "array",
           "items": {
             "type": "string"

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -431,9 +431,6 @@ export const AutoPromotionOptionsSchema: GenMessage<AutoPromotionOptions> = /*@_
  * AutoRollbackConfig describes the conditions under which a Stage should
  * automatically roll back to the last known-good (verified) Freight.
  *
- * +kubebuilder:validation:XValidation:message="onPromotion items must be Failed or Errored",rule="!has(self.onPromotion) || self.onPromotion.all(p, p == 'Failed' || p == 'Errored')"
- * +kubebuilder:validation:XValidation:message="onVerification items must be Failed or Error",rule="!has(self.onVerification) || self.onVerification.all(p, p == 'Failed' || p == 'Error')"
- *
  * @generated from message github.com.akuity.kargo.api.v1alpha1.AutoRollbackConfig
  */
 export type AutoRollbackConfig = Message<"github.com.akuity.kargo.api.v1alpha1.AutoRollbackConfig"> & {
@@ -447,6 +444,8 @@ export type AutoRollbackConfig = Message<"github.com.akuity.kargo.api.v1alpha1.A
    *
    * +optional
    * +listType=set
+   * +kubebuilder:validation:MaxItems=2
+   * +kubebuilder:validation:Enum=Failed;Errored
    *
    * @generated from field: repeated string onPromotion = 1;
    */
@@ -460,6 +459,8 @@ export type AutoRollbackConfig = Message<"github.com.akuity.kargo.api.v1alpha1.A
    *
    * +optional
    * +listType=set
+   * +kubebuilder:validation:MaxItems=2
+   * +kubebuilder:validation:Enum=Failed;Error
    *
    * @generated from field: repeated string onVerification = 2;
    */

--- a/ui/src/gen/api/v2/models/autoRollbackConfig.ts
+++ b/ui/src/gen/api/v2/models/autoRollbackConfig.ts
@@ -15,7 +15,9 @@ due to transient issues with the deployment itself (network, credential
 expirations, etc...). Defaults to [].
 
 +optional
-+listType=set */
++listType=set
++kubebuilder:validation:MaxItems=2
++kubebuilder:validation:Enum=Failed;Errored */
   onPromotion?: string[];
   /** OnVerification is the list of terminal verification phases that should
 trigger an automated rollback. Only Failed and Error are accepted (note:
@@ -23,6 +25,8 @@ trigger an automated rollback. Only Failed and Error are accepted (note:
 defaults to [Failed].
 
 +optional
-+listType=set */
++listType=set
++kubebuilder:validation:MaxItems=2
++kubebuilder:validation:Enum=Failed;Error */
   onVerification?: string[];
 }

--- a/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
@@ -62,33 +62,33 @@
                 "properties": {
                   "onPromotion": {
                     "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].",
+                    "enum": [
+                      "Failed",
+                      "Errored"
+                    ],
                     "items": {
                       "description": "PromotionPhase is a high-level summary of the current state of a Promotion.",
                       "type": "string"
                     },
+                    "maxItems": 2,
                     "type": "array",
                     "x-kubernetes-list-type": "set"
                   },
                   "onVerification": {
                     "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].",
+                    "enum": [
+                      "Failed",
+                      "Error"
+                    ],
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 2,
                     "type": "array",
                     "x-kubernetes-list-type": "set"
                   }
                 },
-                "type": "object",
-                "x-kubernetes-validations": [
-                  {
-                    "message": "onPromotion items must be Failed or Errored",
-                    "rule": "!has(self.onPromotion) || self.onPromotion.all(p, p == 'Failed' || p == 'Errored')"
-                  },
-                  {
-                    "message": "onVerification items must be Failed or Error",
-                    "rule": "!has(self.onVerification) || self.onVerification.all(p, p == 'Failed' || p == 'Error')"
-                  }
-                ]
+                "type": "object"
               },
               "stage": {
                 "description": "Stage is the name of the Stage to which this policy applies.\n\nDeprecated: Use StageSelector instead.",


### PR DESCRIPTION
## Description

Installing the ProjectConfig CRD had failed with a Kubernetes CEL cost budget error on the autoRollback validation rules.

```
$ k apply -f charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
The CustomResourceDefinition "projectconfigs.kargo.akuity.io" is invalid:
* spec.validation.openAPIV3Schema.properties[spec].properties[promotionPolicies].items.properties[autoRollback].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds bud
get by factor of 2.0x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
* spec.validation.openAPIV3Schema.properties[spec].properties[promotionPolicies].items.properties[autoRollback].x-kubernetes-validations[1].rule: Forbidden: estimated rule cost exceeds bud
get by factor of 2.0x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
```

The fix replaces the CEL rules with enum constraints directly on the array items:
  - onPromotion items: enum: [Failed, Errored]
  - onVerification items: enum: [Failed, Error]

`maxItems: 2` is also added since each field has at most 2 valid values

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Changes ten lines or fewer.

(additional code is generated)

### Quality

<!-- Check all that apply. -->

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
