### PR TITLE
fix(ui): disable freight creation without warehouses

### DIFF
--- a/ui/src/features/project/pipelines/pipelines.tsx
+++ b/ui/src/features/project/pipelines/pipelines.tsx
@@ -1,7 +1,7 @@
 import { faDocker } from '@fortawesome/free-brands-svg-icons';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Dropdown, Flex, Result } from 'antd';
+import { Button, Dropdown, Flex, Result, Tooltip } from 'antd';
 import classNames from 'classnames';
 import { useMemo, useState } from 'react';
 import { generatePath, Link, useNavigate, useParams } from 'react-router-dom';
@@ -246,7 +246,15 @@ export const Pipelines = (props: { creatingStage?: boolean; creatingWarehouse?: 
                           },
                           {
                             key: '2',
-                            label: 'Freight',
+                            label:
+                              warehouses.length === 0 ? (
+                                <Tooltip title='Create a Warehouse before creating Freight.'>
+                                  <span>Freight</span>
+                                </Tooltip>
+                              ) : (
+                                'Freight'
+                              ),
+                            disabled: warehouses.length === 0,
                             children: warehouses.map((warehouse) => ({
                               key: warehouse?.metadata?.name || '',
                               label: warehouse?.metadata?.name || '',


### PR DESCRIPTION
## Description

Disables the Freight creation menu item when the project has no Warehouses and explains the prerequisite with a tooltip.

<img width="329" height="361" alt="image" src="https://github.com/user-attachments/assets/813b0043-fab9-4d9c-896c-3ef49b6714a4" />

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
