### PR TITLE
feat(credentials/ecr): add cross-account ECR registry support

### DIFF
--- a/docs/docs/40-operator-guide/40-security/50-ambient-credentials.md
+++ b/docs/docs/40-operator-guide/40-security/50-ambient-credentials.md
@@ -67,6 +67,30 @@ should be limited only to read-only access to applicable ECR repositories.
 
 :::info
 
+**Cross-account ECR registries**
+
+If the ECR registry URL belongs to a different AWS account than the one in which
+the Kargo controller is running, Kargo will automatically attempt a second
+role-assumption step before falling back to the controller's own role:
+
+1. **Controller's account** — attempt to assume `kargo-project-<project name>`
+   in the controller's own AWS account and use it to obtain an ECR auth token.
+2. **ECR registry's account** _(cross-account only)_ — if step 1 fails and the
+   ECR registry account differs from the controller account, attempt to assume
+   `kargo-project-<project name>` in the ECR account. This requires:
+   - The controller's IAM role (or the step-1 project role) must be permitted to
+     `sts:AssumeRole` on `arn:aws:iam::<ecr-account>:role/kargo-project-<project>`.
+   - That cross-account role must trust the controller's IAM role and have
+     read-only ECR permissions in the ECR account.
+3. **Controller's role directly** — if both role-assumption attempts fail, Kargo
+   falls back to the controller's own IAM role. For organisations without strict
+   multi-account tenancy requirements this can simplify setup, but is not
+   recommended for production.
+
+:::
+
+:::info
+
 If the Kargo controller is unable to assume a Project-specific IAM role, it will
 fall back to using its own IAM role directly. For organizations without strict
 tenancy requirements, this can eliminate the need to manage a large number of

