### PR TITLE
fix: validate AutoRollbackConfig elements with CEL instead of array-level enum

### DIFF
--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -212,7 +212,8 @@ message AutoRollbackConfig {
   // +optional
   // +listType=set
   // +kubebuilder:validation:MaxItems=2
-  // +kubebuilder:validation:Enum=Failed;Errored
+  // +kubebuilder:validation:XValidation:message="onPromotion[0] must be Failed or Errored",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
+  // +kubebuilder:validation:XValidation:message="onPromotion[1] must be Failed or Errored",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'"
   repeated string onPromotion = 1;
 
   // OnVerification is the list of terminal verification phases that should
@@ -223,7 +224,8 @@ message AutoRollbackConfig {
   // +optional
   // +listType=set
   // +kubebuilder:validation:MaxItems=2
-  // +kubebuilder:validation:Enum=Failed;Error
+  // +kubebuilder:validation:XValidation:message="onVerification[0] must be Failed or Error",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
+  // +kubebuilder:validation:XValidation:message="onVerification[1] must be Failed or Error",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'"
   repeated string onVerification = 2;
 }
 

--- a/api/v1alpha1/project_config_types.go
+++ b/api/v1alpha1/project_config_types.go
@@ -120,7 +120,8 @@ type AutoRollbackConfig struct {
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=2
-	// +kubebuilder:validation:Enum=Failed;Errored
+	// +kubebuilder:validation:XValidation:message="onPromotion[0] must be Failed or Errored",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
+	// +kubebuilder:validation:XValidation:message="onPromotion[1] must be Failed or Errored",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'"
 	OnPromotion []PromotionPhase `json:"onPromotion,omitempty" protobuf:"bytes,1,rep,name=onPromotion"`
 	// OnVerification is the list of terminal verification phases that should
 	// trigger an automated rollback. Only Failed and Error are accepted (note:
@@ -130,7 +131,8 @@ type AutoRollbackConfig struct {
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=2
-	// +kubebuilder:validation:Enum=Failed;Error
+	// +kubebuilder:validation:XValidation:message="onVerification[0] must be Failed or Error",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
+	// +kubebuilder:validation:XValidation:message="onVerification[1] must be Failed or Error",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'"
 	OnVerification []VerificationPhase `json:"onVerification,omitempty" protobuf:"bytes,2,rep,name=onVerification"`
 }
 

--- a/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
@@ -122,9 +122,6 @@ spec:
                             necessarily indicate a problem with the Freight, since promotions might fail
                             due to transient issues with the deployment itself (network, credential
                             expirations, etc...). Defaults to [].
-                          enum:
-                          - Failed
-                          - Errored
                           items:
                             description: PromotionPhase is a high-level summary of
                               the current state of a Promotion.
@@ -132,20 +129,31 @@ spec:
                           maxItems: 2
                           type: array
                           x-kubernetes-list-type: set
+                          x-kubernetes-validations:
+                          - message: onPromotion[0] must be Failed or Errored
+                            rule: self.size() == 0 || self[0] == 'Failed' || self[0]
+                              == 'Errored'
+                          - message: onPromotion[1] must be Failed or Errored
+                            rule: self.size() <= 1 || self[1] == 'Failed' || self[1]
+                              == 'Errored'
                         onVerification:
                           description: |-
                             OnVerification is the list of terminal verification phases that should
                             trigger an automated rollback. Only Failed and Error are accepted (note:
                             "Error", not "Errored" as in onPromotion). When absent or empty,
                             defaults to [Failed].
-                          enum:
-                          - Failed
-                          - Error
                           items:
                             type: string
                           maxItems: 2
                           type: array
                           x-kubernetes-list-type: set
+                          x-kubernetes-validations:
+                          - message: onVerification[0] must be Failed or Error
+                            rule: self.size() == 0 || self[0] == 'Failed' || self[0]
+                              == 'Error'
+                          - message: onVerification[1] must be Failed or Error
+                            rule: self.size() <= 1 || self[1] == 'Failed' || self[1]
+                              == 'Error'
                       type: object
                     stage:
                       description: |-

--- a/docs/docs/90-api-documentation.md
+++ b/docs/docs/90-api-documentation.md
@@ -1632,8 +1632,8 @@ RawFormat specifies the format for raw resource representation.
  AutoRollbackConfig describes the conditions under which a Stage should automatically roll back to the last known-good (verified) Freight.
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| onPromotion | string |  OnPromotion is the list of terminal Promotion phases that should trigger an automated rollback. Only Failed and Errored are accepted. Note that unsuccessful promotions (as opposed to unsuccessful verifications) may not necessarily indicate a problem with the Freight, since promotions might fail due to transient issues with the deployment itself (network, credential expirations, etc...). Defaults to [].  +optional +listType=set   |
-| onVerification | string |  OnVerification is the list of terminal verification phases that should trigger an automated rollback. Only Failed and Error are accepted (note: "Error", not "Errored" as in onPromotion). When absent or empty, defaults to [Failed].  +optional +listType=set   |
+| onPromotion | string |  OnPromotion is the list of terminal Promotion phases that should trigger an automated rollback. Only Failed and Errored are accepted. Note that unsuccessful promotions (as opposed to unsuccessful verifications) may not necessarily indicate a problem with the Freight, since promotions might fail due to transient issues with the deployment itself (network, credential expirations, etc...). Defaults to [].  +optional +listType=set    |
+| onVerification | string |  OnVerification is the list of terminal verification phases that should trigger an automated rollback. Only Failed and Error are accepted (note: "Error", not "Errored" as in onPromotion). When absent or empty, defaults to [Failed].  +optional +listType=set    |
 
 
 ### AzureWebhookReceiverConfig {#github-com-akuity-kargo-api-v1alpha1-AzureWebhookReceiverConfig}

--- a/pkg/client/generated/models/auto_rollback_config.go
+++ b/pkg/client/generated/models/auto_rollback_config.go
@@ -24,7 +24,8 @@ type AutoRollbackConfig struct {
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=2
-	// +kubebuilder:validation:Enum=Failed;Errored
+	// +kubebuilder:validation:XValidation:message="onPromotion[0] must be Failed or Errored",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
+	// +kubebuilder:validation:XValidation:message="onPromotion[1] must be Failed or Errored",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'"
 	OnPromotion []string `json:"onPromotion"`
 
 	// OnVerification is the list of terminal verification phases that should
@@ -35,7 +36,8 @@ type AutoRollbackConfig struct {
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=2
-	// +kubebuilder:validation:Enum=Failed;Error
+	// +kubebuilder:validation:XValidation:message="onVerification[0] must be Failed or Error",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
+	// +kubebuilder:validation:XValidation:message="onVerification[1] must be Failed or Error",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'"
 	OnVerification []string `json:"onVerification"`
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -6428,14 +6428,14 @@
       "type": "object",
       "properties": {
         "onPromotion": {
-          "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:Enum=Failed;Errored",
+          "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:XValidation:message=\"onPromotion[0] must be Failed or Errored\",rule=\"self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'\"\n+kubebuilder:validation:XValidation:message=\"onPromotion[1] must be Failed or Errored\",rule=\"self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'\"",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "onVerification": {
-          "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:Enum=Failed;Error",
+          "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].\n\n+optional\n+listType=set\n+kubebuilder:validation:MaxItems=2\n+kubebuilder:validation:XValidation:message=\"onVerification[0] must be Failed or Error\",rule=\"self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'\"\n+kubebuilder:validation:XValidation:message=\"onVerification[1] must be Failed or Error\",rule=\"self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'\"",
           "type": "array",
           "items": {
             "type": "string"

--- a/ui/src/gen/api/v1alpha1/generated_pb.ts
+++ b/ui/src/gen/api/v1alpha1/generated_pb.ts
@@ -445,7 +445,8 @@ export type AutoRollbackConfig = Message<"github.com.akuity.kargo.api.v1alpha1.A
    * +optional
    * +listType=set
    * +kubebuilder:validation:MaxItems=2
-   * +kubebuilder:validation:Enum=Failed;Errored
+   * +kubebuilder:validation:XValidation:message="onPromotion[0] must be Failed or Errored",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
+   * +kubebuilder:validation:XValidation:message="onPromotion[1] must be Failed or Errored",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'"
    *
    * @generated from field: repeated string onPromotion = 1;
    */
@@ -460,7 +461,8 @@ export type AutoRollbackConfig = Message<"github.com.akuity.kargo.api.v1alpha1.A
    * +optional
    * +listType=set
    * +kubebuilder:validation:MaxItems=2
-   * +kubebuilder:validation:Enum=Failed;Error
+   * +kubebuilder:validation:XValidation:message="onVerification[0] must be Failed or Error",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
+   * +kubebuilder:validation:XValidation:message="onVerification[1] must be Failed or Error",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'"
    *
    * @generated from field: repeated string onVerification = 2;
    */

--- a/ui/src/gen/api/v2/models/autoRollbackConfig.ts
+++ b/ui/src/gen/api/v2/models/autoRollbackConfig.ts
@@ -17,7 +17,8 @@ expirations, etc...). Defaults to [].
 +optional
 +listType=set
 +kubebuilder:validation:MaxItems=2
-+kubebuilder:validation:Enum=Failed;Errored */
++kubebuilder:validation:XValidation:message="onPromotion[0] must be Failed or Errored",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
++kubebuilder:validation:XValidation:message="onPromotion[1] must be Failed or Errored",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'" */
   onPromotion?: string[];
   /** OnVerification is the list of terminal verification phases that should
 trigger an automated rollback. Only Failed and Error are accepted (note:
@@ -27,6 +28,7 @@ defaults to [Failed].
 +optional
 +listType=set
 +kubebuilder:validation:MaxItems=2
-+kubebuilder:validation:Enum=Failed;Error */
++kubebuilder:validation:XValidation:message="onVerification[0] must be Failed or Error",rule="self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
++kubebuilder:validation:XValidation:message="onVerification[1] must be Failed or Error",rule="self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'" */
   onVerification?: string[];
 }

--- a/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
@@ -62,30 +62,42 @@
                 "properties": {
                   "onPromotion": {
                     "description": "OnPromotion is the list of terminal Promotion phases that should trigger\nan automated rollback. Only Failed and Errored are accepted. Note that\nunsuccessful promotions (as opposed to unsuccessful verifications) may not\nnecessarily indicate a problem with the Freight, since promotions might fail\ndue to transient issues with the deployment itself (network, credential\nexpirations, etc...). Defaults to [].",
-                    "enum": [
-                      "Failed",
-                      "Errored"
-                    ],
                     "items": {
                       "description": "PromotionPhase is a high-level summary of the current state of a Promotion.",
                       "type": "string"
                     },
                     "maxItems": 2,
                     "type": "array",
-                    "x-kubernetes-list-type": "set"
+                    "x-kubernetes-list-type": "set",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "onPromotion[0] must be Failed or Errored",
+                        "rule": "self.size() == 0 || self[0] == 'Failed' || self[0] == 'Errored'"
+                      },
+                      {
+                        "message": "onPromotion[1] must be Failed or Errored",
+                        "rule": "self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Errored'"
+                      }
+                    ]
                   },
                   "onVerification": {
                     "description": "OnVerification is the list of terminal verification phases that should\ntrigger an automated rollback. Only Failed and Error are accepted (note:\n\"Error\", not \"Errored\" as in onPromotion). When absent or empty,\ndefaults to [Failed].",
-                    "enum": [
-                      "Failed",
-                      "Error"
-                    ],
                     "items": {
                       "type": "string"
                     },
                     "maxItems": 2,
                     "type": "array",
-                    "x-kubernetes-list-type": "set"
+                    "x-kubernetes-list-type": "set",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "onVerification[0] must be Failed or Error",
+                        "rule": "self.size() == 0 || self[0] == 'Failed' || self[0] == 'Error'"
+                      },
+                      {
+                        "message": "onVerification[1] must be Failed or Error",
+                        "rule": "self.size() <= 1 || self[1] == 'Failed' || self[1] == 'Error'"
+                      }
+                    ]
                   }
                 },
                 "type": "object"


### PR DESCRIPTION
## Description

The previous [fix](https://github.com/akuity/kargo/pull/6485), wasn't proper and would fail valid ProjectConfigs with:

```
$ k apply -f ./kargo/projectconfig.yaml                                                                                                                                                                                                                                                                                        The ProjectConfig "auto-rollback" is invalid:
* spec.promotionPolicies[0].autoRollback.onPromotion: Unsupported value: []interface {}{"Failed"}: supported values: "Failed", "Errored"
```

The problem was that +kubebuilder:validation:Enum markers on the OnPromotion and OnVerification slice fields placed the enum constraint at the array schema level, causing Kubernetes to reject any array value because the serialized array (e.g. ['Failed']) never equals one of the enum strings. This broke AutoRollbackConfig entirely.

Replace with two XValidation CEL rules per field. Each rule checks one element (self[0] or self[1]), keeping the string-comparison count at two per rule so the Kubernetes static CEL cost estimator stays below its 10M-unit per-rule budget.

## Checklist

### Eligibility

- [x] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding documentation.

### AI Use Disclosure
This PR was written:
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:
- [x] Are signed off by their author (`git commit -s`) **(required)**
