### PR TITLE
fix(cli): use cliClientID when refreshing OIDC tokens

### DIFF
--- a/pkg/cli/client/token_refresher.go
+++ b/pkg/cli/client/token_refresher.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/akuity/kargo/pkg/cli/config"
+	"github.com/akuity/kargo/pkg/client/generated/models"
 	"github.com/akuity/kargo/pkg/client/generated/system"
 )
 
@@ -126,7 +127,7 @@ func redeemRefreshToken(
 	}
 
 	cfg := oauth2.Config{
-		ClientID: res.Payload.OidcConfig.ClientID,
+		ClientID: clientIDForRefresh(res.Payload.OidcConfig),
 		Endpoint: provider.Endpoint(),
 	}
 
@@ -144,4 +145,16 @@ func redeemRefreshToken(
 		return "", "", errors.New("no id_token in token response")
 	}
 	return idToken, token.RefreshToken, nil
+}
+
+// clientIDForRefresh returns the OIDC client ID to use when redeeming a refresh
+// token. When the server advertises a client ID specifically meant for CLI use,
+// that ID must be used, because the refresh token was issued to that client
+// during login (see ssoLogin). Otherwise, identity providers such as Dex reject
+// the refresh as an attempt to claim a token belonging to a different client.
+func clientIDForRefresh(cfg *models.OIDCConfig) string {
+	if cfg.CliClientID != "" {
+		return cfg.CliClientID
+	}
+	return cfg.ClientID
 }

--- a/pkg/cli/client/token_refresher_test.go
+++ b/pkg/cli/client/token_refresher_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuity/kargo/pkg/cli/config"
+	"github.com/akuity/kargo/pkg/client/generated/models"
 )
 
 func TestNewTokenRefresher(t *testing.T) {
@@ -195,6 +196,39 @@ func TestRefreshToken(t *testing.T) {
 			newCfg, err :=
 				tf.refreshToken(t.Context(), testCase.setup(), false)
 			testCase.assertions(t, cfg, newCfg, err)
+		})
+	}
+}
+
+func TestClientIDForRefresh(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cfg      *models.OIDCConfig
+		expected string
+	}{
+		{
+			name:     "only client ID is set",
+			cfg:      &models.OIDCConfig{ClientID: "kargo"},
+			expected: "kargo",
+		},
+		{
+			name: "CLI client ID is set; takes precedence",
+			cfg: &models.OIDCConfig{
+				ClientID:    "kargo",
+				CliClientID: "kargo-cli",
+			},
+			expected: "kargo-cli",
+		},
+		{
+			name:     "CLI client ID is empty; falls back to client ID",
+			cfg:      &models.OIDCConfig{ClientID: "kargo", CliClientID: ""},
+			expected: "kargo",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, testCase.expected, clientIDForRefresh(testCase.cfg))
 		})
 	}
 }


### PR DESCRIPTION
**All pull requests must reference an existing issue with no blocking labels.**

## Issue Reference

Closes #6522

## Description

The Kargo CLI authenticates via the CLI-specific OIDC client (`cliClientID`)
during `kargo login`, but token refresh used the web `clientID`. When a server
advertises distinct `clientID` and `cliClientID` (e.g. with Dex, which requires
separate clients for web vs. `localhost` CLI login), the identity provider
rejects the refresh because the refresh token was issued to a different client.
The user is then forced to re-authenticate as soon as the ID token expires.

This change makes `redeemRefreshToken` use `cliClientID` when the server
advertises one, mirroring the existing behavior of `ssoLogin`. The selection is
extracted into a small helper (`clientIDForRefresh`) and unit-tested. Setups
where `cliClientID` is empty are unaffected.

## Checklist

- [x] The PR is linked to an existing issue.
- [x] The linked issue has no blocking labels (`kind/proposal`,
  `needs discussion`, `needs research`, `maintainer only`, `area/security`,
  `size/large`, `size/x-large`, `size/xx-large`).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.

### AI Use Disclosure

Select one:

- [ ] This PR was written by a human _without_ AI assistance.
- [x] This PR was written by a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] This PR was written by an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] This PR was written entirely by AI. No human has reviewed this prior to opening the PR.

### Sign-Off

- [x] All commits are signed off (`git commit -s`) **(required)**
- [ ] All commits are cryptographically signed (`git commit -S`) **(encouraged)**
