### PR TITLE
fix(ui): scope Waiting for Approval to non-terminated git-wait-for-pr step

### DIFF
--- a/ui/src/features/common/promotion-status/utils.ts
+++ b/ui/src/features/common/promotion-status/utils.ts
@@ -26,6 +26,32 @@ export const isPromotionPhaseTerminal = (promotionPhase: PromotionStatusPhase) =
   return false;
 };
 
+// PromotionStepStatusPhase mirrors the PromotionStepStatus constants in
+// promotion_types.go. Unlike a Promotion's overall phase, an individual step's
+// only non-terminal status is "Running".
+export enum PromotionStepStatusPhase {
+  RUNNING = 'Running',
+  SUCCEEDED = 'Succeeded',
+  FAILED = 'Failed',
+  ERRORED = 'Errored',
+  ABORTED = 'Aborted',
+  SKIPPED = 'Skipped'
+}
+
+// backend equivalent logic - read in promotion_types.go
+export const isPromotionStepStatusTerminal = (stepStatus?: string) => {
+  switch (stepStatus) {
+    case PromotionStepStatusPhase.SUCCEEDED:
+    case PromotionStepStatusPhase.FAILED:
+    case PromotionStepStatusPhase.ERRORED:
+    case PromotionStepStatusPhase.ABORTED:
+    case PromotionStepStatusPhase.SKIPPED:
+      return true;
+  }
+
+  return false;
+};
+
 export const isPromotionRetryable = (phase: PromotionStatusPhase) => {
   switch (phase) {
     case PromotionStatusPhase.FAILED:

--- a/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
+++ b/ui/src/features/project/pipelines/nodes/pull-request-link.tsx
@@ -9,6 +9,7 @@ import Link from 'antd/es/typography/Link';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 
+import { isPromotionStepStatusTerminal } from '@ui/features/common/promotion-status/utils';
 import { getPromotionOutputsByStepAlias } from '@ui/features/stage/utils/promotion';
 import { useGetPromotion } from '@ui/gen/api/v2/core/core';
 import { Stage } from '@ui/gen/api/v2/models';
@@ -39,9 +40,13 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
     [promotion]
   );
 
-  const indexOfPullRequest = promotion?.spec?.steps?.findIndex(
-    (step: { uses?: string }) => step?.uses === 'git-open-pr' || step?.uses === 'git-wait-for-pr'
-  );
+  // "Waiting for Approval" tracks the git-wait-for-pr step, which is the only
+  // step that actually waits on a pull request. git-open-pr succeeds as soon as
+  // the PR is opened and never represents a waiting state.
+  const indexOfPullRequest =
+    promotion?.spec?.steps?.findIndex(
+      (step: { uses?: string }) => step?.uses === 'git-wait-for-pr'
+    ) ?? -1;
 
   if (getPromotionQuery.isFetching) {
     return <Spin size='small' />;
@@ -57,7 +62,6 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
   }
 
   const step = promotion.spec.steps[indexOfPullRequest];
-  const stepType = step?.uses;
   const stepMetadata = promotion?.status?.stepExecutionMetadata?.[indexOfPullRequest];
   const stepStatus = stepMetadata?.status;
 
@@ -71,18 +75,10 @@ export const PullRequestLink = (props: PullRequestLinkProps) => {
     return null;
   }
 
-  // For git-open-pr: only show when succeeded
-  // For git-wait-for-pr: show when running (has PR URL) or succeeded
-  const isGitWaitForPr = stepType === 'git-wait-for-pr';
-  const isGitOpenPr = stepType === 'git-open-pr';
-  const hasPullRequestStepSucceeded = stepStatus === 'Succeeded';
-  const hasPullRequestStepRunning = stepStatus === 'Running';
-
-  const isStatusAcceptable =
-    (isGitOpenPr && hasPullRequestStepSucceeded) ||
-    (isGitWaitForPr && (hasPullRequestStepSucceeded || hasPullRequestStepRunning));
-
-  if (!isStatusAcceptable) {
+  // Only surface "Waiting for Approval" while the pull request step has not yet
+  // terminated. Once it reaches a terminal status (e.g. the PR is merged or the
+  // step fails), the Promotion is no longer waiting on approval.
+  if (isPromotionStepStatusTerminal(stepStatus)) {
     return null;
   }
 


### PR DESCRIPTION
## Problem

The **Waiting for Approval** indicator on a Stage node stayed visible for the
entire duration of a Promotion, rather than only while a pull request was
actually awaiting approval.

Two things caused this:

1. The component discovered the PR step with `findIndex`, which matched
   `git-open-pr` first (it precedes `git-wait-for-pr` in a typical promotion).
   `git-open-pr` reaches `Succeeded` the moment the PR is opened and stays
   terminal for the rest of the Promotion.
2. The show condition accepted a `Succeeded` status, so once the matched step
   succeeded the indicator stuck around until the whole Promotion terminated.

## Fix

- Track **only** the `git-wait-for-pr` step — the sole step that actually waits
  on a pull request. `git-open-pr` succeeds as soon as the PR is opened and
  never represents a waiting state, so it is no longer considered.
- Show the indicator **only while that step has not yet terminated**. At the
  step level, `Running` is the only non-terminal status; `Succeeded`, `Failed`,
  `Errored`, `Aborted`, and `Skipped` are all terminal.
- Add an `isPromotionStepStatusTerminal` helper (and a `PromotionStepStatusPhase`
  enum) mirroring the `PromotionStepStatus` constants in `promotion_types.go`.

## Behavior change

Promotions without a `git-wait-for-pr` step no longer show the indicator, since
nothing is actually waiting on approval.

## Testing

- `pnpm typecheck` passes
- `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
