### PR TITLE
chore: throw error when deprecated Allow/Ignore Tags fields are used

### DIFF
--- a/pkg/controller/git/commit/tag_based_selector.go
+++ b/pkg/controller/git/commit/tag_based_selector.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -70,35 +71,22 @@ func newTagBasedSelector(
 		return nil, err
 	}
 
-	// TODO(v1.11.0): Return an error if sub.AllowTags is non-empty.
-	// TODO(v1.13.0): Remove this block after the AllowTags field is removed.
+	// TODO(v1.13.0): Remove this check after the AllowTags field is removed.
 	if sub.AllowTags != "" { // nolint: staticcheck
-		var allowTagsRegex *regexp.Regexp
-		if allowTagsRegex, err = regexp.Compile(sub.AllowTags); err != nil { // nolint: staticcheck
-			return nil, fmt.Errorf(
-				"error compiling regular expression %q: %w",
-				sub.AllowTags, err, // nolint: staticcheck
-			)
-		}
-		s.allowTagsRegexes = append(s.allowTagsRegexes, allowTagsRegex)
+		return nil, errors.New(
+			"AllowTags is deprecated and unsupported as of v1.11.0; use AllowTagsRegexes instead",
+		)
 	}
 
 	if s.ignoreTagsRegexes, err = compileRegexes(sub.IgnoreTagsRegexes); err != nil {
 		return nil, err
 	}
 
-	// TODO(v1.11.0): Return an error if sub.IgnoreTags is non-empty.
-	// TODO(v1.13.0): Remove this block after the IgnoreTags field is removed.
+	// TODO(v1.13.0): Remove this check after the IgnoreTags field is removed.
 	if len(sub.IgnoreTags) > 0 { // nolint: staticcheck
-		ignoreTagsRegexStrs := make([]string, len(sub.IgnoreTags)) // nolint: staticcheck
-		for i, ignoreTag := range sub.IgnoreTags {                 // nolint: staticcheck
-			ignoreTagsRegexStrs[i] = fmt.Sprintf("^%s$", regexp.QuoteMeta(ignoreTag))
-		}
-		ignoreTagsRegexes, err := compileRegexes(ignoreTagsRegexStrs)
-		if err != nil {
-			return nil, err
-		}
-		s.ignoreTagsRegexes = append(s.ignoreTagsRegexes, ignoreTagsRegexes...)
+		return nil, errors.New(
+			"IgnoreTags is deprecated and unsupported as of v1.11.0; use IgnoreTagsRegexes instead",
+		)
 	}
 
 	s.filterTagsByDiffPathsFn = s.filterTagsByDiffPaths

--- a/pkg/controller/git/commit/tag_based_selector_test.go
+++ b/pkg/controller/git/commit/tag_based_selector_test.go
@@ -107,12 +107,22 @@ func TestNewTagBasedSelector(t *testing.T) {
 		},
 		{
 			// TODO(v1.13.0): Remove this test once AllowTags is removed.
-			name: "error compiling AllowTags regex",
+			name: "error using deprecated AllowTags",
 			sub: kargoapi.GitSubscription{
-				AllowTags: "[", // Invalid regex
+				AllowTags: `^v1\.`,
 			},
 			assertions: func(t *testing.T, _ *tagBasedSelector, err error) {
-				require.ErrorContains(t, err, "error compiling regular expression")
+				require.ErrorContains(t, err, "AllowTags is deprecated")
+			},
+		},
+		{
+			// TODO(v1.13.0): Remove this test once IgnoreTags is removed.
+			name: "error using deprecated IgnoreTags",
+			sub: kargoapi.GitSubscription{
+				IgnoreTags: []string{"v1.0.0"},
+			},
+			assertions: func(t *testing.T, _ *tagBasedSelector, err error) {
+				require.ErrorContains(t, err, "IgnoreTags is deprecated")
 			},
 		},
 		{
@@ -136,25 +146,19 @@ func TestNewTagBasedSelector(t *testing.T) {
 			},
 		},
 		{
-			// TODO(v1.13.0): Update this test once AllowTags and IgnoreTags are
-			// removed.
 			name: "success",
 			sub: kargoapi.GitSubscription{
 				RepoURL:           "https://github.com/foo/bar",
-				AllowTags:         `^v1\.`,
 				AllowTagsRegexes:  []string{`^v2\.`},
-				IgnoreTags:        []string{"v1.0.0"},
 				IgnoreTagsRegexes: []string{`^v1\.0\..*`},
 			},
 			assertions: func(t *testing.T, s *tagBasedSelector, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, s.baseSelector)
-				require.Len(t, s.allowTagsRegexes, 2)
+				require.Len(t, s.allowTagsRegexes, 1)
 				require.Equal(t, `^v2\.`, s.allowTagsRegexes[0].String())
-				require.Equal(t, `^v1\.`, s.allowTagsRegexes[1].String())
-				require.Len(t, s.ignoreTagsRegexes, 2)
+				require.Len(t, s.ignoreTagsRegexes, 1)
 				require.Equal(t, `^v1\.0\..*`, s.ignoreTagsRegexes[0].String())
-				require.Equal(t, `^v1\.0\.0$`, s.ignoreTagsRegexes[1].String())
 			},
 		},
 	}

