### PR TITLE
fix(argocd): Makes the updater more tolerant to discovery failures

### DIFF
--- a/pkg/promotion/runner/builtin/argocd_updater.go
+++ b/pkg/promotion/runner/builtin/argocd_updater.go
@@ -11,7 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/api"
@@ -802,7 +805,9 @@ func (a *argocdUpdater) getAuthorizedApplications(
 			client.MatchingLabelsSelector{Selector: labelSelector},
 		}
 
-		if err = a.argocdClient.List(ctx, appList, listOpts...); err != nil {
+		if err = a.withDiscoveryRetry(ctx, func(ctx context.Context) error {
+			return a.argocdClient.List(ctx, appList, listOpts...)
+		}); err != nil {
 			return nil, fmt.Errorf("error listing Argo CD Applications matching selector: %w", err)
 		}
 
@@ -812,8 +817,12 @@ func (a *argocdUpdater) getAuthorizedApplications(
 		}
 	} else {
 		// Get single Application by name
-		app, err := argocd.GetApplication(ctx, a.argocdClient, namespace, update.Name)
-		if err != nil {
+		var app *argocd.Application
+		if err := a.withDiscoveryRetry(ctx, func(ctx context.Context) error {
+			var getErr error
+			app, getErr = argocd.GetApplication(ctx, a.argocdClient, namespace, update.Name)
+			return getErr
+		}); err != nil {
 			return nil, fmt.Errorf(
 				"error finding Argo CD Application %q in namespace %q: %w",
 				update.Name, namespace, err,
@@ -867,6 +876,64 @@ func (a *argocdUpdater) getAuthorizedApplications(
 	}
 
 	return authorizedApps, nil
+}
+
+// discoveryRetryBackoff bounds retries of Argo CD Application reads that fail
+// because the API server's discovery information was momentarily incomplete.
+// Five attempts over a capped exponential backoff (~15s total) comfortably fit
+// within the step's default 5m timeout while giving a flapping aggregated
+// discovery endpoint time to recover.
+var discoveryRetryBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: time.Second,
+	Factor:   2,
+	Jitter:   0.1,
+	Cap:      15 * time.Second,
+}
+
+// withDiscoveryRetry runs fn, retrying it with backoff for as long as it fails
+// because the discovery-backed RESTMapper could not map the Argo CD Application
+// kind due to incomplete or temporarily unavailable API discovery. It does NOT
+// retry when the Application kind is genuinely not served by the cluster (e.g.
+// the Argo CD CRDs are not installed), so a real misconfiguration still fails
+// fast instead of blocking for the full backoff.
+//
+// The passed function requires a context to help cancel any inflight work rather
+// than waiting for the retry period
+func (a *argocdUpdater) withDiscoveryRetry(ctx context.Context, fn func(ctx context.Context) error) error {
+	logger := logging.LoggerFromContext(ctx)
+	return retry.OnError(discoveryRetryBackoff, isIncompleteDiscoveryError, func() error {
+		err := fn(ctx)
+		if isIncompleteDiscoveryError(err) {
+			logger.Debug(
+				"could not map Argo CD Application kind because API discovery was "+
+					"incomplete; retrying",
+				"error", err.Error(),
+			)
+		}
+		return err
+	})
+}
+
+// isIncompleteDiscoveryError reports whether err indicates that the
+// discovery-backed RESTMapper could not map a kind because a discovery call
+// failed or returned incomplete results -- as opposed to the kind genuinely not
+// being served by the cluster.
+//
+// controller-runtime's RESTMapper returns an *apiutil.ErrResourceDiscoveryFailed
+// only when discovery for a GroupVersion fails or comes back incomplete. This is
+// transient and worth retrying: on the next attempt the mapper performs a
+// targeted discovery of just that group-version, which typically succeeds. When
+// the kind is genuinely absent, that targeted discovery returns NotFound and the
+// mapper instead returns a bare *meta.NoKindMatchError, which is not matched
+// here, so the caller fails fast rather than looping until the backoff is
+// exhausted.
+func isIncompleteDiscoveryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var discoveryErr *apiutil.ErrResourceDiscoveryFailed
+	return errors.As(err, &discoveryErr)
 }
 
 // authorizeArgoCDAppUpdate returns an error if the Argo CD Application

--- a/pkg/promotion/runner/builtin/argocd_updater_test.go
+++ b/pkg/promotion/runner/builtin/argocd_updater_test.go
@@ -5,13 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -1735,7 +1740,8 @@ func Test_argoCDUpdater_syncApplication(t *testing.T) {
 					string,
 					string,
 				) {
-				}},
+				},
+			},
 			app: &argocd.Application{
 				ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
 				Spec: argocd.ApplicationSpec{
@@ -1766,7 +1772,8 @@ func Test_argoCDUpdater_syncApplication(t *testing.T) {
 					string,
 					string,
 				) {
-				}},
+				},
+			},
 			app: &argocd.Application{
 				ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
 				Spec: argocd.ApplicationSpec{
@@ -3135,6 +3142,144 @@ func Test_argoCDUpdater_validateSourceUpdatesApplicable(t *testing.T) {
 				testCase.apps,
 			)
 			testCase.assertions(t, err)
+		})
+	}
+}
+
+// incompleteDiscoveryErr builds the error that controller-runtime's
+// discovery-backed RESTMapper returns when discovery for the Argo CD Application
+// group-version fails or comes back incomplete.
+func incompleteDiscoveryErr() error {
+	gv := schema.GroupVersion{Group: "argoproj.io", Version: "v1alpha1"}
+	discErr := apiutil.ErrResourceDiscoveryFailed{
+		gv: &meta.NoResourceMatchError{PartialResource: gv.WithResource("")},
+	}
+	return &discErr
+}
+
+// noKindMatchErr builds the error that the RESTMapper returns when the Argo CD
+// Application kind is genuinely not served by the cluster (e.g. the CRDs are not
+// installed).
+func noKindMatchErr() error {
+	return &meta.NoKindMatchError{
+		GroupKind:        schema.GroupKind{Group: "argoproj.io", Kind: "Application"},
+		SearchedVersions: []string{"v1alpha1"},
+	}
+}
+
+func Test_isIncompleteDiscoveryError(t *testing.T) {
+	testCases := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"nil error": {
+			err:      nil,
+			expected: false,
+		},
+		"incomplete discovery error": {
+			err:      incompleteDiscoveryErr(),
+			expected: true,
+		},
+		"wrapped incomplete discovery error": {
+			err:      fmt.Errorf("error getting Application: %w", incompleteDiscoveryErr()),
+			expected: true,
+		},
+		"genuine no-kind-match error is not retriable": {
+			err:      noKindMatchErr(),
+			expected: false,
+		},
+		"genuine no-resource-match error is not retriable": {
+			err: &meta.NoResourceMatchError{
+				PartialResource: schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1"},
+			},
+			expected: false,
+		},
+		"unrelated error": {
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, isIncompleteDiscoveryError(testCase.err))
+		})
+	}
+}
+
+func Test_argoCDUpdater_withDiscoveryRetry(t *testing.T) {
+	// Use a fast backoff so the retry tests do not sleep for seconds.
+	original := discoveryRetryBackoff
+	discoveryRetryBackoff = wait.Backoff{
+		Steps:    5,
+		Duration: time.Millisecond,
+		Factor:   1,
+	}
+	t.Cleanup(func() { discoveryRetryBackoff = original })
+
+	testCases := map[string]struct {
+		fn            func(callCount *int) error
+		assertErr     func(*testing.T, error)
+		expectedCalls int
+	}{
+		"succeeds on first attempt": {
+			fn: func(callCount *int) error {
+				*callCount++
+				return nil
+			},
+			assertErr:     func(t *testing.T, err error) { assert.NoError(t, err) },
+			expectedCalls: 1,
+		},
+		"retries incomplete discovery error then succeeds": {
+			fn: func(callCount *int) error {
+				*callCount++
+				if *callCount < 3 {
+					return incompleteDiscoveryErr()
+				}
+				return nil
+			},
+			assertErr:     func(t *testing.T, err error) { assert.NoError(t, err) },
+			expectedCalls: 3,
+		},
+		"does not retry a genuine no-match error": {
+			fn: func(callCount *int) error {
+				*callCount++
+				return noKindMatchErr()
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.True(t, meta.IsNoMatchError(err))
+			},
+			expectedCalls: 1,
+		},
+		"does not retry an unrelated error": {
+			fn: func(callCount *int) error {
+				*callCount++
+				return errors.New("boom")
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "boom")
+			},
+			expectedCalls: 1,
+		},
+		"gives up after exhausting attempts": {
+			fn: func(callCount *int) error {
+				*callCount++
+				return incompleteDiscoveryErr()
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.True(t, isIncompleteDiscoveryError(err))
+			},
+			expectedCalls: 5,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var callCount int
+			runner := &argocdUpdater{}
+			err := runner.withDiscoveryRetry(context.Background(), func(_ context.Context) error {
+				return testCase.fn(&callCount)
+			})
+			testCase.assertErr(t, err)
+			assert.Equal(t, testCase.expectedCalls, callCount)
 		})
 	}
 }


### PR DESCRIPTION
In new clusters or on a fresh startup, there can be hiccups when the initial discovery step happens for the k8s client. These were rare, but we did observe it happening several times (especially in tests). This adds retries to the discovery if and only if it was a partial discovery and not when something genuinely doesn't exist

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [X] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.
