### PR TITLE
fix(controller): deflake startVerification via injected clock

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -1071,7 +1071,7 @@ func (r *RegularStageReconciler) verifyStageFreight(
 				logger.Debug("aborting verification of Stage Freight")
 
 				// Abort the verification.
-				newVI, err = r.abortVerification(ctx, *curFreight, abortReq)
+				newVI, err = r.abortVerification(ctx, *curFreight, abortReq, endTime)
 				if newVI != nil {
 					newStatus.FreightHistory.Current().VerificationHistory.UpdateOrPush(*newVI)
 				}
@@ -1085,7 +1085,7 @@ func (r *RegularStageReconciler) verifyStageFreight(
 			}
 
 			// Get the latest result of the verification.
-			newVI, err = r.getVerificationResult(ctx, *curFreight)
+			newVI, err = r.getVerificationResult(ctx, *curFreight, endTime)
 			if newVI != nil {
 				newStatus.FreightHistory.Current().VerificationHistory.UpdateOrPush(*newVI)
 
@@ -1134,7 +1134,7 @@ func (r *RegularStageReconciler) verifyStageFreight(
 	}
 
 	// Start a new (re-)verification.
-	newVI, err = r.startVerification(ctx, stage, *curFreight, reverifyReq, startTime)
+	newVI, err = r.startVerification(ctx, stage, *curFreight, reverifyReq, startTime, endTime)
 	if newVI != nil {
 		newStatus.FreightHistory.Current().VerificationHistory.UpdateOrPush(*newVI)
 
@@ -1308,6 +1308,7 @@ func (r *RegularStageReconciler) startVerification(
 	freight kargoapi.FreightCollection,
 	req *kargoapi.VerificationRequest,
 	startTime time.Time,
+	endTime func() time.Time,
 ) (*kargoapi.VerificationInfo, error) {
 	newVI := &kargoapi.VerificationInfo{
 		ID:        uuid.NewString(),
@@ -1324,7 +1325,7 @@ func (r *RegularStageReconciler) startVerification(
 	// Return early, as we cannot start the verification if the Rollouts
 	// integration is disabled.
 	if !r.cfg.RolloutsIntegrationEnabled {
-		newVI.FinishTime = ptr.To(metav1.Now())
+		newVI.FinishTime = ptr.To(metav1.NewTime(endTime()))
 		newVI.Phase = kargoapi.VerificationPhaseError
 		newVI.Message = "Rollouts integration is disabled on this controller: cannot start verification"
 		return newVI, nil
@@ -1341,7 +1342,7 @@ func (r *RegularStageReconciler) startVerification(
 			Name:      stage.Name,
 		}, freight.ID)
 		if err != nil {
-			newVI.FinishTime = ptr.To(metav1.Now())
+			newVI.FinishTime = ptr.To(metav1.NewTime(endTime()))
 			newVI.Phase = kargoapi.VerificationPhaseError
 			newVI.Message = err.Error()
 			return newVI, nil
@@ -1350,7 +1351,7 @@ func (r *RegularStageReconciler) startVerification(
 		if existingAnalysisRun != nil {
 			logger.Debug("AnalysisRun already exists for FreightCollection")
 
-			newVI.FinishTime = ptr.To(metav1.Now())
+			newVI.FinishTime = ptr.To(metav1.NewTime(endTime()))
 			newVI.Phase = kargoapi.VerificationPhase(existingAnalysisRun.Status.Phase)
 			newVI.AnalysisRun = &kargoapi.AnalysisRunReference{
 				Name:      existingAnalysisRun.Name,
@@ -1423,7 +1424,7 @@ func (r *RegularStageReconciler) startVerification(
 	}
 	ar, err := builder.Build(ctx, stage.Namespace, stage.Spec.Verification, builderOpts...)
 	if err != nil {
-		newVI.FinishTime = ptr.To(metav1.Now())
+		newVI.FinishTime = ptr.To(metav1.NewTime(endTime()))
 		newVI.Phase = kargoapi.VerificationPhaseError
 		newVI.Message = fmt.Errorf(
 			"error building AnalysisRun for Stage %q and Freight collection %q in namespace %q: %w",
@@ -1435,7 +1436,7 @@ func (r *RegularStageReconciler) startVerification(
 		return newVI, nil
 	}
 	if err = r.client.Create(ctx, ar); err != nil {
-		newVI.FinishTime = ptr.To(metav1.Now())
+		newVI.FinishTime = ptr.To(metav1.NewTime(endTime()))
 		newVI.Phase = kargoapi.VerificationPhaseError
 		newVI.Message = fmt.Errorf(
 			"error creating AnalysisRun %q in namespace %q: %w",
@@ -1468,6 +1469,7 @@ func (r *RegularStageReconciler) startVerification(
 func (r *RegularStageReconciler) getVerificationResult(
 	ctx context.Context,
 	freight kargoapi.FreightCollection,
+	endTime func() time.Time,
 ) (*kargoapi.VerificationInfo, error) {
 	// Ensure all necessary information is available to get the verification.
 	currentVI := freight.VerificationHistory.Current()
@@ -1487,7 +1489,7 @@ func (r *RegularStageReconciler) getVerificationResult(
 		return &kargoapi.VerificationInfo{
 			ID:         currentVI.ID,
 			StartTime:  currentVI.StartTime,
-			FinishTime: ptr.To(metav1.Now()),
+			FinishTime: ptr.To(metav1.NewTime(endTime())),
 			Phase:      kargoapi.VerificationPhaseError,
 			Message:    "Rollouts integration is disabled on this controller: cannot get verification result",
 		}, nil
@@ -1545,6 +1547,7 @@ func (r *RegularStageReconciler) abortVerification(
 	ctx context.Context,
 	freight kargoapi.FreightCollection,
 	req *kargoapi.VerificationRequest,
+	endTime func() time.Time,
 ) (*kargoapi.VerificationInfo, error) {
 	// Ensure all necessary information is available to abort the verification.
 	currentVI := freight.VerificationHistory.Current()
@@ -1577,7 +1580,7 @@ func (r *RegularStageReconciler) abortVerification(
 			ID:          currentVI.ID,
 			Actor:       actor,
 			StartTime:   currentVI.StartTime,
-			FinishTime:  ptr.To(metav1.Now()),
+			FinishTime:  ptr.To(metav1.NewTime(endTime())),
 			Phase:       kargoapi.VerificationPhaseError,
 			Message:     "Rollouts integration is disabled on this controller: cannot abort verification",
 			AnalysisRun: currentVI.AnalysisRun.DeepCopy(),
@@ -1603,7 +1606,7 @@ func (r *RegularStageReconciler) abortVerification(
 			ID:         currentVI.ID,
 			Actor:      actor,
 			StartTime:  currentVI.StartTime,
-			FinishTime: ptr.To(metav1.Now()),
+			FinishTime: ptr.To(metav1.NewTime(endTime())),
 			Phase:      kargoapi.VerificationPhaseError,
 			Message: fmt.Errorf(
 				"error terminating AnalysisRun %q in namespace %q: %w", ar.Name, ar.Namespace, err,
@@ -1621,7 +1624,7 @@ func (r *RegularStageReconciler) abortVerification(
 		ID:          currentVI.ID,
 		Actor:       actor,
 		StartTime:   currentVI.StartTime,
-		FinishTime:  ptr.To(metav1.Now()),
+		FinishTime:  ptr.To(metav1.NewTime(endTime())),
 		Phase:       kargoapi.VerificationPhaseFailed,
 		Message:     "Verification aborted by user",
 		AnalysisRun: currentVI.AnalysisRun.DeepCopy(),

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -3612,7 +3612,9 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 	require.NoError(t, kargoapi.AddToScheme(scheme))
 	require.NoError(t, rolloutsapi.AddToScheme(scheme))
 
-	now := time.Now()
+	startTime := time.Now()
+	endTime := startTime.Add(5 * time.Minute)
+	fixedEndTime := func() time.Time { return endTime }
 
 	tests := []struct {
 		name             string
@@ -3648,8 +3650,9 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.NotEmpty(t, vi.ID)
 				assert.Equal(t, kargoapi.VerificationPhaseError, vi.Phase)
 				assert.Contains(t, vi.Message, "Rollouts integration is disabled")
-				assert.Equal(t, now, vi.StartTime.Time)
-				assert.NotNil(t, vi.FinishTime)
+				assert.Equal(t, startTime, vi.StartTime.Time)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -3692,13 +3695,12 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.NotEmpty(t, vi.ID)
 				assert.Equal(t, kargoapi.VerificationPhaseSuccessful, vi.Phase)
 				assert.Equal(t, "existing-analysis", vi.AnalysisRun.Name)
-				// Both timestamps should be the reconciliation time so that
-				// startTime <= finishTime always holds regardless of when the
-				// AnalysisRun internally ran.
+				// StartTime is the injected reconciliation time; FinishTime is
+				// the injected end time stamped when the result is recorded.
 				require.NotNil(t, vi.StartTime)
 				require.NotNil(t, vi.FinishTime)
-				assert.Equal(t, now.Unix(), vi.StartTime.Unix())
-				assert.Equal(t, now.Unix(), vi.FinishTime.Unix())
+				assert.Equal(t, startTime.Unix(), vi.StartTime.Unix())
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -3746,8 +3748,8 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				assert.Equal(t, "existing-analysis", vi.AnalysisRun.Name)
 				require.NotNil(t, vi.StartTime)
 				require.NotNil(t, vi.FinishTime)
-				assert.Equal(t, now.Unix(), vi.StartTime.Unix())
-				assert.Equal(t, now.Unix(), vi.FinishTime.Unix())
+				assert.Equal(t, startTime.Unix(), vi.StartTime.Unix())
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -4032,7 +4034,7 @@ func TestRegularStageReconciler_startVerification(t *testing.T) {
 				},
 			}
 
-			vi, err := r.startVerification(t.Context(), tt.stage, tt.freightCol, tt.req, now)
+			vi, err := r.startVerification(t.Context(), tt.stage, tt.freightCol, tt.req, startTime, fixedEndTime)
 			tt.assertions(t, c, vi, err)
 		})
 	}
@@ -4044,7 +4046,8 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 	require.NoError(t, rolloutsapi.AddToScheme(scheme))
 
 	now := time.Now()
-	fiveMinutesLater := now.Add(5 * time.Minute)
+	endTime := now.Add(5 * time.Minute)
+	fixedEndTime := func() time.Time { return endTime }
 
 	tests := []struct {
 		name             string
@@ -4114,6 +4117,8 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				assert.Equal(t, kargoapi.VerificationPhaseError, vi.Phase)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.Contains(t, vi.Message, "Rollouts integration is disabled")
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -4215,12 +4220,12 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 					Status: rolloutsapi.AnalysisRunStatus{
 						Phase:       rolloutsapi.AnalysisPhaseSuccessful,
 						Message:     "Analysis completed successfully",
-						CompletedAt: &metav1.Time{Time: fiveMinutesLater},
+						CompletedAt: &metav1.Time{Time: endTime},
 						MetricResults: []rolloutsapi.MetricResult{
 							{
 								Measurements: []rolloutsapi.Measurement{
 									{
-										FinishedAt: &metav1.Time{Time: fiveMinutesLater},
+										FinishedAt: &metav1.Time{Time: endTime},
 									},
 								},
 							},
@@ -4235,7 +4240,8 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				assert.Equal(t, kargoapi.VerificationPhaseSuccessful, vi.Phase)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.Equal(t, "Analysis completed successfully", vi.Message)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -4266,12 +4272,12 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 					Status: rolloutsapi.AnalysisRunStatus{
 						Phase:       "Failed",
 						Message:     "Something went wrong",
-						CompletedAt: &metav1.Time{Time: fiveMinutesLater},
+						CompletedAt: &metav1.Time{Time: endTime},
 						MetricResults: []rolloutsapi.MetricResult{
 							{
 								Measurements: []rolloutsapi.Measurement{
 									{
-										FinishedAt: &metav1.Time{Time: fiveMinutesLater},
+										FinishedAt: &metav1.Time{Time: endTime},
 									},
 								},
 							},
@@ -4286,7 +4292,8 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				assert.Equal(t, kargoapi.VerificationPhaseFailed, vi.Phase)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.Equal(t, "Something went wrong", vi.Message)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 				assert.Equal(t, string(rolloutsapi.AnalysisPhaseFailed), vi.AnalysisRun.Phase)
 			},
 		},
@@ -4318,12 +4325,12 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 					Status: rolloutsapi.AnalysisRunStatus{
 						Phase:       rolloutsapi.AnalysisPhaseError,
 						Message:     "Something went wrong",
-						CompletedAt: &metav1.Time{Time: fiveMinutesLater},
+						CompletedAt: &metav1.Time{Time: endTime},
 						MetricResults: []rolloutsapi.MetricResult{
 							{
 								Measurements: []rolloutsapi.Measurement{
 									{
-										FinishedAt: &metav1.Time{Time: fiveMinutesLater},
+										FinishedAt: &metav1.Time{Time: endTime},
 									},
 								},
 							},
@@ -4338,7 +4345,8 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				assert.Equal(t, kargoapi.VerificationPhaseError, vi.Phase)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.Equal(t, "Something went wrong", vi.Message)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 				assert.Equal(t, string(rolloutsapi.AnalysisPhaseError), vi.AnalysisRun.Phase)
 			},
 		},
@@ -4366,7 +4374,7 @@ func TestRegularStageReconciler_getVerificationResult(t *testing.T) {
 				},
 			}
 
-			vi, err := r.getVerificationResult(t.Context(), tt.freight)
+			vi, err := r.getVerificationResult(t.Context(), tt.freight, fixedEndTime)
 			tt.assertions(t, vi, err)
 		})
 	}
@@ -4378,6 +4386,8 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 	require.NoError(t, rolloutsapi.AddToScheme(scheme))
 
 	now := time.Now()
+	endTime := now.Add(5 * time.Minute)
+	fixedEndTime := func() time.Time { return endTime }
 
 	tests := []struct {
 		name             string
@@ -4477,7 +4487,8 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 				assert.Contains(t, vi.Message, "Rollouts integration is disabled")
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.NotNil(t, vi.StartTime)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 			},
 		},
 		{
@@ -4561,7 +4572,8 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 				assert.Equal(t, "Verification aborted by user", vi.Message)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.NotNil(t, vi.StartTime)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 				assert.Equal(t, "test-analysis", vi.AnalysisRun.Name)
 
 				// Verify analysis run was patched with terminate = true
@@ -4618,7 +4630,8 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 				assert.Equal(t, "Verification aborted by user", vi.Message)
 				assert.Equal(t, "test-verification", vi.ID)
 				assert.NotNil(t, vi.StartTime)
-				assert.NotNil(t, vi.FinishTime)
+				require.NotNil(t, vi.FinishTime)
+				assert.Equal(t, endTime.Unix(), vi.FinishTime.Unix())
 				assert.Equal(t, "test-analysis", vi.AnalysisRun.Name)
 			},
 		},
@@ -4710,7 +4723,7 @@ func TestRegularStageReconciler_abortVerification(t *testing.T) {
 				},
 			}
 
-			vi, err := r.abortVerification(t.Context(), tt.freightCol, tt.req)
+			vi, err := r.abortVerification(t.Context(), tt.freightCol, tt.req, fixedEndTime)
 			tt.assertions(t, c, vi, err)
 		})
 	}


### PR DESCRIPTION
## Summary

`TestRegularStageReconciler_startVerification` is flaky on `main`. The "finds existing analysis run" cases assert the returned `VerificationInfo.FinishTime` against a fixed time, but production `startVerification` ignored the caller's injected reconciliation time and read the wall clock again via `metav1.Now()`. When the two reads straddled a one-second boundary, `FinishTime` landed a second after `StartTime` and the assertion failed by 1 — frequently on the slower CI runner.

## Changes

- **`regular_stages.go`**: thread the `endTime func() time.Time` clock already used by the sibling `verifyStageFreight` into `startVerification`, `getVerificationResult`, and `abortVerification`. Every synchronous-return path now stamps `FinishTime` from the injected clock instead of `metav1.Now()`, so `startTime <= finishTime` holds deterministically and all three functions become time-testable. Paths that use the AnalysisRun's own `CreationTimestamp`/`CompletedAt`, or carry forward an existing `FinishTime`, are unchanged.
- **`regular_stages_test.go`**: inject a fixed end clock and assert exact `FinishTime` equality across the three functions' tests, mirroring the existing `TestRegularStageReconciler_verifyStageFreight` pattern. In the `startVerification` test, the injected start value is renamed `now` → `startTime` so the assertions read against the value actually passed in.

## Test

```
go test ./pkg/controller/stages/ -run TestRegularStageReconciler -count=20
ok  github.com/akuity/kargo/pkg/controller/stages
```

20 iterations pass with no off-by-one failures.