### PR TITLE
fix(tar_extractor): log closeErr instead of io.CopyN error in file close handler

### DIFF
--- a/pkg/promotion/runner/builtin/tar_extractor.go
+++ b/pkg/promotion/runner/builtin/tar_extractor.go
@@ -358,7 +358,7 @@ func (t *tarExtractor) extractToDir(
 			// Limit copying to the declared size
 			written, err := io.CopyN(outFile, tarReader, header.Size)
 			if closeErr := outFile.Close(); closeErr != nil {
-				logger.Error(err, fmt.Sprintf("failed to close file %s", targetPath))
+				logger.Error(closeErr, fmt.Sprintf("failed to close file %s", targetPath))
 			}
 			if err != nil && err != io.EOF {
 				return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},


### PR DESCRIPTION
## Summary

In the tar extractor (`pkg/promotion/runner/builtin/tar_extractor.go:361`), the file close error handler logged the wrong error variable:

```go
written, err := io.CopyN(outFile, tarReader, header.Size)
if closeErr := outFile.Close(); closeErr != nil {
    logger.Error(err, fmt.Sprintf("failed to close file %s", targetPath))
}
```

`logger.Error(err, ...)` was called with `err` (the return value from `io.CopyN`) instead of `closeErr` (the return value from `outFile.Close()`).

**Impact:**
1. When `Close()` fails but `CopyN` succeeded, `err` is `nil`, so the logger receives a nil error and the actual close failure is silently discarded
2. When both fail, the logger reports the `CopyN` error rather than the close error, obscuring the root cause

**Fix**: Changed `err` to `closeErr` in the logger call.