### PR TITLE
ci(cve-scan): fetch VEX by monitored image/line (VEX_IMAGE=kargo-oss)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,9 +316,9 @@ jobs:
         GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
         GRYPE_REGISTRY_INSECURE_USE_HTTP: "true" # job-local registry service
         CRANE_INSECURE: "true" # job-local registry is plain HTTP
+        VEX_IMAGE: kargo-oss # monitored image name for the VEX lookup
         FAIL_ON: "" # report-only; set to "high" to enforce
-      # VEX lookups use the canonical published repo path.
-      run: ./hack/cve-scan.sh "registry:localhost:5000/kargo:scan" "ghcr.io/akuity/kargo"
+      run: ./hack/cve-scan.sh "registry:localhost:5000/kargo:scan"
 
   build-cli:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,10 +119,10 @@ jobs:
     - name: Scan image for CVEs
       env:
         GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+        VEX_IMAGE: kargo-oss # monitored image name for the VEX lookup
         FAIL_ON: "" # report-only; set to "high" to enforce
-      # Scan the just-pushed digest; VEX lookups always use the canonical
-      # (non-unstable) repo path.
-      run: ./hack/cve-scan.sh "registry:${{ steps.repo.outputs.repo }}@${{ steps.image.outputs.digest }}" "ghcr.io/akuity/kargo"
+      # Scan the just-pushed digest.
+      run: ./hack/cve-scan.sh "registry:${{ steps.repo.outputs.repo }}@${{ steps.image.outputs.digest }}"
     - name: Publish SBOM
       if: github.event_name == 'release'
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/hack/cve-scan.sh
+++ b/hack/cve-scan.sh
@@ -11,30 +11,30 @@
 #
 # This is the canonical scan recipe used across Akuity image pipelines.
 #
-# Usage: cve-scan.sh <image-ref> [<vex-repo>]
+# Usage: cve-scan.sh <image-ref>
 #
 #   <image-ref>  Image to scan, with an explicit grype scheme, e.g.:
-#                  docker:us-docker.pkg.dev/akuity/akp/akuity-platform:1.2.3
+#                  docker:ghcr.io/akuity/kargo:v1.2.3
 #                    (image in the local docker daemon, typical for PR builds)
-#                  registry:us-docker.pkg.dev/akuity/akp/akuity-platform@sha256:...
+#                  registry:ghcr.io/akuity/kargo@sha256:...
 #                    (image in a remote registry, typical for pushed images;
 #                     prefer scanning by digest)
-#   <vex-repo>   Repository path used to look up VEX statements at
-#                ${VEX_BASE_URL}/pkg/oci/<vex-repo>/vex.json. Defaults to the
-#                repository derived from <image-ref> (scheme/tag/digest
-#                stripped). A missing VEX document is not an error: VEX
-#                publishing may not yet cover this image.
 #
 # Environment:
 #   GRYPE_CMD     Path to the grype binary (default: "grype" on PATH)
 #   FAIL_ON       Severity threshold to fail on ("critical", "high", ...).
 #                 Empty (default) = report only, never fail.
-#   VEX_BASE_URL  Base URL of the VEX repository (default: https://vex.akuity.io)
+#   VEX_BASE_URL  Base URL of the VEX mirror (default: https://vex.akuity.io)
+#   VEX_IMAGE     Monitored image name whose dispositions to apply, looked up at
+#                 ${VEX_BASE_URL}/vex/<VEX_IMAGE>/<VEX_LINE>.json (e.g.
+#                 "kargo-oss"). Unset => scan without VEX (the image may not be
+#                 monitored). A missing doc is not an error.
+#   VEX_LINE      Release line to apply (e.g. "1.10"); default "latest".
 
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-    echo "usage: $0 <image-ref> [<vex-repo>]" >&2
+    echo "usage: $0 <image-ref>" >&2
     exit 2
 fi
 
@@ -42,6 +42,8 @@ IMAGE_REF="$1"
 GRYPE_CMD="${GRYPE_CMD:-grype}"
 FAIL_ON="${FAIL_ON:-}"
 VEX_BASE_URL="${VEX_BASE_URL:-https://vex.akuity.io}"
+VEX_IMAGE="${VEX_IMAGE:-}"
+VEX_LINE="${VEX_LINE:-latest}"
 
 # Derive the repository from the image ref: strip the grype scheme prefix,
 # any digest, and any tag (a colon after the last slash).
@@ -56,7 +58,6 @@ if [[ "$base" == *:* ]]; then
     tag="${base##*:}"
     repo="${repo%:*}"
 fi
-VEX_REPO="${2:-$repo}"
 
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
@@ -65,10 +66,10 @@ trap 'rm -rf "$workdir"' EXIT
 # (<repo>@sha256:...) -- never the bare repo or <repo>:<tag>. The published doc
 # carries the logical repo @id (it can't know each patch's digest), so we must
 # re-stamp it to the digest of the image we are about to scan before applying.
