### PR TITLE
chore: reconfigure governance bot to see outside collaborators as "maintainers"

### DIFF
--- a/.github/governance.yaml
+++ b/.github/governance.yaml
@@ -1,5 +1,6 @@
 # Users with these relationships to the events are counted as maintainers.
 maintainerAssociations:
+- COLLABORATOR
 - MEMBER
 - OWNER
 


### PR DESCRIPTION
This does _not_ give anyone new permissions. It only exempts them from a policy they already weren't meant to be beholden to.

Crucially, this exempts @akuitybot from the PR policy so that automated backport PRs cease being automatically converted to drafts.