### PR TITLE
fix(ci): opt backport workflow out of checkout v7 fork-PR guard

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        allow-unsafe-pr-checkout: true
     - name: Create backport PRs
       uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
       # xref: https://github.com/korthout/backport-action#inputs


### PR DESCRIPTION
actions/checkout v7 refuses to run in a pull_request_target workflow when the triggering PR is from a fork and the commit being checked out matches any SHA in the event payload -- including the PR's merge_commit_sha. Since this workflow runs only after a PR merges, the base branch tip it checks out (the default ref; no ref is specified) is frequently that very merge commit, so the guard misfires and the backport job dies at checkout.

Setting allow-unsafe-pr-checkout: true is safe here despite the scary name:

- The job's `if` requires the PR to be merged, so the content checked out is the base repository's base branch -- code a maintainer already reviewed and merged. It is trunk, not unreviewed fork code.
- The checked-out code is never executed. korthout/backport-action only cherry-picks commits and calls the GitHub API; it does not run repo build scripts, tests, or hooks in the privileged context.
- Both paths into the privileged run (merging, labeling) require write/triage access to begin with.

This is the intended opt-out for exactly this pattern; the input is deliberately conspicuous so the justification lives here in the history.