### PR TITLE
fix: unblock auto-promotion with required soak times

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,13 @@ Signed-off-by: Legal Name <email@example.com>
 
 Use `git commit -s` to add this automatically.
 
+### Pull requests
+
+Before creating or substantially updating a pull request, read and follow
+`.github/PULL_REQUEST_TEMPLATE.md`. Preserve its structure, complete every
+applicable checklist accurately, and include all automated and manual testing
+performed.
+
 ### Problem-solving
 
 - **Read before guessing.** Understand existing code, tests, and error messages

--- a/pkg/api/warehouse.go
+++ b/pkg/api/warehouse.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -215,7 +214,10 @@ func ListFreightFromWarehouse(
 		return freight, nil
 	}
 
-	// Filter out Freight whose soak time has not yet elapsed
+	// Filter out Freight whose soak time has not yet elapsed. The soak check is
+	// scoped to the configured upstream Stages in opts.VerifiedIn mirroring
+	// the canonical semantics in Stage.IsFreightAvailable rather than the
+	// full set of Stages in which the Freight has been verified.
 	filtered := make([]kargoapi.Freight, 0, len(freight))
 	for _, f := range freight {
 		if opts.ApprovedFor != "" {
@@ -225,30 +227,27 @@ func ListFreightFromWarehouse(
 			}
 		}
 
-		// Track set of Stages that have passed the verification soak time
-		// for the Freight.
-		verifiedStages := sets.New[string]()
-		for stage := range f.Status.VerifiedIn {
+		// Count how many of the configured upstream Stages the Freight has
+		// soaked in.
+		var soakedIn int
+		for _, stage := range opts.VerifiedIn {
 			if f.HasSoakedIn(stage, opts.RequiredSoakTime) {
-				verifiedStages.Insert(stage)
+				soakedIn++
 			}
 		}
 
-		// Filter out Freight that has passed its verification soak time in ALL
-		// the specified VerifiedIn Stages if AvailabilityStrategy is set to All.
-		// Otherwise, include Freight if it has passed the soak time in a single
-		// Stage.
 		if opts.AvailabilityStrategy == kargoapi.FreightAvailabilityStrategyAll {
-			// If Freight is verified in ALL upstream Stages, then it is
-			// available.
-			if verifiedStages.Equal(sets.New(opts.VerifiedIn...)) {
+			// Freight is available only if it has soaked in ALL the configured
+			// upstream Stages.
+			if soakedIn == len(opts.VerifiedIn) {
 				filtered = append(filtered, f)
 			}
 			continue
 		}
 
-		// If Freight is verified in ANY upstream Stage, then it is available.
-		if verifiedStages.Len() > 0 {
+		// Freight is available if it has soaked in ANY of the configured
+		// upstream Stages.
+		if soakedIn > 0 {
 			filtered = append(filtered, f)
 		}
 	}

--- a/pkg/api/warehouse_test.go
+++ b/pkg/api/warehouse_test.go
@@ -116,6 +116,7 @@ func TestListFreightFromWarehouse(t *testing.T) {
 	const testStage = "fake-stage"
 	const testUpstreamStage = "fake-upstream-stage"
 	const testUpstreamStage2 = "fake-upstream-stage2"
+	const testUpstreamOfUpstreamStage = "fake-upstream-of-upstream-stage"
 
 	testCases := []struct {
 		name        string
@@ -382,6 +383,144 @@ func TestListFreightFromWarehouse(t *testing.T) {
 				require.Equal(t, "fake-freight-1", freight[0].Name)
 				require.Equal(t, testProject, freight[1].Namespace)
 				require.Equal(t, "fake-freight-2", freight[1].Name)
+			},
+		},
+		{
+			// Regression test for a bug where AvailabilityStrategy: All did an
+			// exact set-equality check between the Stages the Freight had soaked
+			// in and the configured upstream Stages. Freight that had also soaked
+			// in a Stage NOT in VerifiedIn (e.g. an upstream-of-upstream Stage)
+			// formed a superset that never equaled the configured set, so it was
+			// never considered available.
+			name: "success with AvailabilityStrategy All and extra soaked Stage",
+			opts: &ListWarehouseFreightOptions{
+				AvailabilityStrategy: kargoapi.FreightAvailabilityStrategyAll,
+				VerifiedIn:           []string{testUpstreamStage, testUpstreamStage2},
+				RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					// This should be returned: it has soaked in both configured
+					// upstream Stages AND additionally in an upstream-of-upstream
+					// Stage that is not in VerifiedIn.
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "fake-freight-1",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: testWarehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							testUpstreamStage: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+							testUpstreamStage2: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+							testUpstreamOfUpstreamStage: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, freight []kargoapi.Freight, err error) {
+				require.NoError(t, err)
+				require.Len(t, freight, 1)
+				require.Equal(t, testProject, freight[0].Namespace)
+				require.Equal(t, "fake-freight-1", freight[0].Name)
+			},
+		},
+		{
+			name: "success with AvailabilityStrategy All and partial soak",
+			opts: &ListWarehouseFreightOptions{
+				AvailabilityStrategy: kargoapi.FreightAvailabilityStrategyAll,
+				VerifiedIn:           []string{testUpstreamStage, testUpstreamStage2},
+				RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					// This should NOT be returned: it has soaked in only one of the
+					// two configured upstream Stages.
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "fake-freight-1",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: testWarehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							testUpstreamStage: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+							testUpstreamStage2: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 30 * time.Minute},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, freight []kargoapi.Freight, err error) {
+				require.NoError(t, err)
+				require.Empty(t, freight)
+			},
+		},
+		{
+			name: "success with AvailabilityStrategy OneOf and soak in non-upstream Stage",
+			opts: &ListWarehouseFreightOptions{
+				AvailabilityStrategy: kargoapi.FreightAvailabilityStrategyOneOf,
+				VerifiedIn:           []string{testUpstreamStage, testUpstreamStage2},
+				RequiredSoakTime:     &metav1.Duration{Duration: time.Hour},
+			},
+			objects: []client.Object{
+				&kargoapi.Freight{
+					// This should NOT be returned: it has only soaked in a Stage
+					// that is not one of the configured upstream Stages.
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "fake-freight-1",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: testWarehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							testUpstreamOfUpstreamStage: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+						},
+					},
+				},
+				&kargoapi.Freight{
+					// This should be returned: it has soaked in one of the
+					// configured upstream Stages.
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "fake-freight-2",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: testWarehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							testUpstreamStage: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, freight []kargoapi.Freight, err error) {
+				require.NoError(t, err)
+				require.Len(t, freight, 1)
+				require.Equal(t, testProject, freight[0].Namespace)
+				require.Equal(t, "fake-freight-2", freight[0].Name)
 			},
 		},
 		{

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -364,7 +364,7 @@ func (r *RegularStageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Reconcile the Stage.
 	logger.Debug("reconciling Stage")
-	newStatus, needsRequeue, reconcileErr := r.reconcile(ctx, stage, time.Now())
+	newStatus, needsRequeue, soakRequeueAfter, reconcileErr := r.reconcile(ctx, stage, time.Now())
 	logger.Debug("done reconciling Stage")
 
 	// Record the current refresh token as having been handled.
@@ -394,14 +394,22 @@ func (r *RegularStageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	// Otherwise, requeue after a delay.
 	// TODO: Make the requeue delay configurable.
-	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	requeueAfter := 5 * time.Minute
+	// Prefer a soak-aware requeue when one was computed and it is sooner than
+	// the default poll interval. This ensures the Stage is re-reconciled
+	// promptly when a piece of verified Freight's soak time elapses, rather
+	// than waiting for the next poll.
+	if soakRequeueAfter > 0 && soakRequeueAfter < requeueAfter {
+		requeueAfter = soakRequeueAfter
+	}
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *RegularStageReconciler) reconcile(
 	ctx context.Context,
 	stage *kargoapi.Stage,
 	startTime time.Time,
-) (kargoapi.StageStatus, bool, error) {
+) (kargoapi.StageStatus, bool, time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 
 	// working is the Stage the sub-reconcilers operate on. Its status is
@@ -428,6 +436,11 @@ func (r *RegularStageReconciler) reconcile(
 	})
 
 	var requestRequeue bool
+	// soakRequeueAfter is a soft requeue hint: the shortest remaining soak time
+	// across the Stage's requested Freight that is verified upstream but not yet
+	// soaked. It lets Reconcile wake the Stage up precisely when that soak
+	// completes instead of waiting for the default poll interval.
+	var soakRequeueAfter time.Duration
 	subReconcilers := []struct {
 		name      string
 		reconcile func() (kargoapi.StageStatus, error)
@@ -501,7 +514,19 @@ func (r *RegularStageReconciler) reconcile(
 			reconcile: func() (kargoapi.StageStatus, error) {
 				status, err := r.autoPromoteFreight(ctx, working)
 				if err != nil {
-					err = fmt.Errorf("failed to auto-promote Freight: %w", err)
+					return status, fmt.Errorf("failed to auto-promote Freight: %w", err)
+				}
+				// When auto-promotion is enabled, determine how long until the
+				// next piece of verified-but-not-yet-soaked Freight becomes
+				// available, so we can requeue precisely when its soak completes.
+				if status.AutoPromotionEnabled {
+					remaining, soakErr := r.shortestRemainingSoak(ctx, working)
+					if soakErr != nil {
+						return status, fmt.Errorf(
+							"failed to compute remaining soak time: %w", soakErr,
+						)
+					}
+					soakRequeueAfter = remaining
 				}
 				return status, err
 			},
@@ -521,7 +546,7 @@ func (r *RegularStageReconciler) reconcile(
 		// If an error occurred during the sub-reconciler, then we should
 		// return the error which will cause the Stage to be requeued.
 		if err != nil {
-			return newStatus, false, err
+			return newStatus, false, 0, err
 		}
 
 		// Patch the status of the Stage after each sub-reconciler to show progress.
@@ -543,7 +568,7 @@ func (r *RegularStageReconciler) reconcile(
 		conditions.Delete(&newStatus, kargoapi.ConditionTypeReconciling)
 	}
 
-	return newStatus, requestRequeue, nil
+	return newStatus, requestRequeue, soakRequeueAfter, nil
 }
 
 // syncPromotions synchronizes the Promotions for a Stage. It determines the
@@ -2016,6 +2041,99 @@ func (r *RegularStageReconciler) getPromotableFreight(
 	}
 
 	return promotableFreight, nil
+}
+
+// soakRequeueBuffer is added to a computed remaining soak time when determining
+// a soak-aware requeue delay. It ensures the controller wakes up a hair after a
+// soak requirement is satisfied rather than a moment before, avoiding an extra
+// no-op reconcile.
+const soakRequeueBuffer = 2 * time.Second
+
+// shortestRemainingSoak returns the shortest remaining soak time across all of
+// the Stage's requested Freight that is verified in a configured upstream Stage
+// but has not yet satisfied its RequiredSoakTime. The returned duration
+// includes a small buffer and is intended for use as a soft requeue hint, so
+// that the Stage is re-reconciled promptly when a piece of Freight's soak
+// completes instead of waiting for the default poll interval.
+//
+// It returns zero when there is nothing to wait for: no source configures a
+// soak time, or every relevant piece of Freight has either already soaked or is
+// no longer accruing soak time (i.e. is no longer in the upstream Stage).
+func (r *RegularStageReconciler) shortestRemainingSoak(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+) (time.Duration, error) {
+	var shortest time.Duration
+	for _, req := range stage.Spec.RequestedFreight {
+		// Only sources with a soak requirement and upstream Stages can have a
+		// pending soak.
+		if req.Sources.Direct ||
+			req.Sources.RequiredSoakTime == nil ||
+			len(req.Sources.Stages) == 0 {
+			continue
+		}
+		soak := req.Sources.RequiredSoakTime.Duration
+		if soak <= 0 {
+			continue
+		}
+
+		warehouse, err := api.GetWarehouse(
+			ctx,
+			r.client,
+			types.NamespacedName{Namespace: stage.Namespace, Name: req.Origin.Name},
+		)
+		if err != nil {
+			return 0, err
+		}
+		if warehouse == nil {
+			continue
+		}
+
+		// List Freight verified in the configured upstream Stage(s), ignoring
+		// soak, so we can find Freight that is verified but not yet soaked. The
+		// AvailabilityStrategy is honored so the candidate set matches the one
+		// used to determine availability.
+		freight, err := api.ListFreightFromWarehouse(
+			ctx,
+			r.client,
+			warehouse,
+			&api.ListWarehouseFreightOptions{
+				VerifiedIn:           req.Sources.Stages,
+				AvailabilityStrategy: req.Sources.AvailabilityStrategy,
+			},
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		for _, f := range freight {
+			for _, upstream := range req.Sources.Stages {
+				// The soak clock only advances while the Freight is both verified
+				// in and currently in the upstream Stage. Freight that has left
+				// the upstream Stage without completing its soak will not accrue
+				// more soak time, so requeuing would not help it.
+				if _, verified := f.Status.VerifiedIn[upstream]; !verified {
+					continue
+				}
+				if _, current := f.Status.CurrentlyIn[upstream]; !current {
+					continue
+				}
+				remaining := soak - f.GetLongestSoak(upstream)
+				if remaining <= 0 {
+					// Already soaked in this upstream Stage.
+					continue
+				}
+				if shortest == 0 || remaining < shortest {
+					shortest = remaining
+				}
+			}
+		}
+	}
+
+	if shortest == 0 {
+		return 0, nil
+	}
+	return shortest + soakRequeueBuffer, nil
 }
 
 // handleDelete handles the deletion of the given Stage. It clears the

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -372,6 +372,174 @@ func TestRegularStageReconciler_Reconcile(t *testing.T) {
 				assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
 			},
 		},
+		{
+			name: "soak-aware requeue for partially soaked upstream Freight",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "fake-project",
+					Name:       "test-stage",
+					Finalizers: []string{kargoapi.FinalizerName},
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: "test-warehouse",
+						},
+						Sources: kargoapi.FreightSources{
+							Stages:           []string{"upstream-stage"},
+							RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+						},
+					}},
+					PromotionTemplate: &kargoapi.PromotionTemplate{
+						Spec: kargoapi.PromotionTemplateSpec{
+							Steps: []kargoapi.PromotionStep{{Uses: "fake-step"}},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.ProjectConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "fake-project",
+					},
+					Spec: kargoapi.ProjectConfigSpec{
+						PromotionPolicies: []kargoapi.PromotionPolicy{{
+							Stage:                "test-stage",
+							AutoPromotionEnabled: true,
+						}},
+					},
+				},
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "soaking-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							"upstream-stage": {},
+						},
+						CurrentlyIn: map[string]kargoapi.CurrentStage{
+							// 58m of a 1h requirement, so ~2m remain.
+							"upstream-stage": {Since: &metav1.Time{Time: time.Now().Add(-58 * time.Minute)}},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, c client.Client, result ctrl.Result, err error) {
+				require.NoError(t, err)
+
+				// The requeue should be soak-aware: sooner than the default poll
+				// interval and roughly equal to the remaining soak.
+				assert.Greater(t, result.RequeueAfter, time.Minute)
+				assert.Less(t, result.RequeueAfter, 3*time.Minute)
+
+				// The Freight has not yet soaked, so no Promotion should exist.
+				promoList := &kargoapi.PromotionList{}
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
+				assert.Empty(t, promoList.Items)
+			},
+		},
+		{
+			name: "default requeue and promotion for already soaked Freight",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "fake-project",
+					Name:       "test-stage",
+					Finalizers: []string{kargoapi.FinalizerName},
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: "test-warehouse",
+						},
+						Sources: kargoapi.FreightSources{
+							Stages:           []string{"upstream-stage"},
+							RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+						},
+					}},
+					PromotionTemplate: &kargoapi.PromotionTemplate{
+						Spec: kargoapi.PromotionTemplateSpec{
+							Steps: []kargoapi.PromotionStep{{Uses: "fake-step"}},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.ProjectConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "fake-project",
+					},
+					Spec: kargoapi.ProjectConfigSpec{
+						PromotionPolicies: []kargoapi.PromotionPolicy{{
+							Stage:                "test-stage",
+							AutoPromotionEnabled: true,
+						}},
+					},
+				},
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "fake-project",
+						Name:              "soaked-freight",
+						CreationTimestamp: metav1.Time{Time: time.Now()},
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							"upstream-stage": {
+								LongestCompletedSoak: &metav1.Duration{Duration: 2 * time.Hour},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, c client.Client, result ctrl.Result, err error) {
+				require.NoError(t, err)
+
+				// Nothing is pending soak, so the default poll interval applies.
+				assert.Equal(t, 5*time.Minute, result.RequeueAfter)
+
+				// The already-soaked Freight should have been auto-promoted.
+				promoList := &kargoapi.PromotionList{}
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
+				require.Len(t, promoList.Items, 1)
+				assert.Equal(t, "soaked-freight", promoList.Items[0].Spec.Freight)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -637,7 +805,7 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 				healthChecker: &health.MockAggregatingChecker{},
 			}
 
