### PR TITLE
fix(ui): avoid analysis run chart on undefined values as analysis was terminated 

### DIFF
--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -776,7 +776,7 @@ const transformMeasurementValue = (
 ): MeasurementValueInfo => {
   if (value === undefined || value === '') {
     return {
-      canChart: true,
+      canChart: false,
       chartValue: null,
       tableValue: null
     };

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -776,6 +776,7 @@ const transformMeasurementValue = (
 ): MeasurementValueInfo => {
   if (value === undefined || value === '') {
     return {
+      // most probably AR was terminated so value wasn't recorded, so no point of chart without any values
       canChart: false,
       chartValue: null,
       tableValue: null


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #<!-- issue number, or delete this line if not applicable -->

Some background:

If one of many verification is failed, rollouts will terminate rest from middle with **Successful** stamp on phase. While this is one of issue on its own (as far as UI concerned), there is something else that pops up. The value of result is not stamped if analysis is terminated in between, so it creates empty successful result, which makes UI's chart looks empty.

Here is example of such manifest:

```yaml
status:
  phase: Failed
  message: Metric "fail-fast" assessed Failed due to failed (1) > failureLimit (0)
  metricResults:
    - name: success-rate
      phase: Successful
      measurements:
        - phase: Successful
          startedAt: 2026-07-13T06:41:24Z
          finishedAt: 2026-07-13T06:41:24Z
          value: "99"
      count: 1
      successful: 1
      consecutiveSuccess: 1
    - name: fail-fast
      phase: Failed
      measurements:
        - phase: Failed
          startedAt: 2026-07-13T06:41:24Z
          finishedAt: 2026-07-13T06:41:24Z
          value: "42"
      count: 1
      failed: 1
    - name: test
      phase: Successful
      measurements:
        - phase: Successful # <----- notice this measurement has not value
          message: Metric Terminated
          startedAt: 2026-07-13T06:41:24Z
          finishedAt: 2026-07-13T06:41:24Z
          metadata:
            job-name: 8a3a75b2-4d92-454b-a829-af3b7ed2dc04.test.1
            job-namespace: metrics
      message: Metric Terminated
      count: 1
      successful: 1
      consecutiveSuccess: 1
  startedAt: 2026-07-13T06:41:24Z
  runSummary:
    count: 3
    successful: 2
    failed: 1
```

Here is how chart looked like before:

<img width="882" height="617" alt="Screenshot 2026-07-13 at 3 06 22 PM (2)" src="https://github.com/user-attachments/assets/aaefe435-e274-435e-9b70-abf64607f1f6" />

After this change:

<img width="872" height="465" alt="Screenshot 2026-07-13 at 3 06 51 PM (2)" src="https://github.com/user-attachments/assets/92cc1b5a-833d-4fb4-a924-5a13f205c2b4" />

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [ ] Adds or updates corresponding tests
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [x] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
