### PR TITLE
fix(controller): prevent AnnotateStageWithArgoCDContext mutating caller state

### DIFF
--- a/pkg/api/stage.go
+++ b/pkg/api/stage.go
@@ -228,11 +228,16 @@ func RefreshStage(
 // the latest Promotion.
 //
 // If no ArgoCD apps are found, the annotation is removed.
+//
+// This deliberately takes the Stage's identity rather than a caller's working
+// Stage object. This is to avoid the patchAnnotation() call in this method
+// overwriting pending status changes to the working Stage object with live
+// status, which may be stale in comparison.
 func AnnotateStageWithArgoCDContext(
 	ctx context.Context,
 	c client.Client,
 	healthChecks []kargoapi.HealthCheckStep,
-	stage *kargoapi.Stage,
+	stage types.NamespacedName,
 ) error {
 	var argoCDApps []map[string]any
 	for _, healthCheck := range healthChecks {
@@ -255,9 +260,16 @@ func AnnotateStageWithArgoCDContext(
 		}
 	}
 
+	target := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stage.Namespace,
+			Name:      stage.Name,
+		},
+	}
+
 	// If we did not find any ArgoCD apps, we should remove the annotation.
 	if len(argoCDApps) == 0 {
-		return deleteAnnotation(ctx, c, stage, kargoapi.AnnotationKeyArgoCDContext)
+		return deleteAnnotation(ctx, c, target, kargoapi.AnnotationKeyArgoCDContext)
 	}
 
 	// Marshal the ArgoCD context to JSON and set the annotation on the Stage.
@@ -265,7 +277,7 @@ func AnnotateStageWithArgoCDContext(
 	if err != nil {
 		return fmt.Errorf("failed to marshal ArgoCD context: %w", err)
 	}
-	return patchAnnotation(ctx, c, stage, kargoapi.AnnotationKeyArgoCDContext, string(argoCDAppsJSON))
+	return patchAnnotation(ctx, c, target, kargoapi.AnnotationKeyArgoCDContext, string(argoCDAppsJSON))
 }
 
 // ReverifyStageFreight forces reconfirmation of the verification of the

--- a/pkg/api/stage_test.go
+++ b/pkg/api/stage_test.go
@@ -833,12 +833,15 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{},
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.ErrorContains(t, err, "not found")
 	})
 
@@ -852,19 +855,22 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{
-			{
-				Uses: "argocd-update",
-				Config: &apiextensionsv1.JSON{
-					Raw: []byte(`{"apps": [{"name": "fake-argo-app", "namespace": "fake-argo-namespace"}]}`),
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{
+				{
+					Uses: "argocd-update",
+					Config: &apiextensionsv1.JSON{
+						Raw: []byte(`{"apps": [{"name": "fake-argo-app", "namespace": "fake-argo-namespace"}]}`),
+					},
 				},
 			},
-		}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.NoError(t, err)
 
 		stage, err := GetStage(t.Context(), c, types.NamespacedName{
@@ -890,12 +896,15 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{},
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.NoError(t, err)
 
 		stage, err := GetStage(t.Context(), c, types.NamespacedName{

--- a/pkg/controller/stages/control_flow_stages.go
+++ b/pkg/controller/stages/control_flow_stages.go
@@ -238,7 +238,12 @@ func (r *ControlFlowStageReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Remove any stale annotations from the Stage which are not relevant to
 	// a control flow Stage.
 	if stage.GetAnnotations()[kargoapi.AnnotationKeyArgoCDContext] != "" {
-		if err := api.AnnotateStageWithArgoCDContext(ctx, r.client, nil, stage); err != nil {
+		if err := api.AnnotateStageWithArgoCDContext(
+			ctx,
+			r.client,
+			nil,
+			client.ObjectKeyFromObject(stage),
+		); err != nil {
 			logger.Error(err, "failed to remove Argo CD context annotation from Stage")
 		}
 	}

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -700,7 +700,12 @@ func (r *RegularStageReconciler) syncPromotions(
 				//
 				// NB: If the health checks do not include ArgoCD Applications,
 				// then the annotation will be removed.
-				if err := api.AnnotateStageWithArgoCDContext(ctx, r.client, p.Status.HealthChecks, stage); err != nil {
+				if err := api.AnnotateStageWithArgoCDContext(
+					ctx,
+					r.client,
+					p.Status.HealthChecks,
+					client.ObjectKeyFromObject(stage),
+				); err != nil {
 					// Let the error be logged, but do not return it as it is not
 					// critical to the operation of the Stage.
 					logger.Error(err, "failed to annotate Stage with ArgoCD context")


### PR DESCRIPTION
Small follow-up to #6559

On a successful patch, the controller-runtime client hydrates the patched object from the server's response. Any helper that patches a caller-owned object therefore overwrites the caller's in-memory copy -- in its entirety, status included -- as a side effect.

AnnotateStageWithArgoCDContext had exactly this shape: it accepted a caller-owned *Stage and patched it directly. Its one substantive caller is the Stage reconciler, which invokes it mid-pass on the working copy whose status accumulates the results of each sub-reconciler. A successful annotation silently reverted that working status to persisted state. Nothing currently reads the working status between that call and the point where the reconcile loop reassigns it, so this has never produced wrong behavior -- but that safety is circumstantial, unenforced, and invisible at the call site. Code added to syncPromotions downstream of the annotation call would inherit the hazard without any signal that it exists.

The helper only ever needed the Stage's identity. It now takes a types.NamespacedName (matching its neighbors RefreshStage and ReverifyStageFreight) and patches an internally constructed stub, making the side effect impossible rather than merely unobserved. A doc comment records the reasoning so the signature does not regress.