### PR TITLE
feat(api): resolve promotion Targets for a Stage

### DIFF
--- a/charts/kargo/templates/controller/cluster-roles.yaml
+++ b/charts/kargo/templates/controller/cluster-roles.yaml
@@ -76,6 +76,14 @@ rules:
 - apiGroups:
   - kargo.akuity.io
   resources:
+  - targets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kargo.akuity.io
+  resources:
   - clusterpromotiontasks
   - promotiontasks
   - warehouses

--- a/pkg/api/target.go
+++ b/pkg/api/target.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// GetTargetsForStage returns the Target(s) that Freight promoted to the given
+// Stage is destined for.
+//
+// When the Stage defines a TargetSelector, the Target resources in the Stage's
+// namespace whose labels satisfy the selector are returned. Otherwise a single
+// ephemeral Target -- synthesized from the Stage and NOT persisted -- is
+// returned, representing the Stage's default destination.
+func GetTargetsForStage(
+	ctx context.Context,
+	c client.Client,
+	stage *kargoapi.Stage,
+) ([]kargoapi.Target, error) {
+	if stage.Spec.TargetSelector == nil {
+		return []kargoapi.Target{defaultTargetForStage(stage)}, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(stage.Spec.TargetSelector)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error parsing target selector for Stage %q in namespace %q: %w",
+			stage.Name, stage.Namespace, err,
+		)
+	}
+
+	list := &kargoapi.TargetList{}
+	if err = c.List(
+		ctx,
+		list,
+		client.InNamespace(stage.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return nil, fmt.Errorf(
+			"error listing Targets for Stage %q in namespace %q: %w",
+			stage.Name, stage.Namespace, err,
+		)
+	}
+	return list.Items, nil
+}
+
+// defaultTargetForStage synthesizes the ephemeral, non-persisted Target used
+// when a Stage does not define a TargetSelector. It shares the Stage's name and
+// namespace and carries the Stage label (plus the Stage's shard label, when
+// present) so it is indistinguishable from a Target a user might define for the
+// same destination.
+func defaultTargetForStage(stage *kargoapi.Stage) kargoapi.Target {
+	labels := map[string]string{
+		kargoapi.LabelKeyStage: stage.Name,
+	}
+	if shard := stage.Labels[kargoapi.LabelKeyShard]; shard != "" {
+		labels[kargoapi.LabelKeyShard] = shard
+	}
+	return kargoapi.Target{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stage.Name,
+			Namespace: stage.Namespace,
+			Labels:    labels,
+		},
+	}
+}

