### PR TITLE
build(deps): bump bundled Helm to v3.21.2 and grpc-health-probe to v0.4.52

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ ARG TARGETARCH
 
 WORKDIR /tools
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.50 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.52 && \
     curl -fL -o /tools/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
     chmod +x /tools/grpc_health_probe
 
@@ -81,7 +81,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.50 && \
 # so we always ship a current, CVE-patched build. This is intentionally ahead of
 # the helm.sh/helm/v3 library in go.mod: the standalone binary carries no k8s
 # dependency cascade, so we track the latest Helm 3 minor for CVE coverage.
-ARG HELM_VERSION=v3.21.0
+ARG HELM_VERSION=v3.21.2
 RUN curl -fL -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz && \
     curl -fL -o /tmp/helm.tar.gz.sha256sum https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz.sha256sum && \
     echo "$(awk '{print $1}' /tmp/helm.tar.gz.sha256sum)  /tmp/helm.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
## Summary

The published Kargo image bundles standalone `helm` and `grpc_health_probe` binaries (copied into `/usr/local/bin` from the `tools` stage). Grype scans of the image attribute the large majority of its Critical/High CVEs to **these bundled binaries**, not to Kargo's own code — Kargo's binary (built on Go 1.26.4) is nearly clean.

This bumps both to their latest patched releases. Only the version pins change; both are fetched with an inline-verified SHA256 from their official release channels.

| Binary | Old | New | Build Go |
|---|---|---|---|
| Helm | v3.21.0 | **v3.21.2** | go1.26.4 |
| grpc-health-probe | v0.4.50 | **v0.4.52** | go1.26.4 |

## CVE impact (grype 0.112.0, verified by scanning the release binaries)

- **helm v3.21.0** shipped Go 1.25.10 + `x/crypto v0.49.0`, `x/net v0.52.0`, `containerd v1.7.30`, `oras-go v2.6.0` → **3 Critical + ~14 High**. v3.21.2 ships Go 1.26.4 + `x/crypto v0.53.0`, `x/net v0.55.0`, `oras-go v2.6.1`, clearing all of them except:
  - `GHSA-xhf5-7wjv-pqxp` — Helm's `containerd v1.7.32` (fix is 1.7.33; Helm hasn't bumped yet)
  - `GHSA-fxhp-mv3v-67qp` — `oras-go` (no upstream fix at any version)
- **grpc_health_probe v0.4.50** was built with Go 1.26.3 → 4 High stdlib CVEs (CVE-2026-27145, CVE-2026-42504, GO-2026-5037/5038). **v0.4.52 (Go 1.26.4) scans clean.**

Net for the OSS image: **3 Crit / 24 High → 0 Crit / 2 High**, and both residuals are upstream-limited (no fix / awaiting upstream bump) — candidates for VEX `not_affected`/tracking, not blockers.

Stays on the latest Helm 3 minor, per the existing policy comment in the Dockerfile.

## Backport

Labeled `backport/release-1.11` so the fix lands in 1.11 (the 1.11.0-rc.1 image carries these CVEs).