--- a/pkg/credentials/ecr/common.go
+++ b/pkg/credentials/ecr/common.go
@@ -9,8 +9,12 @@ import (
 
 const tokenCacheExpiryMargin = 5 * time.Minute
 
-// ecrURLRegex is a regex that matches ECR URLs.
+// ecrURLRegex is a regex that matches ECR URLs and captures the region.
 var ecrURLRegex = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr\.(.+)\.amazonaws\.com/`)
+
+// ecrURLAccountRegex is a regex that matches ECR URLs and captures the account
+// ID and region.
+var ecrURLAccountRegex = regexp.MustCompile(`^([0-9]{12})\.dkr\.ecr\.(.+)\.amazonaws\.com/`)
 
 // tokenCacheKey returns a cache key in the form of a hash for the given parts.
 // Using a hash ensures that any sensitive data is not stored in a decodable

--- a/pkg/credentials/ecr/managed_identity.go
+++ b/pkg/credentials/ecr/managed_identity.go
@@ -42,6 +42,7 @@ type ManagedIdentityProvider struct {
 	getAuthTokenFn func(
 		ctx context.Context,
 		region string,
+		ecrAccountID string,
 		project string,
 	) (string, time.Time, error)
 }
@@ -113,14 +114,15 @@ func (p *ManagedIdentityProvider) GetCredentials(
 	ctx context.Context,
 	req credentials.Request,
 ) (*credentials.Credentials, error) {
-	// Extract the region from the ECR URL
-	matches := ecrURLRegex.FindStringSubmatch(req.RepoURL)
-	if len(matches) != 2 { // This doesn't look like an ECR URL
+	// Extract the account ID and region from the ECR URL
+	matches := ecrURLAccountRegex.FindStringSubmatch(req.RepoURL)
+	if len(matches) != 3 { // This doesn't look like an ECR URL
 		return nil, nil
 	}
 
-	region := matches[1]
-	cacheKey := tokenCacheKey(region, req.Project)
+	ecrAccountID := matches[1]
+	region := matches[2]
+	cacheKey := tokenCacheKey(region, ecrAccountID, req.Project)
 
 	logger := logging.LoggerFromContext(ctx).WithValues(
 		"provider", "ecrManagedIdentity",
@@ -135,7 +137,7 @@ func (p *ManagedIdentityProvider) GetCredentials(
 	logger.Debug("auth token cache miss")
 
 	// Cache miss, get a new token
-	encodedToken, expiry, err := p.getAuthTokenFn(ctx, region, req.Project)
+	encodedToken, expiry, err := p.getAuthTokenFn(ctx, region, ecrAccountID, req.Project)
 	if err != nil {
 		// This might mean the controller's IAM role isn't authorized to assume the
 		// project-specific IAM role, or that the project-specific IAM role doesn't
@@ -162,12 +164,20 @@ func (p *ManagedIdentityProvider) GetCredentials(
 	return decodeAuthToken(encodedToken)
 }
 
-// getAuthToken returns an ECR authorization token obtained by assuming a
-// project-specific IAM role and using that to obtain a short-lived ECR access
-// token.
+// getAuthToken returns an ECR authorization token. It attempts the following
+// in order, stopping at the first success:
+//
+//  1. Assume kargo-project-<project> in the controller's own AWS account and
+//     use those credentials to obtain an ECR auth token.
+//  2. If the ECR registry belongs to a different account, assume
+//     kargo-project-<project> in that account and obtain an ECR auth token
+//     from there. This supports multi-account AWS setups where ECR registries
+//     live in team-owned accounts separate from the EKS platform account.
+//  3. Fall back to using the controller's IAM role directly.
 func (p *ManagedIdentityProvider) getAuthToken(
 	ctx context.Context,
 	region string,
+	ecrAccountID string,
 	project string,
 ) (string, time.Time, error) {
 	logger := logging.LoggerFromContext(ctx)
@@ -179,56 +189,109 @@ func (p *ManagedIdentityProvider) getAuthToken(
 	}
 	cfg.HTTPClient = cleanhttp.DefaultClient()
 
-	ecrSvc := ecr.NewFromConfig(aws.Config{
-		HTTPClient: cleanhttp.DefaultClient(),
-		Region:     region,
-		Credentials: stscreds.NewAssumeRoleProvider(
-			sts.NewFromConfig(cfg),
-			fmt.Sprintf(roleARNFormat, p.accountID, project),
-		),
-	})
+	stsSvc := sts.NewFromConfig(cfg)
 
 	logger = logger.WithValues(
 		"awsAccountID", p.accountID,
+		"ecrAccountID", ecrAccountID,
 		"awsRegion", region,
 		"project", project,
 	)
 
-	output, err := ecrSvc.GetAuthorizationToken(
+	// Step 1: try kargo-project-<project> in the controller's account.
+	token, expiry, err := p.getAuthTokenWithRole(
 		ctx,
-		&ecr.GetAuthorizationTokenInput{},
+		fmt.Sprintf(roleARNFormat, p.accountID, project),
+		region,
+		stsSvc,
+		logger,
 	)
+	if err == nil && token != "" {
+		return token, expiry, nil
+	}
+
+	// Step 2: if the ECR registry is in a different account, try
+	// kargo-project-<project> in that account.
+	if ecrAccountID != p.accountID {
+		logger.Debug(
+			"ECR registry is in a different account than the controller; " +
+				"attempting to assume project-specific role in ECR account",
+		)
+		token, expiry, err = p.getAuthTokenWithRole(
+			ctx,
+			fmt.Sprintf(roleARNFormat, ecrAccountID, project),
+			region,
+			stsSvc,
+			logger,
+		)
+		if err == nil && token != "" {
+			return token, expiry, nil
+		}
+	}
+
+	// Step 3: fall back to the controller's IAM role directly.
+	logger.Debug(
+		"Falling back to using controller's IAM role directly.",
+	)
+	cfg.Region = region
+	ecrSvc := ecr.NewFromConfig(cfg)
+	output, err := ecrSvc.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
 	if err != nil {
 		var re *awshttp.ResponseError
-		if !errors.As(err, &re) || re.HTTPStatusCode() != http.StatusForbidden {
-			return "", time.Time{}, err
-		}
-		logger.Debug(
-			"Controller IAM role is not authorized to assume project-specific role " +
-				"or project-specific role is not authorized to obtain an ECR auth token. " +
-				"Falling back to using controller's IAM role directly.",
-		)
-
-		cfg.Region = region
-		ecrSvc = ecr.NewFromConfig(cfg)
-		output, err = ecrSvc.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
-		if err != nil {
-			if !errors.As(err, &re) || re.HTTPStatusCode() != http.StatusForbidden {
-				return "", time.Time{}, err
-			}
+		if errors.As(err, &re) && re.HTTPStatusCode() == http.StatusForbidden {
 			logger.Debug(
 				"Controller's IAM role is not authorized to obtain an ECR auth token. " +
 					"Treating this as no credentials found.",
 			)
 			return "", time.Time{}, nil
 		}
+		return "", time.Time{}, err
+	}
+
+	var expiry2 time.Time
+	if output.AuthorizationData[0].ExpiresAt != nil {
+		expiry2 = *output.AuthorizationData[0].ExpiresAt
+	}
+	logger.Debug("got ECR authorization token via controller role")
+	return *output.AuthorizationData[0].AuthorizationToken, expiry2, nil
+}
+
+// getAuthTokenWithRole attempts to obtain an ECR auth token by assuming the
+// given IAM role. Returns an empty token (and nil error) if the role cannot be
+// assumed or does not have ECR permissions, so the caller can try alternatives.
+func (p *ManagedIdentityProvider) getAuthTokenWithRole(
+	ctx context.Context,
+	roleARN string,
+	region string,
+	stsSvc *sts.Client,
+	logger interface{ Debug(string, ...any) },
+) (string, time.Time, error) {
+	ecrSvc := ecr.NewFromConfig(aws.Config{
+		HTTPClient: cleanhttp.DefaultClient(),
+		Region:     region,
+		Credentials: stscreds.NewAssumeRoleProvider(
+			stsSvc,
+			roleARN,
+		),
+	})
+
+	output, err := ecrSvc.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		var re *awshttp.ResponseError
+		if errors.As(err, &re) && re.HTTPStatusCode() == http.StatusForbidden {
+			logger.Debug(
+				"not authorized to assume role or role lacks ECR permissions",
+				"roleARN", roleARN,
+			)
+			return "", time.Time{}, nil
+		}
+		return "", time.Time{}, err
 	}
 
 	var expiry time.Time
 	if output.AuthorizationData[0].ExpiresAt != nil {
 		expiry = *output.AuthorizationData[0].ExpiresAt
 	}
-
-	logger.Debug("got ECR authorization token")
+	logger.Debug("got ECR authorization token", "roleARN", roleARN)
 	return *output.AuthorizationData[0].AuthorizationToken, expiry, nil
 }

--- a/pkg/credentials/ecr/managed_identity_test.go
+++ b/pkg/credentials/ecr/managed_identity_test.go
@@ -154,7 +154,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 			credType: credentials.TypeImage,
 			repoURL:  fakeRepoURL,
 			setupCache: func(c *cache.Cache) {
-				cacheKey := tokenCacheKey(fakeRegion, fakeProject)
+				cacheKey := tokenCacheKey(fakeRegion, fakeAccountID, fakeProject)
 				c.Set(cacheKey, fakeToken, cache.DefaultExpiration)
 			},
 			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
@@ -173,6 +173,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 					context.Context,
 					string,
 					string,
+					string,
 				) (string, time.Time, error) {
 					return fakeToken, time.Now().Add(12 * time.Hour), nil
 				},
@@ -189,7 +190,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 				// Verify the token was cached with a TTL based on the
 				// token's actual expiry
 				items := c.Items()
-				item, found := items[tokenCacheKey(fakeRegion, fakeProject)]
+				item, found := items[tokenCacheKey(fakeRegion, fakeAccountID, fakeProject)]
 				assert.True(t, found)
 				expectedTTL := 12*time.Hour - 5*time.Minute // 12h expiry - 5m margin
 				actualTTL := time.Until(time.Unix(0, item.Expiration))
@@ -203,6 +204,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 				tokenCache: cache.New(10*time.Hour, time.Hour),
 				getAuthTokenFn: func(
 					context.Context,
+					string,
 					string,
 					string,
 				) (string, time.Time, error) {
@@ -224,6 +226,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 				tokenCache: cache.New(10*time.Hour, time.Hour),
 				getAuthTokenFn: func(
 					context.Context,
+					string,
 					string,
 					string,
 				) (string, time.Time, error) {


### PR DESCRIPTION
## Description

Closes #5587

When the ECR registry URL belongs to a different AWS account than the controller, Kargo now attempts to assume `kargo-project-<project>` in the ECR account before falling back to the controller's own IAM role.

Resolution order:
1. Assume `kargo-project-<project>` in the controller's account (existing)
2. If ECR account != controller account, assume `kargo-project-<project>` in the ECR account (new)
3. Fall back to the controller's IAM role directly (existing)

Same-account setups are unaffected — step 2 is skipped entirely.

Extracted account ID from ECR URL via `ecrURLAccountRegex` (`common.go`) and threaded it through `getAuthToken`. Refactored the fallback logic into `getAuthTokenWithRole` to avoid duplication.

Docs: updated `ambient-credentials.md` to document the 3-step flow and the IAM trust/permission requirements for cross-account registries.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels.
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [x] Adds or updates corresponding documentation.

### AI Use Disclosure

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] Are signed off by their author (`git commit -s`)
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**