### PR TITLE
fix(kubeclient): move defer after error check to prevent nil pointer panic

### DIFF
--- a/pkg/kubeclient/auth.go
+++ b/pkg/kubeclient/auth.go
@@ -39,12 +39,12 @@ func GetCredential(ctx context.Context, cfg *rest.Config) (string, error) {
 	// #nosec G704 -- This code executes client-side and does not, therefore,
 	// represent a vector for SSRF attacks.
 	res, err := rc.Do(req)
-	defer func() {
-		_ = res.Body.Close()
-	}()
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
 	return strings.TrimPrefix(
 		res.Header.Get(xKargoUserCredentialHeader),
 		"Bearer ",


### PR DESCRIPTION
## Summary

In `GetCredential` (`pkg/kubeclient/auth.go`), the `defer` statement capturing `res.Body.Close()` was registered **before** the error check on `rc.Do()`:

```go
res, err := rc.Do(req)
defer func() {
    _ = res.Body.Close()
}()
if err != nil {
    return "", err
}
```

When `http.Client.Do()` returns an error, the `res` value is `nil` per the Go standard library contract. Because the deferred function captures `res` by reference through the closure, when the deferred close runs at function exit, it dereferences `res.Body` on a nil `res`, causing a **panic**.

This function is called to retrieve Kubernetes credentials, so any transient network error or misconfigured REST config will crash the server.

**Fix**: Moved the `defer` to after the `if err != nil` check so `res.Body.Close()` only runs when `res` is non-nil.