-# We stamp to the SCANNED image's repo@digest (not VEX_REPO): the statements
-# come from VEX_REPO's published doc, but must carry the scanned image's
-# identity to match. The package-level suppression is driven by the version-
-# pinned subcomponent purls, which we leave untouched.
+# We stamp to the SCANNED image's repo@digest: the statements come from the
+# published per-line doc, but must carry the scanned image's identity to match.
+# The package-level suppression is driven by the version-pinned subcomponent
+# purls, which we leave untouched.
 resolve_stamp_ref() {
     # Already digest-pinned: reuse the digest directly.
     if [[ "$IMAGE_REF" == *@sha256:* ]]; then
@@ -103,23 +104,30 @@ resolve_stamp_ref() {
 }
 
 # --- Fetch VEX statements (tolerate absence) --------------------------------
+# VEX comes from the published per-line doc for the monitored image; the caller
+# supplies VEX_IMAGE (monitored name) + VEX_LINE (default "latest"). Unset
+# VEX_IMAGE => the image isn't monitored, so scan without VEX.
 vex_args=()
-vex_url="${VEX_BASE_URL}/pkg/oci/${VEX_REPO}/vex.json"
-if curl -fsSL --retry 3 --max-time 30 "$vex_url" -o "$workdir/vex.json" 2>/dev/null \
-    && jq -e .statements "$workdir/vex.json" >/dev/null 2>&1; then
-    stamp_ref="$(resolve_stamp_ref)"
-    if [[ -n "$stamp_ref" ]]; then
-        # Re-stamp every statement's product @id to the scanned digest.
-        jq --arg ref "$stamp_ref" \
-            '.statements[].products[]."@id" = $ref' \
-            "$workdir/vex.json" > "$workdir/vex.stamped.json"
-        echo "Applying VEX from $vex_url (re-stamped to $stamp_ref)"
-        vex_args=(--vex "$workdir/vex.stamped.json")
-    else
-        echo "::notice::VEX found at ${vex_url} but ${IMAGE_REF} is not digest-pinned and no repo digest could be resolved; scanning without VEX. Scan a registry:<repo>@<digest> ref (or install crane) to enable suppression."
-    fi
+if [[ -z "$VEX_IMAGE" ]]; then
+    echo "::notice::VEX_IMAGE not set; scanning ${IMAGE_REF} without VEX."
 else
-    echo "::notice::No VEX statements published for ${VEX_REPO} (${vex_url}); scanning without VEX."
+    vex_url="${VEX_BASE_URL}/vex/${VEX_IMAGE}/${VEX_LINE}.json"
+    if curl -fsSL --retry 3 --max-time 30 "$vex_url" -o "$workdir/vex.json" 2>/dev/null \
+        && jq -e .statements "$workdir/vex.json" >/dev/null 2>&1; then
+        stamp_ref="$(resolve_stamp_ref)"
+        if [[ -n "$stamp_ref" ]]; then
+            # Re-stamp every statement's product @id to the scanned digest.
+            jq --arg ref "$stamp_ref" \
+                '.statements[].products[]."@id" = $ref' \
+                "$workdir/vex.json" > "$workdir/vex.stamped.json"
+            echo "Applying VEX from $vex_url (re-stamped to $stamp_ref)"
+            vex_args=(--vex "$workdir/vex.stamped.json")
+        else
+            echo "::notice::VEX found at ${vex_url} but ${IMAGE_REF} is not digest-pinned and no repo digest could be resolved; scanning without VEX. Scan a registry:<repo>@<digest> ref (or install crane) to enable suppression."
+        fi
+    else
+        echo "::notice::No VEX published for ${VEX_IMAGE}/${VEX_LINE} (${vex_url}); scanning without VEX."
+    fi
 fi
 
 # --- Scan --------------------------------------------------------------------


### PR DESCRIPTION
Syncs `hack/cve-scan.sh` to the canonical version and points the VEX lookup at the raw per-line mirror akuityio/cve-triage now publishes (`vex/<image>/<line>.json`, replacing `pkg/oci/<repo>/vex.json`).

- `cve-scan.sh`: fetch `${VEX_BASE_URL}/vex/${VEX_IMAGE}/${VEX_LINE:-latest}.json`, driven by `VEX_IMAGE`/`VEX_LINE` env (replaces the repo-derived path + the positional VEX-repo override). `resolve_stamp_ref()` + the crane re-stamp are unchanged — grype still needs the product `@id` re-stamped to the scanned digest.
- ci + release scan steps set `VEX_IMAGE: kargo-oss`.

The old `pkg/oci` path was removed when the mirror deployed, so this restores VEX suppression for kargo's pre-release/release scans (a 404 is tolerated meanwhile — scan proceeds without VEX). Matches akuityio/akuity-platform#11679 (reference). Refs akuityio/akuity-platform#11442.