### PR TITLE
docs(git-clone): document recurseSubmodules option

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/git-clone.md
@@ -32,6 +32,7 @@ system to access the git repos.
 | `repoURL` | `string` | Y | The URL of a remote Git repository to clone. **Deprecated:** Support for SSH URLs (`ssh://` and SCP-style `git@host:path`) is deprecated as of v1.10.0 and will be removed in v1.13.0. Use HTTPS URLs instead. |
 | `insecureSkipTLSVerify` | `boolean` | N | Whether to bypass TLS certificate verification when cloning (and for all subsequent operations involving this clone). Setting this to `true` is highly discouraged in production. |
 | `blobless` | `boolean` | N | Whether to perform a [blobless clone][] (`--filter=blob:none`). Defaults to `false`. Useful for large repositories, especially when combined with sparse checkouts. Requires that the Git server support partial clones; the clone will fail if it does not. |
+| `recurseSubmodules` | `boolean` | N | Whether to recursively initialize and update [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for every checkout. Defaults to `false`. When `true`, the equivalent of `git submodule update --init --recursive` is run for each working tree. Any credentials provided for `repoURL` must also be valid for all submodule repositories, or the step will fail. |
 | `author` | `[]object` | N | Default authorship information for any commits made to the cloned repository. If provided, this overrides any system-level defaults. Note: Configuration of the [`git-commit`](./git-commit.md) step can override this information. |
 | `author.name` | `string` | Y | The committer's name. |
 | `author.email` | `string` | Y | The committer's email address. |
@@ -166,6 +167,41 @@ steps:
 `blobless: true` requires that the Git server support partial clones. Most
 hosted services (GitHub, GitLab, Gitea) do; some older self-hosted servers do
 not, in which case the clone will fail.
+
+:::
+
+### Submodules
+
+If the repository references [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules),
+set `recurseSubmodules: true` to recursively initialize and update them for
+every checkout. This runs the equivalent of `git submodule update --init
+--recursive` against each working tree after it has been checked out.
+
+```yaml
+vars:
+- name: gitRepo
+  value: https://github.com/example/repo.git
+steps:
+- uses: git-clone
+  config:
+    repoURL: ${{ vars.gitRepo }}
+    recurseSubmodules: true
+    checkout:
+    - commit: ${{ commitFrom(vars.gitRepo).ID }}
+      path: ./src
+    - branch: stage/${{ ctx.stage }}
+      create: true
+      path: ./out
+# Work with the checkouts, including their submodules...
+```
+
+:::note
+
+The [credentials](#credentials) provided for `repoURL` must also be valid for
+every submodule repository. If a submodule resides in a repository that requires
+different credentials, the submodule update will fail. Submodules that use
+relative URLs and live on the same host as `repoURL` typically work without
+additional configuration.
 
 :::
 


### PR DESCRIPTION
## Summary

The `git-clone` promotion step gained a `recurseSubmodules` field in v1.9.0 (#4974), but it was never documented in the reference docs. This PR documents it.

Fixes #6363

## Changes

- Add a `recurseSubmodules` row to the Configuration table in the `git-clone` reference docs.
- Add a dedicated **Submodules** section with an example, mirroring the existing **Sparse Checkout** section, explaining that it runs the equivalent of `git submodule update --init --recursive` for each checkout and that the provided credentials must also be valid for the submodule repositories.

## Notes

Docs-only change; no code or tests affected.