### PR TITLE
fix(ui): guard undefined measurement values in metric chart tooltip

### DIFF
--- a/ui/src/features/common/analysis-modal/metric-chart/metric-chart.tsx
+++ b/ui/src/features/common/analysis-modal/metric-chart/metric-chart.tsx
@@ -22,14 +22,12 @@ import { AnalysisStatus, TransformedMeasurement } from '../types';
 import { chartDotColors } from '../utils';
 
 import styles from './metric-chart.module.less';
+import { defaultValueFormatter } from './utils';
 
 const { Text } = Typography;
 
 const CHART_HEIGHT = 254;
 const X_AXIS_HEIGHT = 45;
-
-const defaultValueFormatter = (value: number | string | null) =>
-  value === null ? '' : value.toString();
 
 const timeTickFormatter = (axisData?: string) => {
   if (axisData === undefined) {
@@ -57,7 +55,7 @@ const MeasurementDot = ({ cx, cy, payload }: MeasurementDotProps) => (
 
 type TooltipContentProps = TooltipProps<ValueType, NameType> & {
   conditionKeys: string[];
-  valueFormatter: (value: number | string | null) => string;
+  valueFormatter: (value?: number | string | null) => string;
 };
 
 const TooltipContent = ({
@@ -78,8 +76,8 @@ const TooltipContent = ({
   } else if (conditionKeys.length > 0) {
     const sublabels = conditionKeys.map((cKey: string) =>
       conditionKeys.length > 1
-        ? `${valueFormatter(data.chartValue[cKey])} (${cKey})`
-        : valueFormatter(data.chartValue[cKey])
+        ? `${valueFormatter(data.chartValue?.[cKey])} (${cKey})`
+        : valueFormatter(data.chartValue?.[cKey])
     );
     label = sublabels.join(' , ');
   } else {
@@ -107,7 +105,7 @@ interface MetricChartProps {
   max?: number;
   min?: number;
   successThresholds: number[];
-  valueFormatter?: (value: number | string | null) => string;
+  valueFormatter?: (value?: number | string | null) => string;
   yAxisFormatter?: (value: number | string, index: number) => string;
   yAxisLabel?: string;
 }

--- a/ui/src/features/common/analysis-modal/metric-chart/utils.test.ts
+++ b/ui/src/features/common/analysis-modal/metric-chart/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+
+import { defaultValueFormatter } from './utils';
+
+describe('defaultValueFormatter', () => {
+  const testCases: {
+    name: string;
+    value?: number | string | null;
+    expected: string;
+  }[] = [
+    // Regression: a conditionKey present in the deduped union but absent from a
+    // data point's chartValue yields undefined. Guarding only null previously
+    // threw "Cannot read properties of undefined (reading 'toString')".
+    { name: 'undefined coalesces to empty string', value: undefined, expected: '' },
+    { name: 'null coalesces to empty string', value: null, expected: '' },
+    { name: 'zero is stringified, not treated as empty', value: 0, expected: '0' },
+    { name: 'number is stringified', value: 4.05, expected: '4.05' },
+    { name: 'empty string is preserved', value: '', expected: '' },
+    { name: 'string is preserved', value: 'n/a', expected: 'n/a' }
+  ];
+
+  for (const testCase of testCases) {
+    test(testCase.name, () => {
+      expect(defaultValueFormatter(testCase.value)).toBe(testCase.expected);
+    });
+  }
+});

--- a/ui/src/features/common/analysis-modal/metric-chart/utils.ts
+++ b/ui/src/features/common/analysis-modal/metric-chart/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats a measurement value for display in the metric chart.
+ *
+ * Coalesces both null and undefined to an empty string. A data point's
+ * chartValue object does not always carry every key in the deduped
+ * conditionKeys union, so lookups such as `data.chartValue?.[cKey]` can be
+ * undefined -- guarding only null (as an earlier version did) let
+ * `undefined.toString()` throw.
+ */
+export const defaultValueFormatter = (value?: number | string | null): string =>
+  value === null || value === undefined ? '' : value.toString();


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #<!-- issue number, or delete this line if not applicable -->

<!-- Describe what this PR does and why. -->

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [ ] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
