### PR TITLE
feat(ui): restore auto-promotion Resume button/dropdown/drawer

### DIFF
--- a/ui/src/features/project/pipelines/list/columns/action-column.tsx
+++ b/ui/src/features/project/pipelines/list/columns/action-column.tsx
@@ -1,10 +1,12 @@
 import { faTruckArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button } from 'antd';
+import { Button, Space } from 'antd';
 import { ColumnType } from 'antd/es/table';
 
 import { isStageControlFlow } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { Stage } from '@ui/gen/api/v2/models';
+
+import { ResumeAutoPromotionAction } from './resume-auto-promotion-action';
 
 type Props = {
   onPromote: (stage: Stage) => void;
@@ -17,13 +19,16 @@ export const actionColumn = (props: Props): ColumnType<Stage> => ({
     }
 
     return (
-      <Button
-        onClick={() => props.onPromote(stage)}
-        size='small'
-        icon={<FontAwesomeIcon icon={faTruckArrowRight} />}
-      >
-        Promote
-      </Button>
+      <Space size={6}>
+        <ResumeAutoPromotionAction stage={stage} />
+        <Button
+          onClick={() => props.onPromote(stage)}
+          size='small'
+          icon={<FontAwesomeIcon icon={faTruckArrowRight} />}
+        >
+          Promote
+        </Button>
+      </Space>
     );
   }
 });

--- a/ui/src/features/project/pipelines/list/columns/resume-auto-promotion-action.tsx
+++ b/ui/src/features/project/pipelines/list/columns/resume-auto-promotion-action.tsx
@@ -1,0 +1,25 @@
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from 'antd';
+import { useState } from 'react';
+
+import { stageHasAutoPromotionHold } from '@ui/features/project/pipelines/promotion/auto-promotion';
+import { ResumeAutoPromotionDrawer } from '@ui/features/project/pipelines/promotion/resume-auto-promotion-drawer';
+import { Stage } from '@ui/gen/api/v2/models';
+
+export const ResumeAutoPromotionAction = ({ stage }: { stage: Stage }) => {
+  const [open, setOpen] = useState(false);
+
+  if (!stageHasAutoPromotionHold(stage)) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button size='small' icon={<FontAwesomeIcon icon={faPlay} />} onClick={() => setOpen(true)}>
+        Resume
+      </Button>
+      <ResumeAutoPromotionDrawer stage={stage} open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};

--- a/ui/src/features/project/pipelines/nodes/promotion/use-get-promotion-dropdown-items.tsx
+++ b/ui/src/features/project/pipelines/nodes/promotion/use-get-promotion-dropdown-items.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useMutation } from '@tanstack/react-query';
 import { Typography } from 'antd';
 import { ItemType } from 'antd/es/menu/interface';
+import { useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
@@ -10,11 +11,15 @@ import { IAction, useActionContext } from '@ui/features/project/pipelines/contex
 import { useDictionaryContext } from '@ui/features/project/pipelines/context/dictionary-context';
 import { isStageControlFlow } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { useGetUpstreamFreight } from '@ui/features/project/pipelines/nodes/use-get-upstream-freight';
+import { stageHasAutoPromotionHold } from '@ui/features/project/pipelines/promotion/auto-promotion';
+import { ResumeAutoPromotionDrawer } from '@ui/features/project/pipelines/promotion/resume-auto-promotion-drawer';
 import { useManualApprovalModal } from '@ui/features/project/pipelines/promotion/use-manual-approval-modal';
 import { promoteToStage, queryFreightsRest } from '@ui/gen/api/v2/core/core';
 import { Stage } from '@ui/gen/api/v2/models';
 
 export const useGetPromotionDropdownItems = (stage: Stage) => {
+  const [resumeAutoPromotionOpen, setResumeAutoPromotionOpen] = useState(false);
+
   const projectName = stage?.metadata?.namespace || '';
   const stageName = stage?.metadata?.name || '';
 
@@ -26,6 +31,7 @@ export const useGetPromotionDropdownItems = (stage: Stage) => {
   const totalSubscribersToThisStage = dictionaryContext?.subscribersByStage?.[stageName]?.size || 0;
 
   const controlFlow = isStageControlFlow(stage);
+  const hasAutoPromotionHold = stageHasAutoPromotionHold(stage);
 
   const upstreamFreights = useGetUpstreamFreight(stage);
 
@@ -115,6 +121,14 @@ export const useGetPromotionDropdownItems = (stage: Stage) => {
       label: 'Promote',
       onClick: () => actionContext?.actPromote(IAction.PROMOTE, stage)
     });
+
+    if (hasAutoPromotionHold) {
+      dropdownItems.push({
+        key: 'resume-auto-promotion',
+        label: 'Resume auto-promotion',
+        onClick: () => setResumeAutoPromotionOpen(true)
+      });
+    }
   }
 
   if (controlFlow || totalSubscribersToThisStage > 1) {
@@ -182,5 +196,14 @@ export const useGetPromotionDropdownItems = (stage: Stage) => {
     });
   }
 
