### PR TITLE
feat(ui): display and support Secret type for generic secrets

### DIFF
--- a/pkg/client/generated/models/create_generic_credentials_request.go
+++ b/pkg/client/generated/models/create_generic_credentials_request.go
@@ -25,6 +25,11 @@ type CreateGenericCredentialsRequest struct {
 
 	// replicate
 	Replicate bool `json:"replicate,omitempty"`
+
+	// Type is the Kubernetes Secret type (e.g. "Opaque" or
+	// "kubernetes.io/dockerconfigjson"). It is immutable, so it may only be set
+	// at creation time. When empty, Kubernetes defaults it to "Opaque".
+	Type string `json:"type,omitempty"`
 }
 
 // Validate validates this create generic credentials request

--- a/pkg/server/create_generic_credentials_v1alpha1.go
+++ b/pkg/server/create_generic_credentials_v1alpha1.go
@@ -22,6 +22,7 @@ type genericCredentials struct {
 	name        string
 	description string
 	replicate   bool
+	secretType  string
 	data        map[string]string
 }
 
@@ -84,10 +85,14 @@ func (s *server) validateGenericCredentialsRequest(
 // createGenericCredentialsRequest is the request body for creating generic
 // credentials.
 type createGenericCredentialsRequest struct {
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	Replicate   bool              `json:"replicate,omitempty"`
-	Data        map[string]string `json:"data,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Replicate   bool   `json:"replicate,omitempty"`
+	// Type is the Kubernetes Secret type (e.g. "Opaque" or
+	// "kubernetes.io/dockerconfigjson"). It is immutable, so it may only be set
+	// at creation time. When empty, Kubernetes defaults it to "Opaque".
+	Type string            `json:"type,omitempty"`
+	Data map[string]string `json:"data,omitempty"`
 } // @name CreateGenericCredentialsRequest
 
 // @id CreateProjectGenericCredentials
@@ -126,6 +131,7 @@ func (s *server) createProjectGenericCredentials(c *gin.Context) {
 			name:        req.Name,
 			description: req.Description,
 			replicate:   req.Replicate,
+			secretType:  req.Type,
 			data:        req.Data,
 		},
 	)
@@ -171,6 +177,7 @@ func (s *server) createSystemGenericCredentials(c *gin.Context) {
 			name:        req.Name,
 			description: req.Description,
 			replicate:   req.Replicate,
+			secretType:  req.Type,
 			data:        req.Data,
 		},
 	)
@@ -215,6 +222,7 @@ func (s *server) createSharedGenericCredentials(c *gin.Context) {
 			name:        req.Name,
 			description: req.Description,
 			replicate:   req.Replicate,
+			secretType:  req.Type,
 			data:        req.Data,
 		},
 	)
@@ -265,6 +273,12 @@ func (s *server) genericCredentialsToK8sSecret(
 			},
 		},
 		Data: secretsData,
+	}
+
+	// Secret type is immutable, so it is only ever set at creation time. When
+	// empty, Kubernetes defaults it to corev1.SecretTypeOpaque.
+	if creds.secretType != "" {
+		secret.Type = corev1.SecretType(creds.secretType)
 	}
 
 	annotations := make(map[string]string)

--- a/pkg/server/create_generic_credentials_v1alpha1_test.go
+++ b/pkg/server/create_generic_credentials_v1alpha1_test.go
@@ -217,6 +217,35 @@ func Test_server_createProjectGenericCredentials(t *testing.T) {
 						map[string][]byte{"foo": []byte("bar"), "bat": []byte("baz")},
 						secret.Data,
 					)
+					// No type was requested, so it defaults to empty (Opaque).
+					require.Empty(t, secret.Type)
+				},
+			},
+			{
+				name: "creates Secret with k8s type",
+				body: mustJSONBody(createGenericCredentialsRequest{
+					Name: testSecret.Name,
+					Type: string(corev1.SecretTypeDockerConfigJson),
+					Data: testData,
+				}),
+				clientBuilder: fake.NewClientBuilder().WithObjects(testProject),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+
+					resSecret := &corev1.Secret{}
+					err := json.Unmarshal(w.Body.Bytes(), resSecret)
+					require.NoError(t, err)
+					require.Equal(t, corev1.SecretTypeDockerConfigJson, resSecret.Type)
+
+					// Verify the Secret was created in the cluster with the type.
+					secret := &corev1.Secret{}
+					err = c.Get(
+						t.Context(),
+						client.ObjectKeyFromObject(resSecret),
+						secret,
+					)
+					require.NoError(t, err)
+					require.Equal(t, corev1.SecretTypeDockerConfigJson, secret.Type)
 				},
 			},
 		},
@@ -453,4 +482,57 @@ func Test_server_createSharedGenericCredentials(t *testing.T) {
 			},
 		},
 	)
+}
+
+func Test_server_genericCredentialsToK8sSecret(t *testing.T) {
+	s := &server{
+		cfg: config.ServerConfig{
+			SystemResourcesNamespace: testSystemResourcesNamespace,
+			SharedResourcesNamespace: testSharedResourcesNamespace,
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		creds  genericCredentials
+		assert func(*testing.T, *corev1.Secret)
+	}{
+		{
+			name: "no type defaults to empty (Opaque)",
+			creds: genericCredentials{
+				project: "fake-project",
+				name:    "fake-secret",
+				data:    map[string]string{"foo": "bar"},
+			},
+			assert: func(t *testing.T, secret *corev1.Secret) {
+				require.Equal(t, "fake-project", secret.Namespace)
+				require.Equal(t, "fake-secret", secret.Name)
+				require.Empty(t, secret.Type)
+				require.Equal(
+					t,
+					kargoapi.LabelValueCredentialTypeGeneric,
+					secret.Labels[kargoapi.LabelKeyCredentialType],
+				)
+				require.Equal(t, map[string][]byte{"foo": []byte("bar")}, secret.Data)
+			},
+		},
+		{
+			name: "type is set when provided",
+			creds: genericCredentials{
+				project:    "fake-project",
+				name:       "fake-secret",
+				secretType: string(corev1.SecretTypeDockerConfigJson),
+				data:       map[string]string{".dockerconfigjson": "{}"},
+			},
+			assert: func(t *testing.T, secret *corev1.Secret) {
+				require.Equal(t, corev1.SecretTypeDockerConfigJson, secret.Type)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.assert(t, s.genericCredentialsToK8sSecret(testCase.creds))
+		})
+	}
 }

--- a/swagger.json
+++ b/swagger.json
@@ -4842,6 +4842,10 @@
         },
         "replicate": {
           "type": "boolean"
+        },
+        "type": {
+          "description": "Type is the Kubernetes Secret type (e.g. \"Opaque\" or\n\"kubernetes.io/dockerconfigjson\"). It is immutable, so it may only be set\nat creation time. When empty, Kubernetes defaults it to \"Opaque\".",
+          "type": "string"
         }
       }
     },

--- a/ui/src/features/common/settings/secrets/create-credentials-modal.tsx
+++ b/ui/src/features/common/settings/secrets/create-credentials-modal.tsx
@@ -2,7 +2,7 @@ import { faAsterisk, faCode, faExternalLink } from '@fortawesome/free-solid-svg-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import { Checkbox, Input, Modal, Segmented, Typography } from 'antd';
+import { AutoComplete, Checkbox, Input, Modal, Segmented, Typography } from 'antd';
 import { Controller, useForm } from 'react-hook-form';
 
 import { FieldContainer } from '@ui/features/common/form/field-container';
@@ -20,7 +20,7 @@ import {
 } from '@ui/gen/api/v2/credentials/credentials';
 import { V1Secret } from '@ui/gen/api/v2/models';
 
-import { createFormSchema } from './schema-validator';
+import { createFormSchema, SecretFormValues } from './schema-validator';
 import { SecretEditor } from './secret-editor';
 import { CredentialsType } from './types';
 import { constructDefaults, labelForKey, typeLabel } from './utils';
@@ -51,6 +51,19 @@ const genericCredentialPlaceholders = {
   description: placeholders.description
 };
 
+// Common Kubernetes Secret types offered as suggestions. The field is free-form,
+// so any valid Secret type may be entered. Secret type is immutable and can only
+// be set at creation time.
+const k8sSecretTypeOptions = [
+  'Opaque',
+  'kubernetes.io/dockerconfigjson',
+  'kubernetes.io/dockercfg',
+  'kubernetes.io/basic-auth',
+  'kubernetes.io/ssh-auth',
+  'kubernetes.io/tls',
+  'kubernetes.io/service-account-token'
+].map((value) => ({ value }));
+
 const repoUrlPatternPlaceholder = '(?:https?://)?(?:www.)?github.com/[w.-]+/[w.-]+(?:.git)?';
 
 type Props = ModalComponentProps & {
@@ -62,8 +75,8 @@ type Props = ModalComponentProps & {
 };
 
 export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...props }: Props) => {
-  const { control, handleSubmit, watch } = useForm({
-    defaultValues: { ...constructDefaults(init, props.type === 'generic' ? props.type : 'git') },
+  const { control, handleSubmit, watch } = useForm<SecretFormValues>({
+    defaultValues: constructDefaults(init, props.type === 'generic' ? props.type : 'git'),
     resolver: zodResolver(createFormSchema(props.type === 'generic', editing))
   });
 
@@ -114,6 +127,7 @@ export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...p
       data: Record<string, string>;
       description?: string;
       replicate?: boolean;
+      type?: string;
     }) =>
       project
         ? createProjectGenericCredentials(project, payload)
@@ -143,16 +157,11 @@ export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...p
     if (credentialType === 'generic') {
       const data: Record<string, string> = {};
 
-      // @ts-expect-error zod infer problem
-      if (values?.data?.length > 0) {
-        // @ts-expect-error zod infer problem
-        for (const [k, v] of values.data) {
-          data[k] = v;
-        }
+      for (const [k, v] of values.data ?? []) {
+        data[k] = v;
       }
 
-      // @ts-expect-error zod infer problem
-      const replicate = values.replicate as boolean | undefined;
+      const replicate = values.replicate;
 
       if (editing) {
         return updateGenericMutation.mutate({ data, description: values.description, replicate });
@@ -162,15 +171,16 @@ export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...p
         name: values.name,
         data,
         description: values.description,
-        replicate
+        replicate,
+        type: values.secretType
       });
     }
 
     if (editing) {
-      return updateRepoMutation.mutate(values as ReturnType<typeof constructDefaults>);
+      return updateRepoMutation.mutate(values);
     }
 
-    return createRepoMutation.mutate(values as ReturnType<typeof constructDefaults>);
+    return createRepoMutation.mutate(values);
   });
 
   const isPending =
@@ -271,9 +281,33 @@ export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...p
           </div>
         )
       )}
+      {credentialType === 'generic' && (
+        <div className='mb-4'>
+          <label className='block mb-2'>Type</label>
+          <Controller
+            name='secretType'
+            control={control}
+            render={({ field }) => (
+              <AutoComplete
+                className='w-full'
+                options={k8sSecretTypeOptions}
+                placeholder='Opaque'
+                disabled={editing}
+                filterOption={(inputValue, option) =>
+                  (option?.value ?? '').toLowerCase().includes(inputValue.toLowerCase())
+                }
+                value={field.value}
+                onChange={(value) => field.onChange(value)}
+              />
+            )}
+          />
+          <Typography.Text type='secondary' className='text-xs'>
+            The Kubernetes Secret type
+          </Typography.Text>
+        </div>
+      )}
       {credentialType === 'generic' && !project && (
         <Controller
-          // @ts-expect-error zod infer problem
           name='replicate'
           control={control}
           render={({ field }) => (
@@ -293,12 +327,8 @@ export const CreateCredentialsModal = ({ project, onSuccess, editing, init, ...p
         />
       )}
       {credentialType === 'generic' && (
-        // @ts-expect-error expected type is there
         <FieldContainer control={control} name='data' label='Data'>
-          {({ field }) => (
-            // @ts-expect-error expected type is there
-            <SecretEditor secret={field.value as [string, string][]} onChange={field.onChange} />
-          )}
+          {({ field }) => <SecretEditor secret={field.value ?? []} onChange={field.onChange} />}
         </FieldContainer>
       )}
     </Modal>

--- a/ui/src/features/common/settings/secrets/generic-credentials-list.tsx
+++ b/ui/src/features/common/settings/secrets/generic-credentials-list.tsx
@@ -86,6 +86,11 @@ export const GenericCredentialsList = ({ project = '', description }: Props) => 
             render: (_, record) => record?.metadata?.name
           },
           {
+            title: 'Type',
+            key: 'type',
+            render: (_, record) => <Tag>{record?.type}</Tag>
+          },
+          {
             title: 'Keys',
             key: 'secrets',
             render: (_, record) => {

--- a/ui/src/features/common/settings/secrets/schema-validator.ts
+++ b/ui/src/features/common/settings/secrets/schema-validator.ts
@@ -6,87 +6,80 @@ import { zodValidators } from '@ui/utils/validators';
 const imageNameRegex =
   /^(?![a-zA-Z][a-zA-Z0-9+.-]*:\/\/)(\w+([.-]\w+)*(:\d+)?\/)?(\w+([.-]\w+)*)(\/\w+([.-]\w+)*)*$/;
 
-export const createFormSchema = (genericCreds: boolean, editing?: boolean) => {
-  let schema = z
-    .object({
-      name: zodValidators.requiredString.regex(
-        dnsRegex,
-        'Credentials name must be a valid DNS subdomain.'
-      ),
-      description: z.string().optional(),
-      type: zodValidators.requiredString,
-      repoUrl: zodValidators.requiredString,
-      repoUrlIsRegex: z.boolean().optional(),
-      username: zodValidators.requiredString,
-      password: editing ? z.string().optional() : zodValidators.requiredString
+// secretFormSchema is the unified shape backing both the repo credentials form
+// and the generic secret form. Repo- and generic-specific requirements are
+// enforced via conditional refinements in createFormSchema, so the inferred
+// type stays stable across both modes.
+const secretFormSchema = z.object({
+  name: zodValidators.requiredString.regex(
+    dnsRegex,
+    'Credentials name must be a valid DNS subdomain.'
+  ),
+  description: z.string().optional(),
+  type: zodValidators.requiredString,
+  repoUrl: z.string().optional(),
+  repoUrlIsRegex: z.boolean().optional(),
+  username: z.string().optional(),
+  password: z.string().optional(),
+  secretType: z.string().optional(),
+  data: z.array(z.tuple([z.string(), z.string()])).optional(),
+  replicate: z.boolean().optional()
+});
+
+export type SecretFormValues = z.infer<typeof secretFormSchema>;
+
+export const createFormSchema = (genericCreds: boolean, editing?: boolean) =>
+  secretFormSchema
+    .refine((data) => genericCreds || !!data.repoUrl, {
+      error: 'Repo URL is required.',
+      path: ['repoUrl']
     })
-    .check(
-      z.refine(
-        (data) => {
-          if (data.type === 'git' && !data.repoUrlIsRegex) {
-            try {
-              new URL(data.repoUrl);
-            } catch {
+    .refine((data) => genericCreds || !!data.username, {
+      error: 'Username is required.',
+      path: ['username']
+    })
+    .refine((data) => genericCreds || editing || !!data.password, {
+      error: 'Password is required.',
+      path: ['password']
+    })
+    .refine(
+      (data) => {
+        if (!genericCreds && data.type === 'git' && data.repoUrl && !data.repoUrlIsRegex) {
+          try {
+            new URL(data.repoUrl);
+          } catch {
+            return false;
+          }
+        }
+        return true;
+      },
+      { error: 'Repo URL must be a valid git URL.', path: ['repoUrl'] }
+    )
+    .refine(
+      (data) => {
+        if (!genericCreds && data.type === 'helm' && data.repoUrl && !data.repoUrlIsRegex) {
+          try {
+            const url = new URL(data.repoUrl);
+            if (url.protocol !== 'http:' && url.protocol !== 'https:' && url.protocol !== 'oci:') {
               return false;
             }
+          } catch {
+            return false;
           }
-
-          return true;
-        },
-        { error: 'Repo URL must be a valid git URL.', path: ['repoUrl'] }
-      ),
-      z.refine(
-        (data) => {
-          if (data.type === 'helm' && !data.repoUrlIsRegex) {
-            try {
-              const url = new URL(data.repoUrl);
-              if (
-                url.protocol !== 'http:' &&
-                url.protocol !== 'https:' &&
-                url.protocol !== 'oci:'
-              ) {
-                return false;
-              }
-            } catch {
-              return false;
-            }
-          }
-          return true;
-        },
-        {
-          error: 'Repo URL must be a valid Helm chart repository.',
-          path: ['repoUrl']
         }
-      ),
-      z.refine(
-        (data) => {
-          if (data.type === 'image' && !data.repoUrlIsRegex) {
-            return imageNameRegex.test(data.repoUrl);
-          }
-          return true;
-        },
-        {
-          error: 'Repo URL must be a valid container registry.',
-          path: ['repoUrl']
+        return true;
+      },
+      { error: 'Repo URL must be a valid Helm chart repository.', path: ['repoUrl'] }
+    )
+    .refine(
+      (data) => {
+        if (!genericCreds && data.type === 'image' && data.repoUrl && !data.repoUrlIsRegex) {
+          return imageNameRegex.test(data.repoUrl);
         }
-      )
-    );
-
-  if (genericCreds) {
-    // @ts-expect-error err
-    schema = z.object({
-      name: zodValidators.requiredString.regex(
-        dnsRegex,
-        'Credentials name must be a valid DNS subdomain.'
-      ),
-      description: z.string().optional(),
-      type: zodValidators.requiredString,
-      data: z.array(z.array(z.string())),
-      replicate: z.boolean().optional()
+        return true;
+      },
+      { error: 'Repo URL must be a valid container registry.', path: ['repoUrl'] }
+    )
+    .refine((data) => ['git', 'helm', 'image', 'generic'].includes(data.type), {
+      error: "Type must be one of 'git', 'helm', 'image' or 'generic'."
     });
-  }
-
-  return schema.refine((data) => ['git', 'helm', 'image', 'generic'].includes(data.type), {
-    error: "Type must be one of 'git', 'helm', 'image' or 'generic'."
-  });
-};

--- a/ui/src/features/common/settings/secrets/utils.tsx
+++ b/ui/src/features/common/settings/secrets/utils.tsx
@@ -9,6 +9,7 @@ import {
 } from '@ui/features/common/utils';
 import { V1Secret } from '@ui/gen/api/v2/models';
 
+import { SecretFormValues } from './schema-validator';
 import { CredentialTypeLabelKey, CredentialsDataKey, CredentialsType } from './types';
 
 export const typeLabel = (type: CredentialsType) => (
@@ -38,7 +39,7 @@ export const labelForKey = (s: string) =>
     .replace(/^./, (str) => str.toUpperCase())
     .replace('Url', 'URL');
 
-export const constructDefaults = (init?: V1Secret, type?: string) => {
+export const constructDefaults = (init?: V1Secret, type?: string): SecretFormValues => {
   if (!init) {
     return {
       name: '',
@@ -49,7 +50,8 @@ export const constructDefaults = (init?: V1Secret, type?: string) => {
       username: '',
       password: '',
       data: [],
-      replicate: false
+      replicate: false,
+      secretType: 'Opaque'
     };
   }
 
@@ -66,7 +68,8 @@ export const constructDefaults = (init?: V1Secret, type?: string) => {
     username: stringData[CredentialsDataKey.Username],
     password: '',
     data: redactSecretStringData(init),
-    replicate: annotations[REPLICATE_TO_ANNOTATION_KEY] === REPLICATE_TO_ALL_VALUE
+    replicate: annotations[REPLICATE_TO_ANNOTATION_KEY] === REPLICATE_TO_ALL_VALUE,
+    secretType: init?.type || 'Opaque'
   };
 };
 

--- a/ui/src/gen/api/v2/models/createGenericCredentialsRequest.ts
+++ b/ui/src/gen/api/v2/models/createGenericCredentialsRequest.ts
@@ -12,4 +12,8 @@ export interface CreateGenericCredentialsRequest {
   description?: string;
   name?: string;
   replicate?: boolean;
+  /** Type is the Kubernetes Secret type (e.g. "Opaque" or
+"kubernetes.io/dockerconfigjson"). It is immutable, so it may only be set
+at creation time. When empty, Kubernetes defaults it to "Opaque". */
+  type?: string;
 }


### PR DESCRIPTION
## Description

Closes #6445

Adds support for the Kubernetes Secret `type` field to the generic secrets ("Add Secret") UI flow. Previously the UI always created `Opaque` Secrets and never surfaced a Secret's type, so types like `kubernetes.io/dockerconfigjson` (needed for `imagePullSecrets`) could only be created via `kargo apply`.

- **Backend:** the generic-credentials *create* REST API now accepts an optional `type`, which is applied to the created Secret. When empty, Kubernetes defaults it to `Opaque`. Secret type is immutable, so it is only settable on create; the read path already preserves it (no change needed there). Swagger spec and Go client regenerated.
- **UI:** a "Type" field (AutoComplete defaulting to `Opaque`, with common Kubernetes secret types as suggestions) on the create modal, shown read-only when editing since the type is immutable; a "Type" column in the generic secrets list.
- **Cleanup:** unified the repo and generic form schemas into a single zod schema and derived the form value type via `z.infer`, removing the `@ts-expect-error` directives and the schema-reassignment hack.

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
