### PR TITLE
feat(oci-push): support pushing a local archive

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
@@ -80,9 +80,10 @@ recorded via standard OCI annotations.
 
 :::note
 
-The `tar` step used below to produce the archive is planned but not yet
-available. Until then, produce the archive with another step (for example, by
-invoking `tar` from a script) and point `srcPath` at the result.
+The `tar` step used below to produce the archive is a companion contribution
+currently in review ([#6666](https://github.com/akuity/kargo/pull/6666)). Until
+it merges and ships, produce the archive another way (for example, by invoking
+`tar` from a script) and point `srcPath` at the result.
 
 :::
 
@@ -90,8 +91,9 @@ invoking `tar` from a script) and point `srcPath` at the result.
 steps:
 - uses: tar
   config:
-    path: ./manifests
+    inPath: ./manifests
     outPath: ./manifests.tar.gz
+    gzip: true
 - uses: oci-push
   config:
     srcPath: ./manifests.tar.gz

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/oci-push.md
@@ -1,25 +1,53 @@
 ---
 sidebar_label: oci-push
-description: Copies or retags OCI artifacts (container images, Helm charts) between registries.
+description: Pushes OCI artifacts to a registry, either by copying/retagging between registries or by uploading a local archive.
 ---
 
 # `oci-push`
 
-`oci-push` copies or retags OCI artifacts between registries or within the same
-registry. This step supports container images and Helm charts stored in OCI
-registries, making it useful for promoting artifacts through a pipeline — for
-example, retagging an image with a release version or copying it to a production
-registry. Multi-arch image indexes are copied in full. Registry authentication
-is supported for both source and destination.
+`oci-push` pushes OCI artifacts to a registry. It operates in one of two modes:
+
+- **Copy/retag** (`srcRef`): copies or retags an existing artifact between
+  registries or within the same registry. This supports container images and
+  Helm charts stored in OCI registries — for example, retagging an image with a
+  release version or copying it to a production registry. Multi-arch image
+  indexes are copied in full.
+- **Push a local archive** (`srcPath`): uploads a local file from the workspace
+  (such as a tarball of rendered manifests) as a single-layer OCI artifact, with
+  configurable media types. This is useful for publishing rendered manifests as
+  an artifact for consumption by Argo CD, Flux, or other OCI-aware tooling.
+
+Registry authentication is supported for both source and destination.
+
+Exactly one of `srcRef` or `srcPath` must be specified.
 
 ## Configuration
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `srcRef` | `string` | Y | Reference to the source OCI artifact. Supports both tag format `registry/repository:tag` and digest format `registry/repository@sha256:digest`. For Helm OCI artifacts, the `oci://` prefix is supported (e.g., `oci://registry/repository:tag`) and will use Helm-specific credential lookup. |
+| `srcRef` | `string` | Y* | Reference to the source OCI artifact. Supports both tag format `registry/repository:tag` and digest format `registry/repository@sha256:digest`. For Helm OCI artifacts, the `oci://` prefix is supported (e.g., `oci://registry/repository:tag`) and will use Helm-specific credential lookup. Mutually exclusive with `srcPath`. |
+| `srcPath` | `string` | Y* | Path, relative to the workspace, of a local file to push as a single-layer OCI artifact (e.g., a tarball produced by an earlier step). Mutually exclusive with `srcRef`. |
 | `destRef` | `string` | Y | Destination reference including tag (e.g., `registry/repository:tag`). For Helm OCI artifacts, the `oci://` prefix is supported. For retag-in-place, use the same repository as `srcRef` with the new tag. |
-| `annotations` | `object` | N | Annotations to set on the destination artifact. Keys may be prefixed with `index:` or `manifest:` to scope them to the index or image manifest respectively. Unprefixed keys default to the image manifest. For single images, `index:`-prefixed keys are ignored. Values support expressions. Existing annotations on the source artifact are preserved; specified annotations are added or overwritten. |
+| `mediaType` | `string` | N | Media type of the artifact layer when pushing a local file via `srcPath`. Defaults to `application/vnd.oci.image.layer.v1.tar+gzip`. Ignored when using `srcRef`. |
+| `artifactType` | `string` | N | Declares the type of artifact being pushed via `srcPath`. It is applied as the manifest's config media type (following the convention used by Helm, Flux, and ORAS). Ignored when using `srcRef`. |
+| `annotations` | `object` | N | Annotations to set on the destination artifact. Keys may be prefixed with `index:` or `manifest:` to scope them to the index or image manifest respectively. Unprefixed keys default to the image manifest. For single images (including local-archive pushes), `index:`-prefixed keys are ignored. Values support expressions. When copying with `srcRef`, existing annotations on the source artifact are preserved; specified annotations are added or overwritten. |
 | `insecureSkipTLSVerify` | `boolean` | N | Whether to skip TLS verification for both source and destination registries. Defaults to `false`. |
+
+`*` Exactly one of `srcRef` or `srcPath` is required.
+
+:::note
+
+`srcPath` is content-agnostic: it pushes any file as a single layer, so it is
+not limited to tarballs. A compressed tarball is the common case, but single
+non-tar files (e.g., a WASM module or an SBOM) work as well — set `mediaType`
+and `artifactType` to describe the content.
+
+Producing canonical Helm charts via `srcPath` is not supported, because a Helm
+chart's manifest config blob must carry the chart's `Chart.yaml` metadata. Use
+the copy/retag mode (`srcRef` with the `oci://` prefix) to promote existing Helm
+charts between registries.
+
+:::
 
 ## Outputs
 
@@ -37,9 +65,43 @@ child images. Exceeding this limit causes a terminal (non-retryable) error.
 
 This limit is not enforced when `srcRef` and `destRef` refer to the same
 repository (i.e. retagging within the same registry and path), since no blob
-transfer occurs in that case.
+transfer occurs in that case. It is always enforced for local-archive pushes
+(`srcPath`), based on the file's size.
 
 ## Examples
+
+### Pushing a Local Archive
+
+In this example, a directory of rendered manifests is packaged into a tarball
+and pushed to an OCI registry as an artifact — the pattern used to publish
+manifests for consumption by Argo CD, Flux, or other OCI-aware tooling. The
+`mediaType` and `artifactType` follow Flux's OCI conventions, and provenance is
+recorded via standard OCI annotations.
+
+:::note
+
+The `tar` step used below to produce the archive is planned but not yet
+available. Until then, produce the archive with another step (for example, by
+invoking `tar` from a script) and point `srcPath` at the result.
+
+:::
+
+```yaml
+steps:
+- uses: tar
+  config:
+    path: ./manifests
+    outPath: ./manifests.tar.gz
+- uses: oci-push
+  config:
+    srcPath: ./manifests.tar.gz
+    destRef: oci://ghcr.io/example/config/app:${{ ctx.promotion }}
+    mediaType: application/vnd.cncf.flux.content.v1.tar+gzip
+    artifactType: application/vnd.cncf.flux.config.v1+json
+    annotations:
+      org.opencontainers.image.source: ${{ commitFrom("https://github.com/example/app.git").repoURL }}
+      org.opencontainers.image.revision: ${{ commitFrom("https://github.com/example/app.git").id }}
+```
 
 ### Retagging an Image with a Release Version
 

--- a/pkg/promotion/runner/builtin/oci_pusher.go
+++ b/pkg/promotion/runner/builtin/oci_pusher.go
@@ -3,11 +3,17 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/xeipuuv/gojsonschema"
 
@@ -48,8 +54,9 @@ func init() {
 }
 
 // ociPusher is an implementation of the promotion.StepRunner interface that
-// copies/retags OCI artifacts (container images and Helm charts) between
-// registries.
+// pushes OCI artifacts to a registry. It can copy/retag artifacts (container
+// images and Helm charts) between registries, or push a local file from the
+// workspace as a single-layer OCI artifact.
 type ociPusher struct {
 	schemaLoader    gojsonschema.JSONLoader
 	credsDB         credentials.Database
@@ -96,27 +103,12 @@ func (p *ociPusher) run(
 	stepCtx *promotion.StepContext,
 	cfg builtin.OCIPushConfig,
 ) (promotion.StepResult, error) {
-	srcRef, srcCredType, err := parseOCIReference(cfg.SrcRef)
-	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
-			&promotion.TerminalError{
-				Err: fmt.Errorf("failed to parse source reference %q: %w", cfg.SrcRef, err),
-			}
-	}
-
 	dstRef, dstCredType, err := parseOCIReference(cfg.DestRef)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusFailed},
 			&promotion.TerminalError{
 				Err: fmt.Errorf("failed to parse destination reference %q: %w", cfg.DestRef, err),
 			}
-	}
-
-	srcOpts, err := buildOCIRemoteOptions(
-		ctx, p.credsDB, stepCtx.Project, srcRef, srcCredType, cfg.InsecureSkipTLSVerify,
-	)
-	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
 	}
 
 	dstOpts, err := buildOCIRemoteOptions(
@@ -126,15 +118,17 @@ func (p *ociPusher) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
 	}
 
