### PR TITLE
chore: manual backports of #6559 and #6560

### DIFF
--- a/pkg/api/stage.go
+++ b/pkg/api/stage.go
@@ -228,11 +228,16 @@ func RefreshStage(
 // the latest Promotion.
 //
 // If no ArgoCD apps are found, the annotation is removed.
+//
+// This deliberately takes the Stage's identity rather than a caller's working
+// Stage object. This is to avoid the patchAnnotation() call in this method
+// overwriting pending status changes to the working Stage object with live
+// status, which may be stale in comparison.
 func AnnotateStageWithArgoCDContext(
 	ctx context.Context,
 	c client.Client,
 	healthChecks []kargoapi.HealthCheckStep,
-	stage *kargoapi.Stage,
+	stage types.NamespacedName,
 ) error {
 	var argoCDApps []map[string]any
 	for _, healthCheck := range healthChecks {
@@ -255,9 +260,16 @@ func AnnotateStageWithArgoCDContext(
 		}
 	}
 
+	target := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stage.Namespace,
+			Name:      stage.Name,
+		},
+	}
+
 	// If we did not find any ArgoCD apps, we should remove the annotation.
 	if len(argoCDApps) == 0 {
-		return deleteAnnotation(ctx, c, stage, kargoapi.AnnotationKeyArgoCDContext)
+		return deleteAnnotation(ctx, c, target, kargoapi.AnnotationKeyArgoCDContext)
 	}
 
 	// Marshal the ArgoCD context to JSON and set the annotation on the Stage.
@@ -265,7 +277,7 @@ func AnnotateStageWithArgoCDContext(
 	if err != nil {
 		return fmt.Errorf("failed to marshal ArgoCD context: %w", err)
 	}
-	return patchAnnotation(ctx, c, stage, kargoapi.AnnotationKeyArgoCDContext, string(argoCDAppsJSON))
+	return patchAnnotation(ctx, c, target, kargoapi.AnnotationKeyArgoCDContext, string(argoCDAppsJSON))
 }
 
 // ReverifyStageFreight forces reconfirmation of the verification of the

--- a/pkg/api/stage_test.go
+++ b/pkg/api/stage_test.go
@@ -833,12 +833,15 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{},
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.ErrorContains(t, err, "not found")
 	})
 
