### PR TITLE
feat(promotion): expose ctx.targetFreight.alias in expression language

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -197,13 +197,22 @@ ctx
 ├── stage: string             # The name of the Stage
 ├── promotion: string         # The name of the Promotion
 ├── targetFreight
-│   ├── name: string          # The name of the Freight that is initiated this Promotion
+│   ├── name: string          # The name of the Freight that initiated this Promotion
+│   ├── alias: string         # The human-friendly alias of the Freight
 │   └── origin
 │       └── name: string      # The name of the Warehouse that contains the Freight
 └── meta
     └── promotion
-        └── actor: string     # The creator of the Promotion
+        ├── actor: string     # The creator of the Promotion
+        └── rollback: bool    # Whether this Promotion is a rollback
 ```
+
+:::warning
+Freight aliases (`ctx.targetFreight.alias`) are mutable — they can be changed
+by users at any time after Freight is created. Avoid using an alias anywhere
+its value must remain stable, such as in git commit messages, artifact paths,
+or any other durable record.
+:::
 
 The following example promotion process clones a repository and checks out
 two branches to different directories, uses Kustomize with source from one

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -193,6 +193,7 @@ The `ctx` object has the following structure:
 
 ```console
 ctx
+├── uiBaseUrl: string         # The base URL of the Kargo UI
 ├── project: string           # The name of the Project
 ├── stage: string             # The name of the Stage
 ├── promotion: string         # The name of the Promotion
@@ -202,9 +203,11 @@ ctx
 │   └── origin
 │       └── name: string      # The name of the Warehouse that contains the Freight
 └── meta
