### PR TITLE
fix(git-merge-pr): resilience to concurrent-merge races via mergeable_state + 405 retry

### DIFF
--- a/pkg/gitprovider/github/github.go
+++ b/pkg/gitprovider/github/github.go
@@ -52,6 +52,13 @@ const (
 	mergeableStateUnknown = "unknown"
 )
 
+// mergeBaseModifiedMsg is the substring GitHub includes in the message of a 405
+// merge error when the base branch moved between the mergeability check and the
+// merge call. This is the one transient 405 (it clears on retry); all other 405s
+// from the merge endpoint are permanent. Full message: "Base branch was
+// modified. Review and try the merge again."
+const mergeBaseModifiedMsg = "Base branch was modified"
+
 var registration = gitprovider.Registration{
 	Predicate: func(repoURL string) bool {
 		u, err := url.Parse(repoURL)
@@ -368,17 +375,25 @@ func (p *provider) MergePullRequest(
 		&github.PullRequestOptions{MergeMethod: opts.MergeMethod},
 	)
 	if err != nil {
-		// GitHub returns 405 ("Method Not Allowed") when the merge cannot be
-		// performed -- most notably "Base branch was modified" when the base tip
-		// moved between the mergeability check above and this merge call (a TOCTOU
-		// race that fires whenever concurrent merges land on the same base). The
-		// gate above already rejected the permanent conditions (conflict, blocked,
-		// etc.), so a 405 here is transient: report "not ready" so the caller
-		// retries. The next attempt re-runs the gate, which surfaces any condition
-		// that has since become permanent (e.g. a real conflict) as such.
+		// GitHub returns 405 ("Method Not Allowed") whenever the merge cannot be
+		// performed, which spans both transient and permanent conditions. The one
+		// transient case is "Base branch was modified": the base tip moved between
+		// the mergeability check above and this merge call (a TOCTOU race that
+		// fires when concurrent merges land on the same base). It is the only 405
+		// we retry -- report "not ready" so the caller tries again on the next
+		// reconciliation.
+		//
+		// Other 405s are permanent and must not be retried, or the step would loop
+		// forever under wait=true. The most common is a configured merge method
+		// that is disabled on the repo (e.g. mergeMethod: squash with squash
+		// merges turned off): the gate sees the PR as mergeable, so every retry
+		// would re-attempt and re-fail. We fall through and surface GitHub's
+		// message (carried by the wrapped error) so the misconfiguration is
+		// visible instead of silently looping.
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && ghErr.Response != nil &&
-			ghErr.Response.StatusCode == http.StatusMethodNotAllowed {
+			ghErr.Response.StatusCode == http.StatusMethodNotAllowed &&
+			strings.Contains(ghErr.Message, mergeBaseModifiedMsg) {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("error merging pull request %d: %w", id, err)

--- a/pkg/gitprovider/github/github.go
+++ b/pkg/gitprovider/github/github.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -366,6 +368,19 @@ func (p *provider) MergePullRequest(
 		&github.PullRequestOptions{MergeMethod: opts.MergeMethod},
 	)
 	if err != nil {
+		// GitHub returns 405 ("Method Not Allowed") when the merge cannot be
+		// performed -- most notably "Base branch was modified" when the base tip
+		// moved between the mergeability check above and this merge call (a TOCTOU
+		// race that fires whenever concurrent merges land on the same base). The
+		// gate above already rejected the permanent conditions (conflict, blocked,
+		// etc.), so a 405 here is transient: report "not ready" so the caller
+		// retries. The next attempt re-runs the gate, which surfaces any condition
+		// that has since become permanent (e.g. a real conflict) as such.
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response != nil &&
+			ghErr.Response.StatusCode == http.StatusMethodNotAllowed {
+			return nil, false, nil
+		}
 		return nil, false, fmt.Errorf("error merging pull request %d: %w", id, err)
 	}
 	if mergeResult == nil {

--- a/pkg/gitprovider/github/github.go
+++ b/pkg/gitprovider/github/github.go
@@ -22,6 +22,34 @@ const (
 	prStateOpen   = "open"
 )
 
+// GitHub pull request mergeable states. GitHub computes mergeability
+// asynchronously and reports the outcome via the PR's mergeable_state field.
+// These values are not formally documented but are stable in practice.
+const (
+	// mergeableStateClean indicates the PR is mergeable and all required checks
+	// have passed.
+	mergeableStateClean = "clean"
+	// mergeableStateUnstable indicates the PR is mergeable, but some
+	// non-required checks are failing.
+	mergeableStateUnstable = "unstable"
+	// mergeableStateHasHooks indicates the PR is mergeable and pre-receive hooks
+	// are configured.
+	mergeableStateHasHooks = "has_hooks"
+	// mergeableStateBlocked indicates the merge is blocked by required reviews or
+	// checks that have not yet been satisfied.
+	mergeableStateBlocked = "blocked"
+	// mergeableStateBehind indicates the head branch is behind the base branch,
+	// typically because the base branch moved forward.
+	mergeableStateBehind = "behind"
+	// mergeableStateDraft indicates the PR is a draft and cannot be merged.
+	mergeableStateDraft = "draft"
+	// mergeableStateDirty indicates the PR has merge conflicts.
+	mergeableStateDirty = "dirty"
+	// mergeableStateUnknown indicates GitHub has not finished computing
+	// mergeability.
+	mergeableStateUnknown = "unknown"
+)
+
 var registration = gitprovider.Registration{
 	Predicate: func(repoURL string) bool {
 		u, err := url.Parse(repoURL)
@@ -296,16 +324,36 @@ func (p *provider) MergePullRequest(
 		return nil, false, fmt.Errorf("pull request %d not found", id)
 	}
 
-	switch {
-	case ghPR.MergedAt != nil:
+	if ghPR.MergedAt != nil {
 		pr := convertGithubPR(*ghPR)
 		return &pr, true, nil
-
-	case ptr.Deref(ghPR.State, prStateClosed) != prStateOpen:
+	}
+	if ptr.Deref(ghPR.State, prStateClosed) != prStateOpen {
 		return nil, false, fmt.Errorf("pull request %d is closed but not merged", id)
+	}
 
-	case ptr.Deref(ghPR.Draft, false) || !ptr.Deref(ghPR.Mergeable, false):
+	// Decide whether to attempt the merge based on GitHub's mergeable_state. This
+	// is richer than the Mergeable boolean: it lets us distinguish a permanent
+	// conflict (which will never resolve on its own) from transient conditions
+	// such as pending checks, a base branch that has moved forward, or
+	// mergeability that GitHub is still computing -- all of which a caller should
+	// retry rather than fail on.
+	switch ghPR.GetMergeableState() {
+	case mergeableStateClean, mergeableStateUnstable, mergeableStateHasHooks:
+		// Mergeable now; fall through to the merge attempt below.
+	case mergeableStateDirty:
+		// A genuine merge conflict will not clear without human intervention.
+		return nil, false, fmt.Errorf("pull request %d has conflicts and cannot be merged", id)
+	case mergeableStateBlocked, mergeableStateBehind, mergeableStateDraft, mergeableStateUnknown:
+		// Not ready to merge yet, but the condition may clear; signal "not ready"
+		// so the caller can retry on a subsequent reconciliation.
 		return nil, false, nil
+	default:
+		// mergeable_state is unset or unrecognized; fall back to the Mergeable
+		// boolean and the draft flag.
+		if ptr.Deref(ghPR.Draft, false) || !ptr.Deref(ghPR.Mergeable, false) {
+			return nil, false, nil
+		}
 	}
 
 	// Merge the PR

--- a/pkg/gitprovider/github/github_test.go
+++ b/pkg/gitprovider/github/github_test.go
@@ -453,6 +453,93 @@ func TestMergePullRequest(t *testing.T) {
 			},
 		},
 		{
+			name:     "mergeable_state clean proceeds to merge",
+			prNumber: 201,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(201)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(201),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("clean"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/201"),
+					}, &github.Response{}, nil).Once()
+
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(201), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(&github.PullRequestMergeResult{
+						SHA:    github.Ptr("merge_sha"),
+						Merged: github.Ptr(true),
+					}, &github.Response{}, nil)
+
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(201)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(201),
+						State:          github.Ptr("closed"),
+						Merged:         github.Ptr(true),
+						MergeCommitSHA: github.Ptr("merge_sha"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/201"),
+						MergedAt:       &github.Timestamp{Time: time.Now()},
+					}, &github.Response{}, nil).Once()
+			},
+			expectedMerged: true,
+		},
+		{
+			name:     "mergeable_state unknown is not ready",
+			prNumber: 202,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(202)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(202),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      nil,
+						MergeableState: github.Ptr("unknown"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/202"),
+					}, &github.Response{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:     "mergeable_state behind is not ready",
+			prNumber: 203,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(203)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(203),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("behind"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/203"),
+					}, &github.Response{}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name:     "mergeable_state dirty fails with conflict",
+			prNumber: 204,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(204)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(204),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(false),
+						MergeableState: github.Ptr("dirty"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/204"),
+					}, &github.Response{}, nil)
+			},
+			expectError:   true,
+			errorContains: "has conflicts and cannot be merged",
+		},
+		{
 			name:     "merge call fails",
 			prNumber: 555,
 			setupMock: func(m *mockGithubClient) {

--- a/pkg/gitprovider/github/github_test.go
+++ b/pkg/gitprovider/github/github_test.go
@@ -590,6 +590,37 @@ func TestMergePullRequest(t *testing.T) {
 			expectedMerged: false,
 		},
 		{
+			name:     "merge call returns 405 for disabled merge method is terminal",
+			prNumber: 406,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(406)).
+					Return(&github.PullRequest{
+						Number:    github.Ptr(406),
+						State:     github.Ptr("open"),
+						Merged:    github.Ptr(false),
+						Mergeable: github.Ptr(true),
+						Head:      &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:   github.Ptr("https://github.com/akuity/kargo/pull/406"),
+					}, &github.Response{}, nil).Once()
+
+				// The PR is mergeable, but the configured merge method is disabled
+				// on the repo. GitHub returns a 405 with a different message. This
+				// is permanent: the provider must surface it as an error rather
+				// than treating it as not-ready (which would loop forever under
+				// wait=true).
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(406), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						// Real message observed from GitHub when the configured
+						// merge method is disabled on the repo.
+						Message: "Squash merges are not allowed on this repository.",
+					})
+			},
+			expectError:   true,
+			errorContains: "Squash merges are not allowed",
+		},
+		{
 			name:     "nil merge result",
 			prNumber: 333,
 			setupMock: func(m *mockGithubClient) {

--- a/pkg/gitprovider/github/github_test.go
+++ b/pkg/gitprovider/github/github_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -561,6 +562,32 @@ func TestMergePullRequest(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "error merging pull request",
+		},
+		{
+			name:     "merge call returns 405 base branch modified is not ready",
+			prNumber: 405,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(405)).
+					Return(&github.PullRequest{
+						Number:    github.Ptr(405),
+						State:     github.Ptr("open"),
+						Merged:    github.Ptr(false),
+						Mergeable: github.Ptr(true),
+						Head:      &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:   github.Ptr("https://github.com/akuity/kargo/pull/405"),
+					}, &github.Response{}, nil).Once()
+
+				// The base branch moved between the mergeability check and this
+				// merge call; GitHub returns a 405. The provider treats it as
+				// not-ready (no error, not merged) so the caller retries.
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(405), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						Message:  "Base branch was modified. Review and try the merge again.",
+					})
+			},
+			expectedMerged: false,
 		},
 		{
 			name:     "nil merge result",

--- a/pkg/gitprovider/github/pr_integration_test.go
+++ b/pkg/gitprovider/github/pr_integration_test.go
@@ -89,14 +89,14 @@ func TestMergeGate(t *testing.T) {
 		prNumber, cleanup := gptest.SetupCleanPR(t, repoCfg, prov)
 		defer cleanup()
 
-		state := waitForMergeableComputed(t, prov, prNumber)
-		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
+		ghPR := waitForMergeableComputed(t, prov, prNumber)
+		require.Equal(t, "clean", ghPR.GetMergeableState())
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.True(t, merged)
 		require.NotNil(t, mergedPR)
-		t.Logf("gate proceeded with the merge (commit %s)", mergedPR.MergeCommitSHA)
+		logGateComparison(t, prNumber, ghPR, gateMerge)
 	})
 
 	t.Run("dirty fails with conflict", func(t *testing.T) {
@@ -106,16 +106,15 @@ func TestMergeGate(t *testing.T) {
 		prNumber, cleanup := gptest.SetupConflictingPR(t, repoCfg, prov)
 		defer cleanup()
 
-		state := waitForMergeableComputed(t, prov, prNumber)
-		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
-		require.Equal(t, "dirty", state, "expected GitHub to report a conflict")
+		ghPR := waitForMergeableComputed(t, prov, prNumber)
+		require.Equal(t, "dirty", ghPR.GetMergeableState(), "expected GitHub to report a conflict")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.Error(t, mergeErr)
 		require.Contains(t, mergeErr.Error(), "has conflicts and cannot be merged")
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
-		t.Logf("gate returned a terminal error: %v", mergeErr)
+		logGateComparison(t, prNumber, ghPR, gateFail)
 	})
 
 	t.Run("blocked is not ready", func(t *testing.T) {
@@ -129,27 +128,64 @@ func TestMergeGate(t *testing.T) {
 		defer cleanup()
 
 		// With an unsatisfied required status check, GitHub blocks the merge.
-		state := waitForMergeableComputed(t, prov, prNumber)
-		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
-		require.Equal(t, "blocked", state, "expected GitHub to block the merge")
+		ghPR := waitForMergeableComputed(t, prov, prNumber)
+		require.Equal(t, "blocked", ghPR.GetMergeableState(), "expected GitHub to block the merge")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
-		t.Logf("gate returned not-ready (no merge, no error), so the caller retries")
+		logGateComparison(t, prNumber, ghPR, gateRetry)
 	})
+}
+
+// Gate outcomes, used to compare the new mergeable_state gate against the legacy
+// Mergeable-boolean gate.
+const (
+	gateMerge = "merge"
+	gateFail  = "fail (terminal error)"
+	gateRetry = "not-ready (retry)"
+)
+
+// logGateComparison records, for one PR, the inputs GitHub returned, the outcome
+// the legacy gate (Draft || !Mergeable) would have produced, and the new gate's
+// observed outcome -- flagging where the added mergeable_state detail changes
+// behavior. The legacy gate can only ever merge or retry; it cannot distinguish
+// a permanent conflict (so it would retry "dirty" forever) and trusts the
+// Mergeable boolean (so it would attempt to merge a "blocked" PR that GitHub
+// then rejects).
+func logGateComparison(
+	t *testing.T,
+	prNumber int64,
+	ghPR github.PullRequest,
+	newGate string,
+) {
+	t.Helper()
+	legacy := gateMerge
+	if ghPR.GetDraft() || !ghPR.GetMergeable() {
+		legacy = gateRetry
+	}
+	verdict := "same as legacy"
+	if legacy != newGate {
+		verdict = "DIVERGES from legacy"
+	}
+	t.Logf(
+		"PR #%d: mergeable_state=%q mergeable=%v draft=%v",
+		prNumber, ghPR.GetMergeableState(), ghPR.GetMergeable(), ghPR.GetDraft(),
+	)
+	t.Logf("  legacy boolean gate -> %s", legacy)
+	t.Logf("  new gate            -> %s  (%s)", newGate, verdict)
 }
 
 // waitForMergeableComputed polls the PR until GitHub has finished computing its
 // mergeability (mergeable_state is neither empty nor "unknown") and returns the
-// resolved state. GitHub computes mergeability asynchronously, so reading too
-// early would observe "unknown" and mask the state the test is exercising.
+// resolved PR. GitHub computes mergeability asynchronously, so reading too early
+// would observe "unknown" and mask the state the test is exercising.
 func waitForMergeableComputed(
 	t *testing.T,
 	prov gitprovider.Interface,
 	prNumber int64,
-) string {
+) github.PullRequest {
 	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for {
@@ -158,7 +194,7 @@ func waitForMergeableComputed(
 		ghPR, ok := pr.Object.(github.PullRequest)
 		require.True(t, ok, "expected PR object to be a github.PullRequest")
 		if state := ghPR.GetMergeableState(); state != "" && state != "unknown" {
-			return state
+			return ghPR
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for mergeable_state of PR %d", prNumber)

--- a/pkg/gitprovider/github/pr_integration_test.go
+++ b/pkg/gitprovider/github/pr_integration_test.go
@@ -89,14 +89,14 @@ func TestMergeGate(t *testing.T) {
 		prNumber, cleanup := gptest.SetupCleanPR(t, repoCfg, prov)
 		defer cleanup()
 
-		ghPR := waitForMergeableComputed(t, prov, prNumber)
-		require.Equal(t, "clean", ghPR.GetMergeableState())
+		state := waitForMergeableComputed(t, prov, prNumber)
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.True(t, merged)
 		require.NotNil(t, mergedPR)
-		logGateComparison(t, prNumber, ghPR, gateMerge)
+		t.Logf("gate proceeded with the merge (commit %s)", mergedPR.MergeCommitSHA)
 	})
 
 	t.Run("dirty fails with conflict", func(t *testing.T) {
@@ -106,15 +106,16 @@ func TestMergeGate(t *testing.T) {
 		prNumber, cleanup := gptest.SetupConflictingPR(t, repoCfg, prov)
 		defer cleanup()
 
-		ghPR := waitForMergeableComputed(t, prov, prNumber)
-		require.Equal(t, "dirty", ghPR.GetMergeableState(), "expected GitHub to report a conflict")
+		state := waitForMergeableComputed(t, prov, prNumber)
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
+		require.Equal(t, "dirty", state, "expected GitHub to report a conflict")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.Error(t, mergeErr)
 		require.Contains(t, mergeErr.Error(), "has conflicts and cannot be merged")
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
-		logGateComparison(t, prNumber, ghPR, gateFail)
+		t.Logf("gate returned a terminal error: %v", mergeErr)
 	})
 
 	t.Run("blocked is not ready", func(t *testing.T) {
@@ -128,64 +129,27 @@ func TestMergeGate(t *testing.T) {
 		defer cleanup()
 
 		// With an unsatisfied required status check, GitHub blocks the merge.
-		ghPR := waitForMergeableComputed(t, prov, prNumber)
-		require.Equal(t, "blocked", ghPR.GetMergeableState(), "expected GitHub to block the merge")
+		state := waitForMergeableComputed(t, prov, prNumber)
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
+		require.Equal(t, "blocked", state, "expected GitHub to block the merge")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
-		logGateComparison(t, prNumber, ghPR, gateRetry)
+		t.Logf("gate returned not-ready (no merge, no error), so the caller retries")
 	})
-}
-
-// Gate outcomes, used to compare the new mergeable_state gate against the legacy
-// Mergeable-boolean gate.
-const (
-	gateMerge = "merge"
-	gateFail  = "fail (terminal error)"
-	gateRetry = "not-ready (retry)"
-)
-
-// logGateComparison records, for one PR, the inputs GitHub returned, the outcome
-// the legacy gate (Draft || !Mergeable) would have produced, and the new gate's
-// observed outcome -- flagging where the added mergeable_state detail changes
-// behavior. The legacy gate can only ever merge or retry; it cannot distinguish
-// a permanent conflict (so it would retry "dirty" forever) and trusts the
-// Mergeable boolean (so it would attempt to merge a "blocked" PR that GitHub
-// then rejects).
-func logGateComparison(
-	t *testing.T,
-	prNumber int64,
-	ghPR github.PullRequest,
-	newGate string,
-) {
-	t.Helper()
-	legacy := gateMerge
-	if ghPR.GetDraft() || !ghPR.GetMergeable() {
-		legacy = gateRetry
-	}
-	verdict := "same as legacy"
-	if legacy != newGate {
-		verdict = "DIVERGES from legacy"
-	}
-	t.Logf(
-		"PR #%d: mergeable_state=%q mergeable=%v draft=%v",
-		prNumber, ghPR.GetMergeableState(), ghPR.GetMergeable(), ghPR.GetDraft(),
-	)
-	t.Logf("  legacy boolean gate -> %s", legacy)
-	t.Logf("  new gate            -> %s  (%s)", newGate, verdict)
 }
 
 // waitForMergeableComputed polls the PR until GitHub has finished computing its
 // mergeability (mergeable_state is neither empty nor "unknown") and returns the
-// resolved PR. GitHub computes mergeability asynchronously, so reading too early
-// would observe "unknown" and mask the state the test is exercising.
+// resolved state. GitHub computes mergeability asynchronously, so reading too
+// early would observe "unknown" and mask the state the test is exercising.
 func waitForMergeableComputed(
 	t *testing.T,
 	prov gitprovider.Interface,
 	prNumber int64,
-) github.PullRequest {
+) string {
 	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for {
@@ -194,7 +158,7 @@ func waitForMergeableComputed(
 		ghPR, ok := pr.Object.(github.PullRequest)
 		require.True(t, ok, "expected PR object to be a github.PullRequest")
 		if state := ghPR.GetMergeableState(); state != "" && state != "unknown" {
-			return ghPR
+			return state
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for mergeable_state of PR %d", prNumber)

--- a/pkg/gitprovider/github/pr_integration_test.go
+++ b/pkg/gitprovider/github/pr_integration_test.go
@@ -59,11 +59,10 @@ func TestCreateAndMergePullRequest(t *testing.T) {
 // against real GitHub PRs, confirming that GitHub reports the states the gate
 // relies on.
 //
-// Setup requirements (env vars, host credential-helper, and the branch
-// protection needed by the "behind" subtest) are documented in
-// pkg/gitprovider/testing/README.md. The "behind" subtest skips unless
-// TEST_GITHUB_REQUIRE_UP_TO_DATE=true and the repo's main branch requires
-// branches to be up to date before merging.
+// Setup requirements (env vars and the branch protection needed by the
+// "blocked" subtest) are documented in pkg/gitprovider/testing/README.md. The
+// "blocked" subtest skips unless TEST_GITHUB_REQUIRE_STATUS_CHECK=true and the
+// repo's main branch requires a status check the PR will not satisfy.
 func TestMergeGate(t *testing.T) {
 	repoURL := gptest.RequireEnv(t, "TEST_GITHUB_REPO_URL")
 	token := gptest.RequireEnv(t, "TEST_GITHUB_TOKEN")
@@ -77,23 +76,38 @@ func TestMergeGate(t *testing.T) {
 	prov, err := NewProvider(repoURL, &gitprovider.Options{Token: token})
 	require.NoError(t, err)
 
+	// A required status check is repo-global, so it blocks every PR -- including
+	// the clean one. The "clean"/"dirty" subtests therefore assume an unprotected
+	// main, while "blocked" assumes the required check is configured. The two
+	// modes are mutually exclusive; select with TEST_GITHUB_REQUIRE_STATUS_CHECK.
+	protected := os.Getenv("TEST_GITHUB_REQUIRE_STATUS_CHECK") == "true"
+
 	t.Run("clean merges", func(t *testing.T) {
+		if protected {
+			t.Skip("repo has a required status check; clean assumes unprotected main")
+		}
 		prNumber, cleanup := gptest.SetupCleanPR(t, repoCfg, prov)
 		defer cleanup()
 
-		waitForMergeableComputed(t, prov, prNumber)
+		state := waitForMergeableComputed(t, prov, prNumber)
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.True(t, merged)
 		require.NotNil(t, mergedPR)
+		t.Logf("gate proceeded with the merge (commit %s)", mergedPR.MergeCommitSHA)
 	})
 
 	t.Run("dirty fails with conflict", func(t *testing.T) {
+		if protected {
+			t.Skip("repo has a required status check; dirty assumes unprotected main")
+		}
 		prNumber, cleanup := gptest.SetupConflictingPR(t, repoCfg, prov)
 		defer cleanup()
 
 		state := waitForMergeableComputed(t, prov, prNumber)
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
 		require.Equal(t, "dirty", state, "expected GitHub to report a conflict")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
@@ -101,25 +115,29 @@ func TestMergeGate(t *testing.T) {
 		require.Contains(t, mergeErr.Error(), "has conflicts and cannot be merged")
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
+		t.Logf("gate returned a terminal error: %v", mergeErr)
 	})
 
-	t.Run("behind is not ready", func(t *testing.T) {
-		if os.Getenv("TEST_GITHUB_REQUIRE_UP_TO_DATE") != "true" {
+	t.Run("blocked is not ready", func(t *testing.T) {
+		if !protected {
 			t.Skip(
-				"TEST_GITHUB_REQUIRE_UP_TO_DATE must be true and the repo's main " +
-					"branch must require branches to be up to date before merging",
+				"set TEST_GITHUB_REQUIRE_STATUS_CHECK=true with the repo's main " +
+					"branch requiring a status check the PR will not satisfy",
 			)
 		}
-		prNumber, cleanup := gptest.SetupBehindPR(t, repoCfg, prov)
+		prNumber, cleanup := gptest.SetupCleanPR(t, repoCfg, prov)
 		defer cleanup()
 
+		// With an unsatisfied required status check, GitHub blocks the merge.
 		state := waitForMergeableComputed(t, prov, prNumber)
-		require.Equal(t, "behind", state, "expected GitHub to report an out-of-date branch")
+		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
+		require.Equal(t, "blocked", state, "expected GitHub to block the merge")
 
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
+		t.Logf("gate returned not-ready (no merge, no error), so the caller retries")
 	})
 }
 

--- a/pkg/gitprovider/github/pr_integration_test.go
+++ b/pkg/gitprovider/github/pr_integration_test.go
@@ -3,8 +3,11 @@
 package github
 
 import (
+	"os"
 	"testing"
+	"time"
 
+	"github.com/google/go-github/v76/github"
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/pkg/gitprovider"
@@ -50,4 +53,98 @@ func TestCreateAndMergePullRequest(t *testing.T) {
 			ExpectMergeErr: true,
 		},
 	})
+}
+
+// TestMergeGate exercises the mergeable_state-aware gate in MergePullRequest
+// against real GitHub PRs, confirming that GitHub reports the states the gate
+// relies on.
+//
+// Setup requirements (env vars, host credential-helper, and the branch
+// protection needed by the "behind" subtest) are documented in
+// pkg/gitprovider/testing/README.md. The "behind" subtest skips unless
+// TEST_GITHUB_REQUIRE_UP_TO_DATE=true and the repo's main branch requires
+// branches to be up to date before merging.
+func TestMergeGate(t *testing.T) {
+	repoURL := gptest.RequireEnv(t, "TEST_GITHUB_REPO_URL")
+	token := gptest.RequireEnv(t, "TEST_GITHUB_TOKEN")
+
+	repoCfg := gptest.RepoConfig{
+		RepoURL:     repoURL,
+		Token:       token,
+		GitUsername: gptest.RequireEnv(t, "TEST_GITHUB_USERNAME"),
+	}
+
+	prov, err := NewProvider(repoURL, &gitprovider.Options{Token: token})
+	require.NoError(t, err)
+
+	t.Run("clean merges", func(t *testing.T) {
+		prNumber, cleanup := gptest.SetupCleanPR(t, repoCfg, prov)
+		defer cleanup()
+
+		waitForMergeableComputed(t, prov, prNumber)
+
+		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
+		require.NoError(t, mergeErr)
+		require.True(t, merged)
+		require.NotNil(t, mergedPR)
+	})
+
+	t.Run("dirty fails with conflict", func(t *testing.T) {
+		prNumber, cleanup := gptest.SetupConflictingPR(t, repoCfg, prov)
+		defer cleanup()
+
+		state := waitForMergeableComputed(t, prov, prNumber)
+		require.Equal(t, "dirty", state, "expected GitHub to report a conflict")
+
+		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
+		require.Error(t, mergeErr)
+		require.Contains(t, mergeErr.Error(), "has conflicts and cannot be merged")
+		require.False(t, merged)
+		require.Nil(t, mergedPR)
+	})
+
+	t.Run("behind is not ready", func(t *testing.T) {
+		if os.Getenv("TEST_GITHUB_REQUIRE_UP_TO_DATE") != "true" {
+			t.Skip(
+				"TEST_GITHUB_REQUIRE_UP_TO_DATE must be true and the repo's main " +
+					"branch must require branches to be up to date before merging",
+			)
+		}
+		prNumber, cleanup := gptest.SetupBehindPR(t, repoCfg, prov)
+		defer cleanup()
+
+		state := waitForMergeableComputed(t, prov, prNumber)
+		require.Equal(t, "behind", state, "expected GitHub to report an out-of-date branch")
+
+		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
+		require.NoError(t, mergeErr)
+		require.False(t, merged)
+		require.Nil(t, mergedPR)
+	})
+}
+
+// waitForMergeableComputed polls the PR until GitHub has finished computing its
+// mergeability (mergeable_state is neither empty nor "unknown") and returns the
+// resolved state. GitHub computes mergeability asynchronously, so reading too
+// early would observe "unknown" and mask the state the test is exercising.
+func waitForMergeableComputed(
+	t *testing.T,
+	prov gitprovider.Interface,
+	prNumber int64,
+) string {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		pr, err := prov.GetPullRequest(t.Context(), prNumber)
+		require.NoError(t, err)
+		ghPR, ok := pr.Object.(github.PullRequest)
+		require.True(t, ok, "expected PR object to be a github.PullRequest")
+		if state := ghPR.GetMergeableState(); state != "" && state != "unknown" {
+			return state
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for mergeable_state of PR %d", prNumber)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }

--- a/pkg/gitprovider/testing/README.md
+++ b/pkg/gitprovider/testing/README.md
@@ -27,23 +27,30 @@ with the `repo` scope works (`gh auth token` if it has that scope).
 ### GitHub `TestMergeGate` extras
 
 `TestMergeGate` verifies the `mergeable_state`-aware merge gate. Its `clean` and
-`dirty` subtests need only the three GitHub variables above. The `behind` subtest
-is **opt-in** and additionally requires:
+`dirty` subtests need only the three GitHub variables above. The `blocked`
+subtest is **opt-in** and additionally requires:
 
-- `TEST_GITHUB_REQUIRE_UP_TO_DATE=true`, and
-- the repo's `main` branch protected with **"Require branches to be up to date
-  before merging"** (otherwise GitHub merges out-of-date branches and the state
-  never becomes `behind`):
+- `TEST_GITHUB_REQUIRE_STATUS_CHECK=true`, and
+- the repo's `main` branch protected with a **required status check the PR will
+  never satisfy**. With an unsatisfied required check, GitHub reports the PR's
+  `mergeable_state` as `blocked` — the same not-ready gate branch as `behind`:
 
   ```bash
   gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'
-  {"required_status_checks":{"strict":true,"contexts":[]},
+  {"required_status_checks":{"strict":true,"contexts":["kargo-required-check"]},
    "enforce_admins":true,"required_pull_request_reviews":null,"restrictions":null}
   JSON
   ```
 
-  Branch protection is free on **public** repos; on private repos it needs
-  GitHub Pro. The subtest skips cleanly when not configured.
+  Branch protection needs a **public** repo or GitHub Pro. Because a required
+  check is repo-global, it blocks *every* PR — so this mode is mutually exclusive
+  with the `clean`/`dirty` subtests, which skip when
+  `TEST_GITHUB_REQUIRE_STATUS_CHECK=true`. Run the two modes separately. Each
+  subtest skips cleanly when its mode is not selected.
+
+  (`behind` itself is not exercised live: it additionally requires a *passing*
+  required check on an out-of-date branch, i.e. publishing commit statuses. It
+  takes the same gate path as `blocked` and is covered by the unit tests.)
 
 ## Running (in the dev container)
 

--- a/pkg/gitprovider/testing/README.md
+++ b/pkg/gitprovider/testing/README.md
@@ -45,48 +45,31 @@ is **opt-in** and additionally requires:
   Branch protection is free on **public** repos; on private repos it needs
   GitHub Pro. The subtest skips cleanly when not configured.
 
-## Running
+## Running (in the dev container)
+
+These tests assume the Kargo container environment. The shared helpers shell out
+to `git` through Kargo's git client, which sets
+`GIT_ASKPASS=/usr/local/bin/credential-helper` — a binary that exists in the
+Kargo image but is not part of the `dev-tools` image and is not present on a
+developer host. The container also avoids the macOS keychain credential helper,
+which otherwise hijacks authentication and can hang non-interactive runs.
+
+Run inside the `dev-tools` container, building the credential helper to its
+expected path first:
 
 ```bash
-export TEST_GITHUB_REPO_URL=https://github.com/<owner>/<repo>
-export TEST_GITHUB_TOKEN=$(gh auth token)
-export TEST_GITHUB_USERNAME=<owner>
+make hack-build-dev-tools   # once, builds kargo:dev-tools
 
-go test -v -tags 'integration github' \
-  -run TestMergeGate ./pkg/gitprovider/github/
+docker run --rm -u root \
+  -v "$PWD":/workspaces/kargo -w /workspaces/kargo \
+  -e TEST_GITHUB_REPO_URL=https://github.com/<owner>/<repo> \
+  -e TEST_GITHUB_TOKEN="$(gh auth token)" \
+  -e TEST_GITHUB_USERNAME=<owner> \
+  kargo:dev-tools bash -c '
+    go build -o /usr/local/bin/credential-helper ./cmd/credential-helper &&
+    go test -v -tags "integration github" \
+      -run TestMergeGate ./pkg/gitprovider/github/'
 ```
 
-Swap the tag and variables for other providers (e.g. `-tags 'integration gitlab'`).
-
-## Host setup (running outside the dev container)
-
-The shared helpers shell out to `git` through Kargo's git client, which is built
-for the Kargo container. Two things must be handled on a developer host:
-
-1. **Credential helper binary.** Kargo's git client sets
-   `GIT_ASKPASS=/usr/local/bin/credential-helper`. That binary ships in the
-   container but not on a host. Build and install it once:
-
-   ```bash
-   go build -o /tmp/credential-helper ./cmd/credential-helper
-   sudo install -m 0755 /tmp/credential-helper /usr/local/bin/credential-helper
-   ```
-
-2. **macOS keychain credential helper.** Apple's `/usr/bin/git` enables
-   `credential.helper=osxkeychain` via a system gitconfig, which can pop a GUI
-   password prompt and hang non-interactive runs. Shim `git` with a wrapper that
-   disables the system config, and put it first on `PATH`:
-
-   ```bash
-   mkdir -p /tmp/gitwrap
-   cat > /tmp/gitwrap/git <<'EOF'
-   #!/bin/sh
-   export GIT_CONFIG_NOSYSTEM=1
-   export GIT_TERMINAL_PROMPT=0
-   exec /usr/bin/git "$@"
-   EOF
-   chmod +x /tmp/gitwrap/git
-   export PATH=/tmp/gitwrap:$PATH
-   ```
-
-Neither step is needed when running the tests inside the Kargo dev container.
+Swap the tag and variables for other providers (e.g. `-tags "integration gitlab"`
+with the `TEST_GITLAB_*` variables).

--- a/pkg/gitprovider/testing/README.md
+++ b/pkg/gitprovider/testing/README.md
@@ -1,0 +1,92 @@
+# Git provider integration tests
+
+The `gitprovider` packages include integration tests that exercise
+`CreatePullRequest` / `MergePullRequest` against a **real** Git hosting provider.
+They are build-tagged and **never run in CI** — there is no Make target that
+builds the `integration` tag. Run them manually when changing provider behavior.
+
+Each provider has its own `pr_integration_test.go` (build tag
+`integration && <provider>`) backed by the shared helpers in this package
+(`helpers.go`, build tag `integration`).
+
+## Required environment variables
+
+Every test skips (does not fail) when its variables are unset. Point them at a
+**disposable** repository — the tests create branches, commits, and PRs.
+
+| Provider | Variables |
+|----------|-----------|
+| GitHub   | `TEST_GITHUB_REPO_URL`, `TEST_GITHUB_TOKEN`, `TEST_GITHUB_USERNAME` |
+| GitLab   | `TEST_GITLAB_REPO_URL`, `TEST_GITLAB_TOKEN`, `TEST_GITLAB_USERNAME` |
+| Gitea    | `TEST_GITEA_REPO_URL`, `TEST_GITEA_TOKEN`, `TEST_GITEA_USERNAME` |
+| Azure    | `TEST_AZURE_REPO_URL`, `TEST_AZURE_TOKEN`, `TEST_AZURE_USERNAME` |
+
+`*_TOKEN` must grant push access and PR create/merge. For GitHub, a classic PAT
+with the `repo` scope works (`gh auth token` if it has that scope).
+
+### GitHub `TestMergeGate` extras
+
+`TestMergeGate` verifies the `mergeable_state`-aware merge gate. Its `clean` and
+`dirty` subtests need only the three GitHub variables above. The `behind` subtest
+is **opt-in** and additionally requires:
+
+- `TEST_GITHUB_REQUIRE_UP_TO_DATE=true`, and
+- the repo's `main` branch protected with **"Require branches to be up to date
+  before merging"** (otherwise GitHub merges out-of-date branches and the state
+  never becomes `behind`):
+
+  ```bash
+  gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'
+  {"required_status_checks":{"strict":true,"contexts":[]},
+   "enforce_admins":true,"required_pull_request_reviews":null,"restrictions":null}
+  JSON
+  ```
+
+  Branch protection is free on **public** repos; on private repos it needs
+  GitHub Pro. The subtest skips cleanly when not configured.
+
+## Running
+
+```bash
+export TEST_GITHUB_REPO_URL=https://github.com/<owner>/<repo>
+export TEST_GITHUB_TOKEN=$(gh auth token)
+export TEST_GITHUB_USERNAME=<owner>
+
+go test -v -tags 'integration github' \
+  -run TestMergeGate ./pkg/gitprovider/github/
+```
+
+Swap the tag and variables for other providers (e.g. `-tags 'integration gitlab'`).
+
+## Host setup (running outside the dev container)
+
+The shared helpers shell out to `git` through Kargo's git client, which is built
+for the Kargo container. Two things must be handled on a developer host:
+
+1. **Credential helper binary.** Kargo's git client sets
+   `GIT_ASKPASS=/usr/local/bin/credential-helper`. That binary ships in the
+   container but not on a host. Build and install it once:
+
+   ```bash
+   go build -o /tmp/credential-helper ./cmd/credential-helper
+   sudo install -m 0755 /tmp/credential-helper /usr/local/bin/credential-helper
+   ```
+
+2. **macOS keychain credential helper.** Apple's `/usr/bin/git` enables
+   `credential.helper=osxkeychain` via a system gitconfig, which can pop a GUI
+   password prompt and hang non-interactive runs. Shim `git` with a wrapper that
+   disables the system config, and put it first on `PATH`:
+
+   ```bash
+   mkdir -p /tmp/gitwrap
+   cat > /tmp/gitwrap/git <<'EOF'
+   #!/bin/sh
+   export GIT_CONFIG_NOSYSTEM=1
+   export GIT_TERMINAL_PROMPT=0
+   exec /usr/bin/git "$@"
+   EOF
+   chmod +x /tmp/gitwrap/git
+   export PATH=/tmp/gitwrap:$PATH
+   ```
+
+Neither step is needed when running the tests inside the Kargo dev container.

--- a/pkg/gitprovider/testing/helpers.go
+++ b/pkg/gitprovider/testing/helpers.go
@@ -324,38 +324,6 @@ func SetupConflictingPR(
 	return prNumber, func() { deleteBranchAndClose(cfg, featureRepo, branchName) }
 }
 
-// SetupBehindPR creates a PR whose feature branch is behind main without
-// conflicting: the feature branch and main each add a different file. When the
-// repo requires branches to be up to date before merging, GitHub reports the PR's
-// mergeable_state as "behind". It returns the PR number and a cleanup function
-// that deletes the feature branch.
-func SetupBehindPR(
-	t *testing.T, cfg RepoConfig, prov gitprovider.Interface,
-) (int64, func()) {
-	t.Helper()
-	branchName := uniqueBranchName("behind")
-
-	// Feature branch adds a file. Per-run filenames keep the setup idempotent.
-	featureRepo := cloneMain(t, cfg)
-	require.NoError(t, featureRepo.CreateChildBranch(branchName))
-	commitFileAndPush(
-		t, featureRepo,
-		fmt.Sprintf("feature-%s.txt", branchName), "feature\n", "feature change",
-	)
-
-	// main advances with a non-conflicting change, leaving the feature branch
-	// behind.
-	mainRepo := cloneMain(t, cfg)
-	defer mainRepo.Close() // nolint: errcheck
-	commitFileAndPush(
-		t, mainRepo,
-		fmt.Sprintf("mainline-%s.txt", branchName), "mainline\n", "advance main",
-	)
-
-	prNumber := openPR(t, prov, branchName, "integration test: behind")
-	return prNumber, func() { deleteBranchAndClose(cfg, featureRepo, branchName) }
-}
-
 // fetchMain fetches the latest main branch from the remote.
 func fetchMain(t *testing.T, cfg RepoConfig, repo git.Repo) {
 	t.Helper()

--- a/pkg/gitprovider/testing/helpers.go
+++ b/pkg/gitprovider/testing/helpers.go
@@ -211,6 +211,150 @@ func cloneAndPush(
 	return repo
 }
 
+// cloneMain clones the test repo at its main branch and returns the working
+// copy.
+func cloneMain(t *testing.T, cfg RepoConfig) git.Repo {
+	t.Helper()
+	repo, err := git.Clone(
+		cfg.RepoURL,
+		cfg.clientOpts(),
+		&git.CloneOptions{Branch: "main", SingleBranch: true},
+	)
+	require.NoError(t, err)
+	return repo
+}
+
+// commitFileAndPush writes a file in the repo's working tree, commits it, and
+// pushes the currently checked-out branch.
+func commitFileAndPush(
+	t *testing.T, repo git.Repo, name, content, message string,
+) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo.Dir(), name), []byte(content), 0600,
+	))
+	require.NoError(t, repo.AddAllAndCommit(message, nil))
+	require.NoError(t, repo.Push(nil))
+}
+
+// openPR opens a pull request from headBranch into main and returns its number.
+func openPR(
+	t *testing.T,
+	prov gitprovider.Interface,
+	headBranch, title string,
+) int64 {
+	t.Helper()
+	pr, err := prov.CreatePullRequest(
+		t.Context(),
+		&gitprovider.CreatePullRequestOpts{
+			Title: title,
+			Head:  headBranch,
+			Base:  "main",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	require.True(t, pr.Open)
+	return pr.Number
+}
+
+// deleteBranchAndClose deletes the remote feature branch over an authenticated
+// URL and closes the repo. Unlike cleanupBranch, it embeds credentials in the
+// push URL and disables interactive prompts, so it never blocks waiting for
+// input on hosts with a GUI credential helper. Best-effort.
+func deleteBranchAndClose(cfg RepoConfig, repo git.Repo, branchName string) {
+	// nolint:gosec // Test helper; the push URL is built from test config, not
+	// external input. The authed URL avoids depending on the credential-helper
+	// binary path, which is not present on developer hosts.
+	cmd := exec.Command(
+		"git", "push", cfg.authedRepoURL(), "--delete", branchName,
+	)
+	cmd.Dir = repo.Dir()
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("HOME=%s", repo.HomeDir()),
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	_ = cmd.Run()
+	repo.Close() // nolint: errcheck
+}
+
+// SetupCleanPR creates a PR with a single non-conflicting commit. It returns the
+// PR number and a cleanup function that deletes the feature branch.
+func SetupCleanPR(
+	t *testing.T, cfg RepoConfig, prov gitprovider.Interface,
+) (int64, func()) {
+	t.Helper()
+	branchName := uniqueBranchName("clean")
+	repo := cloneAndPush(t, cfg, branchName)
+	prNumber := openPR(t, prov, branchName, "integration test: clean")
+	return prNumber, func() { deleteBranchAndClose(cfg, repo, branchName) }
+}
+
+// SetupConflictingPR creates a PR whose feature branch conflicts with main: both
+// add the same file with different content, producing an add/add conflict. GitHub
+// reports the PR's mergeable_state as "dirty". It returns the PR number and a
+// cleanup function that deletes the feature branch.
+func SetupConflictingPR(
+	t *testing.T, cfg RepoConfig, prov gitprovider.Interface,
+) (int64, func()) {
+	t.Helper()
+	branchName := uniqueBranchName("dirty")
+	// A per-run filename keeps the setup idempotent across runs while still
+	// producing an add/add conflict (both branches add the same new path).
+	conflictFile := fmt.Sprintf("conflict-%s.txt", branchName)
+
+	// Feature branch adds the file with one content.
+	featureRepo := cloneMain(t, cfg)
+	require.NoError(t, featureRepo.CreateChildBranch(branchName))
+	commitFileAndPush(
+		t, featureRepo, conflictFile, "feature content\n", "feature change",
+	)
+
+	// main adds the same file with different content, diverging from the feature
+	// branch.
+	mainRepo := cloneMain(t, cfg)
+	defer mainRepo.Close() // nolint: errcheck
+	commitFileAndPush(
+		t, mainRepo, conflictFile, "main content\n", "conflicting main change",
+	)
+
+	prNumber := openPR(t, prov, branchName, "integration test: dirty")
+	return prNumber, func() { deleteBranchAndClose(cfg, featureRepo, branchName) }
+}
+
+// SetupBehindPR creates a PR whose feature branch is behind main without
+// conflicting: the feature branch and main each add a different file. When the
+// repo requires branches to be up to date before merging, GitHub reports the PR's
+// mergeable_state as "behind". It returns the PR number and a cleanup function
+// that deletes the feature branch.
+func SetupBehindPR(
+	t *testing.T, cfg RepoConfig, prov gitprovider.Interface,
+) (int64, func()) {
+	t.Helper()
+	branchName := uniqueBranchName("behind")
+
+	// Feature branch adds a file. Per-run filenames keep the setup idempotent.
+	featureRepo := cloneMain(t, cfg)
+	require.NoError(t, featureRepo.CreateChildBranch(branchName))
+	commitFileAndPush(
+		t, featureRepo,
+		fmt.Sprintf("feature-%s.txt", branchName), "feature\n", "feature change",
+	)
+
+	// main advances with a non-conflicting change, leaving the feature branch
+	// behind.
+	mainRepo := cloneMain(t, cfg)
+	defer mainRepo.Close() // nolint: errcheck
+	commitFileAndPush(
+		t, mainRepo,
+		fmt.Sprintf("mainline-%s.txt", branchName), "mainline\n", "advance main",
+	)
+
+	prNumber := openPR(t, prov, branchName, "integration test: behind")
+	return prNumber, func() { deleteBranchAndClose(cfg, featureRepo, branchName) }
+}
+
 // fetchMain fetches the latest main branch from the remote.
 func fetchMain(t *testing.T, cfg RepoConfig, repo git.Repo) {
 	t.Helper()

--- a/pkg/gitprovider/testing/helpers.go
+++ b/pkg/gitprovider/testing/helpers.go
@@ -104,7 +104,7 @@ func RunPRTests(
 		t.Run(tc.Name, func(t *testing.T) {
 			branchName := uniqueBranchName(tc.Name)
 			repo := cloneAndPush(t, cfg, branchName)
-			defer cleanupBranch(repo, branchName)
+			defer deleteBranchAndClose(cfg, repo, branchName)
 
 			pr, err := prov.CreatePullRequest(
 				t.Context(),
@@ -258,10 +258,11 @@ func openPR(
 	return pr.Number
 }
 
-// deleteBranchAndClose deletes the remote feature branch over an authenticated
-// URL and closes the repo. Unlike cleanupBranch, it embeds credentials in the
-// push URL and disables interactive prompts, so it never blocks waiting for
-// input on hosts with a GUI credential helper. Best-effort.
+// deleteBranchAndClose deletes the remote feature branch and closes the repo.
+// It pushes the delete over an authenticated URL with interactive prompts
+// disabled, so it authenticates without relying on ambient credentials and
+// never blocks waiting for input (e.g. on a host with a GUI credential helper).
+// Best-effort.
 func deleteBranchAndClose(cfg RepoConfig, repo git.Repo, branchName string) {
 	// nolint:gosec // Test helper; the push URL is built from test config, not
 	// external input. The authed URL avoids depending on the credential-helper
@@ -397,17 +398,6 @@ func requireParentCount(
 	require.Equal(t, expected, parentCount,
 		"commit %s: expected %d parent(s), got %d", sha, expected, parentCount,
 	)
-}
-
-// cleanupBranch deletes the remote branch and closes the repo. Best-effort.
-func cleanupBranch(repo git.Repo, branchName string) {
-	cmd := exec.Command("git", "push", "origin", "--delete", branchName)
-	cmd.Dir = repo.Dir()
-	cmd.Env = append(
-		os.Environ(), fmt.Sprintf("HOME=%s", repo.HomeDir()),
-	)
-	_ = cmd.Run()
-	repo.Close() // nolint: errcheck
 }
 
 // runGit runs a git command in the given directory and fails the test on error.


### PR DESCRIPTION
## What

Makes the `git-merge-pr` step's GitHub provider resilient to the concurrent-merge race in #5761, in two complementary places:

1. The **pre-merge gate** reads GitHub's richer `mergeable_state` field instead of relying solely on the `Mergeable` boolean.
2. The **merge call** treats a transient `405 "Base branch was modified"` as *not ready* (rather than a hard failure), so the step retries.

## Why

`MergePullRequest` previously gated the merge attempt on `ptr.Deref(ghPR.Mergeable, false)`. That boolean is tri-state (`true`/`false`/`nil`, computed asynchronously by GitHub) and collapses several genuinely different conditions into one "not ready" outcome:

- a **real merge conflict** (`dirty`) — will never resolve without a human
- the **base branch moved forward** (`behind`) — the time-of-check/time-of-use race described in #5761
- **blocked** by required reviews/checks (`blocked`) — clears when checks pass
- mergeability **still being computed** (`unknown`) — clears on its own

Today all of these look identical: a vague "not ready" that either retries forever (when `wait: true`) or fails with an unhelpful message (when `wait: false`).

A correct gate is necessary but not sufficient: it is a snapshot, so the base branch can still move between the mergeability `GET` and the `PUT …/merge`. GitHub then rejects the merge with `405 "Base branch was modified"`, which previously terminated the promotion. That residual race is the second half of this fix.

## How

**Gate** — switch on `mergeable_state`:

| state | behavior |
|---|---|
| `clean`, `unstable`, `has_hooks` | proceed to merge |
| `dirty` | **terminal error** (`pull request N has conflicts and cannot be merged`) |
| `behind`, `blocked`, `draft`, `unknown` | not ready → caller retries |
| unset / unrecognized | fall back to the prior `Mergeable`/`Draft` boolean logic |

**Merge-time 405** — detect a `405` from the merge call and return not-ready (`nil, false, nil`) so the step's `wait` loop returns `Running` and retries on the next reconciliation. Because the gate already rejects the permanent conditions *before* the merge call, a 405 here is the transient TOCTOU race; and the retry re-runs the gate, which surfaces any condition that has since become permanent (e.g. a real conflict) as such.

> Note: the retry rides the `wait: true → Running` path — the documented mechanism for not-ready retries. Set `wait: true` on the `git-merge-pr` step to benefit.

## Testing

- **Unit** (`TestMergePullRequest`): cases for `clean`, `unknown`, `behind`, `dirty`, and the merge-time `405`. Existing cases (which leave `mergeable_state` unset) exercise the boolean fallback path unchanged.
- **Integration** (`TestMergeGate`, build-tagged `integration && github`): drives a real GitHub repo into `clean` / `dirty` / `blocked` and asserts the gate against the live API. Verified in the dev container. Setup is documented in `pkg/gitprovider/testing/README.md`. The shared `RunPRTests` cleanup was also made hang-free (benefits all providers).

Fixes #5761