-	desc, err := remote.Get(srcRef, srcOpts...)
-	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
-			fmt.Errorf("failed to get source artifact %q: %w", cfg.SrcRef, err)
+	var (
+		digest v1.Hash
+		status kargoapi.PromotionStepStatus
+	)
+	if cfg.SrcPath != "" {
+		digest, status, err = p.pushLocalFile(stepCtx, cfg, dstRef, dstOpts)
+	} else {
+		digest, status, err = p.pushRemoteArtifact(ctx, stepCtx, cfg, dstRef, dstOpts)
 	}
-
-	digest, err := p.push(desc, srcRef, dstRef, cfg.Annotations, dstOpts)
 	if err != nil {
-		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, err
+		return promotion.StepResult{Status: status}, err
 	}
 
 	// Extract tag from destination reference if available.
@@ -151,6 +145,139 @@ func (p *ociPusher) run(
 			"tag":    tag,
 		},
 	}, nil
+}
+
+// pushRemoteArtifact copies/retags the artifact identified by cfg.SrcRef to the
+// destination reference. It returns the digest of the pushed artifact and, on
+// failure, the promotion step status to report alongside the error.
+func (p *ociPusher) pushRemoteArtifact(
+	ctx context.Context,
+	stepCtx *promotion.StepContext,
+	cfg builtin.OCIPushConfig,
+	dstRef name.Reference,
+	dstOpts []remote.Option,
+) (v1.Hash, kargoapi.PromotionStepStatus, error) {
+	srcRef, srcCredType, err := parseOCIReference(cfg.SrcRef)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusFailed, &promotion.TerminalError{
+			Err: fmt.Errorf("failed to parse source reference %q: %w", cfg.SrcRef, err),
+		}
+	}
+
+	srcOpts, err := buildOCIRemoteOptions(
+		ctx, p.credsDB, stepCtx.Project, srcRef, srcCredType, cfg.InsecureSkipTLSVerify,
+	)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored, err
+	}
+
+	desc, err := remote.Get(srcRef, srcOpts...)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to get source artifact %q: %w", cfg.SrcRef, err)
+	}
+
+	digest, err := p.push(desc, srcRef, dstRef, cfg.Annotations, dstOpts)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored, err
+	}
+	return digest, kargoapi.PromotionStepStatusSucceeded, nil
+}
+
+// defaultLayerMediaType is the media type applied to the artifact layer when
+// pushing a local file via srcPath and no media type is configured.
+const defaultLayerMediaType = types.OCILayer
+
+// pushLocalFile pushes a local file from the workspace to the destination
+// reference as a single-layer OCI artifact. The layer media type and artifact
+// type (carried as the manifest config media type) are taken from the
+// configuration, and scoped annotations are applied to the manifest. It returns
+// the digest of the pushed artifact and, on failure, the promotion step status
+// to report alongside the error.
+func (p *ociPusher) pushLocalFile(
+	stepCtx *promotion.StepContext,
+	cfg builtin.OCIPushConfig,
+	dstRef name.Reference,
+	dstOpts []remote.Option,
+) (v1.Hash, kargoapi.PromotionStepStatus, error) {
+	absPath, err := securejoin.SecureJoin(stepCtx.WorkDir, cfg.SrcPath)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusFailed, &promotion.TerminalError{
+			Err: fmt.Errorf("failed to resolve source path %q: %w", cfg.SrcPath, err),
+		}
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusFailed, &promotion.TerminalError{
+			Err: fmt.Errorf("failed to stat source path %q: %w", cfg.SrcPath, err),
+		}
+	}
+	if info.IsDir() {
+		return v1.Hash{}, kargoapi.PromotionStepStatusFailed, &promotion.TerminalError{
+			Err: fmt.Errorf("source path %q is a directory; expected a file", cfg.SrcPath),
+		}
+	}
+
+	// A local push always transfers the blob, so enforce the size limit
+	// unconditionally. A negative maxArtifactSize disables the check. This
+	// mirrors the cross-repository size check on the retag path.
+	if p.maxArtifactSize >= 0 && info.Size() > p.maxArtifactSize {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored, &promotion.TerminalError{
+			Err: fmt.Errorf(
+				"artifact size %s exceeds maximum allowed size of %s",
+				libfmt.FormatByteCount(info.Size()), libfmt.FormatByteCount(p.maxArtifactSize),
+			),
+		}
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to read source path %q: %w", cfg.SrcPath, err)
+	}
+
+	layerMediaType := defaultLayerMediaType
+	if cfg.MediaType != "" {
+		layerMediaType = types.MediaType(cfg.MediaType)
+	}
+
+	layer := static.NewLayer(data, layerMediaType)
+	img, err := ggcrmutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to build artifact: %w", err)
+	}
+	// empty.Image is a Docker manifest by default; emit an OCI manifest instead.
+	img = ggcrmutate.MediaType(img, types.OCIManifestSchema1)
+	if cfg.ArtifactType != "" {
+		// This ggcr version has no top-level manifest artifactType, so carry the
+		// artifact type via the config media type per the OCI/Helm/Flux/ORAS
+		// convention.
+		img = ggcrmutate.ConfigMediaType(img, types.MediaType(cfg.ArtifactType))
+	}
+
+	// Apply manifest-scoped annotations. This is a single image manifest, so
+	// index-scoped keys are ignored, matching the retag path's behavior for
+	// single images.
+	scopes := p.parseAnnotationScopes(cfg.Annotations)
+	annotated, err := mutate.Annotations(img, nil, scopes.manifest)
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to annotate artifact: %w", err)
+	}
+	img = annotated.(v1.Image) //nolint:forcetypeassert
+
+	if err = remote.Write(dstRef, img, dstOpts...); err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to push artifact to %q: %w", dstRef.String(), err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return v1.Hash{}, kargoapi.PromotionStepStatusErrored,
+			fmt.Errorf("failed to compute artifact digest: %w", err)
+	}
+	return digest, kargoapi.PromotionStepStatusSucceeded, nil
 }
 
 // annotationScopes holds annotations separated by their target scope.

