### PR TITLE
fix(controller): sub-reconcilers no longer act on stale status

### DIFF
--- a/pkg/controller/management/clusterconfigs/cluster_configs.go
+++ b/pkg/controller/management/clusterconfigs/cluster_configs.go
@@ -146,7 +146,21 @@ func (r *reconciler) reconcile(
 	clusterCfg *kargoapi.ClusterConfig,
 ) (kargoapi.ClusterConfigStatus, error) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *clusterCfg.Status.DeepCopy()
+
+	// working is the ClusterConfig the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// clusterCfg itself is only ever touched by PatchStatus, which refreshes it
+	// from the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := clusterCfg.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -154,7 +168,7 @@ func (r *reconciler) reconcile(
 	}{{
 		name: "syncing WebhookReceivers",
 		reconcile: func() (kargoapi.ClusterConfigStatus, error) {
-			return r.syncWebhookReceivers(ctx, clusterCfg)
+			return r.syncWebhookReceivers(ctx, working)
 		},
 	}}
 	for _, subR := range subReconcilers {
@@ -170,7 +184,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the ClusterConfig after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against clusterCfg
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -182,6 +198,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update ClusterConfig status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	// At this point, we have successfully reconciled the ClusterConfig and

--- a/pkg/controller/management/projectconfigs/project_configs.go
+++ b/pkg/controller/management/projectconfigs/project_configs.go
@@ -155,7 +155,21 @@ func (r *reconciler) reconcile(
 	error,
 ) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *projectCfg.Status.DeepCopy()
+
+	// working is the ProjectConfig the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// projectCfg itself is only ever touched by PatchStatus, which refreshes it
+	// from the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := projectCfg.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -163,7 +177,7 @@ func (r *reconciler) reconcile(
 	}{{
 		name: "syncing WebhookReceivers",
 		reconcile: func() (kargoapi.ProjectConfigStatus, error) {
-			return r.syncWebhookReceivers(ctx, projectCfg)
+			return r.syncWebhookReceivers(ctx, working)
 		},
 	}}
 	for _, subR := range subReconcilers {
@@ -179,7 +193,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the ProjectConfig after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against projectCfg
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -191,6 +207,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update Project status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	// At this point, we have successfully reconciled the ProjectConfig and

--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -310,7 +310,21 @@ func (r *reconciler) reconcile(
 	project *kargoapi.Project,
 ) (kargoapi.ProjectStatus, error) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *project.Status.DeepCopy()
+
+	// working is the Project the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// project itself is only ever touched by PatchStatus, which refreshes it from
+	// the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := project.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -319,13 +333,13 @@ func (r *reconciler) reconcile(
 		{
 			name: "syncing project resources",
 			reconcile: func() (kargoapi.ProjectStatus, error) {
-				return r.syncProject(ctx, project)
+				return r.syncProject(ctx, working)
 			},
 		},
 		{
 			name: "collecting project stats",
 			reconcile: func() (kargoapi.ProjectStatus, error) {
-				return r.collectStats(ctx, project)
+				return r.collectStats(ctx, working)
 			},
 		},
 	}
@@ -342,7 +356,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the Project after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against project
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -354,6 +370,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update Project status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	return status, nil

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -397,6 +397,57 @@ func TestReconciler_reconcile(t *testing.T) {
 				require.NotNil(t, status.Stats)
 			},
 		},