-    └── promotion
-        ├── actor: string     # The creator of the Promotion
-        └── rollback: bool    # Whether this Promotion is a rollback
+    ├── promotion
+    │   ├── actor: string     # The creator of the Promotion
+    │   └── rollback: bool    # Whether this Promotion is a rollback
+    └── step
+        └── alias: string     # The alias of the current step
 ```
 
 :::warning

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -601,6 +601,7 @@ func (r *reconciler) promote(
 		workingPromo,
 		stage,
 		promotion.WithActor(api.CreateActorAnnotationValue(&promo)),
+		promotion.WithTargetFreightAlias(targetFreight.Alias),
 		promotion.WithUIBaseURL(r.cfg.APIServerBaseURL),
 		promotion.WithWorkDir(promotionWorkDir(workingPromo.UID)),
 	)

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -254,7 +254,7 @@ func RunningPromotionsByArgoCDApplications(
 					for _, app := range appsList {
 						if app, ok := app.(map[string]any); ok {
 							if nameTemplate, ok := app["name"].(string); ok {
-								env := evaluator.BuildExprEnv(
+								env := promotion.BuildExprEnv(
 									promoCtx,
 									promotion.ExprEnvWithOutputs(promoCtx.State),
 									promotion.ExprEnvWithTaskOutputs(dirStep.Alias, promoCtx.State),

--- a/pkg/promotion/evaluator.go
+++ b/pkg/promotion/evaluator.go
@@ -89,6 +89,40 @@ func ExprEnvWithTaskOutputs(alias string, outputs State) ExprEnvOption {
 	}
 }
 
+// BuildCtxMap builds the "ctx" entry of the expression language environment
+// for a Promotion step. The returned map has a single "ctx" key whose value
+// contains all promotion and step context fields available to expressions.
+//
+// It is exported so that external step executors (e.g. pod-based runners that
+// receive a StepContext over a file channel) can build a consistent expression
+// environment without reimplementing this mapping.
+func BuildCtxMap(stepCtx StepContext) map[string]any {
+	return map[string]any{
+		"ctx": map[string]any{
+			"uiBaseUrl": stepCtx.UIBaseURL,
+			"project":   stepCtx.Project,
+			"promotion": stepCtx.Promotion,
+			"stage":     stepCtx.Stage,
+			"targetFreight": map[string]any{
+				"name":  stepCtx.TargetFreightRef.Name,
+				"alias": stepCtx.TargetFreightAlias,
+				"origin": map[string]any{
+					"name": stepCtx.TargetFreightRef.Origin.Name,
+				},
+			},
+			"meta": map[string]any{
+				"promotion": map[string]any{
+					"actor":    stepCtx.PromotionActor,
+					"rollback": stepCtx.Rollback,
+				},
+				"step": map[string]any{
+					"alias": stepCtx.Alias,
+				},
+			},
+		},
+	}
+}
+
 // BuildExprEnv builds an environment map for evaluating expressions in
 // Promotion steps. The environment includes context information, such as the
 // Project, Promotion, Stage, and target Freight reference.
@@ -96,28 +130,18 @@ func ExprEnvWithTaskOutputs(alias string, outputs State) ExprEnvOption {
 // The environment can be extended with additional options provided via the
 // ExprEnvOption functional options. These options can be used to add variables
 // or modify the expression language environment.
-func (p *StepEvaluator) BuildExprEnv(promoCtx Context, opts ...ExprEnvOption) map[string]any {
-	env := map[string]any{
-		"ctx": map[string]any{
-			"project":   promoCtx.Project,
-			"promotion": promoCtx.Promotion,
-			"stage":     promoCtx.Stage,
-			"targetFreight": map[string]any{
-				"name": promoCtx.TargetFreightRef.Name,
-				"origin": map[string]any{
-					"name": promoCtx.TargetFreightRef.Origin.Name,
-				},
-			},
-			"meta": map[string]any{
-				"promotion": map[string]any{
-					"actor":    promoCtx.Actor,
-					"rollback": promoCtx.Rollback,
-				},
-			},
-		},
-	}
+func BuildExprEnv(promoCtx Context, opts ...ExprEnvOption) map[string]any {
+	env := BuildCtxMap(StepContext{
+		UIBaseURL:          promoCtx.UIBaseURL,
+		Project:            promoCtx.Project,
+		Promotion:          promoCtx.Promotion,
+		Stage:              promoCtx.Stage,
+		TargetFreightRef:   promoCtx.TargetFreightRef,
+		TargetFreightAlias: promoCtx.TargetFreightAlias,
+		PromotionActor:     promoCtx.Actor,
+		Rollback:           promoCtx.Rollback,
+	})
 
-	// Apply all provided options
 	for _, opt := range opts {
 		opt(env)
 	}
@@ -152,7 +176,7 @@ func (p *StepEvaluator) Vars(ctx context.Context, promoCtx Context, step Step) (
 	for _, v := range promoCtx.Vars {
 		newVar, err := expressions.EvaluateTemplate(
 			v.Value,
-			p.BuildExprEnv(promoCtx, ExprEnvWithVars(vars)),
+			BuildExprEnv(promoCtx, ExprEnvWithVars(vars)),
 			exprOpts...,
 		)
 		if err != nil {
@@ -166,7 +190,7 @@ func (p *StepEvaluator) Vars(ctx context.Context, promoCtx Context, step Step) (
 	for _, v := range step.Vars {
 		newVar, err := expressions.EvaluateTemplate(
 			v.Value,
-			p.BuildExprEnv(
+			BuildExprEnv(
 				promoCtx,
 				ExprEnvWithStepMetas(promoCtx),
 				ExprEnvWithOutputs(promoCtx.State),
@@ -202,7 +226,7 @@ func (p *StepEvaluator) ShouldSkip(ctx context.Context, promoCtx Context, step S
 		return false, err
 	}
 
-	env := p.BuildExprEnv(
+	env := BuildExprEnv(
 		promoCtx,
 		ExprEnvWithStepMetas(promoCtx),
 		ExprEnvWithOutputs(promoCtx.State),
@@ -253,7 +277,7 @@ func (p *StepEvaluator) Config(ctx context.Context, promoCtx Context, step Step)
 		return nil, err
 	}
 
-	env := p.BuildExprEnv(
+	env := BuildExprEnv(
 		promoCtx,
 		ExprEnvWithStepMetas(promoCtx),
 		ExprEnvWithOutputs(promoCtx.State),
@@ -311,19 +335,20 @@ func (p *StepEvaluator) BuildStepContext(
 	}
 
 	return &StepContext{
-		UIBaseURL:        promoCtx.UIBaseURL,
-		WorkDir:          promoCtx.WorkDir,
-		SharedState:      promoCtx.State.DeepCopy(),
-		Alias:            step.Alias,
-		Config:           stepCfg,
-		Project:          promoCtx.Project,
-		Stage:            promoCtx.Stage,
-		Promotion:        promoCtx.Promotion,
-		PromotionActor:   promoCtx.Actor,
-		Rollback:         promoCtx.Rollback,
-		FreightRequests:  freightRequests,
-		Freight:          *promoCtx.Freight.DeepCopy(),
-		TargetFreightRef: promoCtx.TargetFreightRef,
+		UIBaseURL:          promoCtx.UIBaseURL,
+		WorkDir:            promoCtx.WorkDir,
+		SharedState:        promoCtx.State.DeepCopy(),
+		Alias:              step.Alias,
+		Config:             stepCfg,
+		Project:            promoCtx.Project,
+		Stage:              promoCtx.Stage,
+		Promotion:          promoCtx.Promotion,
+		PromotionActor:     promoCtx.Actor,
+		Rollback:           promoCtx.Rollback,
+		FreightRequests:    freightRequests,
+		Freight:            *promoCtx.Freight.DeepCopy(),
+		TargetFreightRef:   promoCtx.TargetFreightRef,
+		TargetFreightAlias: promoCtx.TargetFreightAlias,
 	}, nil
 }
 

--- a/pkg/promotion/evaluator.go
+++ b/pkg/promotion/evaluator.go
@@ -96,6 +96,9 @@ func ExprEnvWithTaskOutputs(alias string, outputs State) ExprEnvOption {
 // It is exported so that external step executors (e.g. pod-based runners that
 // receive a StepContext over a file channel) can build a consistent expression
 // environment without reimplementing this mapping.
+// NOTE: When modifying the structure returned by this function, update the
+// ctx object documentation in
+// docs/docs/50-user-guide/60-reference-docs/40-expressions.md.
 func BuildCtxMap(stepCtx StepContext) map[string]any {
 	return map[string]any{
 		"ctx": map[string]any{
@@ -131,6 +134,10 @@ func BuildCtxMap(stepCtx StepContext) map[string]any {
 // ExprEnvOption functional options. These options can be used to add variables
 // or modify the expression language environment.
 func BuildExprEnv(promoCtx Context, opts ...ExprEnvOption) map[string]any {
+	var stepAlias string
+	if promoCtx.currentStepMetadata != nil {
+		stepAlias = promoCtx.currentStepMetadata.Alias
+	}
 	env := BuildCtxMap(StepContext{
 		UIBaseURL:          promoCtx.UIBaseURL,
 		Project:            promoCtx.Project,
@@ -140,6 +147,7 @@ func BuildExprEnv(promoCtx Context, opts ...ExprEnvOption) map[string]any {
 		TargetFreightAlias: promoCtx.TargetFreightAlias,
 		PromotionActor:     promoCtx.Actor,
 		Rollback:           promoCtx.Rollback,
+		Alias:              stepAlias,
 	})
 
 	for _, opt := range opts {

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -22,11 +22,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "basic context environment",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -53,7 +54,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -62,11 +63,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with variables option",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -100,7 +102,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -114,11 +116,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with step metas option",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -169,7 +172,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -188,11 +191,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with outputs option",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -227,7 +231,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -242,11 +246,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with task outputs option - has task outputs",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -284,7 +289,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -303,11 +308,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with task outputs option - no task outputs",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -339,7 +345,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},
@@ -348,11 +354,12 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with multiple options",
 			promoCtx: Context{
-				Project:            "test-project",
-				Stage:              "test-stage",
-				Promotion:          "test-promotion",
-				Actor:              "test-actor",
-				TargetFreightAlias: "test-alias",
+				Project:             "test-project",
+				Stage:               "test-stage",
+				Promotion:           "test-promotion",
+				Actor:               "test-actor",
+				TargetFreightAlias:  "test-alias",
+				currentStepMetadata: &StepMetadata{Alias: "test-step"},
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -406,7 +413,7 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"rollback": false,
 						},
 						"step": map[string]any{
-							"alias": "",
+							"alias": "test-step",
 						},
 					},
 				},

--- a/pkg/promotion/evaluator_test.go
+++ b/pkg/promotion/evaluator_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestStepEvaluator_BuildExprEnv(t *testing.T) {
-	testClient := fake.NewClientBuilder().Build()
-
 	tests := []struct {
 		name     string
 		promoCtx Context
@@ -24,10 +22,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "basic context environment",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -37,11 +36,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -51,6 +52,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"actor":    "test-actor",
 							"rollback": false,
 						},
+						"step": map[string]any{
+							"alias": "",
+						},
 					},
 				},
 			},
@@ -58,10 +62,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with variables option",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -78,11 +83,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -91,6 +98,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 						"promotion": map[string]any{
 							"actor":    "test-actor",
 							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
 						},
 					},
 				},
@@ -104,10 +114,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with step metas option",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -141,11 +152,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -154,6 +167,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 						"promotion": map[string]any{
 							"actor":    "test-actor",
 							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
 						},
 					},
 				},
@@ -172,10 +188,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with outputs option",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -193,11 +210,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -206,6 +225,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 						"promotion": map[string]any{
 							"actor":    "test-actor",
 							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
 						},
 					},
 				},
@@ -220,10 +242,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with task outputs option - has task outputs",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -244,11 +267,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -257,6 +282,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 						"promotion": map[string]any{
 							"actor":    "test-actor",
 							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
 						},
 					},
 				},
@@ -275,10 +303,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with task outputs option - no task outputs",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -293,11 +322,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -307,6 +338,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"actor":    "test-actor",
 							"rollback": false,
 						},
+						"step": map[string]any{
+							"alias": "",
+						},
 					},
 				},
 			},
@@ -314,10 +348,11 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 		{
 			name: "with multiple options",
 			promoCtx: Context{
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				TargetFreightRef: kargoapi.FreightReference{
 					Name: "test-freight",
 					Origin: kargoapi.FreightOrigin{
@@ -354,11 +389,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "test-project",
 					"promotion": "test-promotion",
 					"stage":     "test-stage",
 					"targetFreight": map[string]any{
-						"name": "test-freight",
+						"name":  "test-freight",
+						"alias": "test-alias",
 						"origin": map[string]any{
 							"name": "test-warehouse",
 						},
@@ -367,6 +404,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 						"promotion": map[string]any{
 							"actor":    "test-actor",
 							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
 						},
 					},
 				},
@@ -398,11 +438,13 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 			},
 			expected: map[string]any{
 				"ctx": map[string]any{
+					"uiBaseUrl": "",
 					"project":   "",
 					"promotion": "",
 					"stage":     "",
 					"targetFreight": map[string]any{
-						"name": "",
+						"name":  "",
+						"alias": "",
 						"origin": map[string]any{
 							"name": "",
 						},
@@ -412,6 +454,9 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 							"actor":    "",
 							"rollback": false,
 						},
+						"step": map[string]any{
+							"alias": "",
+						},
 					},
 				},
 			},
@@ -420,8 +465,94 @@ func TestStepEvaluator_BuildExprEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			evaluator := NewStepEvaluator(testClient, nil)
-			result := evaluator.BuildExprEnv(tt.promoCtx, tt.opts...)
+			result := BuildExprEnv(tt.promoCtx, tt.opts...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildCtxMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepCtx  StepContext
+		expected map[string]any
+	}{
+		{
+			name: "full step context",
+			stepCtx: StepContext{
+				UIBaseURL:          "https://kargo.example.com",
+				Project:            "test-project",
+				Promotion:          "test-promotion",
+				Stage:              "test-stage",
+				Alias:              "my-step",
+				PromotionActor:     "test-actor",
+				Rollback:           true,
+				TargetFreightAlias: "test-alias",
+				TargetFreightRef: kargoapi.FreightReference{
+					Name: "test-freight",
+					Origin: kargoapi.FreightOrigin{
+						Name: "test-warehouse",
+					},
+				},
+			},
+			expected: map[string]any{
+				"ctx": map[string]any{
+					"uiBaseUrl": "https://kargo.example.com",
+					"project":   "test-project",
+					"promotion": "test-promotion",
+					"stage":     "test-stage",
+					"targetFreight": map[string]any{
+						"name":  "test-freight",
+						"alias": "test-alias",
+						"origin": map[string]any{
+							"name": "test-warehouse",
+						},
+					},
+					"meta": map[string]any{
+						"promotion": map[string]any{
+							"actor":    "test-actor",
+							"rollback": true,
+						},
+						"step": map[string]any{
+							"alias": "my-step",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "empty step context",
+			stepCtx: StepContext{},
+			expected: map[string]any{
+				"ctx": map[string]any{
+					"uiBaseUrl": "",
+					"project":   "",
+					"promotion": "",
+					"stage":     "",
+					"targetFreight": map[string]any{
+						"name":  "",
+						"alias": "",
+						"origin": map[string]any{
+							"name": "",
+						},
+					},
+					"meta": map[string]any{
+						"promotion": map[string]any{
+							"actor":    "",
+							"rollback": false,
+						},
+						"step": map[string]any{
+							"alias": "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildCtxMap(tt.stepCtx)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -1450,12 +1581,13 @@ func TestStepEvaluator_BuildStepContext(t *testing.T) {
 		{
 			name: "builds step context with all fields",
 			promoCtx: Context{
-				UIBaseURL: "https://kargo.example.com",
-				WorkDir:   "/tmp/workdir",
-				Project:   "test-project",
-				Stage:     "test-stage",
-				Promotion: "test-promotion",
-				Actor:     "test-actor",
+				UIBaseURL:          "https://kargo.example.com",
+				WorkDir:            "/tmp/workdir",
+				Project:            "test-project",
+				Stage:              "test-stage",
+				Promotion:          "test-promotion",
+				Actor:              "test-actor",
+				TargetFreightAlias: "test-alias",
 				State: State{
 					"key": "value",
 				},
@@ -1498,6 +1630,7 @@ func TestStepEvaluator_BuildStepContext(t *testing.T) {
 				assert.Equal(t, "test-actor", stepCtx.PromotionActor)
 				assert.Equal(t, "target-freight", stepCtx.TargetFreightRef.Name)
 				assert.Equal(t, "target-warehouse", stepCtx.TargetFreightRef.Origin.Name)
+				assert.Equal(t, "test-alias", stepCtx.TargetFreightAlias)
 
 				// Verify state is deep copied
 				assert.Equal(t, State{"key": "value"}, stepCtx.SharedState)

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -54,6 +54,9 @@ type Context struct {
 	Freight kargoapi.FreightCollection
 	// TargetFreightRef is the actual Freight that triggered this Promotion.
 	TargetFreightRef kargoapi.FreightReference
+	// TargetFreightAlias is the human-friendly alias of the Freight that
+	// triggered this Promotion.
+	TargetFreightAlias string
 	// StartFromStep is the index of the step from which the promotion should
 	// begin execution.
 	StartFromStep int64
@@ -127,6 +130,13 @@ func WithWorkDir(dir string) ContextOption {
 func WithActor(actor string) ContextOption {
 	return func(c *Context) {
 		c.Actor = actor
+	}
+}
+
+// WithTargetFreightAlias sets the TargetFreightAlias of the Context.
+func WithTargetFreightAlias(alias string) ContextOption {
+	return func(c *Context) {
+		c.TargetFreightAlias = alias
 	}
 }
 
@@ -418,6 +428,9 @@ type StepContext struct {
 	Freight kargoapi.FreightCollection
 	// TargetFreightRef is the actual Freight that triggered this Promotion.
 	TargetFreightRef kargoapi.FreightReference
+	// TargetFreightAlias is the human-friendly alias of the Freight that
+	// triggered this Promotion.
+	TargetFreightAlias string
 }
 
 // StepResult represents the results of a single Step of a user-defined promotion


### PR DESCRIPTION
## Description

Resolves https://github.com/akuity/kargo/issues/4584

**Feature:**
- Adds `ctx.targetFreight.alias` to the promotion expression language environment, giving step authors access to the human-friendly alias of the Freight being promoted.

**Refactor:**
- Adds `TargetFreightAlias` to StepContext so that external step executors receiving a serialized StepContext (e.g. pod-based runners) can access the alias without needing the full promotion Context.
- Exports `BuildCtxMap(StepContext)` `map[string]any` as a package-level function so that external executors can construct a consistent expression environment without reimplementing the field mapping.
- Promotes `BuildExprEnv` from a method on `StepEvaluator` to a package-level function — it never used receiver state, and the cleanup makes the public surface clearer.


### Demo

https://github.com/user-attachments/assets/1251a24b-3a28-41e8-9386-2d2e9346ada1



## Checklist

### Eligibility
- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).

### Quality

- [x] Adds or updates corresponding tests.
- [x] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:
- [x] Are signed off by their author (`git commit -s`) **(required)**
