### PR TITLE
fix(controller): validate new GitHub App tokens before first use

### DIFF
--- a/pkg/credentials/github/app.go
+++ b/pkg/credentials/github/app.go
@@ -40,11 +40,6 @@ const (
 	tokenCacheExpiryMargin = 5 * time.Minute
 
 	tokenValidationRequestTimeout = 10 * time.Second
-
-	// retryKeySuffix is appended to a token's singleflight key when retrying a
-	// mint whose winner's context was canceled, so that all callers recovering
-	// from that shared failure coalesce again instead of racing.
-	retryKeySuffix = ":retry"
 )
 
 var base64Regex = regexp.MustCompile(`^[a-zA-Z0-9+/]*={0,2}$`)
@@ -71,6 +66,12 @@ type AppCredentialProvider struct {
 	// minted installation access token. This is set as a field so that it can be overridden in
 	// tests to avoid long waits.
 	validationBackoff []time.Duration
+
+	// mintTimeoutBuffer is added to the sum of validationBackoff when computing the maximum time to
+	// wait for a token to be minted and validated. It accounts for network round-trips that are not
+	// captured by the backoff schedule. This is set as a field so that it can be overridden in tests
+	// to avoid long waits.
+	mintTimeoutBuffer time.Duration
 
 	getAccessTokenFn func(
 		appOrClientID string,
@@ -104,6 +105,10 @@ func NewAppCredentialProvider() credentials.Provider {
 			10 * time.Second,
 			30 * time.Second,
 		},
+		// This is set to 10 seconds to account for the sum of the durations + accounting for any
+		// slow network round-trips. This is moderately generous because it is used only as a
+		// fail-safe
+		mintTimeoutBuffer: 10 * time.Second,
 	}
 	p.getAccessTokenFn = p.getAccessToken
 	p.validateAccessTokenFn = p.validateAccessToken
@@ -209,7 +214,24 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	// they miss the cache in unison when that entry expires and, without coordination, would each
 	// mint their own token. Coalescing concurrent mints for the same cache key avoids that
 	// thundering herd.
-	accessToken, err, _ := p.mintGroup.Do(cacheKey, func() (any, error) {
+	var accessToken any
+	var err error
+
+	// maxWait bounds how long the mint may run. Because the mint executes under an orphaned context
+	// (see mintAndCacheToken) rather than any caller's context, this is the only thing bounding its
+	// duration. It is the sum of the validation backoff schedule plus a buffer for network
+	// round-trips.
+	maxWait := p.mintTimeoutBuffer
+	for _, d := range p.validationBackoff {
+		maxWait += d
+	}
+
+	// NOTE(thomastaylor312): Right now if there is a single error that isn't a context error, it
+	// will fail all of the other requests as well. This _could_ end up biting us if we have a
+	// transient error. If that ever becomes the case, we can add an OR to this that uses the
+	// `shared` return value from the singleflight `DoChan` channel and then re-enqueue here as
+	// well, but for now we'll let real errors fall through to everyone.
+	ch := p.mintGroup.DoChan(cacheKey, func() (any, error) {
 		return p.mintAndCacheToken(
 			ctx,
 			appOrClientID,
@@ -217,42 +239,22 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 			encodedPrivateKey,
 			repoURL,
 			cacheKey,
+			maxWait,
 		)
 	})
-	// NOTE(thomastaylor312): This is to handle the edge case where the context of the first minting
-	// operation to fire is canceled or timed out, but this context is not. In that case, we immediately
-	// re-enqueue a request to mint a new token. Otherwise, if a whole bunch of running promotions
-	// use the same credentials and the first one to fire is canceled, all of the others will be
-	// canceled as well, which is not what we want. This is best effort to avoid the issue, but it
-	// isn't perfect. It only handles _one_ canceled operation, but is better than nothing for now.
-	//
-	// The retry deliberately runs under a suffixed key rather than Forget + reuse of the primary
-	// key. Forget detaches whatever call is currently registered for the key, so with several
-	// waiters recovering from the same canceled flight, each Forget could orphan a replacement
-	// flight another waiter had already started.
-	//
-	// Right now if there is a single error that isn't a context error, it will fail all of the
-	// other requests as well. This _could_ end up biting us if we have a transient error. If that
-	// ever becomes the case, we can add an OR to this that uses the `shared` return value from the
-	// singleflight `Do` call and then re-enqueue here as well, but for now we'll let real errors
-	// fall through to everyone.
-	if err != nil &&
-		(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) &&
-		ctx.Err() == nil {
-		accessToken, err, _ = p.mintGroup.Do(cacheKey+retryKeySuffix, func() (any, error) {
-			return p.mintAndCacheToken(
-				ctx,
-				appOrClientID,
-				installationID,
-				encodedPrivateKey,
-				repoURL,
-				cacheKey,
-			)
-		})
+	select {
+	case <-ctx.Done():
+		// See the comment in mintAndCacheToken for why we don't cancel the minting process here.
+		return nil, fmt.Errorf(
+			"mint token process interrupted, cache refresh will continue in the background: %w",
+			ctx.Err(),
+		)
+	case result := <-ch:
+		accessToken, err = result.Val, result.Err
 	}
-	// At this point if we're checking an error, we've now already retried
+
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error minting installation access token: %w", err)
 	}
 
 	return &credentials.Credentials{
@@ -272,15 +274,22 @@ func (p *AppCredentialProvider) mintAndCacheToken(
 	encodedPrivateKey string,
 	repoURL string,
 	cacheKey string,
+	maxWait time.Duration,
 ) (string, error) {
 	logger := logging.LoggerFromContext(ctx)
 
-	// A concurrent call may have minted and cached a token between this
-	// call's cache miss and its turn in the singleflight group.
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("installation access token cached by concurrent call")
-		return entry.(string), nil // nolint: forcetypeassert
-	}
+	// NOTE(thomastaylor312): We use a separate, orphaned context for running this function so that
+	// we can control timeout for the entire operation here. This function is only called from
+	// within a singleflight group, and if we have the "winner" of the first goroutine to execute
+	// this function get canceled, it cancels it for everyone. Initially, I had plumbed through
+	// handling for this, but it was a bunch of logic that, ultimately, is unnecessary. Even if all
+	// callers cancel, (essentially orphaning the function from an "owning" goroutine entirely), we
+	// still want to finish the work of minting and caching the token so that future callers can get
+	// it from the cache. So, we just use a separate context here that is not tied to any caller's
+	// context. We _do_, reattach the current logger so we have all its current context (and also
+	// helps us trace back where it was called from if needed)
+	orphanedCtx, cancel := context.WithTimeout(logging.ContextWithLogger(context.Background(), logger), maxWait)
+	defer cancel()
 
 	token, err := p.getAccessTokenFn(
 		appOrClientID,
@@ -300,7 +309,7 @@ func (p *AppCredentialProvider) mintAndCacheToken(
 	// difficult-to-diagnose "repository not found" errors. Waiting until the
 	// token demonstrably works before releasing it to the caller prevents
 	// this.
-	if err = p.waitForTokenUsable(ctx, token.AccessToken, repoURL); err != nil {
+	if err = p.waitForTokenUsable(orphanedCtx, token.AccessToken, repoURL); err != nil {
 		return "", err
 	}
 
@@ -469,11 +478,10 @@ func (p *AppCredentialProvider) tokenCacheKey(
 	return fmt.Sprintf(
 		"%x",
 		sha256.Sum256(
-			[]byte(
-				fmt.Sprintf(
-					"%s:%d:%s:%s",
-					appOrClientID, installationID, encodedPrivateKey, repoURL,
-				),
+			fmt.Appendf(
+				nil,
+				"%s:%d:%s:%s",
+				appOrClientID, installationID, encodedPrivateKey, repoURL,
 			),
 		),
 	)

--- a/pkg/credentials/github/app.go
+++ b/pkg/credentials/github/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jferrl/go-githubauth"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/credentials"
@@ -39,6 +40,11 @@ const (
 	tokenCacheExpiryMargin = 5 * time.Minute
 
 	tokenValidationRequestTimeout = 10 * time.Second
+
+	// retryKeySuffix is appended to a token's singleflight key when retrying a
+	// mint whose winner's context was canceled, so that all callers recovering
+	// from that shared failure coalesce again instead of racing.
+	retryKeySuffix = ":retry"
 )
 
 var base64Regex = regexp.MustCompile(`^[a-zA-Z0-9+/]*={0,2}$`)
@@ -56,6 +62,10 @@ func init() {
 
 type AppCredentialProvider struct {
 	tokenCache *cache.Cache
+
+	// mintGroup coalesces concurrent mints of the token for any given cache
+	// key into a single mint whose result is shared by all callers.
+	mintGroup singleflight.Group
 
 	// validationBackoff is the schedule of waits between successive attempts to validate a newly
 	// minted installation access token. This is set as a field so that it can be overridden in
@@ -195,7 +205,83 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	}
 	logger.Debug("installation access token cache miss")
 
-	// Cache miss, get a new token
+	// Cache miss, get a new token. All consumers of any given repository share one cache entry, so
+	// they miss the cache in unison when that entry expires and, without coordination, would each
+	// mint their own token. Coalescing concurrent mints for the same cache key avoids that
+	// thundering herd.
+	accessToken, err, _ := p.mintGroup.Do(cacheKey, func() (any, error) {
+		return p.mintAndCacheToken(
+			ctx,
+			appOrClientID,
+			installationID,
+			encodedPrivateKey,
+			repoURL,
+			cacheKey,
+		)
+	})
+	// NOTE(thomastaylor312): This is to handle the edge case where the context of the first minting
+	// operation to fire is canceled or timed out, but this context is not. In that case, we immediately
+	// re-enqueue a request to mint a new token. Otherwise, if a whole bunch of running promotions
+	// use the same credentials and the first one to fire is canceled, all of the others will be
+	// canceled as well, which is not what we want. This is best effort to avoid the issue, but it
+	// isn't perfect. It only handles _one_ canceled operation, but is better than nothing for now.
+	//
+	// The retry deliberately runs under a suffixed key rather than Forget + reuse of the primary
+	// key. Forget detaches whatever call is currently registered for the key, so with several
+	// waiters recovering from the same canceled flight, each Forget could orphan a replacement
+	// flight another waiter had already started.
+	//
+	// Right now if there is a single error that isn't a context error, it will fail all of the
+	// other requests as well. This _could_ end up biting us if we have a transient error. If that
+	// ever becomes the case, we can add an OR to this that uses the `shared` return value from the
+	// singleflight `Do` call and then re-enqueue here as well, but for now we'll let real errors
+	// fall through to everyone.
+	if err != nil &&
+		(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) &&
+		ctx.Err() == nil {
+		accessToken, err, _ = p.mintGroup.Do(cacheKey+retryKeySuffix, func() (any, error) {
+			return p.mintAndCacheToken(
+				ctx,
+				appOrClientID,
+				installationID,
+				encodedPrivateKey,
+				repoURL,
+				cacheKey,
+			)
+		})
+	}
+	// At this point if we're checking an error, we've now already retried
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentials.Credentials{
+		Username: accessTokenUsername,
+		// We know the type is string so we're not checking the assertion here
+		Password: accessToken.(string), // nolint: forcetypeassert
+	}, nil
+}
+
+// mintAndCacheToken mints a new installation access token, waits for it to
+// become usable, caches it, and returns it. It is intended to be executed
+// within the provider's singleflight group.
+func (p *AppCredentialProvider) mintAndCacheToken(
+	ctx context.Context,
+	appOrClientID string,
+	installationID int64,
+	encodedPrivateKey string,
+	repoURL string,
+	cacheKey string,
+) (string, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	// A concurrent call may have minted and cached a token between this
+	// call's cache miss and its turn in the singleflight group.
+	if entry, exists := p.tokenCache.Get(cacheKey); exists {
+		logger.Debug("installation access token cached by concurrent call")
+		return entry.(string), nil // nolint: forcetypeassert
+	}
+
 	token, err := p.getAccessTokenFn(
 		appOrClientID,
 		installationID,
@@ -203,7 +289,7 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 		repoURL,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error getting installation access token: %w", err)
+		return "", fmt.Errorf("error getting installation access token: %w", err)
 	}
 	logger.Debug("obtained new installation access token")
 
@@ -215,7 +301,7 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	// token demonstrably works before releasing it to the caller prevents
 	// this.
 	if err = p.waitForTokenUsable(ctx, token.AccessToken, repoURL); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	ttl := credentials.CalculateCacheTTL(token.Expiry, tokenCacheExpiryMargin)
@@ -226,10 +312,7 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	)
 	p.tokenCache.Set(cacheKey, token.AccessToken, ttl)
 
-	return &credentials.Credentials{
-		Username: accessTokenUsername,
-		Password: token.AccessToken,
-	}, nil
+	return token.AccessToken, nil
 }
 
 // waitForTokenUsable checks that a newly minted installation access token is actually usable,

--- a/pkg/credentials/github/app.go
+++ b/pkg/credentials/github/app.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"slices"
@@ -21,6 +22,7 @@ import (
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/credentials"
+	ghutil "github.com/akuity/kargo/pkg/github"
 	"github.com/akuity/kargo/pkg/logging"
 )
 
@@ -35,6 +37,8 @@ const (
 	accessTokenUsername = "kargo"
 
 	tokenCacheExpiryMargin = 5 * time.Minute
+
+	tokenValidationRequestTimeout = 10 * time.Second
 )
 
 var base64Regex = regexp.MustCompile(`^[a-zA-Z0-9+/]*={0,2}$`)
@@ -53,12 +57,23 @@ func init() {
 type AppCredentialProvider struct {
 	tokenCache *cache.Cache
 
+	// validationBackoff is the schedule of waits between successive attempts to validate a newly
+	// minted installation access token. This is set as a field so that it can be overridden in
+	// tests to avoid long waits.
+	validationBackoff []time.Duration
+
 	getAccessTokenFn func(
 		appOrClientID string,
 		installationID int64,
 		encodedPrivateKey string,
 		repoURL string,
 	) (*oauth2.Token, error)
+
+	validateAccessTokenFn func(
+		ctx context.Context,
+		accessToken string,
+		repoURL string,
+	) (bool, error)
 }
 
 // NewAppCredentialProvider returns an implementation of credentials.Provider.
@@ -71,8 +86,17 @@ func NewAppCredentialProvider() credentials.Provider {
 			40*time.Minute, // Default ttl for each entry
 			time.Hour,      // Cleanup interval
 		),
+		// GitHub's own recommendation for retrying use of a newly minted token that has not yet
+		// replicated to all of their edge caches. See the Github support response in
+		// https://github.com/aws-amplify/amplify-hosting/issues/4080
+		validationBackoff: []time.Duration{
+			3 * time.Second,
+			10 * time.Second,
+			30 * time.Second,
+		},
 	}
 	p.getAccessTokenFn = p.getAccessToken
+	p.validateAccessTokenFn = p.validateAccessToken
 	return p
 }
 
@@ -159,6 +183,7 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 		"provider", "githubApp",
 		"repoURL", repoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
 	// Check the cache for the token
 	if entry, exists := p.tokenCache.Get(cacheKey); exists {
@@ -182,6 +207,17 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	}
 	logger.Debug("obtained new installation access token")
 
+	// GitHub replicates newly minted tokens to its infrastructure
+	// asynchronously, so a token used immediately after being minted is
+	// sometimes rejected. Since GitHub masks authorization failures on private
+	// repositories as 404s, this manifested for a long time as intermittent,
+	// difficult-to-diagnose "repository not found" errors. Waiting until the
+	// token demonstrably works before releasing it to the caller prevents
+	// this.
+	if err = p.waitForTokenUsable(ctx, token.AccessToken, repoURL); err != nil {
+		return nil, err
+	}
+
 	ttl := credentials.CalculateCacheTTL(token.Expiry, tokenCacheExpiryMargin)
 	logger.Debug(
 		"caching installation access token",
@@ -194,6 +230,97 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 		Username: accessTokenUsername,
 		Password: token.AccessToken,
 	}, nil
+}
+
+// waitForTokenUsable checks that a newly minted installation access token is actually usable,
+// retrying on a fixed backoff schedule if it is not. A token that cannot be validated after
+// exhausting the schedule is presumed usable, since erring on that side leaves the caller no worse
+// off than if no validation had been attempted. A non-nil error is returned only if the provided
+// context is canceled. This is required due to how GitHub replicates newly minted tokens to its
+// edge caches. See https://github.com/aws-amplify/amplify-hosting/issues/4080 for more information
+func (p *AppCredentialProvider) waitForTokenUsable(
+	ctx context.Context,
+	accessToken string,
+	repoURL string,
+) error {
+	logger := logging.LoggerFromContext(ctx)
+	start := time.Now()
+	// We start at 1 here because this is mostly used for logging and we want the first attempt to
+	// be logged as "1" rather than "0". We subtract 1 in the single place we use it as an index
+	for attempt := 1; ; attempt++ {
+		valid, err := p.validateAccessTokenFn(ctx, accessToken, repoURL)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			logger.Debug(
+				"error validating installation access token",
+				"attempt", attempt,
+				"error", err.Error(),
+			)
+		}
+		if valid {
+			logger.Debug(
+				"installation access token validated",
+				"attempts", attempt,
+				"elapsed", time.Since(start),
+			)
+			return nil
+		}
+		if attempt > len(p.validationBackoff) {
+			logger.Info(
+				"proceeding with installation access token that could not be "+
+					"validated; it may not have finished replicating on GitHub's "+
+					"end and operations using it may fail",
+				"attempts", attempt,
+				"elapsed", time.Since(start),
+			)
+			return nil
+		}
+		timer := time.NewTimer(p.validationBackoff[attempt-1])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// validateAccessToken checks whether an installation access token is usable yet by making a
+// lightweight, authenticated request for metadata about the repository to which the token is
+// scoped. Installations implicitly have read access to the metadata of any repository they can
+// access, so any authorization failure (401, 403, or GitHub's masking of such failures as 404) is
+// interpreted as the token not (yet) being usable. Any other failure says nothing about the
+// token's validity and is surfaced as an error.
+func (p *AppCredentialProvider) validateAccessToken(
+	ctx context.Context,
+	accessToken string,
+	repoURL string,
+) (bool, error) {
+	_, _, owner, repoName, err := ghutil.ParseRepoURL(repoURL)
+	if err != nil {
+		return false, err
+	}
+	client, err := ghutil.NewClient(repoURL, &ghutil.ClientOptions{Token: accessToken})
+	if err != nil {
+		return false, fmt.Errorf("error creating GitHub client: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, tokenValidationRequestTimeout)
+	defer cancel()
+	_, resp, err := client.Repositories.Get(ctx, owner, repoName)
+	if err == nil {
+		return true, nil
+	}
+	if resp != nil {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+			// These are the failures with the potential to resolve on their own
+			// once the token has finished replicating on GitHub's end.
+			return false, nil
+		}
+	}
+	return false, fmt.Errorf("error validating installation access token: %w", err)
 }
 
 // getAccessToken gets an installation access token for the given app/client ID,
@@ -258,11 +385,13 @@ func (p *AppCredentialProvider) tokenCacheKey(
 ) string {
 	return fmt.Sprintf(
 		"%x",
-		sha256.Sum256([]byte(
-			fmt.Sprintf(
-				"%s:%d:%s:%s",
-				appOrClientID, installationID, encodedPrivateKey, repoURL),
-		),
+		sha256.Sum256(
+			[]byte(
+				fmt.Sprintf(
+					"%s:%d:%s:%s",
+					appOrClientID, installationID, encodedPrivateKey, repoURL,
+				),
+			),
 		),
 	)
 }

--- a/pkg/credentials/github/app_test.go
+++ b/pkg/credentials/github/app_test.go
@@ -1,10 +1,13 @@
 package github
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -22,7 +25,9 @@ func TestNewAppCredentialProvider(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	assert.NotNil(t, provider.tokenCache)
+	assert.NotEmpty(t, provider.validationBackoff)
 	assert.NotNil(t, provider.getAccessTokenFn)
+	assert.NotNil(t, provider.validateAccessTokenFn)
 }
 
 func TestAppCredentialProvider_Supports(t *testing.T) {
@@ -343,6 +348,11 @@ func TestAppCredentialProvider_GetCredentials(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+			provider.validateAccessTokenFn = func(
+				context.Context, string, string,
+			) (bool, error) {
+				return true, nil
+			}
 
 			if testCase.getAccessTokenFn != nil {
 				provider.getAccessTokenFn = testCase.getAccessTokenFn
@@ -463,6 +473,11 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+			provider.validateAccessTokenFn = func(
+				context.Context, string, string,
+			) (bool, error) {
+				return true, nil
+			}
 
 			if testCase.setupCache != nil {
 				testCase.setupCache(provider.tokenCache)
@@ -480,6 +495,189 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 				fakeRepoURL,
 			)
 			testCase.assertions(t, provider.tokenCache, creds, err)
+		})
+	}
+}
+
+func TestAppCredentialProvider_waitForTokenUsable(t *testing.T) {
+	const fakeRepoURL = "https://github.com/example/repo"
+
+	// Keep waits between validation attempts negligible in all test cases.
+	testBackoff := []time.Duration{
+		time.Millisecond,
+		time.Millisecond,
+		time.Millisecond,
+	}
+
+	testCases := []struct {
+		name                  string
+		getCtx                func() context.Context
+		validateAccessTokenFn func(
+			attempt int,
+		) (bool, error)
+		assertions func(t *testing.T, attempts int, err error)
+	}{
+		{
+			name: "token is immediately valid",
+			validateAccessTokenFn: func(int) (bool, error) {
+				return true, nil
+			},
+			assertions: func(t *testing.T, attempts int, err error) {
+				require.NoError(t, err)
+				require.Equal(t, 1, attempts)
+			},
+		},
+		{
+			name: "token becomes valid after retries",
+			validateAccessTokenFn: func(attempt int) (bool, error) {
+				return attempt >= 3, nil
+			},
+			assertions: func(t *testing.T, attempts int, err error) {
+				require.NoError(t, err)
+				require.Equal(t, 3, attempts)
+			},
+		},
+		{
+			name: "validation errors are tolerated",
+			validateAccessTokenFn: func(attempt int) (bool, error) {
+				if attempt == 1 {
+					return false, errors.New("something went wrong")
+				}
+				return true, nil
+			},
+			assertions: func(t *testing.T, attempts int, err error) {
+				require.NoError(t, err)
+				require.Equal(t, 2, attempts)
+			},
+		},
+		{
+			name: "token never validates; presumed usable",
+			validateAccessTokenFn: func(int) (bool, error) {
+				return false, nil
+			},
+			assertions: func(t *testing.T, attempts int, err error) {
+				require.NoError(t, err)
+				// One attempt up front + one per element of the backoff
+				// schedule
+				require.Equal(t, len(testBackoff)+1, attempts)
+			},
+		},
+		{
+			name: "context canceled",
+			getCtx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			validateAccessTokenFn: func(int) (bool, error) {
+				return false, nil
+			},
+			assertions: func(t *testing.T, _ int, err error) {
+				require.ErrorIs(t, err, context.Canceled)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var attempts int
+			provider := &AppCredentialProvider{
+				validationBackoff: testBackoff,
+				validateAccessTokenFn: func(
+					context.Context, string, string,
+				) (bool, error) {
+					attempts++
+					return testCase.validateAccessTokenFn(attempts)
+				},
+			}
+			ctx := t.Context()
+			if testCase.getCtx != nil {
+				ctx = testCase.getCtx()
+			}
+			err := provider.waitForTokenUsable(ctx, "fake-token", fakeRepoURL)
+			testCase.assertions(t, attempts, err)
+		})
+	}
+}
+
+func TestAppCredentialProvider_validateAccessToken(t *testing.T) {
+	const fakeAccessToken = "fake-token"
+
+	testCases := []struct {
+		name       string
+		statusCode int
+		// getRepoURL optionally overrides the repo URL used in the test case.
+		// It receives the test server's URL.
+		getRepoURL func(srvURL string) string
+		assertions func(t *testing.T, valid bool, err error)
+	}{
+		{
+			name:       "token is usable",
+			statusCode: http.StatusOK,
+			assertions: func(t *testing.T, valid bool, err error) {
+				require.NoError(t, err)
+				require.True(t, valid)
+			},
+		},
+		{
+			name:       "authorization failure; token is not (yet) usable",
+			statusCode: http.StatusNotFound,
+			assertions: func(t *testing.T, valid bool, err error) {
+				require.NoError(t, err)
+				require.False(t, valid)
+			},
+		},
+		{
+			name:       "unexpected status is an error",
+			statusCode: http.StatusInternalServerError,
+			assertions: func(t *testing.T, valid bool, err error) {
+				require.ErrorContains(
+					t, err, "error validating installation access token",
+				)
+				require.False(t, valid)
+			},
+		},
+		{
+			name: "owner and repo name cannot be extracted",
+			getRepoURL: func(string) string {
+				return "https://github.com/example"
+			},
+			assertions: func(t *testing.T, valid bool, err error) {
+				require.ErrorContains(
+					t, err, "could not extract repository owner and name",
+				)
+				require.False(t, valid)
+			},
+		},
+	}
+	p := &AppCredentialProvider{}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					require.Equal(
+						t, "/api/v3/repos/example/repo", r.URL.Path,
+					)
+					require.Equal(
+						t,
+						fmt.Sprintf("Bearer %s", fakeAccessToken),
+						r.Header.Get("Authorization"),
+					)
+					w.WriteHeader(testCase.statusCode)
+				},
+			))
+			t.Cleanup(srv.Close)
+			// By default, the test server plays the role of a GitHub
+			// Enterprise host
+			repoURL := fmt.Sprintf("%s/example/repo", srv.URL)
+			if testCase.getRepoURL != nil {
+				repoURL = testCase.getRepoURL(srv.URL)
+			}
+			valid, err := p.validateAccessToken(
+				t.Context(),
+				fakeAccessToken,
+				repoURL,
+			)
+			testCase.assertions(t, valid, err)
 		})
 	}
 }

--- a/pkg/credentials/github/app_test.go
+++ b/pkg/credentials/github/app_test.go
@@ -28,6 +28,7 @@ func TestNewAppCredentialProvider(t *testing.T) {
 
 	assert.NotNil(t, provider.tokenCache)
 	assert.NotEmpty(t, provider.validationBackoff)
+	assert.NotZero(t, provider.mintTimeoutBuffer)
 	assert.NotNil(t, provider.getAccessTokenFn)
 	assert.NotNil(t, provider.validateAccessTokenFn)
 }
@@ -562,11 +563,12 @@ func TestAppCredentialProvider_getUsernameAndPassword_coalescing(
 	}
 }
 
-// This exercises the edge case where the context of the call that wins the
-// singleflight race is canceled mid-mint. The winner must fail with the
-// context error, while coalesced callers whose own contexts are still live
-// must recover rather than sharing the winner's fate -- and must do so via a
-// SINGLE shared replacement mint, not one mint each.
+// This exercises the case where the context of the call that wins the
+// singleflight race is canceled mid-mint. Because the mint runs under an
+// orphaned context, the winner's cancellation must NOT cancel the shared mint.
+// The winner stops waiting and returns an "interrupted" error, but the single
+// mint runs to completion and the coalesced callers whose contexts are still
+// live receive the token from that SAME mint.
 func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
 	t *testing.T,
 ) {
@@ -649,10 +651,13 @@ func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
 	time.Sleep(100 * time.Millisecond)
 	cancel()
 
-	// The winner's own context was canceled, so it must NOT have retried.
-	require.ErrorIs(t, <-winnerErr, context.Canceled)
+	// The winner's own context was canceled, so it stops waiting and returns an
+	// interrupted error -- but it must NOT have canceled the shared mint.
+	winErr := <-winnerErr
+	require.ErrorIs(t, winErr, context.Canceled)
+	require.ErrorContains(t, winErr, "cache refresh will continue in the background")
 
-	// Allow the replacement mint to validate.
+	// Allow the orphaned mint to validate.
 	close(release)
 
 	for range numWaiters {
@@ -662,11 +667,104 @@ func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
 		require.Equal(t, fakeAccessToken, res.creds.Password)
 	}
 
-	// The canceled mint plus exactly ONE shared replacement, no matter how the
-	// recovering waiters interleaved. When recovery used Forget + a retry on
-	// the primary key, each recovering waiter could orphan another's
-	// in-flight replacement mint and start its own.
-	require.Equal(t, int32(2), mints.Load())
+	// Exactly one mint: the winner's cancellation did not spawn a replacement,
+	// and the single orphaned mint served every coalesced waiter.
+	require.Equal(t, int32(1), mints.Load())
+
+	// That orphaned mint also cached the token for future callers.
+	cacheKey := provider.tokenCacheKey(
+		fakeAppOrClientID,
+		fakeInstallationID,
+		fakePrivateKey,
+		fakeRepoURL,
+	)
+	cached, found := provider.tokenCache.Get(cacheKey)
+	require.True(t, found)
+	require.Equal(t, fakeAccessToken, cached)
+}
+
+// This exercises the fail-safe that bounds the mint. The mint runs under an
+// orphaned context whose deadline is maxWait, so validation that never succeeds
+// (e.g. GitHub never confirming the token) must be cut off with a context
+// deadline error rather than hanging forever.
+func TestAppCredentialProvider_getUsernameAndPassword_timeout(t *testing.T) {
+	const (
+		fakeAppOrClientID  = "fake-id"
+		fakeInstallationID = int64(456)
+		fakePrivateKey     = "private-key"
+		fakeRepoURL        = "https://github.com/example/repo"
+		fakeAccessToken    = "test-token"
+	)
+
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+	// Keep the orphaned context's deadline short so the test does not linger.
+	provider.validationBackoff = nil
+	provider.mintTimeoutBuffer = 50 * time.Millisecond
+	provider.getAccessTokenFn = func(
+		string, int64, string, string,
+	) (*oauth2.Token, error) {
+		return &oauth2.Token{
+			AccessToken: fakeAccessToken,
+			Expiry:      time.Now().Add(time.Hour),
+		}, nil
+	}
+	// Validation never resolves on its own; it only returns once the mint's
+	// orphaned context hits its deadline.
+	provider.validateAccessTokenFn = func(
+		ctx context.Context, _, _ string,
+	) (bool, error) {
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+
+	creds, err := provider.getUsernameAndPassword(
+		t.Context(),
+		fakeAppOrClientID,
+		fakeInstallationID,
+		fakePrivateKey,
+		fakeRepoURL,
+	)
+	require.ErrorContains(t, err, "error minting installation access token")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, creds)
+}
+
+// A real (non-context) error from the mint is delivered to the caller rather
+// than swallowed, and it triggers exactly one mint attempt.
+func TestAppCredentialProvider_getUsernameAndPassword_realError(t *testing.T) {
+	const (
+		fakeAppOrClientID  = "fake-id"
+		fakeInstallationID = int64(456)
+		fakePrivateKey     = "private-key"
+		fakeRepoURL        = "https://github.com/example/repo"
+	)
+
+	var mints atomic.Int32
+
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+	provider.getAccessTokenFn = func(
+		string, int64, string, string,
+	) (*oauth2.Token, error) {
+		mints.Add(1)
+		return nil, errors.New("token error")
+	}
+	provider.validateAccessTokenFn = func(
+		context.Context, string, string,
+	) (bool, error) {
+		return true, nil
+	}
+
+	creds, err := provider.getUsernameAndPassword(
+		t.Context(),
+		fakeAppOrClientID,
+		fakeInstallationID,
+		fakePrivateKey,
+		fakeRepoURL,
+	)
+	require.ErrorContains(t, err, "token error")
+	require.Nil(t, creds)
+	// The error must not have triggered a retry.
+	require.Equal(t, int32(1), mints.Load())
 }
 
 func TestAppCredentialProvider_waitForTokenUsable(t *testing.T) {

--- a/pkg/credentials/github/app_test.go
+++ b/pkg/credentials/github/app_test.go
@@ -8,6 +8,8 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -497,6 +499,174 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 			testCase.assertions(t, provider.tokenCache, creds, err)
 		})
 	}
