### PR TITLE
chore(deps): bump golang from 1.26.4-trixie to 1.26.5-trixie in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: &golangImage golang:1.26.4-trixie
+      image: &golangImage golang:1.26.5-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,7 +243,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: &golangImage golang:1.26.4-trixie
+      image: &golangImage golang:1.26.5-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]


### PR DESCRIPTION
Dependabot bumped the `golang` base image in `Dockerfile` and `Dockerfile.dev` in #6593, but the same image is also pinned in `ci.yaml` and `release.yaml`. This brings those in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)