--- a/pkg/api/target_test.go
+++ b/pkg/api/target_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestGetTargetsForStage(t *testing.T) {
+	const (
+		testNamespace = "kargo-demo"
+		testStageName = "test"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	newStage := func() *kargoapi.Stage {
+		return &kargoapi.Stage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testStageName,
+				Namespace: testNamespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		stage       *kargoapi.Stage
+		objects     []client.Object
+		interceptor interceptor.Funcs
+		assertions  func(*testing.T, []kargoapi.Target, error)
+	}{
+		{
+			name:  "no selector: synthesizes an ephemeral default Target",
+			stage: newStage(),
+			objects: []client.Object{
+				// An unrelated Target that must NOT be returned when no selector
+				// is set.
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"env": "prod"},
+					},
+				},
+			},
+			assertions: func(t *testing.T, targets []kargoapi.Target, err error) {
+				require.NoError(t, err)
+				require.Len(t, targets, 1)
+				target := targets[0]
+				require.Equal(t, testStageName, target.Name)
+				require.Equal(t, testNamespace, target.Namespace)
+				require.Equal(t, testStageName, target.Labels[kargoapi.LabelKeyStage])
+				// Ephemeral: never persisted, so it has no resource version.
+				require.Empty(t, target.ResourceVersion)
+			},
+		},
+		{
+			name: "no selector: mirrors the Stage shard label",
+			stage: func() *kargoapi.Stage {
+				s := newStage()
+				s.Labels = map[string]string{kargoapi.LabelKeyShard: "shard-1"}
+				return s
+			}(),
+			assertions: func(t *testing.T, targets []kargoapi.Target, err error) {
+				require.NoError(t, err)
+				require.Len(t, targets, 1)
+				require.Equal(t, "shard-1", targets[0].Labels[kargoapi.LabelKeyShard])
+			},
+		},
+		{
+			name: "selector: returns matching Targets in the namespace",
+			stage: func() *kargoapi.Stage {
+				s := newStage()
+				s.Spec.TargetSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"env": "prod"},
+				}
+				return s
+			}(),
+			objects: []client.Object{
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-a",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"env": "prod"},
+					},
+				},
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-b",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"env": "prod"},
+					},
+				},
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dev",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"env": "dev"},
+					},
+				},
+				// Matching labels but a different namespace: must be excluded.
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-elsewhere",
+						Namespace: "other-ns",
+						Labels:    map[string]string{"env": "prod"},
+					},
+				},
+			},
+			assertions: func(t *testing.T, targets []kargoapi.Target, err error) {
+				require.NoError(t, err)
+				names := make([]string, len(targets))
+				for i, tg := range targets {
+					names[i] = tg.Name
+				}
+				require.ElementsMatch(t, []string{"prod-a", "prod-b"}, names)
+			},
+		},
+		{
+			name: "selector: no matches returns an empty list",
+			stage: func() *kargoapi.Stage {
+				s := newStage()
+				s.Spec.TargetSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"env": "prod"},
+				}
+				return s
+			}(),
+			assertions: func(t *testing.T, targets []kargoapi.Target, err error) {
+				require.NoError(t, err)
+				require.Empty(t, targets)
+			},
+		},
+		{
+			name: "selector: propagates list errors",
+			stage: func() *kargoapi.Stage {
+				s := newStage()
+				s.Spec.TargetSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"env": "prod"},
+				}
+				return s
+			}(),
+			interceptor: interceptor.Funcs{
+				List: func(
+					_ context.Context,
+					_ client.WithWatch,
+					_ client.ObjectList,
+					_ ...client.ListOption,
+				) error {
+					return errors.New("something went wrong")
+				},
+			},
+			assertions: func(t *testing.T, _ []kargoapi.Target, err error) {
+				require.ErrorContains(t, err, "something went wrong")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.objects...).
+				WithInterceptorFuncs(tc.interceptor).
+				Build()
+
+			targets, err := GetTargetsForStage(context.Background(), c, tc.stage)
+			tc.assertions(t, targets, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `api.GetTargetsForStage`, which resolves the `Target`(s) a `Stage` promotes to, based on `stage.spec.targetSelector` (added in the base PR).

> **Stacked on #6566** (`feat/target-per-stage`), which is itself stacked on #6565. Merge the stack bottom-up: #6565 → #6566 → this. The base is `feat/target-per-stage`; this PR will retarget automatically as the stack merges.

## Behavior

- **`spec.targetSelector == nil`** → returns a single **ephemeral Target synthesized from the Stage** (its name/namespace, a `kargo.akuity.io/stage` label, and the mirrored shard label). Nothing is written to the cluster, so the common selector-less case needs no managed `Target` resource.
- **`spec.targetSelector != nil`** → returns every `Target` in the Stage's namespace whose labels satisfy the selector (`List` + `MatchingLabelsSelector`).

This gives the promotion engine one uniform `[]Target` resolution path while keeping the no-selector case free of any persisted object.

## Why `pkg/api`

The helper lives in `pkg/api` alongside the other client-aware `kargoapi` helpers (`GetStage`, `RefreshStage`, …), so both the controllers and the promotion engine can call it without an import cycle.

## Changes

- `pkg/api/target.go` — `GetTargetsForStage` + the in-memory default synthesis.
- `pkg/api/target_test.go` — table-driven tests (ephemeral default, shard mirroring, selector match scoped to namespace, no-match empty list, list-error propagation).
- `charts/kargo/templates/controller/cluster-roles.yaml` — **read-only** (`get`/`list`/`watch`) RBAC on `targets` for the selector list.

## Verification

- `go build ./...` (both modules) and `make lint-go` — clean (0 issues).
- `go test ./pkg/api/...` — passing (incl. the 5 `GetTargetsForStage` subtests).

## Follow-ups (not in this PR)

- The promotion engine does not yet **call** `GetTargetsForStage`. Wiring it into the promotion process (`pkg/promotion`) is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)