### PR TITLE
ci: derive release version from release.tag_name instead of github.ref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
         images: ${{ steps.repo.outputs.repo }}
         flavor: latest=false
         tags: |
-          type=semver,pattern={{raw}}
+          type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
           type=raw,value=${{ steps.unstable-version.outputs.unstable-version }},enable=${{ github.event_name != 'release'}}
     - name: Build base image
       run: |
@@ -94,7 +94,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         build-args: |
           BASE_IMAGE=localhost:5000/kargo-base
-          VERSION=${{ github.ref_name }}
+          VERSION=${{ github.event.release.tag_name || github.ref_name }}
           GIT_COMMIT=${{ github.sha }}
           GIT_TREE_STATE=clean
         tags: ${{ steps.meta.outputs.tags }}
@@ -170,7 +170,7 @@ jobs:
     - name: Determine Version
       id: version
       run: |
-        VERSION=${{ github.ref_name }}
+        VERSION=${{ github.event.release.tag_name }}
         if ${{ github.event_name != 'release' }}
         then
         VERSION=${{ needs.publish-image.outputs.unstable-version }}
@@ -223,7 +223,7 @@ jobs:
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Build UI
       env:
-        VERSION: ${{ github.ref_name }}
+        VERSION: ${{ github.event.release.tag_name || github.ref_name }}
       working-directory: ./ui
       run: |
         pnpm install
@@ -279,7 +279,7 @@ jobs:
         GOFLAGS: -buildvcs=false
         GOOS: ${{ matrix.os }}
         GOARCH: ${{ matrix.arch }}
-        VERSION: ${{ github.ref_name }}
+        VERSION: ${{ github.event.release.tag_name }}
         GIT_COMMIT: ${{ github.sha }}
         GIT_TREE_STATE: clean
       run: make build-cli
@@ -299,6 +299,7 @@ jobs:
       with:
         file: bin/*
         file_glob: true
+        tag: ${{ github.event.release.tag_name }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate subject
       id: hash


### PR DESCRIPTION
The Release workflow relied on github.ref / github.ref_name to determine the version for the image tag, image/CLI/UI VERSION build args, the Helm chart version, and the upload-release-action tag. github.ref can arrive empty for release-triggered workflows (see actions/runner#2788: https://github.com/actions/runner/issues/2788), which broke the v1.10.8 release run: github.ref came through empty, so docker/metadata-action's type=semver emitted no tags ("tag is needed when pushing to registry") and upload-release-action failed with "Input required and not supplied: tag".

Failed run (note 'ref:' empty in the Docker meta context dump): https://github.com/akuity/kargo/actions/runs/28207444087

Use github.event.release.tag_name, which is populated from the release event payload regardless of how github.ref resolves. Jobs that also run for scheduled/dispatch (unstable) builds fall back to github.ref_name so non-release behavior is unchanged.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [X] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.