--- a/pkg/image/selector_docker_hub_test.go
+++ b/pkg/image/selector_docker_hub_test.go
@@ -235,7 +235,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 				kargoapi.ImageSubscription{
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-					AllowTags:              "nothing-matches-this",
+					AllowTagsRegexes:       []string{"nothing-matches-this"},
 					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
@@ -254,7 +254,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 				kargoapi.ImageSubscription{
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-					AllowTags:              `^bookworm-202310\d\d$`,
+					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
 					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
@@ -278,7 +278,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 				kargoapi.ImageSubscription{
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-					AllowTags:              `^bookworm-202310\d\d$`,
+					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
 					Platform:               "linux/made-up-arch",
 					DiscoveryLimit:         1,
 					CacheByTag:             true,
@@ -298,7 +298,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 				kargoapi.ImageSubscription{
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-					AllowTags:              `^bookworm-202310\d\d$`,
+					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
 					Platform:               platform,
 					DiscoveryLimit:         1,
 					CacheByTag:             true,

--- a/pkg/image/selector_ghcr_test.go
+++ b/pkg/image/selector_ghcr_test.go
@@ -122,7 +122,7 @@ func TestSelectImageGHCR(t *testing.T) {
 			kargoapi.ImageSubscription{
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-				AllowTags:              `^v0.1.0-rc.2\d$`,
+				AllowTagsRegexes:       []string{`^v0.1.0-rc.2\d$`},
 				DiscoveryLimit:         1,
 			},
 			nil,
@@ -145,7 +145,7 @@ func TestSelectImageGHCR(t *testing.T) {
 			kargoapi.ImageSubscription{
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
-				AllowTags:              `^v0.1.0-rc.2\d$`,
+				AllowTagsRegexes:       []string{`^v0.1.0-rc.2\d$`},
 				Platform:               platform,
 				DiscoveryLimit:         1,
 			},

--- a/pkg/image/tag_based_selector.go
+++ b/pkg/image/tag_based_selector.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -53,35 +54,22 @@ func newTagBasedSelector(
 		return nil, fmt.Errorf("error compiling allow tags regex: %w", err)
 	}
 
-	// TODO(v1.11.0): Return an error if sub.AllowTags is non-empty.
-	// TODO(v1.13.0): Remove this block after the AllowTags field is removed.
+	// TODO(v1.13.0): Remove this check after the AllowTags field is removed.
 	if sub.AllowTags != "" { // nolint: staticcheck
-		var allowTagsRegex *regexp.Regexp
-		if allowTagsRegex, err = regexp.Compile(sub.AllowTags); err != nil { // nolint: staticcheck
-			return nil, fmt.Errorf(
-				"error compiling regular expression %q: %w",
-				sub.AllowTags, err, // nolint: staticcheck
-			)
-		}
-		s.allowTagsRegexes = append(s.allowTagsRegexes, allowTagsRegex)
+		return nil, errors.New(
+			"AllowTags is deprecated and unsupported as of v1.11.0; use AllowTagsRegexes instead",
+		)
 	}
 
 	if s.ignoreTagsRegexes, err = compileRegexes(sub.IgnoreTagsRegexes); err != nil {
 		return nil, fmt.Errorf("error compiling ignore tags regex: %w", err)
 	}
 
-	// TODO(v1.11.0): Return an error if sub.IgnoreTags is non-empty.
-	// TODO(v1.13.0): Remove this block after the IgnoreTags field is removed.
+	// TODO(v1.13.0): Remove this check after the IgnoreTags field is removed.
 	if len(sub.IgnoreTags) > 0 { // nolint: staticcheck
-		ignoreTagsRegexStrs := make([]string, len(sub.IgnoreTags))
-		for i, ignoreTag := range sub.IgnoreTags { // nolint: staticcheck
-			ignoreTagsRegexStrs[i] = fmt.Sprintf("^%s$", regexp.QuoteMeta(ignoreTag))
-		}
-		ignoreTagsRegexes, err := compileRegexes(ignoreTagsRegexStrs)
-		if err != nil {
-			return nil, err
-		}
-		s.ignoreTagsRegexes = append(s.ignoreTagsRegexes, ignoreTagsRegexes...)
+		return nil, errors.New(
+			"IgnoreTags is deprecated and unsupported as of v1.11.0; use IgnoreTagsRegexes instead",
+		)
 	}
 
 	return s, nil

--- a/pkg/image/tag_based_selector_test.go
+++ b/pkg/image/tag_based_selector_test.go
@@ -24,13 +24,24 @@ func TestNewTagBasedSelector(t *testing.T) {
 		},
 		{
 			// TODO(v1.13.0): Remove this test once AllowTags is removed.
-			name: "error compiling AllowedTags regex",
+			name: "error using deprecated AllowTags",
 			sub: kargoapi.ImageSubscription{
 				RepoURL:   "example/image",
-				AllowTags: "[", // Invalid regex
+				AllowTags: `^v1\.`,
 			},
 			assertions: func(t *testing.T, _ *tagBasedSelector, err error) {
-				require.ErrorContains(t, err, "error compiling regular expression")
+				require.ErrorContains(t, err, "AllowTags is deprecated")
+			},
+		},
+		{
+			// TODO(v1.13.0): Remove this test once IgnoreTags is removed.
+			name: "error using deprecated IgnoreTags",
+			sub: kargoapi.ImageSubscription{
+				RepoURL:    "example/image",
+				IgnoreTags: []string{"v1.0.0"},
+			},
+			assertions: func(t *testing.T, _ *tagBasedSelector, err error) {
+				require.ErrorContains(t, err, "IgnoreTags is deprecated")
 			},
 		},
 		{
@@ -54,25 +65,19 @@ func TestNewTagBasedSelector(t *testing.T) {
 			},
 		},
 		{
-			// TODO(v1.13.0): Update this test once AllowTags and IgnoreTags are
-			// removed.
 			name: "success",
 			sub: kargoapi.ImageSubscription{
 				RepoURL:           "example/image",
-				AllowTags:         `^v1\.`,
 				AllowTagsRegexes:  []string{`^v2\.`},
-				IgnoreTags:        []string{`v1.0.0`},
 				IgnoreTagsRegexes: []string{`^v1\.0\..*`},
 			},
 			assertions: func(t *testing.T, s *tagBasedSelector, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, s.baseSelector)
-				require.Len(t, s.allowTagsRegexes, 2)
+				require.Len(t, s.allowTagsRegexes, 1)
 				require.Equal(t, `^v2\.`, s.allowTagsRegexes[0].String())
-				require.Equal(t, `^v1\.`, s.allowTagsRegexes[1].String())
-				require.Len(t, s.ignoreTagsRegexes, 2)
+				require.Len(t, s.ignoreTagsRegexes, 1)
 				require.Equal(t, `^v1\.0\..*`, s.ignoreTagsRegexes[0].String())
-				require.Equal(t, `^v1\.0\.0$`, s.ignoreTagsRegexes[1].String())
 			},
 		},
 	}


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/5168
Related to https://github.com/akuity/kargo/issues/6488