+}
+
+func TestAppCredentialProvider_getUsernameAndPassword_coalescing(
+	t *testing.T,
+) {
+	const (
+		fakeAppOrClientID  = "fake-id"
+		fakeInstallationID = int64(456)
+		fakePrivateKey     = "private-key"
+		fakeRepoURL        = "https://github.com/example/repo"
+		fakeAccessToken    = "test-token"
+
+		concurrency = 10
+	)
+
+	var mints atomic.Int32
+
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+	provider.getAccessTokenFn = func(
+		string, int64, string, string,
+	) (*oauth2.Token, error) {
+		mints.Add(1)
+		// Hold the mint open long enough for the other goroutines to pile up
+		// behind it.
+		time.Sleep(50 * time.Millisecond)
+		return &oauth2.Token{
+			AccessToken: fakeAccessToken,
+			Expiry:      time.Now().Add(time.Hour),
+		}, nil
+	}
+	provider.validateAccessTokenFn = func(
+		context.Context, string, string,
+	) (bool, error) {
+		return true, nil
+	}
+
+	creds := make([]*credentials.Credentials, concurrency)
+	errs := make([]error, concurrency)
+	var wg sync.WaitGroup
+	for i := range concurrency {
+		wg.Go(func() {
+			creds[i], errs[i] = provider.getUsernameAndPassword(
+				t.Context(),
+				fakeAppOrClientID,
+				fakeInstallationID,
+				fakePrivateKey,
+				fakeRepoURL,
+			)
+		})
+	}
+	wg.Wait()
+
+	// However the goroutines were scheduled, exactly one token should have
+	// been minted. Callers that missed the in-flight mint entirely find the
+	// token already cached when their own flight begins.
+	require.Equal(t, int32(1), mints.Load())
+	for i := range concurrency {
+		require.NoError(t, errs[i])
+		require.NotNil(t, creds[i])
+		require.Equal(t, fakeAccessToken, creds[i].Password)
+	}
+}
+
+// This exercises the edge case where the context of the call that wins the
+// singleflight race is canceled mid-mint. The winner must fail with the
+// context error, while coalesced callers whose own contexts are still live
+// must recover rather than sharing the winner's fate -- and must do so via a
+// SINGLE shared replacement mint, not one mint each.
+func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
+	t *testing.T,
+) {
+	const (
+		fakeAppOrClientID  = "fake-id"
+		fakeInstallationID = int64(456)
+		fakePrivateKey     = "private-key"
+		fakeRepoURL        = "https://github.com/example/repo"
+		fakeAccessToken    = "test-token"
+	)
+
+	var mints atomic.Int32
+	mintStarted := make(chan struct{})
+	release := make(chan struct{})
+
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+	provider.getAccessTokenFn = func(
+		string, int64, string, string,
+	) (*oauth2.Token, error) {
+		if mints.Add(1) == 1 {
+			close(mintStarted)
+		}
+		return &oauth2.Token{
+			AccessToken: fakeAccessToken,
+			Expiry:      time.Now().Add(time.Hour),
+		}, nil
+	}
+	// Block validation until the provided context is canceled or the test
+	// releases it. This holds the winner's flight open for as long as the
+	// test needs it to remain in progress.
+	provider.validateAccessTokenFn = func(
+		ctx context.Context, _, _ string,
+	) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-release:
+			return true, nil
+		}
+	}
+
+	winnerCtx, cancel := context.WithCancel(t.Context())
+	winnerErr := make(chan error, 1)
+	go func() {
+		_, err := provider.getUsernameAndPassword(
+			winnerCtx,
+			fakeAppOrClientID,
+			fakeInstallationID,
+			fakePrivateKey,
+			fakeRepoURL,
+		)
+		winnerErr <- err
+	}()
+	// The winner is now mid-mint with its flight held open
+	<-mintStarted
+
+	// Several coalesced waiters, all with live contexts, all of which should
+	// recover from the winner's cancellation.
+	const numWaiters = 3
+	type result struct {
+		creds *credentials.Credentials
+		err   error
+	}
+	waiterRes := make(chan result, numWaiters)
+	for range numWaiters {
+		go func() {
+			creds, err := provider.getUsernameAndPassword(
+				t.Context(),
+				fakeAppOrClientID,
+				fakeInstallationID,
+				fakePrivateKey,
+				fakeRepoURL,
+			)
+			waiterRes <- result{creds: creds, err: err}
+		}()
+	}
+
+	// Give the waiters a moment to join the in-flight mint, then cancel the
+	// winner's context.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// The winner's own context was canceled, so it must NOT have retried.
+	require.ErrorIs(t, <-winnerErr, context.Canceled)
+
+	// Allow the replacement mint to validate.
+	close(release)
+
+	for range numWaiters {
+		res := <-waiterRes
+		require.NoError(t, res.err)
+		require.NotNil(t, res.creds)
+		require.Equal(t, fakeAccessToken, res.creds.Password)
+	}
+
+	// The canceled mint plus exactly ONE shared replacement, no matter how the
+	// recovering waiters interleaved. When recovery used Forget + a retry on
+	// the primary key, each recovering waiter could orphan another's
+	// in-flight replacement mint and start its own.
+	require.Equal(t, int32(2), mints.Load())
 }
 
 func TestAppCredentialProvider_waitForTokenUsable(t *testing.T) {


### PR DESCRIPTION
GitHub replicates newly minted installation access tokens to its edge infrastructure asynchronously, so a token used immediately after being minted is sometimes rejected. Because GitHub masks authorization failures on private repositories as 404s, this has long manifested as intermittent "repository not found" errors during git operations that immediately follow a token cache miss (see #5610). The problem became dramatically more frequent in v1.8.0, when tokens began being scoped to individual repositories, multiplying how often new tokens are minted.

Before caching a newly minted token and releasing it to the caller, the GitHub App credential provider now confirms the token actually works by requesting metadata about the repository the token is scoped to, retrying on the backoff schedule GitHub themselves recommend for exactly this situation (3s/10s/30s): https://github.com/aws-amplify/amplify-hosting/issues/4080 contains the issue and the response from GitHub support. In the typical case the first check succeeds and the added cost is a single lightweight API request per mint. A token that cannot be validated after exhausting the schedule is presumed usable, leaving the caller no worse off than before this change.