### PR TITLE
docs: fix stray apostrophe in v1.1.0 release notes

### DIFF
--- a/docs/docs/80-release-notes/98-v1.1.0.md
+++ b/docs/docs/80-release-notes/98-v1.1.0.md
@@ -68,7 +68,7 @@ As always, the Kargo UI has received too many improvements to list in this relea
 
 * Within the view of a single Project, it is now possible to zoom in/out on the pipeline graph and drag to reposition it. This should make it considerably easier to work with long pipelines or Projects containing many pipelines.
 
-* A new user information page accessible from the sidebar displays the currently logged-in user's claims obtained from the identity token issued by the configured' OIDC identity provider. We anticipate this page will be useful for debugging OIDC configuration issues as well as authorization issues.
+* A new user information page accessible from the sidebar displays the currently logged-in user's claims obtained from the identity token issued by the configured OIDC identity provider. We anticipate this page will be useful for debugging OIDC configuration issues as well as authorization issues.
 
 ## 🙏 New Contributors {#new-contributors}
 


### PR DESCRIPTION
Fix a typo in the v1.1.0 release notes where a stray apostrophe appeared after 'configured'.