### PR TITLE
chore(deps): upgrade pnpm to v11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ARG BASE_IMAGE=kargo-base
 ####################################################################################################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:26.4.0 AS ui-builder
 
-ARG PNPM_VERSION=9.0.3
+ARG PNPM_VERSION=11.13.0
 RUN npm install --global pnpm@${PNPM_VERSION}
 
 WORKDIR /ui
-COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
+COPY ["ui/package.json", "ui/pnpm-lock.yaml", "ui/pnpm-workspace.yaml", "./"]
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install
 COPY ["ui/", "."]
@@ -122,10 +122,10 @@ CMD ["/usr/local/bin/kargo"]
 ####################################################################################################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:26.4.0 AS ui-dev
 
-ARG PNPM_VERSION=9.0.3
+ARG PNPM_VERSION=11.13.0
 RUN npm install --global pnpm@${PNPM_VERSION}
 WORKDIR /ui
-COPY ["ui/package.json", "ui/pnpm-lock.yaml", "./"]
+COPY ["ui/package.json", "ui/pnpm-lock.yaml", "ui/pnpm-workspace.yaml", "./"]
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,8 +2,8 @@ FROM golang:1.26.5-trixie
 
 ARG TARGETARCH
 
-ARG NODE_MAJOR=20
-ARG PNPM_VERSION=9.0.3
+ARG NODE_MAJOR=22
+ARG PNPM_VERSION=11.13.0
 
 RUN apt update && apt install -y ca-certificates curl gnupg unzip \
     && mkdir -p /etc/apt/keyrings \

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const tags = require('./tags');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
-/** @type {import('@docusaurus/types').Config} */
+/** @type {string} */
 const siteDescription = 'Kargo is a Kubernetes-native continuous promotion platform that orchestrates the movement of artifacts through environments in GitOps workflows.';
 
 const softwareApplicationJsonLd = {

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,10 +18,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"
   },
-  "packageManager": "pnpm@9.0.3",
-  "pnpm": {
-    "overrides": {}
-  },
+  "packageManager": "pnpm@11.13.0",
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",

--- a/docs/plugins/gtag/package.json
+++ b/docs/plugins/gtag/package.json
@@ -7,10 +7,7 @@
     "build": "tsc --build",
     "watch": "tsc --build --watch"
   },
-  "packageManager": "pnpm@9.0.3",
-  "pnpm": {
-    "overrides": {}
-  },
+  "packageManager": "pnpm@11.13.0",
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/types": "^3.10.1",

--- a/docs/plugins/gtag/pnpm-workspace.yaml
+++ b/docs/plugins/gtag/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  core-js: false

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: false

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   publish = "build/"
   
 [build.environment]
-  NODE_VERSION = "22.13.0"
+  NODE_VERSION = "22.23.1"
   
 [context.deploy-preview]
   ignore = "git diff --quiet main -- docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   publish = "build/"
   
 [build.environment]
-  NODE_VERSION = "22.11.0"
+  NODE_VERSION = "22.13.0"
   
 [context.deploy-preview]
   ignore = "git diff --quiet main -- docs"

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,11 +14,6 @@
     "test": "vitest"
   },
   "license": "ISC",
-  "pnpm": {
-    "overrides": {
-      "@ant-design/icons": "6.1.1"
-    }
-  },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "15.4.0",
     "@eslint/compat": "2.1.0",
@@ -60,7 +55,7 @@
     "vitest": "4.1.9",
     "zx": "8.8.5"
   },
-  "packageManager": "pnpm@9.0.3",
+  "packageManager": "pnpm@11.13.0",
   "dependencies": {
     "@ant-design/v5-patch-for-react-19": "1.0.3",
     "@bufbuild/protobuf": "2.11.0",

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+overrides:
+  '@ant-design/icons': 6.1.1


### PR DESCRIPTION
## Description

Upgrades pnpm to v11.13.0 across the UI and documentation projects. Migrates pnpm settings into workspace configuration, explicitly reviews dependency build scripts, and updates the development image to Node.js 22 as required by pnpm 11.

Validation:

- `pnpm --dir ui install --frozen-lockfile && pnpm --dir ui run typecheck`
- `pnpm --dir docs/plugins/gtag install --frozen-lockfile && pnpm --dir docs/plugins/gtag run build`
- `pnpm --dir docs install --frozen-lockfile`
- `pnpm --dir docs run typecheck` *(fails at the existing `docusaurus.config.js` `string`-to-`Config` TypeScript error)*

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

Made with [Cursor](https://cursor.com)