+		{
+			// Stats collection is gated on the Ready condition. It must see the
+			// readiness computed by syncProject in this same pass even when
+			// intermediate status updates fail.
+			name: "stats reflect readiness computed this pass even when status updates fail",
+			reconciler: &reconciler{
+				ensureNamespaceFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureSystemPermissionsFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureDefaultUserRolesFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+			},
+			// Requires no phase --> conditions migration.
+			// Requires no spec --> ProjectConfig migration.
+			// Is NOT yet ready; becomes ready during this pass.
+			project: &kargoapi.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: testProject},
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					context.Context,
+					client.Client,
+					string,
+					client.Object,
+					client.Patch,
+					...client.SubResourcePatchOption,
+				) error {
+					return fmt.Errorf("status update error")
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				status kargoapi.ProjectStatus,
+				_ client.Client,
+				err error,
+			) {
+				// Status update failures between sub-reconcilers are non-fatal.
+				require.NoError(t, err)
+
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+
+				// Status has stats
+				require.NotNil(t, status.Stats)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -403,14 +403,28 @@ func (r *RegularStageReconciler) reconcile(
 	startTime time.Time,
 ) (kargoapi.StageStatus, bool, error) {
 	logger := logging.LoggerFromContext(ctx)
-	newStatus := *stage.Status.DeepCopy()
+
+	// working is the Stage the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// stage itself is only ever touched by PatchStatus, which refreshes it from
+	// the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := stage.DeepCopy()
+
+	newStatus := *working.Status.DeepCopy()
 
 	// Mark the Stage as reconciling.
 	conditions.Set(&newStatus, &metav1.Condition{
 		Type:               kargoapi.ConditionTypeReconciling,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Reconciling",
-		ObservedGeneration: stage.Generation,
+		ObservedGeneration: working.Generation,
 	})
 
 	var requestRequeue bool
@@ -421,7 +435,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "syncing Promotions",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, hasPendingPromotions, err := r.syncPromotions(ctx, stage)
+				status, hasPendingPromotions, err := r.syncPromotions(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to sync Promotions: %w", err)
 				}
@@ -437,16 +451,16 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "syncing Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				if err := r.syncFreight(ctx, stage); err != nil {
-					return stage.Status, fmt.Errorf("failed to sync Freight: %w", err)
+				if err := r.syncFreight(ctx, working); err != nil {
+					return working.Status, fmt.Errorf("failed to sync Freight: %w", err)
 				}
-				return stage.Status, nil
+				return working.Status, nil
 			},
 		},
 		{
 			name: "assessing health",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status := r.assessHealth(ctx, stage)
+				status := r.assessHealth(ctx, working)
 				// Unknown health is a normal, expected transient state (e.g. waiting
 				// for Argo CD to reconcile after an operation). The Application watcher
 				// will re-enqueue the Stage when the relevant condition changes, so
@@ -458,7 +472,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "verifying Stage Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.verifyStageFreight(ctx, stage, startTime, time.Now)
+				status, err := r.verifyStageFreight(ctx, working, startTime, time.Now)
 				if err != nil {
 					err = fmt.Errorf("failed to verify Stage Freight: %w", err)
 				}
@@ -475,7 +489,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "verifying Freight for Stage",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.markFreightVerifiedForStage(ctx, stage)
+				status, err := r.markFreightVerifiedForStage(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to verify Freight for Stage: %w", err)
 				}
@@ -485,7 +499,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "auto-promoting Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.autoPromoteFreight(ctx, stage)
+				status, err := r.autoPromoteFreight(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to auto-promote Freight: %w", err)
 				}
@@ -502,7 +516,7 @@ func (r *RegularStageReconciler) reconcile(
 
 		// Summarize the conditions after each sub-reconciler to ensure that
 		// we have a consistent view of the Stage status.
-		summarizeConditions(stage, &newStatus, err)
+		summarizeConditions(working, &newStatus, err)
 
 		// If an error occurred during the sub-reconciler, then we should
 		// return the error which will cause the Stage to be requeued.
@@ -510,13 +524,16 @@ func (r *RegularStageReconciler) reconcile(
 			return newStatus, false, err
 		}
 
-		// Patch the status of the Stage after each sub-reconciler to show
-		// progress.
+		// Patch the status of the Stage after each sub-reconciler to show progress.
+		// Failure is non-fatal: working carries this pass's status forward
+		// regardless, and the next patch attempt's diff against stage (which still
+		// reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(ctx, r.client, stage, func(status *kargoapi.StageStatus) {
 			*status = newStatus
 		}); err != nil {
 			logger.Error(err, fmt.Sprintf("failed to update Stage status after %s", subR.name))
 		}