@@ -852,19 +855,22 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{
-			{
-				Uses: "argocd-update",
-				Config: &apiextensionsv1.JSON{
-					Raw: []byte(`{"apps": [{"name": "fake-argo-app", "namespace": "fake-argo-namespace"}]}`),
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{
+				{
+					Uses: "argocd-update",
+					Config: &apiextensionsv1.JSON{
+						Raw: []byte(`{"apps": [{"name": "fake-argo-app", "namespace": "fake-argo-namespace"}]}`),
+					},
 				},
 			},
-		}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.NoError(t, err)
 
 		stage, err := GetStage(t.Context(), c, types.NamespacedName{
@@ -890,12 +896,15 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 			},
 		).Build()
 
-		err := AnnotateStageWithArgoCDContext(t.Context(), c, []kargoapi.HealthCheckStep{}, &kargoapi.Stage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake-stage",
+		err := AnnotateStageWithArgoCDContext(
+			t.Context(),
+			c,
+			[]kargoapi.HealthCheckStep{},
+			types.NamespacedName{
 				Namespace: "fake-namespace",
+				Name:      "fake-stage",
 			},
-		})
+		)
 		require.NoError(t, err)
 
 		stage, err := GetStage(t.Context(), c, types.NamespacedName{

--- a/pkg/controller/management/clusterconfigs/cluster_configs.go
+++ b/pkg/controller/management/clusterconfigs/cluster_configs.go
@@ -146,7 +146,21 @@ func (r *reconciler) reconcile(
 	clusterCfg *kargoapi.ClusterConfig,
 ) (kargoapi.ClusterConfigStatus, error) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *clusterCfg.Status.DeepCopy()
+
+	// working is the ClusterConfig the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// clusterCfg itself is only ever touched by PatchStatus, which refreshes it
+	// from the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := clusterCfg.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -154,7 +168,7 @@ func (r *reconciler) reconcile(
 	}{{
 		name: "syncing WebhookReceivers",
 		reconcile: func() (kargoapi.ClusterConfigStatus, error) {
-			return r.syncWebhookReceivers(ctx, clusterCfg)
+			return r.syncWebhookReceivers(ctx, working)
 		},
 	}}
 	for _, subR := range subReconcilers {
@@ -170,7 +184,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the ClusterConfig after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against clusterCfg
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -182,6 +198,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update ClusterConfig status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	// At this point, we have successfully reconciled the ClusterConfig and

--- a/pkg/controller/management/projectconfigs/project_configs.go
+++ b/pkg/controller/management/projectconfigs/project_configs.go
@@ -155,7 +155,21 @@ func (r *reconciler) reconcile(
 	error,
 ) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *projectCfg.Status.DeepCopy()
+
+	// working is the ProjectConfig the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// projectCfg itself is only ever touched by PatchStatus, which refreshes it
+	// from the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := projectCfg.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -163,7 +177,7 @@ func (r *reconciler) reconcile(
 	}{{
 		name: "syncing WebhookReceivers",
 		reconcile: func() (kargoapi.ProjectConfigStatus, error) {
-			return r.syncWebhookReceivers(ctx, projectCfg)
+			return r.syncWebhookReceivers(ctx, working)
 		},
 	}}
 	for _, subR := range subReconcilers {
@@ -179,7 +193,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the ProjectConfig after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against projectCfg
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -191,6 +207,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update Project status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	// At this point, we have successfully reconciled the ProjectConfig and

--- a/pkg/controller/management/projects/projects.go
+++ b/pkg/controller/management/projects/projects.go
@@ -310,7 +310,21 @@ func (r *reconciler) reconcile(
 	project *kargoapi.Project,
 ) (kargoapi.ProjectStatus, error) {
 	logger := logging.LoggerFromContext(ctx)
-	status := *project.Status.DeepCopy()
+
+	// working is the Project the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// project itself is only ever touched by PatchStatus, which refreshes it from
+	// the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := project.DeepCopy()
+
+	status := *working.Status.DeepCopy()
 
 	subReconcilers := []struct {
 		name      string
@@ -319,13 +333,13 @@ func (r *reconciler) reconcile(
 		{
 			name: "syncing project resources",
 			reconcile: func() (kargoapi.ProjectStatus, error) {
-				return r.syncProject(ctx, project)
+				return r.syncProject(ctx, working)
 			},
 		},
 		{
 			name: "collecting project stats",
 			reconcile: func() (kargoapi.ProjectStatus, error) {
-				return r.collectStats(ctx, project)
+				return r.collectStats(ctx, working)
 			},
 		},
 	}
@@ -342,7 +356,9 @@ func (r *reconciler) reconcile(
 		}
 
 		// Patch the status of the Project after each sub-reconciler to show
-		// progress.
+		// progress. Failure is non-fatal: working carries this pass's status
+		// forward regardless, and the next patch attempt's diff against project
+		// (which still reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(
 			ctx,
 			r.client,
@@ -354,6 +370,7 @@ func (r *reconciler) reconcile(
 				fmt.Sprintf("failed to update Project status after %s", subR.name),
 			)
 		}
+		working.Status = status
 	}
 
 	return status, nil

--- a/pkg/controller/management/projects/projects_test.go
+++ b/pkg/controller/management/projects/projects_test.go
@@ -397,6 +397,57 @@ func TestReconciler_reconcile(t *testing.T) {
 				require.NotNil(t, status.Stats)
 			},
 		},
+		{
+			// Stats collection is gated on the Ready condition. It must see the
+			// readiness computed by syncProject in this same pass even when
+			// intermediate status updates fail.
+			name: "stats reflect readiness computed this pass even when status updates fail",
+			reconciler: &reconciler{
+				ensureNamespaceFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureSystemPermissionsFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+				ensureDefaultUserRolesFn: func(context.Context, *kargoapi.Project) error {
+					return nil
+				},
+			},
+			// Requires no phase --> conditions migration.
+			// Requires no spec --> ProjectConfig migration.
+			// Is NOT yet ready; becomes ready during this pass.
+			project: &kargoapi.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: testProject},
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					context.Context,
+					client.Client,
+					string,
+					client.Object,
+					client.Patch,
+					...client.SubResourcePatchOption,
+				) error {
+					return fmt.Errorf("status update error")
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				status kargoapi.ProjectStatus,
+				_ client.Client,
+				err error,
+			) {
+				// Status update failures between sub-reconcilers are non-fatal.
+				require.NoError(t, err)
+
+				readyCondition := conditions.Get(&status, kargoapi.ConditionTypeReady)
+				require.NotNil(t, readyCondition)
+				require.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+
+				// Status has stats
+				require.NotNil(t, status.Stats)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/stages/control_flow_stages.go
+++ b/pkg/controller/stages/control_flow_stages.go
@@ -238,7 +238,12 @@ func (r *ControlFlowStageReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Remove any stale annotations from the Stage which are not relevant to
 	// a control flow Stage.
 	if stage.GetAnnotations()[kargoapi.AnnotationKeyArgoCDContext] != "" {
-		if err := api.AnnotateStageWithArgoCDContext(ctx, r.client, nil, stage); err != nil {
+		if err := api.AnnotateStageWithArgoCDContext(
+			ctx,
+			r.client,
+			nil,
+			client.ObjectKeyFromObject(stage),
+		); err != nil {
 			logger.Error(err, "failed to remove Argo CD context annotation from Stage")
 		}
 	}

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -403,14 +403,28 @@ func (r *RegularStageReconciler) reconcile(
 	startTime time.Time,
 ) (kargoapi.StageStatus, bool, error) {
 	logger := logging.LoggerFromContext(ctx)
-	newStatus := *stage.Status.DeepCopy()
+
+	// working is the Stage the sub-reconcilers operate on. Its status is
+	// unconditionally brought up to date after each sub-reconciler, whether or
+	// not persisting that status succeeded, so no sub-reconciler ever computes
+	// from a stale view of this pass.
+	//
+	// stage itself is only ever touched by PatchStatus, which refreshes it from
+	// the server's response on success and leaves it alone on failure. It
+	// therefore always reflects persisted state. Because it is also the base
+	// PatchStatus diffs against, a failed patch loses nothing: the next patch
+	// (including the final one in Reconcile) diffs against true server state and
+	// re-carries any unpersisted changes.
+	working := stage.DeepCopy()
+
+	newStatus := *working.Status.DeepCopy()
 
 	// Mark the Stage as reconciling.
 	conditions.Set(&newStatus, &metav1.Condition{
 		Type:               kargoapi.ConditionTypeReconciling,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Reconciling",
-		ObservedGeneration: stage.Generation,
+		ObservedGeneration: working.Generation,
 	})
 
 	var requestRequeue bool
@@ -421,7 +435,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "syncing Promotions",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, hasPendingPromotions, err := r.syncPromotions(ctx, stage)
+				status, hasPendingPromotions, err := r.syncPromotions(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to sync Promotions: %w", err)
 				}
@@ -437,16 +451,16 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "syncing Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				if err := r.syncFreight(ctx, stage); err != nil {
-					return stage.Status, fmt.Errorf("failed to sync Freight: %w", err)
+				if err := r.syncFreight(ctx, working); err != nil {
+					return working.Status, fmt.Errorf("failed to sync Freight: %w", err)
 				}
-				return stage.Status, nil
+				return working.Status, nil
 			},
 		},
 		{
 			name: "assessing health",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status := r.assessHealth(ctx, stage)
+				status := r.assessHealth(ctx, working)
 				// Unknown health is a normal, expected transient state (e.g. waiting
 				// for Argo CD to reconcile after an operation). The Application watcher
 				// will re-enqueue the Stage when the relevant condition changes, so
@@ -458,7 +472,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "verifying Stage Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.verifyStageFreight(ctx, stage, startTime, time.Now)
+				status, err := r.verifyStageFreight(ctx, working, startTime, time.Now)
 				if err != nil {
 					err = fmt.Errorf("failed to verify Stage Freight: %w", err)
 				}
@@ -475,7 +489,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "verifying Freight for Stage",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.markFreightVerifiedForStage(ctx, stage)
+				status, err := r.markFreightVerifiedForStage(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to verify Freight for Stage: %w", err)
 				}
@@ -485,7 +499,7 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "auto-promoting Freight",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, err := r.autoPromoteFreight(ctx, stage)
+				status, err := r.autoPromoteFreight(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to auto-promote Freight: %w", err)
 				}
@@ -502,7 +516,7 @@ func (r *RegularStageReconciler) reconcile(
 
 		// Summarize the conditions after each sub-reconciler to ensure that
 		// we have a consistent view of the Stage status.
-		summarizeConditions(stage, &newStatus, err)
+		summarizeConditions(working, &newStatus, err)
 
 		// If an error occurred during the sub-reconciler, then we should
 		// return the error which will cause the Stage to be requeued.
@@ -510,13 +524,16 @@ func (r *RegularStageReconciler) reconcile(
 			return newStatus, false, err
 		}
 
-		// Patch the status of the Stage after each sub-reconciler to show
-		// progress.
+		// Patch the status of the Stage after each sub-reconciler to show progress.
+		// Failure is non-fatal: working carries this pass's status forward
+		// regardless, and the next patch attempt's diff against stage (which still
+		// reflects persisted state) will include these changes.
 		if err = kubeclient.PatchStatus(ctx, r.client, stage, func(status *kargoapi.StageStatus) {
 			*status = newStatus
 		}); err != nil {
 			logger.Error(err, fmt.Sprintf("failed to update Stage status after %s", subR.name))
 		}
+		working.Status = newStatus
 	}
 
 	// If an immediate requeue was not requested, then we can delete the

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -700,7 +700,12 @@ func (r *RegularStageReconciler) syncPromotions(
 				//
 				// NB: If the health checks do not include ArgoCD Applications,
 				// then the annotation will be removed.
-				if err := api.AnnotateStageWithArgoCDContext(ctx, r.client, p.Status.HealthChecks, stage); err != nil {
+				if err := api.AnnotateStageWithArgoCDContext(
+					ctx,
+					r.client,
+					p.Status.HealthChecks,
+					client.ObjectKeyFromObject(stage),
+				); err != nil {
 					// Let the error be logged, but do not return it as it is not
 					// critical to the operation of the Stage.
 					logger.Error(err, "failed to annotate Stage with ArgoCD context")

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -513,6 +513,80 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 				assert.Nil(t, reconciling)
 			},
 		},
+		{
+			// Sub-reconcilers must see the status computed by their
+			// predecessors in the same pass even when persisting that status
+			// fails. Here, every Stage status update fails, yet the state
+			// computed by syncPromotions must survive through the rest of the
+			// pass and be reflected in the returned status.
+			name: "subreconcilers see status computed earlier in the pass when status updates fail",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "test-project",
+					Name:       "test-stage",
+					Generation: 1,
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{Name: "test-promotion"},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-project",
+						Name:      "test-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-project",
+						Name:      "test-promotion",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "test-collection-id",
+							Freight: map[string]kargoapi.FreightReference{
+								"Warehouse/test-warehouse": {Name: "test-freight"},
+							},
+						},
+					},
+				},
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					c client.Client,
+					subResourceName string,
+					obj client.Object,
+					patch client.Patch,
+					opts ...client.SubResourcePatchOption,
+				) error {
+					// Fail all Stage status updates; let others through.
+					if _, ok := obj.(*kargoapi.Stage); ok {
+						return fmt.Errorf("status update error")
+					}
+					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+				// Status update failures between sub-reconcilers are non-fatal.
+				require.NoError(t, err)
+				require.False(t, requeue)
+
+				// The results of syncPromotions were carried through the rest
+				// of the pass despite never having been persisted.
+				require.NotNil(t, status.LastPromotion)
+				assert.Equal(t, "test-promotion", status.LastPromotion.Name)
+				require.Len(t, status.FreightHistory, 1)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -523,7 +597,7 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 			c := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(objects...).
-				WithStatusSubresource(&kargoapi.Stage{}).
+				WithStatusSubresource(&kargoapi.Stage{}, &kargoapi.Freight{}).
 				WithIndex(
 					&kargoapi.Promotion{},
 					indexer.PromotionsByStageField,


### PR DESCRIPTION
Manual backports of #6559 and #6560

Automated backports of both of these failed because they were attempted prior to a fix to that process in #6561.