-			status, requeue, err := r.reconcile(t.Context(), tt.stage, now)
+			status, requeue, _, err := r.reconcile(t.Context(), tt.stage, now)
 			tt.assertions(t, status, requeue, err)
 		})
 	}
@@ -7103,6 +7271,256 @@ func Test_buildFreightSummary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildFreightSummary(tt.requested, tt.current)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRegularStageReconciler_shortestRemainingSoak(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	now := time.Now()
+
+	const (
+		project   = "fake-project"
+		warehouse = "test-warehouse"
+		upstream  = "upstream-stage"
+	)
+
+	testWarehouse := &kargoapi.Warehouse{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: project,
+			Name:      warehouse,
+		},
+	}
+
+	newStage := func(sources kargoapi.FreightSources) *kargoapi.Stage {
+		return &kargoapi.Stage{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: project,
+				Name:      "test-stage",
+			},
+			Spec: kargoapi.StageSpec{
+				RequestedFreight: []kargoapi.FreightRequest{{
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Sources: sources,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		stage      *kargoapi.Stage
+		objects    []client.Object
+		assertions func(*testing.T, time.Duration, error)
+	}{
+		{
+			name: "no soak time configured",
+			stage: newStage(kargoapi.FreightSources{
+				Stages: []string{upstream},
+			}),
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Zero(t, d)
+			},
+		},
+		{
+			name: "direct sources are ignored",
+			stage: newStage(kargoapi.FreightSources{
+				Direct:           true,
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			}),
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Zero(t, d)
+			},
+		},
+		{
+			name: "freight already soaked yields no requeue",
+			stage: newStage(kargoapi.FreightSources{
+				Stages:           []string{upstream},
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			}),
+			objects: []client.Object{
+				testWarehouse,
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: project,
+						Name:      "soaked-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							upstream: {},
+						},
+						CurrentlyIn: map[string]kargoapi.CurrentStage{
+							// In the upstream Stage for 2h, well beyond the 1h
+							// requirement.
+							upstream: {Since: &metav1.Time{Time: now.Add(-2 * time.Hour)}},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Zero(t, d)
+			},
+		},
+		{
+			name: "verified but no longer in upstream yields no requeue",
+			stage: newStage(kargoapi.FreightSources{
+				Stages:           []string{upstream},
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			}),
+			objects: []client.Object{
+				testWarehouse,
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: project,
+						Name:      "stalled-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							// Verified with an incomplete soak, but no longer in the
+							// upstream Stage, so the soak clock is not running and a
+							// requeue would not help.
+							upstream: {
+								LongestCompletedSoak: &metav1.Duration{Duration: 30 * time.Minute},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Zero(t, d)
+			},
+		},
+		{
+			name: "partially soaked freight yields remaining soak requeue",
+			stage: newStage(kargoapi.FreightSources{
+				Stages:           []string{upstream},
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			}),
+			objects: []client.Object{
+				testWarehouse,
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: project,
+						Name:      "soaking-freight",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{
+							upstream: {},
+						},
+						CurrentlyIn: map[string]kargoapi.CurrentStage{
+							// In the upstream Stage for 58m of a 1h requirement, so
+							// ~2m remain.
+							upstream: {Since: &metav1.Time{Time: now.Add(-58 * time.Minute)}},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				// ~2m remaining plus a small buffer, and well under the 5m poll
+				// interval so it actually takes effect.
+				assert.Greater(t, d, time.Minute)
+				assert.Less(t, d, 3*time.Minute)
+			},
+		},
+		{
+			name: "multiple soaking freight yields the shortest remaining",
+			stage: newStage(kargoapi.FreightSources{
+				Stages:           []string{upstream},
+				RequiredSoakTime: &metav1.Duration{Duration: time.Hour},
+			}),
+			objects: []client.Object{
+				testWarehouse,
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: project,
+						Name:      "freight-a",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{upstream: {}},
+						CurrentlyIn: map[string]kargoapi.CurrentStage{
+							// ~10m remaining.
+							upstream: {Since: &metav1.Time{Time: now.Add(-50 * time.Minute)}},
+						},
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: project,
+						Name:      "freight-b",
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: warehouse,
+					},
+					Status: kargoapi.FreightStatus{
+						VerifiedIn: map[string]kargoapi.VerifiedStage{upstream: {}},
+						CurrentlyIn: map[string]kargoapi.CurrentStage{
+							// ~2m remaining -- the shortest.
+							upstream: {Since: &metav1.Time{Time: now.Add(-58 * time.Minute)}},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, d time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Greater(t, d, time.Minute)
+				assert.Less(t, d, 3*time.Minute)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				WithIndex(
+					&kargoapi.Freight{},
+					indexer.FreightByWarehouseField,
+					indexer.FreightByWarehouse,
+				).
+				WithIndex(
+					&kargoapi.Freight{},
+					indexer.FreightByVerifiedStagesField,
+					indexer.FreightByVerifiedStages,
+				).
+				WithIndex(
+					&kargoapi.Freight{},
+					indexer.FreightApprovedForStagesField,
+					indexer.FreightApprovedForStages,
+				).
+				Build()
+
+			r := &RegularStageReconciler{client: c}
+
+			d, err := r.shortestRemainingSoak(t.Context(), tt.stage)
+			tt.assertions(t, d, err)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #4586

Freight soak filtering considered every Stage in a Freight's verification history instead of only the configured upstream Stages. This could permanently block `All` when Freight had additional verification history and could incorrectly satisfy `OneOf` using a non-upstream Stage.

This change scopes soak checks to the configured upstream Stages. It also calculates the shortest remaining active soak and uses it as a soft Stage requeue hint, ensuring auto-promotion is re-evaluated when soak completes instead of waiting for another event or the five-minute periodic poll.

## Testing

- [x] `go test ./pkg/api -run '^TestListFreightFromWarehouse$' -count=1`
- [x] `go test ./pkg/api -count=1`
- [x] `go build ./pkg/controller/stages/...`
- [x] `go test ./pkg/controller/stages/ -run 'TestRegularStageReconciler_shortestRemainingSoak' -count=1`
- [x] `go test ./pkg/controller/stages/ -run 'TestRegularStageReconciler_Reconcile$' -count=1`
- [x] `go test ./pkg/controller/stages/ -count=1`
- [x] `make lint-go` (0 issues)
- [x] Deployed the current working tree with `make hack-tilt-up` and confirmed the controller rolled to a new Tilt image.
- [x] Manual single-upstream soak: confirmed no Promotion was created before a 45-second soak completed, then confirmed a downstream Promotion was created automatically after the remaining soak plus buffer without another refresh.
- [x] Manual two-upstream `OneOf`: with staggered 20-second soaks, confirmed the Promotion was created after `upstream-a` completed while `upstream-b` had soaked for only 7 seconds.
- [x] Manual two-upstream `All`: with the same staggered soaks, confirmed no early Promotion and that the Promotion was created only after `upstream-b` had also soaked for 22 seconds.

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**