+		working.Status = newStatus
 	}
 
 	// If an immediate requeue was not requested, then we can delete the

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -513,6 +513,80 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 				assert.Nil(t, reconciling)
 			},
 		},
+		{
+			// Sub-reconcilers must see the status computed by their
+			// predecessors in the same pass even when persisting that status
+			// fails. Here, every Stage status update fails, yet the state
+			// computed by syncPromotions must survive through the rest of the
+			// pass and be reflected in the returned status.
+			name: "subreconcilers see status computed earlier in the pass when status updates fail",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "test-project",
+					Name:       "test-stage",
+					Generation: 1,
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{Name: "test-promotion"},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-project",
+						Name:      "test-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-project",
+						Name:      "test-promotion",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "test-collection-id",
+							Freight: map[string]kargoapi.FreightReference{
+								"Warehouse/test-warehouse": {Name: "test-freight"},
+							},
+						},
+					},
+				},
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					c client.Client,
+					subResourceName string,
+					obj client.Object,
+					patch client.Patch,
+					opts ...client.SubResourcePatchOption,
+				) error {
+					// Fail all Stage status updates; let others through.
+					if _, ok := obj.(*kargoapi.Stage); ok {
+						return fmt.Errorf("status update error")
+					}
+					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+				// Status update failures between sub-reconcilers are non-fatal.
+				require.NoError(t, err)
+				require.False(t, requeue)
+
+				// The results of syncPromotions were carried through the rest
+				// of the pass despite never having been persisted.
+				require.NotNil(t, status.LastPromotion)
+				assert.Equal(t, "test-promotion", status.LastPromotion.Name)
+				require.Len(t, status.FreightHistory, 1)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -523,7 +597,7 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(objects...).
-				WithStatusSubresource(&kargoapi.Stage{}).
+				WithStatusSubresource(&kargoapi.Stage{}, &kargoapi.Freight{}).
 				WithIndex(
 					&kargoapi.Promotion{},
 					indexer.PromotionsByStageField,


### PR DESCRIPTION
Several reconcilers (regular Stages, Projects, ProjectConfigs, ClusterConfigs) run a sequence of sub-reconcilers, patching status after each one to show progress. A failed patch was logged and tolerated, but the in-memory object was only ever refreshed from the server's response to a *successful* patch. A failed intermediate patch therefore had two quiet consequences:

1. Every later sub-reconciler in the pass computed from the pre-patch status, silently dropping the failed sub-reconciler's work for the remainder of the pass -- including from the final end-of-pass patch, which is built from the last sub-reconciler's output. The dropped work was only recovered by full recomputation on a later pass.

2. Decisions with side effects could be made from the stale view. In the Stage reconciler, auto-promotion could re-promote Freight the Stage had just received (under the matchUpstream selection policy) because the Freight history recorded moments earlier was not visible to it. In the Project reconciler, stats collection gates on the Ready condition and would act on the previous pass's value.

These windows only open on transient API errors (these are unguarded merge patches, so conflicts are not a factor), which is why the hazard has gone unnoticed. But work in progress (auto-promotion holds, #6334) is about to make the Stage reconciler's instance of it consequential: acting on stale hold state would auto-promote over a rollback the user just performed.

The fix separates the two roles the reconciled object was playing:

- Sub-reconcilers now operate on a working deep copy whose status is unconditionally brought up to date after every sub-reconciler, whether or not persistence succeeded. No sub-reconciler ever sees a stale view of the current pass.

- The original object is only ever touched by PatchStatus: refreshed from the server's response on success, untouched on failure. It always mirrors persisted state, and because it is also the base PatchStatus diffs against, a failed patch loses nothing -- the next patch (including the final one) diffs against true server state and re-carries the unpersisted changes.

Patching after each sub-reconciler thereby returns to being purely a progress-visibility optimization whose failure costs nothing.

The ProjectConfig and ClusterConfig reconcilers each have only one sub-reconciler today, so they had no observable bug; they receive the same treatment so the pattern is safe by construction whenever a second sub-reconciler is added.

New tests pin both behavioral fixes; both fail against the previous code.