--- a/pkg/promotion/runner/builtin/oci_pusher_test.go
+++ b/pkg/promotion/runner/builtin/oci_pusher_test.go
@@ -1,9 +1,15 @@
 package builtin
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -27,10 +33,23 @@ import (
 func Test_ociPusher_validate(t *testing.T) {
 	tests := []validationTestCase{
 		{
-			name:   "srcRef is not specified",
-			config: promotion.Config{},
+			name: "no source specified",
+			config: promotion.Config{
+				"destRef": "registry.example.com/image:newtag",
+			},
 			expectedProblems: []string{
-				"(root): srcRef is required",
+				"(root): Must validate one and only one schema (oneOf)",
+			},
+		},
+		{
+			name: "both srcRef and srcPath specified",
+			config: promotion.Config{
+				"srcRef":  "registry.example.com/image:tag",
+				"srcPath": "./artifact.tar.gz",
+				"destRef": "registry.example.com/image:newtag",
+			},
+			expectedProblems: []string{
+				"(root): Must validate one and only one schema (oneOf)",
 			},
 		},
 		{
@@ -38,6 +57,22 @@ func Test_ociPusher_validate(t *testing.T) {
 			config: promotion.Config{},
 			expectedProblems: []string{
 				"(root): destRef is required",
+			},
+		},
+		{
+			name: "valid config with srcPath",
+			config: promotion.Config{
+				"srcPath": "./artifact.tar.gz",
+				"destRef": "registry.example.com/image:newtag",
+			},
+		},
+		{
+			name: "valid config with srcPath and media types",
+			config: promotion.Config{
+				"srcPath":      "./artifact.tar.gz",
+				"destRef":      "registry.example.com/image:newtag",
+				"mediaType":    "application/vnd.cncf.flux.content.v1.tar+gzip",
+				"artifactType": "application/vnd.cncf.flux.config.v1+json",
 			},
 		},
 		{
@@ -478,6 +513,232 @@ func Test_ociPusher_run_noAnnotationsMutation(t *testing.T) {
 	manifest, err := dstImg.Manifest()
 	require.NoError(t, err)
 	assert.Equal(t, "annotation", manifest.Annotations["existing"])
+}
+
+// makeTarGz builds an in-memory gzip-compressed tar archive containing a single
+// file, for use as a local artifact in tests.
+func makeTarGz(t *testing.T, fileName, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: fileName,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+// Test that a local archive is pushed as a single-layer OCI artifact with the
+// configured media types and scoped annotations.
+func Test_ociPusher_run_localFile(t *testing.T) {
+	regHandler := registry.New()
+	srv := httptest.NewServer(regHandler)
+	t.Cleanup(srv.Close)
+	regHost := srv.Listener.Addr().String()
+
+	const (
+		layerMediaType = "application/vnd.cncf.flux.content.v1.tar+gzip"
+		artifactType   = "application/vnd.cncf.flux.config.v1+json"
+	)
+
+	workDir := t.TempDir()
+	tarball := makeTarGz(t, "manifests.yaml", "kind: ConfigMap\n")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "artifact.tar.gz"), tarball, 0o644))
+
+	runner := &ociPusher{
+		credsDB:         &credentials.FakeDB{},
+		schemaLoader:    getConfigSchemaLoader(stepKindOCIPush),
+		maxArtifactSize: int64(1 << 30),
+	}
+
+	destRef := fmt.Sprintf("%s/test/local:v1", regHost)
+	result, err := runner.run(context.Background(), &promotion.StepContext{
+		Project: "fake-project",
+		WorkDir: workDir,
+	}, builtin.OCIPushConfig{
+		SrcPath:      "artifact.tar.gz",
+		DestRef:      destRef,
+		MediaType:    layerMediaType,
+		ArtifactType: artifactType,
+		Annotations: map[string]string{
+			"org.opencontainers.image.source":               "https://github.com/example/repo",
+			"manifest:org.opencontainers.image.description": "example manifests",
+			"index:org.opencontainers.image.revision":       "abc123",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(kargoapi.PromotionStepStatusSucceeded), string(result.Status))
+	assert.Equal(t, destRef, result.Output["image"])
+	assert.Equal(t, "v1", result.Output["tag"])
+	digestOut, ok := result.Output["digest"].(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, digestOut)
+
+	// Read the artifact back and verify its structure.
+	dstRef, err := name.ParseReference(destRef)
+	require.NoError(t, err)
+	dstImg, err := remote.Image(dstRef)
+	require.NoError(t, err)
+
+	manifest, err := dstImg.Manifest()
+	require.NoError(t, err)
+
+	// An OCI image manifest, not a Docker one.
+	assert.Equal(t, types.OCIManifestSchema1, manifest.MediaType)
+	// The artifact type is carried via the config media type.
+	assert.Equal(t, types.MediaType(artifactType), manifest.Config.MediaType)
+
+	// A single layer with the configured media type and the exact archive bytes.
+	require.Len(t, manifest.Layers, 1)
+	assert.Equal(t, types.MediaType(layerMediaType), manifest.Layers[0].MediaType)
+
+	layers, err := dstImg.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	rc, err := layers[0].Compressed()
+	require.NoError(t, err)
+	defer rc.Close()
+	gotBytes, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, tarball, gotBytes)
+
+	// Manifest-scoped and unprefixed annotations are applied; index-scoped keys
+	// are dropped for a single image manifest.
+	assert.Equal(t, "https://github.com/example/repo", manifest.Annotations["org.opencontainers.image.source"])
+	assert.Equal(t, "example manifests", manifest.Annotations["org.opencontainers.image.description"])
+	assert.NotContains(t, manifest.Annotations, "org.opencontainers.image.revision")
+
+	// The reported digest matches the pushed manifest.
+	gotDigest, err := dstImg.Digest()
+	require.NoError(t, err)
+	assert.Equal(t, gotDigest.String(), digestOut)
+}
+
+// Test that the layer media type defaults to the OCI tar+gzip layer type when
+// none is configured.
+func Test_ociPusher_run_localFile_defaultMediaType(t *testing.T) {
+	regHandler := registry.New()
+	srv := httptest.NewServer(regHandler)
+	t.Cleanup(srv.Close)
+	regHost := srv.Listener.Addr().String()
+
+	workDir := t.TempDir()
+	tarball := makeTarGz(t, "manifests.yaml", "kind: ConfigMap\n")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "artifact.tar.gz"), tarball, 0o644))
+
+	runner := &ociPusher{
+		credsDB:         &credentials.FakeDB{},
+		schemaLoader:    getConfigSchemaLoader(stepKindOCIPush),
+		maxArtifactSize: int64(1 << 30),
+	}
+
+	destRef := fmt.Sprintf("%s/test/local:default", regHost)
+	result, err := runner.run(context.Background(), &promotion.StepContext{
+		Project: "fake-project",
+		WorkDir: workDir,
+	}, builtin.OCIPushConfig{
+		SrcPath: "artifact.tar.gz",
+		DestRef: destRef,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(kargoapi.PromotionStepStatusSucceeded), string(result.Status))
+
+	dstRef, err := name.ParseReference(destRef)
+	require.NoError(t, err)
+	dstImg, err := remote.Image(dstRef)
+	require.NoError(t, err)
+	manifest, err := dstImg.Manifest()
+	require.NoError(t, err)
+	require.Len(t, manifest.Layers, 1)
+	assert.Equal(t, types.OCILayer, manifest.Layers[0].MediaType)
+}
+
+// Test error handling for local-file pushes.
+func Test_ociPusher_run_localFile_errors(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxArtifactSize int64
+		// setup writes any needed files into workDir and returns the srcPath to
+		// configure (relative to workDir).
+		setup      func(t *testing.T, workDir string) string
+		wantStatus kargoapi.PromotionStepStatus
+		errMsg     string
+	}{
+		{
+			name: "source path is a directory",
+			setup: func(t *testing.T, workDir string) string {
+				require.NoError(t, os.Mkdir(filepath.Join(workDir, "adir"), 0o755))
+				return "adir"
+			},
+			wantStatus: kargoapi.PromotionStepStatusFailed,
+			errMsg:     "is a directory",
+		},
+		{
+			name: "source path does not exist",
+			setup: func(_ *testing.T, _ string) string {
+				return "missing.tar.gz"
+			},
+			wantStatus: kargoapi.PromotionStepStatusFailed,
+			errMsg:     "failed to stat source path",
+		},
+		{
+			name: "path traversal is contained",
+			setup: func(_ *testing.T, _ string) string {
+				// SecureJoin clamps the escape to within workDir, where no such
+				// file exists, so it surfaces as a stat failure.
+				return "../../etc/passwd"
+			},
+			wantStatus: kargoapi.PromotionStepStatusFailed,
+			errMsg:     "failed to stat source path",
+		},
+		{
+			name:            "artifact exceeds size limit",
+			maxArtifactSize: 8,
+			setup: func(t *testing.T, workDir string) string {
+				tarball := makeTarGz(t, "manifests.yaml", "kind: ConfigMap\n")
+				require.NoError(t, os.WriteFile(filepath.Join(workDir, "big.tar.gz"), tarball, 0o644))
+				return "big.tar.gz"
+			},
+			wantStatus: kargoapi.PromotionStepStatusErrored,
+			errMsg:     "exceeds maximum allowed size of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			srcPath := tt.setup(t, workDir)
+
+			maxSize := tt.maxArtifactSize
+			if maxSize == 0 {
+				maxSize = int64(1 << 30)
+			}
+			runner := &ociPusher{
+				credsDB:         &credentials.FakeDB{},
+				schemaLoader:    getConfigSchemaLoader(stepKindOCIPush),
+				maxArtifactSize: maxSize,
+			}
+
+			result, err := runner.run(context.Background(), &promotion.StepContext{
+				Project: "fake-project",
+				WorkDir: workDir,
+			}, builtin.OCIPushConfig{
+				SrcPath: srcPath,
+				DestRef: "registry.example.com/test/local:v1",
+			})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.errMsg)
+			assert.Equal(t, string(tt.wantStatus), string(result.Status))
+			var termErr *promotion.TerminalError
+			assert.ErrorAs(t, err, &termErr)
+		})
+	}
 }
 
 func Test_parseAnnotationScopes(t *testing.T) {

--- a/pkg/promotion/runner/builtin/schemas/oci-push-config.json
+++ b/pkg/promotion/runner/builtin/schemas/oci-push-config.json
@@ -3,19 +3,38 @@
   "title": "OCIPushConfig",
   "type": "object",
   "additionalProperties": false,
-  "required": ["srcRef", "destRef"],
+  "required": ["destRef"],
+  "oneOf": [
+    { "required": ["srcRef"], "not": { "required": ["srcPath"] } },
+    { "required": ["srcPath"], "not": { "required": ["srcRef"] } }
+  ],
   "properties": {
     "srcRef": {
       "type": "string",
-      "description": "SrcRef is the source OCI artifact reference with tag or digest (e.g. 'registry/repo:tag' or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts.",
+      "description": "SrcRef is the source OCI artifact reference with tag or digest (e.g. 'registry/repo:tag' or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts. Mutually exclusive with srcPath.",
       "minLength": 1,
       "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
+    },
+    "srcPath": {
+      "type": "string",
+      "description": "SrcPath is the path, relative to the workspace, of a local file to push as a single-layer OCI artifact (e.g. a tarball produced by an earlier step). Mutually exclusive with srcRef.",
+      "minLength": 1
     },
     "destRef": {
       "type": "string",
       "description": "DestRef is the destination reference including tag (e.g. 'registry/repo:tag' or 'oci://registry/repo:tag'). For retag-in-place, use the same repo as srcRef with the new tag.",
       "minLength": 1,
       "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[:][a-zA-Z0-9._-]+$"
+    },
+    "mediaType": {
+      "type": "string",
+      "description": "MediaType is the media type of the artifact layer when pushing a local file via srcPath. Defaults to 'application/vnd.oci.image.layer.v1.tar+gzip'. Ignored when using srcRef.",
+      "minLength": 1
+    },
+    "artifactType": {
+      "type": "string",
+      "description": "ArtifactType declares the type of artifact being pushed via srcPath. It is applied as the manifest's config media type. Ignored when using srcRef.",
+      "minLength": 1
     },
     "annotations": {
       "type": "object",

--- a/pkg/x/promotion/runner/builtin/zz_config_types.go
+++ b/pkg/x/promotion/runner/builtin/zz_config_types.go
@@ -680,15 +680,25 @@ type OCIPushConfig struct {
 	// 'manifest:' to scope them to the index or image manifest respectively. Unprefixed keys
 	// default to the image manifest. For single images, 'index:'-prefixed keys are ignored.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// ArtifactType declares the type of artifact being pushed via srcPath. It is applied as the
+	// manifest's config media type. Ignored when using srcRef.
+	ArtifactType string `json:"artifactType,omitempty"`
 	// DestRef is the destination reference including tag (e.g. 'registry/repo:tag' or
 	// 'oci://registry/repo:tag'). For retag-in-place, use the same repo as srcRef with the new
 	// tag.
 	DestRef string `json:"destRef"`
 	// Whether to skip TLS verification when communicating with registries. Defaults to false.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+	// MediaType is the media type of the artifact layer when pushing a local file via srcPath.
+	// Defaults to 'application/vnd.oci.image.layer.v1.tar+gzip'. Ignored when using srcRef.
+	MediaType string `json:"mediaType,omitempty"`
+	// SrcPath is the path, relative to the workspace, of a local file to push as a single-layer
+	// OCI artifact (e.g. a tarball produced by an earlier step). Mutually exclusive with srcRef.
+	SrcPath string `json:"srcPath,omitempty"`
 	// SrcRef is the source OCI artifact reference with tag or digest (e.g. 'registry/repo:tag'
-	// or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts.
-	SrcRef string `json:"srcRef"`
+	// or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts. Mutually exclusive
+	// with srcPath.
+	SrcRef string `json:"srcRef,omitempty"`
 }
 
 type SetFreightAliasConfig struct {

--- a/ui/src/gen/directives/oci-push-config.json
+++ b/ui/src/gen/directives/oci-push-config.json
@@ -6,15 +6,30 @@
  "properties": {
   "srcRef": {
    "type": "string",
-   "description": "SrcRef is the source OCI artifact reference with tag or digest (e.g. 'registry/repo:tag' or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts.",
+   "description": "SrcRef is the source OCI artifact reference with tag or digest (e.g. 'registry/repo:tag' or 'registry/repo@sha256:...'). Use 'oci://' prefix for Helm charts. Mutually exclusive with srcPath.",
    "minLength": 1,
    "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[@:][a-zA-Z0-9._:-]+$"
+  },
+  "srcPath": {
+   "type": "string",
+   "description": "SrcPath is the path, relative to the workspace, of a local file to push as a single-layer OCI artifact (e.g. a tarball produced by an earlier step). Mutually exclusive with srcRef.",
+   "minLength": 1
   },
   "destRef": {
    "type": "string",
    "description": "DestRef is the destination reference including tag (e.g. 'registry/repo:tag' or 'oci://registry/repo:tag'). For retag-in-place, use the same repo as srcRef with the new tag.",
    "minLength": 1,
    "pattern": "^(oci://)?[a-zA-Z0-9._-]+(:\\d+)?(/[a-zA-Z0-9._-]+)*[:][a-zA-Z0-9._-]+$"
+  },
+  "mediaType": {
+   "type": "string",
+   "description": "MediaType is the media type of the artifact layer when pushing a local file via srcPath. Defaults to 'application/vnd.oci.image.layer.v1.tar+gzip'. Ignored when using srcRef.",
+   "minLength": 1
+  },
+  "artifactType": {
+   "type": "string",
+   "description": "ArtifactType declares the type of artifact being pushed via srcPath. It is applied as the manifest's config media type. Ignored when using srcRef.",
+   "minLength": 1
   },
   "annotations": {
    "type": "object",


### PR DESCRIPTION
## Summary

Enhances the `oci-push` promotion step to push a **local archive** from the workspace (e.g. a tarball of rendered manifests) to a registry as a single-layer OCI artifact, alongside the existing registry-to-registry copy/retag mode. This is the `oci-push` half of the work discussed in #1099 (the complementary `tar` step is being contributed separately by @vcalmic).

Media types are settable, per @blakepettersson's request. Because the pinned go-containerregistry has no top-level `manifest.artifactType`, `artifactType` is carried via the manifest's `config.mediaType` — the OCI-1.0-compatible convention used by Helm/Flux/ORAS.

Refs #1099.

## Usage

### Push a local archive (Flux/Argo-style OCI manifests)

Package a directory of rendered manifests and publish it as an OCI artifact for consumption by Argo CD, Flux, or other OCI-aware tooling. Provenance is recorded via standard OCI annotations.

```yaml
steps:
- uses: tar                       # complementary step (forthcoming, #1099)
  config:
    path: ./manifests
    outPath: ./manifests.tar.gz
- uses: oci-push
  config:
    srcPath: ./manifests.tar.gz
    destRef: oci://ghcr.io/example/config/app:${{ ctx.promotion }}
    mediaType: application/vnd.cncf.flux.content.v1.tar+gzip   # layer media type
    artifactType: application/vnd.cncf.flux.config.v1+json     # → config.mediaType
    annotations:
      org.opencontainers.image.source: ${{ commitFrom("https://github.com/example/app.git").repoURL }}
      org.opencontainers.image.revision: ${{ commitFrom("https://github.com/example/app.git").id }}
```

### Minimal (default media type)

`srcPath` is content-agnostic; when `mediaType` is omitted it defaults to `application/vnd.oci.image.layer.v1.tar+gzip`.

```yaml
steps:
- uses: oci-push
  config:
    srcPath: ./artifact.tar.gz
    destRef: registry.example.com/example/app:${{ ctx.promotion }}
```

### Existing copy/retag mode (unchanged)

```yaml
steps:
- uses: oci-push
  config:
    srcRef: registry.example.com/myapp@${{ imageFrom("registry.example.com/myapp").digest }}
    destRef: registry.example.com/myapp:v1.2.3
```

## Config

Exactly one of `srcRef` or `srcPath` is required (enforced via schema `oneOf`).

| Field | Description |
|-------|-------------|
| `srcPath` | Workspace-relative local file to push as a single-layer artifact. Mutually exclusive with `srcRef`. |
| `mediaType` | Layer media type. Default `application/vnd.oci.image.layer.v1.tar+gzip`. `srcPath` only. |
| `artifactType` | Applied as the manifest config media type. `srcPath` only. |

## Notes / scope

- `srcPath` is content-agnostic — not limited to tarballs (e.g. WASM modules, SBOMs work too).
- The artifact size limit (`MAX_OCI_PUSH_ARTIFACT_SIZE`) is always enforced for local-archive pushes, based on the file's size.
- Producing canonical **Helm charts** via `srcPath` is out of scope (their config blob must carry `Chart.yaml` metadata); use the copy/retag mode with the `oci://` prefix to promote existing charts.
- A literal top-level OCI 1.1 `artifactType` and settable config content are natural follow-ups (would need a ggcr bump or a custom manifest wrapper).

## Testing

- Regenerated config types via `make codegen-schema-to-go`.
- New unit tests: schema `oneOf` validation, local-archive happy path (read-back asserts OCI manifest media type, layer media type, `artifactType`-as-config-media-type, scoped annotations, byte round-trip, digest), default media type, and negatives (directory, missing file, contained path traversal, size limit).
- `make lint-go` — clean.
