### PR TITLE
fix: approval no longer makes Freight available across origin boundaries

### DIFF
--- a/api/v1alpha1/stage_types.go
+++ b/api/v1alpha1/stage_types.go
@@ -156,20 +156,33 @@ func (s *Stage) IsControlFlow() bool {
 	}
 }
 
+// RequestsFreightFromOrigin returns whether any of the Stage's Freight requests
+// name the specified origin.
+func (s *Stage) RequestsFreightFromOrigin(origin FreightOrigin) bool {
+	if s == nil {
+		return false
+	}
+	for _, req := range s.Spec.RequestedFreight {
+		if req.Origin.Equals(&origin) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsFreightAvailable answers whether the specified Freight is available to the
 // Stage.
 func (s *Stage) IsFreightAvailable(freight *Freight) bool {
 	if s == nil || freight == nil || s.Namespace != freight.Namespace {
 		return false
 	}
-	if freight.IsApprovedFor(s.Name) {
-		return true
-	}
 	for _, req := range s.Spec.RequestedFreight {
 		if !freight.Origin.Equals(&req.Origin) {
 			continue
 		}
-
+		if freight.IsApprovedFor(s.Name) {
+			return true
+		}
 		if req.Sources.Direct {
 			return true
 		}

--- a/api/v1alpha1/stage_types_test.go
+++ b/api/v1alpha1/stage_types_test.go
@@ -52,10 +52,35 @@ func TestStage_IsFreightAvailable(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:  "freight is approved for stage",
+			name:  "freight is approved for stage but stage does not request freight from its origin",
 			stage: &Stage{ObjectMeta: testStageMeta},
 			freight: &Freight{
 				ObjectMeta: testFreightMeta,
+				Origin:     testOrigin,
+				Status: FreightStatus{
+					ApprovedFor: map[string]ApprovedStage{
+						testStage: {},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "freight is approved for stage and stage requests freight from its origin",
+			stage: &Stage{
+				ObjectMeta: testStageMeta,
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: testOrigin,
+						Sources: FreightSources{
+							Stages: []string{"upstream-stage"},
+						},
+					}},
+				},
+			},
+			freight: &Freight{
+				ObjectMeta: testFreightMeta,
+				Origin:     testOrigin,
 				Status: FreightStatus{
 					ApprovedFor: map[string]ApprovedStage{
 						testStage: {},
@@ -279,6 +304,74 @@ func TestStage_IsFreightAvailable(t *testing.T) {
 				t,
 				testCase.expected,
 				testCase.stage.IsFreightAvailable(testCase.freight),
+			)
+		})
+	}
+}
+
+func TestStage_RequestsFreightFromOrigin(t *testing.T) {
+	testOrigin := FreightOrigin{
+		Kind: FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+
+	testCases := []struct {
+		name     string
+		stage    *Stage
+		origin   FreightOrigin
+		expected bool
+	}{
+		{
+			name:     "stage is nil",
+			origin:   testOrigin,
+			expected: false,
+		},
+		{
+			name:     "stage requests no freight",
+			stage:    &Stage{},
+			origin:   testOrigin,
+			expected: false,
+		},
+		{
+			name: "no request names the origin",
+			stage: &Stage{
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{{
+						Origin: FreightOrigin{
+							Kind: FreightOriginKindWarehouse,
+							Name: "other-warehouse",
+						},
+					}},
+				},
+			},
+			origin:   testOrigin,
+			expected: false,
+		},
+		{
+			name: "a request names the origin",
+			stage: &Stage{
+				Spec: StageSpec{
+					RequestedFreight: []FreightRequest{
+						{
+							Origin: FreightOrigin{
+								Kind: FreightOriginKindWarehouse,
+								Name: "other-warehouse",
+							},
+						},
+						{Origin: testOrigin},
+					},
+				},
+			},
+			origin:   testOrigin,
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				testCase.expected,
+				testCase.stage.RequestsFreightFromOrigin(testCase.origin),
 			)
 		})
 	}

--- a/docs/docs/50-user-guide/20-how-to-guides/50-working-with-freight.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/50-working-with-freight.md
@@ -203,6 +203,15 @@ create a corresponding `Promotion` resource.
 
 :::
 
+:::info
+
+Manual approval bypasses verification requirements only. The `Stage` must still
+request `Freight` from the origin of the `Freight` resource being approved.
+Attempting to approve `Freight` for a `Stage` that does not request `Freight`
+from its origin will fail.
+
+:::
+
 After successfully granting manual approval for a `Freight` resource to be
 promoted to a given `Stage`, the `Freight` resource's `status` field will
 reflect that approval.

--- a/pkg/server/approve_freight_v1alpha1.go
+++ b/pkg/server/approve_freight_v1alpha1.go
@@ -101,6 +101,20 @@ func (s *server) ApproveFreight(
 		return nil, err
 	}
 
+	// Approval bypasses verification and soak requirements, but not origin
+	// membership: an approval for a Stage that doesn't request Freight from the
+	// Freight's origin could never be acted upon and is certainly a mistake.
+	if !stage.RequestsFreightFromOrigin(freight.Origin) {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			// nolint:staticcheck
+			fmt.Errorf(
+				"Stage %q does not request Freight from origin %q",
+				stageName, freight.Origin.String(),
+			),
+		)
+	}
+
 	if freight.IsApprovedFor(stageName) {
 		return &connect.Response[svcv1alpha1.ApproveFreightResponse]{}, nil
 	}
@@ -205,6 +219,20 @@ func (s *server) approveFreight(c *gin.Context) {
 		},
 	); err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	// Approval bypasses verification and soak requirements, but not origin
+	// membership: an approval for a Stage that doesn't request Freight from the
+	// Freight's origin could never be acted upon and is certainly a mistake.
+	if !stage.RequestsFreightFromOrigin(freight.Origin) {
+		_ = c.Error(libhttp.ErrorStr(
+			fmt.Sprintf(
+				"Stage %q does not request Freight from origin %q",
+				stageName, freight.Origin.String(),
+			),
+			http.StatusBadRequest,
+		))
 		return
 	}
 

--- a/pkg/server/approve_freight_v1alpha1_test.go
+++ b/pkg/server/approve_freight_v1alpha1_test.go
@@ -25,6 +25,11 @@ import (
 )
 
 func TestApproveFreight(t *testing.T) {
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
+
 	testCases := []struct {
 		name       string
 		req        *svcv1alpha1.ApproveFreightRequest
@@ -268,6 +273,54 @@ func TestApproveFreight(t *testing.T) {
 			},
 		},
 		{
+			name: "Stage does not request Freight from origin",
+			req: &svcv1alpha1.ApproveFreightRequest{
+				Project: "fake-project",
+				Name:    "fake-freight",
+				Stage:   "fake-stage",
+			},
+			server: &server{
+				validateProjectExistsFn: func(context.Context, string) error {
+					return nil
+				},
+				getFreightByNameOrAliasFn: func(
+					context.Context,
+					client.Client,
+					string,
+					string,
+					string,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{Origin: testOrigin}, nil
+				},
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				authorizeFn: func(
+					context.Context,
+					string,
+					schema.GroupVersionResource,
+					string,
+					client.ObjectKey,
+				) error {
+					return nil
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				_ *fakeevent.EventRecorder,
+				_ *connect.Response[svcv1alpha1.ApproveFreightResponse],
+				err error,
+			) {
+				require.Error(t, err)
+				require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+				require.ErrorContains(t, err, "does not request Freight from origin")
+			},
+		},
+		{
 			name: "error patching Freight",
 			req: &svcv1alpha1.ApproveFreightRequest{
 				Project: "fake-project",
@@ -285,14 +338,18 @@ func TestApproveFreight(t *testing.T) {
 					string,
 					string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{Origin: testOrigin}, nil
 				},
 				getStageFn: func(
 					context.Context,
 					client.Client,
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
+					return &kargoapi.Stage{
+						Spec: kargoapi.StageSpec{
+							RequestedFreight: []kargoapi.FreightRequest{{Origin: testOrigin}},
+						},
+					}, nil
 				},
 				authorizeFn: func(
 					context.Context,
@@ -339,14 +396,18 @@ func TestApproveFreight(t *testing.T) {
 					string,
 					string,
 				) (*kargoapi.Freight, error) {
-					return &kargoapi.Freight{}, nil
+					return &kargoapi.Freight{Origin: testOrigin}, nil
 				},
 				getStageFn: func(
 					context.Context,
 					client.Client,
 					types.NamespacedName,
 				) (*kargoapi.Stage, error) {
-					return &kargoapi.Stage{}, nil
+					return &kargoapi.Stage{
+						Spec: kargoapi.StageSpec{
+							RequestedFreight: []kargoapi.FreightRequest{{Origin: testOrigin}},
+						},
+					}, nil
 				},
 				authorizeFn: func(
 					context.Context,
@@ -394,6 +455,10 @@ func TestApproveFreight(t *testing.T) {
 
 func Test_server_approveFreight(t *testing.T) {
 	const testStageName = "fake-stage"
+	testOrigin := kargoapi.FreightOrigin{
+		Kind: kargoapi.FreightOriginKindWarehouse,
+		Name: "fake-warehouse",
+	}
 	testProject := &kargoapi.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fake-project",
@@ -404,8 +469,19 @@ func Test_server_approveFreight(t *testing.T) {
 			Name:      "fake-freight",
 			Namespace: testProject.Name,
 		},
+		Origin: testOrigin,
 	}
 	testStage := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-stage",
+			Namespace: testProject.Name,
+		},
+		Spec: kargoapi.StageSpec{
+			RequestedFreight: []kargoapi.FreightRequest{{Origin: testOrigin}},
+		},
+	}
+	// Same name as testStage, but doesn't request Freight from testOrigin.
+	testStageWithoutRequest := &kargoapi.Stage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake-stage",
 			Namespace: testProject.Name,
@@ -464,6 +540,37 @@ func Test_server_approveFreight(t *testing.T) {
 				},
 				assertions: func(t *testing.T, w *httptest.ResponseRecorder, _ client.Client) {
 					require.Equal(t, http.StatusForbidden, w.Code)
+				},
+			},
+			{
+				name: "Stage does not request Freight from origin",
+				clientBuilder: fake.NewClientBuilder().
+					WithObjects(testProject, testFreight, testStageWithoutRequest).
+					WithStatusSubresource(testFreight),
+				serverSetup: func(_ *testing.T, s *server) {
+					s.authorizeFn = func(
+						context.Context,
+						string,
+						schema.GroupVersionResource,
+						string,
+						client.ObjectKey,
+					) error {
+						return nil
+					}
+				},
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					require.Equal(t, http.StatusBadRequest, w.Code)
+					require.Contains(t, w.Body.String(), "does not request Freight from origin")
+
+					// Verify the Freight was NOT approved for the Stage
+					freight := &kargoapi.Freight{}
+					err := c.Get(
+						t.Context(),
+						client.ObjectKeyFromObject(testFreight),
+						freight,
+					)
+					require.NoError(t, err)
+					require.False(t, freight.IsApprovedFor(testStageName))
 				},
 			},
 			{


### PR DESCRIPTION
Corrects existing bug found while reviewing #6334

cc @fuskovic 

IsFreightAvailable treated manual approval as an unconditional grant: it returned true for approved Freight before ever consulting the Stage's Freight requests. Freight from an origin a Stage does not request could therefore be promoted to it, so long as someone approved it -- most plausibly by accident, since such a promotion accomplishes nothing the Stage's promotion process can act on.

The codebase already disagreed with itself about this. The other implementation of availability, ListFreightAvailableToStage, only ever queries the Warehouses of requested origins, so cross-origin approvals never surfaced in the UI's listings; they were honored only when named directly in a promote request. Nothing on the approval side guarded the door either: the approve endpoints validated only that the Freight and Stage exist and that the caller may promote to the Stage.

Approval's purpose is to bypass verification -- the hotfix path -- not to bypass a Stage's declared sources. This closes the gap at both layers:

- IsFreightAvailable now applies the approval check only within the origin-matched Freight request, so approval bypasses verification and soak requirements but not origin membership. This is the enforcement point: it guards every promotion path, including Promotions created with kubectl and approvedFor entries planted by direct status patches.

- The approve endpoints now reject approving Freight for a Stage that does not request Freight from its origin, so the mistake is caught when it is made rather than surfacing later as a baffling "Freight not available" on promote.

Existing cross-origin approvals become inert rather than invalid: the approvedFor entry remains on the Freight, but no longer makes the Freight available to the non-requesting Stage.