-  return dropdownItems;
+  return {
+    dropdownItems,
+    resumeAutoPromotionDrawer: (
+      <ResumeAutoPromotionDrawer
+        stage={stage}
+        open={resumeAutoPromotionOpen}
+        onClose={() => setResumeAutoPromotionOpen(false)}
+      />
+    )
+  };
 };

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -81,7 +81,7 @@ export const StageNode = (props: { stage: Stage }) => {
     }
   });
 
-  const dropdownItems = useGetPromotionDropdownItems(props.stage);
+  const { dropdownItems, resumeAutoPromotionDrawer } = useGetPromotionDropdownItems(props.stage);
 
   let descriptionItems: ReactNode;
 
@@ -245,6 +245,8 @@ export const StageNode = (props: { stage: Stage }) => {
           </Link>
         )}
       </Card>
+
+      {resumeAutoPromotionDrawer}
 
       {!graphContext?.stackedNodesParents?.includes(stageNodeIndex) &&
         totalSubscribersToThisStage > 0 && (

--- a/ui/src/features/project/pipelines/promotion/auto-promotion.ts
+++ b/ui/src/features/project/pipelines/promotion/auto-promotion.ts
@@ -5,7 +5,7 @@ type OriginLike = {
   name?: string;
 };
 
-type AutoPromotionHoldEntry = {
+export type AutoPromotionHoldEntry = {
   key: string;
   hold: AutoPromotionHold;
   origin?: OriginLike;

--- a/ui/src/features/project/pipelines/promotion/resume-auto-promotion-drawer.tsx
+++ b/ui/src/features/project/pipelines/promotion/resume-auto-promotion-drawer.tsx
@@ -1,0 +1,162 @@
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Alert, Button, Drawer, Flex, Radio, Typography, message } from 'antd';
+import { ReactNode, useMemo, useState } from 'react';
+import { generatePath, Link, useNavigate } from 'react-router-dom';
+
+import { paths } from '@ui/config/paths';
+import { usePromoteToStage } from '@ui/gen/api/v2/core/core';
+import type { Stage } from '@ui/gen/api/v2/models';
+
+import { AutoPromotionHoldEntry, getAutoPromotionHoldEntries, originLabel } from './auto-promotion';
+
+type ResumeAutoPromotionDrawerProps = {
+  stage: Stage;
+  open: boolean;
+  onClose: () => void;
+};
+
+export const ResumeAutoPromotionDrawer = ({
+  stage,
+  open,
+  onClose
+}: ResumeAutoPromotionDrawerProps) => {
+  const navigate = useNavigate();
+  const [selectedOriginKey, setSelectedOriginKey] = useState('');
+
+  const projectName = stage?.metadata?.namespace || '';
+  const stageName = stage?.metadata?.name || '';
+
+  const entries = useMemo(() => getAutoPromotionHoldEntries(stage), [stage]);
+
+  // selectedOriginKey holds only explicit user choices; the effective
+  // selection falls back to the first held origin whenever the stored choice
+  // no longer matches an existing hold.
+  const effectiveKey = entries.some((entry) => entry.key === selectedOriginKey)
+    ? selectedOriginKey
+    : (entries[0]?.key ?? '');
+  const selectedEntry = entries.find((entry) => entry.key === effectiveKey);
+
+  const promoteMutation = usePromoteToStage({
+    mutation: {
+      onSuccess: (response) => {
+        message.success('Auto-promotion resumed');
+        onClose();
+        const promotionName = response.data?.metadata?.name;
+        if (promotionName) {
+          navigate(
+            generatePath(paths.promotion, {
+              name: projectName,
+              promotionId: promotionName
+            })
+          );
+        }
+      }
+    }
+  });
+
+  const renderFreightLink = (freightName?: string): ReactNode => {
+    if (!freightName || !projectName) {
+      return freightName || 'unknown Freight';
+    }
+    return (
+      <Link
+        to={generatePath(paths.freight, {
+          name: projectName,
+          freightName
+        })}
+        onClick={onClose}
+        style={{ overflowWrap: 'anywhere' }}
+      >
+        {freightName}
+      </Link>
+    );
+  };
+
+  const renderHoldSummary = (entry: AutoPromotionHoldEntry): ReactNode => (
+    <Flex vertical gap={2}>
+      <Typography.Text strong>{originLabel(entry.origin)}</Typography.Text>
+      <Typography.Text type='secondary'>
+        Held at {renderFreightLink(entry.hold.freightName)}.
+      </Typography.Text>
+      {entry.hold.actor && (
+        <Typography.Text type='secondary'>Held by {entry.hold.actor}.</Typography.Text>
+      )}
+    </Flex>
+  );
+
+  const resumeAutoPromotion = () => {
+    if (!projectName || !stageName || !effectiveKey) {
+      return;
+    }
+    promoteMutation.mutate({
+      project: projectName,
+      stage: stageName,
+      data: { origin: effectiveKey }
+    });
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      width={720}
+      title={
+        <Flex align='center' gap={8}>
+          <FontAwesomeIcon icon={faPlay} />
+          Resume auto-promotion
+        </Flex>
+      }
+      footer={
+        <Flex justify='flex-end'>
+          <Button
+            type='primary'
+            icon={<FontAwesomeIcon icon={faPlay} />}
+            onClick={resumeAutoPromotion}
+            loading={promoteMutation.isPending}
+            disabled={!selectedEntry}
+          >
+            Resume auto-promotion
+          </Button>
+        </Flex>
+      }
+    >
+      <div className='-mt-6 -mx-6'>
+        <Alert
+          banner
+          type='info'
+          message='Resuming promotes the Freight that auto-promotion would select for this origin.'
+          description='Kargo creates a Promotion immediately and resumes auto-promotion for this origin.'
+        />
+
+        {entries.length === 0 && (
+          <Alert
+            banner
+            type='warning'
+            message='No auto-promotion hold can be resumed.'
+            description='There are no auto-promotion holds on this Stage.'
+          />
+        )}
+      </div>
+      <Flex vertical gap={16} className='mt-4'>
+        {entries.length === 1 && selectedEntry && renderHoldSummary(selectedEntry)}
+
+        {entries.length > 1 && (
+          <Radio.Group
+            className='w-full'
+            value={effectiveKey}
+            onChange={(event) => setSelectedOriginKey(event.target.value)}
+          >
+            <Flex vertical gap={10}>
+              {entries.map((entry) => (
+                <Radio key={entry.key} value={entry.key} className='w-full m-0'>
+                  <div className='ml-2'>{renderHoldSummary(entry)}</div>
+                </Radio>
+              ))}
+            </Flex>
+          </Radio.Group>
+        )}
+      </Flex>
+    </Drawer>
+  );
+};


### PR DESCRIPTION
The auto-promotion holds PR (#6334) included a pivot on back end implementation that accidentally removed some UI features that had originally been included in that PR, when in fact, they should merely have been adapted to work with the refactored back end.

This PR seeks to restore those features with maximum fidelity to @rpelczar's original design, but adapted to the refactored back end.

@rpelczar please feel free to tweak the PR directly if something isn't sitting right with you.

<img width="574" height="394" alt="Screenshot 2026-07-15 at 3 57 45 PM" src="https://github.com/user-attachments/assets/ae8af64c-e2b0-4625-908f-7bcf59e56fd7" />

<img width="1507" height="502" alt="Screenshot 2026-07-15 at 3 58 15 PM" src="https://github.com/user-attachments/assets/f7ef5031-e7a2-4976-97bb-ea33150f0401" />

<img width="783" height="1077" alt="Screenshot 2026-07-15 at 3 58 42 PM" src="https://github.com/user-attachments/assets/de1f008e-34b1-4067-9707-aa0e8ca9ee21" />

