### PR TITLE
fix: make PatchStatus conflict-safe via optimistic locking

### DIFF
--- a/pkg/kubeclient/patch.go
+++ b/pkg/kubeclient/patch.go
@@ -54,6 +54,9 @@ func PatchStatus[T HasStatus[S], S any](
 	}
 
 	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": resource.GetResourceVersion(),
+		},
 		"status": patchMap,
 	})
 	if err != nil {

--- a/pkg/kubeclient/patch_test.go
+++ b/pkg/kubeclient/patch_test.go
@@ -1,0 +1,144 @@
+package kubeclient
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestPatchStatus(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	testCases := []struct {
+		name        string
+		stage       *kargoapi.Stage
+		update      func(*kargoapi.StageStatus)
+		interceptor interceptor.Funcs
+		assert      func(*testing.T, error)
+	}{
+		{
+			name: "no patch issued for no change",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "default",
+					Name:            "test-stage",
+					ResourceVersion: "1",
+				},
+			},
+			update: func(*kargoapi.StageStatus) {},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					_ context.Context,
+					_ client.Client,
+					_ string,
+					_ client.Object,
+					_ client.Patch,
+					_ ...client.SubResourcePatchOption,
+				) error {
+					t.Fatal("unexpected patch call for no-op update")
+					return nil
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "patch includes resource version",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "default",
+					Name:            "test-stage",
+					ResourceVersion: "42",
+				},
+			},
+			update: func(status *kargoapi.StageStatus) {
+				status.LastHandledRefresh = "some-token"
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					_ context.Context,
+					_ client.Client,
+					_ string,
+					obj client.Object,
+					patch client.Patch,
+					_ ...client.SubResourcePatchOption,
+				) error {
+					data, err := patch.Data(obj)
+					require.NoError(t, err)
+					var body map[string]any
+					require.NoError(t, json.Unmarshal(data, &body))
+					meta, ok := body["metadata"].(map[string]any)
+					require.True(t, ok, "patch body must contain metadata")
+					require.Equal(t, "42", meta["resourceVersion"])
+					return nil
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "conflict returns error",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "default",
+					Name:            "test-stage",
+					ResourceVersion: "1",
+				},
+			},
+			update: func(status *kargoapi.StageStatus) {
+				status.LastHandledRefresh = "some-token"
+			},
+			interceptor: interceptor.Funcs{
+				SubResourcePatch: func(
+					_ context.Context,
+					_ client.Client,
+					_ string,
+					_ client.Object,
+					_ client.Patch,
+					_ ...client.SubResourcePatchOption,
+				) error {
+					return apierrors.NewConflict(
+						schema.GroupResource{
+							Group:    kargoapi.GroupVersion.Group,
+							Resource: "stages",
+						},
+						"test-stage",
+						nil,
+					)
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				require.True(t, apierrors.IsConflict(err))
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.stage).
+				WithStatusSubresource(tc.stage).
+				WithInterceptorFuncs(tc.interceptor).
+				Build()
+			err := PatchStatus(t.Context(), c, tc.stage, tc.update)
+			tc.assert(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This surfaced during manual end-to-end testing of [#6334 ](https://github.com/akuity/kargo/pull/6334)(auto-promotion holds) for scenario E1 in the test matrix when . Before the `PatchStatus` fix, `multi-origin-holds` had only `Warehouse/auto-hold-api` in its status. `Warehouse/auto-hold` was missing entirely, even though the hold-intent promotion for it (P3, promoting `frontend-v001`) had the correct annotation stamped by the webhook and had been processed by the reconciler (we confirmed this because lastPromotion pointed to P5, which is after P3 in ULID order).


The multi-origin `NewestFreight` test stage uses fast `set-metadata` steps, which produce dense reconcile bursts. The symptom was an `autoPromotionHolds` entry written by one reconcile being dropped by the next: the second reconcile read a stale cache snapshot (no holds), computed a patch from that snapshot, and its merge patch replaced the entire `autoPromotionHolds` map, overwriting the first reconcile's hold. The `freightHistory` for the establishing promotion was also absent from the final status for the same reason.

PatchStatus in `pkg/kubeclient/patch.go` issued raw merge patches without a resource version, making every status update a last-writer-wins operation. Two sequential reconciles for the same `Stage` (the second triggered before the informer cache reflected the first's patch) could both succeed, with the later one silently discarding the earlier one's status changes.

## Fix

Include `metadata.resourceVersion` in the merge patch body sent by `PatchStatus`. Kubernetes validates this against the current stored version and returns a 409 Conflict if the object has been modified since the caller last read it. The reconciler treats that as a normal error, requeues, and re-runs with a fresh cache read, picking up all writes made in the interim.

This is the same optimistic-concurrency approach used by `PatchUnstructured`, which already wraps its patches in `MergeFromWithOptimisticLock` and retries on conflict.

Impact
All 28 PatchStatus call sites become conflict-safe. Previously silent overwrites now surface as 409 errors that the reconcile infrastructure already handles correctly (log + requeue). No caller changes are needed.