### PR TITLE
chore(docs): Update event reference for `FreightCreated`

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
@@ -131,6 +131,7 @@ The complete list of built-in Kargo event types is provided below:
 - `PromotionFailed`
 - `PromotionErrored`
 - `PromotionAborted`
+- `FreightCreated`
 - `FreightApproved`
 - `FreightVerificationSucceeded`
 - `FreightVerificationFailed`
@@ -193,6 +194,15 @@ This event is emitted when a promotion run is aborted before completion.
 
 - [Common event fields](#common-event-fields)
 - [Promotion fields](#promotion-fields)
+
+### `FreightCreated`
+
+This event is emitted when a new piece of freight is created by a warehouse or the API server.
+
+**Payload Includes**
+
+- [Common event fields](#common-event-fields)
+- [Freight fields](#freight-fields)
 
 ### `FreightApproved`
 


### PR DESCRIPTION
We missed this when we first added in the FreightCreated event in #6321