### PR TITLE
chore(deps): ignore k8s.io and grpc in dependabot go groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,15 @@ updates:
       day: "sunday"
     commit-message:
       prefix: "chore(deps):"
+    # k8s.io/grpc upgrades are blocked by a dependency conflict; bump these
+    # manually once that's resolved instead of bundling them into a group.
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/controller-tools"
+      - dependency-name: "sigs.k8s.io/cli-utils"
+      - dependency-name: "sigs.k8s.io/kustomize/*"
+      - dependency-name: "google.golang.org/grpc*"
     groups:
       go-patch:
         update-types:
@@ -62,6 +71,15 @@ updates:
       day: "sunday"
     commit-message:
       prefix: "chore(deps/api):"
+    # k8s.io/grpc upgrades are blocked by a dependency conflict; bump these
+    # manually once that's resolved instead of bundling them into a group.
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/controller-tools"
+      - dependency-name: "sigs.k8s.io/cli-utils"
+      - dependency-name: "sigs.k8s.io/kustomize/*"
+      - dependency-name: "google.golang.org/grpc*"
     groups:
       go-patch:
         update-types:
@@ -82,6 +100,15 @@ updates:
       prefix: "chore(deps/tools):"
     allow:
       - dependency-type: "direct"
+    # k8s.io/grpc upgrades are blocked by a dependency conflict; bump these
+    # manually once that's resolved instead of bundling them into a group.
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/controller-tools"
+      - dependency-name: "sigs.k8s.io/cli-utils"
+      - dependency-name: "sigs.k8s.io/kustomize/*"
+      - dependency-name: "google.golang.org/grpc*"
     groups:
       go-patch:
         update-types:
@@ -100,6 +127,15 @@ updates:
       day: "sunday"
     commit-message:
       prefix: "chore(deps/pkg):"
+    # k8s.io/grpc upgrades are blocked by a dependency conflict; bump these
+    # manually once that's resolved instead of bundling them into a group.
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/controller-tools"
+      - dependency-name: "sigs.k8s.io/cli-utils"
+      - dependency-name: "sigs.k8s.io/kustomize/*"
+      - dependency-name: "google.golang.org/grpc*"
     groups:
       go-patch:
         update-types:


### PR DESCRIPTION
## Summary
- A grpc dependency conflict currently blocks upgrading `k8s.io/*` and `sigs.k8s.io/controller-runtime` (and friends).
- The `go-minor`/`go-major` dependabot groups in the root, `/api`, `/hack/tools`, and `/pkg` gomod configs have no exclusion for these, so every grouped PR bundles them with unrelated, safe dependency bumps and ends up failing CI (codegen/lint/test) on the k8s.io schema churn.
- Adds `ignore` rules for `k8s.io/*`, `sigs.k8s.io/controller-runtime`, `sigs.k8s.io/controller-tools`, `sigs.k8s.io/cli-utils`, `sigs.k8s.io/kustomize/*`, and `google.golang.org/grpc*` so future grouped PRs stay clean. These can be removed once the grpc conflict is resolved and we upgrade k8s.io deliberately.

## Test plan
- [ ] CI passes (no functional code change, config only)
- [ ] After merge, confirm next Dependabot run produces grouped PRs that no longer touch k8s.io/grpc