### PR TITLE
fix(controller): keep dead network connections from hanging artifact discovery indefinitely

### DIFF
--- a/pkg/controller/git/bare_repo.go
+++ b/pkg/controller/git/bare_repo.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,10 +16,14 @@ import (
 // BareRepo is an interface for interacting with a bare Git repository.
 type BareRepo interface {
 	// AddWorkTree adds a working tree to the repository.
-	AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree, error)
+	AddWorkTree(
+		ctx context.Context,
+		path string,
+		opts *AddWorkTreeOptions,
+	) (WorkTree, error)
 	// Close cleans up file system resources used by this repository. This should
 	// always be called before a repository goes out of scope.
-	Close() error
+	Close(ctx context.Context) error
 	// Dir returns an absolute path to the repository.
 	Dir() string
 	// HomeDir returns an absolute path to the home directory of the system user
@@ -26,14 +31,14 @@ type BareRepo interface {
 	HomeDir() string
 	// RemoteBranchExists returns a bool indicating if the specified branch exists
 	// in the remote repository.
-	RemoteBranchExists(branch string) (bool, error)
+	RemoteBranchExists(ctx context.Context, branch string) (bool, error)
 	// RemoveWorkTree removes a working tree from the repository. The working tree
 	// will be removed from the file system.
-	RemoveWorkTree(path string) error
+	RemoveWorkTree(ctx context.Context, path string) error
 	// URL returns the remote URL of the repository.
 	URL() string
 	// WorkTrees returns a list of working trees associated with the repository.
-	WorkTrees() ([]WorkTree, error)
+	WorkTrees(ctx context.Context) ([]WorkTree, error)
 }
 
 // bareRepo is an implementation of the BareRepo interface for interacting with
@@ -83,6 +88,7 @@ type BareCloneOptions struct {
 // will also perform any setup that is required for successfully authenticating
 // to the remote repository.
 func CloneBare(
+	ctx context.Context,
 	repoURL string,
 	clientOpts *ClientOptions,
 	cloneOpts *BareCloneOptions,
@@ -100,25 +106,25 @@ func CloneBare(
 			accessURL:   repoURL,
 		},
 	}
-	if err := b.setupDirs(cloneOpts.BaseDir); err != nil {
+	if err := b.setupDirs(ctx, cloneOpts.BaseDir); err != nil {
 		return nil, err
 	}
-	if err := b.setupClient(clientOpts); err != nil {
+	if err := b.setupClient(ctx, clientOpts); err != nil {
 		return nil, err
 	}
-	if err := b.clone(cloneOpts); err != nil {
+	if err := b.clone(ctx, cloneOpts); err != nil {
 		return nil, err
 	}
-	if err := b.saveDirs(); err != nil {
+	if err := b.saveDirs(ctx); err != nil {
 		return nil, err
 	}
-	if err := b.saveOriginalURL(); err != nil {
+	if err := b.saveOriginalURL(ctx); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-func (b *bareRepo) clone(opts *BareCloneOptions) error {
+func (b *bareRepo) clone(ctx context.Context, opts *BareCloneOptions) error {
 	if opts == nil {
 		opts = &BareCloneOptions{}
 	}
@@ -127,7 +133,7 @@ func (b *bareRepo) clone(opts *BareCloneOptions) error {
 		args = append(args, "--filter", "blob:none")
 	}
 	args = append(args, b.accessURL, b.dir)
-	cmd := b.buildGitCommand(args...)
+	cmd := b.buildGitCommand(ctx, args...)
 	cmd.Dir = b.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf("error cloning repo %q into %q: %w", b.originalURL, b.dir, err)
@@ -139,7 +145,11 @@ type LoadBareRepoOptions struct {
 	Credentials *RepoCredentials
 }
 
-func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
+func LoadBareRepo(
+	ctx context.Context,
+	path string,
+	opts *LoadBareRepoOptions,
+) (BareRepo, error) {
 	if opts == nil {
 		opts = &LoadBareRepoOptions{}
 	}
@@ -149,10 +159,10 @@ func LoadBareRepo(path string, opts *LoadBareRepoOptions) (BareRepo, error) {
 			dir:   path,
 		},
 	}
-	if err := b.loadHomeDir(); err != nil {
+	if err := b.loadHomeDir(ctx); err != nil {
 		return nil, fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
-	if err := b.loadURLs(); err != nil {
+	if err := b.loadURLs(ctx); err != nil {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
@@ -178,7 +188,11 @@ type AddWorkTreeOptions struct {
 	Sparse []string
 }
 
-func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree, error) {
+func (b *bareRepo) AddWorkTree(
+	ctx context.Context,
+	path string,
+	opts *AddWorkTreeOptions,
+) (WorkTree, error) {
 	if opts == nil {
 		opts = &AddWorkTreeOptions{}
 	}
@@ -186,7 +200,7 @@ func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree,
 	if err != nil {
 		return nil, fmt.Errorf("error resolving absolute path for %s: %w", path, err)
 	}
-	workTreePaths, err := b.workTrees()
+	workTreePaths, err := b.workTrees(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +213,7 @@ func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree,
 	} else {
 		args = append(args, opts.Ref)
 	}
-	if _, err = libExec.Exec(b.buildGitCommand(args...)); err != nil {
+	if _, err = libExec.Exec(b.buildGitCommand(ctx, args...)); err != nil {
 		return nil, fmt.Errorf("error adding working tree at %q: %w", path, err)
 	}
 	if path, err = filepath.EvalSymlinks(path); err != nil {
@@ -217,30 +231,30 @@ func (b *bareRepo) AddWorkTree(path string, opts *AddWorkTreeOptions) (WorkTree,
 	}
 	// Configure sparse checkout if patterns are specified
 	if len(opts.Sparse) > 0 {
-		if err = wt.configureSparseCheckout(opts.Sparse); err != nil {
+		if err = wt.configureSparseCheckout(ctx, opts.Sparse); err != nil {
 			// Clean up the worktree on failure
-			_ = b.RemoveWorkTree(path)
+			_ = b.RemoveWorkTree(ctx, path)
 			return nil, fmt.Errorf("error configuring sparse checkout for %q: %w", path, err)
 		}
 	}
 	return wt, nil
 }
 
-func (b *bareRepo) Close() error {
-	workTreePaths, err := b.workTrees()
+func (b *bareRepo) Close(ctx context.Context) error {
+	workTreePaths, err := b.workTrees(ctx)
 	if err != nil {
 		return err
 	}
 	for _, workTreePath := range workTreePaths {
-		if err := b.RemoveWorkTree(workTreePath); err != nil {
+		if err := b.RemoveWorkTree(ctx, workTreePath); err != nil {
 			return err
 		}
 	}
 	return os.RemoveAll(b.homeDir)
 }
 
-func (b *bareRepo) RemoveWorkTree(path string) error {
-	workTreePaths, err := b.workTrees()
+func (b *bareRepo) RemoveWorkTree(ctx context.Context, path string) error {
+	workTreePaths, err := b.workTrees(ctx)
 	if err != nil {
 		return err
 	}
@@ -248,7 +262,7 @@ func (b *bareRepo) RemoveWorkTree(path string) error {
 		return fmt.Errorf("no working tree exists at %q", path)
 	}
 	if _, err := libExec.Exec(
-		b.buildGitCommand("worktree", "remove", path),
+		b.buildGitCommand(ctx, "worktree", "remove", path),
 	); err != nil {
 		return fmt.Errorf("error removing working tree at %q: %w", path, err)
 	}
@@ -258,8 +272,8 @@ func (b *bareRepo) RemoveWorkTree(path string) error {
 	return nil
 }
 
-func (b *bareRepo) WorkTrees() ([]WorkTree, error) {
-	workTreePaths, err := b.workTrees()
+func (b *bareRepo) WorkTrees(ctx context.Context) ([]WorkTree, error) {
+	workTreePaths, err := b.workTrees(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -279,8 +293,10 @@ func (b *bareRepo) WorkTrees() ([]WorkTree, error) {
 	return workTrees, err
 }
 
-func (b *bareRepo) workTrees() ([]string, error) {
-	res, err := libExec.Exec(b.buildGitCommand("worktree", "list", "--porcelain"))
+func (b *bareRepo) workTrees(ctx context.Context) ([]string, error) {
+	res, err := libExec.Exec(b.buildGitCommand(
+		ctx, "worktree", "list", "--porcelain",
+	))
 	if err != nil {
 		return nil, fmt.Errorf("error listing working trees: %w", err)
 	}

--- a/pkg/controller/git/bare_repo_test.go
+++ b/pkg/controller/git/bare_repo_test.go
@@ -17,6 +17,7 @@ func TestBareRepo(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := CloneBare(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{
 			Credentials: &testRepoCreds,
@@ -25,7 +26,7 @@ func TestBareRepo(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 	r, ok := rep.(*bareRepo)
 	require.True(t, ok)
 
@@ -61,12 +62,13 @@ func TestBareRepo(t *testing.T) {
 
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
 	workTree, err := rep.AddWorkTree(
+		t.Context(),
 		workingTreePath,
 		&AddWorkTreeOptions{Ref: "main"},
 	)
 
 	require.NoError(t, err)
-	defer workTree.Close()
+	defer workTree.Close(t.Context())
 
 	t.Run("add a working tree", func(t *testing.T) {
 		require.NoError(t, err)
@@ -77,16 +79,16 @@ func TestBareRepo(t *testing.T) {
 
 	t.Run("can list working trees", func(t *testing.T) {
 		var workTrees []WorkTree
-		workTrees, err = rep.WorkTrees()
+		workTrees, err = rep.WorkTrees(t.Context())
 		require.NoError(t, err)
 		require.Len(t, workTrees, 1)
 		require.Equal(t, workTree, workTrees[0])
 	})
 
 	t.Run("can remove a working tree", func(t *testing.T) {
-		err = rep.RemoveWorkTree(workTree.Dir())
+		err = rep.RemoveWorkTree(t.Context(), workTree.Dir())
 		require.NoError(t, err)
-		trees, err := rep.WorkTrees()
+		trees, err := rep.WorkTrees(t.Context())
 		require.NoError(t, err)
 		require.Len(t, trees, 0)
 		_, err = os.Stat(workTree.Dir())
@@ -95,6 +97,7 @@ func TestBareRepo(t *testing.T) {
 
 	t.Run("can load an existing repo", func(t *testing.T) {
 		existingRepo, err := LoadBareRepo(
+			t.Context(),
 			rep.Dir(),
 			&LoadBareRepoOptions{
 				Credentials: &testRepoCreds,
@@ -105,7 +108,7 @@ func TestBareRepo(t *testing.T) {
 	})
 
 	t.Run("can close repo", func(t *testing.T) {
-		require.NoError(t, rep.Close())
+		require.NoError(t, rep.Close(t.Context()))
 		_, err := os.Stat(rep.HomeDir())
 		require.Error(t, err)
 		require.True(t, os.IsNotExist(err))
@@ -287,11 +290,12 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 				))
 			}
 			err := repo.AddAllAndCommit(
+				t.Context(),
 				fmt.Sprintf("add directories %s", uuid.NewString()),
 				nil,
 			)
 			require.NoError(t, err)
-			err = repo.Push(nil)
+			err = repo.Push(t.Context(), nil)
 			require.NoError(t, err)
 		},
 	)
@@ -299,6 +303,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 
 	// Clone as bare repo
 	rep, err := CloneBare(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{
 			Credentials: &testRepoCreds,
@@ -307,11 +312,12 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	t.Run("sparse checkout includes only specified directories", func(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "sparse-worktree")
 		workTree, err := rep.AddWorkTree(
+			t.Context(),
 			workingTreePath,
 			&AddWorkTreeOptions{
 				Ref:    "main",
@@ -319,7 +325,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		defer workTree.Close()
+		defer workTree.Close(t.Context())
 
 		// Verify dir1 and dir2 exist
 		_, err = os.Stat(filepath.Join(workTree.Dir(), "dir1", "file.txt"))
@@ -337,11 +343,12 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 	t.Run("worktree without sparse includes all directories", func(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "full-worktree")
 		workTree, err := rep.AddWorkTree(
+			t.Context(),
 			workingTreePath,
 			&AddWorkTreeOptions{Ref: "main"},
 		)
 		require.NoError(t, err)
-		defer workTree.Close()
+		defer workTree.Close(t.Context())
 
 		// Verify all directories exist
 		for _, dir := range []string{"dir1", "dir2", "dir3"} {
@@ -353,6 +360,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 	t.Run("pattern validation rejects absolute paths", func(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "invalid-abs-worktree")
 		_, err := rep.AddWorkTree(
+			t.Context(),
 			workingTreePath,
 			&AddWorkTreeOptions{
 				Ref:    "main",
@@ -365,6 +373,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 	t.Run("pattern validation rejects path traversal", func(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "invalid-traverse-worktree")
 		_, err := rep.AddWorkTree(
+			t.Context(),
 			workingTreePath,
 			&AddWorkTreeOptions{
 				Ref:    "main",
@@ -377,6 +386,7 @@ func TestBareRepo_SparseCheckout(t *testing.T) {
 	t.Run("glob patterns are rejected", func(t *testing.T) {
 		workingTreePath := filepath.Join(rep.HomeDir(), "glob-worktree")
 		_, err := rep.AddWorkTree(
+			t.Context(),
 			workingTreePath,
 			&AddWorkTreeOptions{
 				Ref:    "main",
@@ -460,19 +470,21 @@ func TestBareRepo_WithFilter(t *testing.T) {
 				))
 			}
 			err := repo.AddAllAndCommit(
+				t.Context(),
 				fmt.Sprintf("add directories %s", uuid.NewString()),
 				nil,
 			)
 			require.NoError(t, err)
-			err = repo.Push(nil)
+			err = repo.Push(t.Context(), nil)
 			require.NoError(t, err)
-			err = repo.Close()
+			err = repo.Close(t.Context())
 			require.NoError(t, err)
 		},
 	)
 	defer testServer.Close()
 
 	rep, err := CloneBare(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{
 			Credentials: &testRepoCreds,
@@ -483,16 +495,17 @@ func TestBareRepo_WithFilter(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	// Verify clone is functional by adding a worktree
 	workingTreePath := filepath.Join(rep.HomeDir(), "worktree")
 	workTree, err := rep.AddWorkTree(
+		t.Context(),
 		workingTreePath,
 		&AddWorkTreeOptions{Ref: "main"},
 	)
 	require.NoError(t, err)
-	defer workTree.Close()
+	defer workTree.Close(t.Context())
 
 	// Verify content can be checked out on-demand (blobs fetched lazily)
 	content, err := os.ReadFile(filepath.Join(workTree.Dir(), "dir1", "file.txt"))

--- a/pkg/controller/git/base_repo.go
+++ b/pkg/controller/git/base_repo.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	libExec "github.com/akuity/kargo/pkg/exec"
 	"github.com/akuity/kargo/pkg/logging"
@@ -22,6 +24,14 @@ const (
 	repoDirConfigKey         = "kargo.repoDir"
 	repoHomeDirConfigKey     = "kargo.repoHomeDir"
 	repoOriginalURLConfigKey = "kargo.repoOriginalURL"
+
+	// cmdWaitDelay is the grace period between context cancellation and
+	// forcible termination of a command. It also bounds how long Wait can
+	// remain blocked on the command's output pipes after cancellation:
+	// killing the command does not unblock Wait if a grandchild process
+	// (e.g. ssh or an askpass helper) inherited the pipes and holds them
+	// open, so a non-zero WaitDelay is required to guarantee Wait returns.
+	cmdWaitDelay = 10 * time.Second
 )
 
 // baseRepo implements the common underpinnings of a Git repository with a
@@ -51,7 +61,7 @@ type ClientOptions struct {
 	InsecureSkipTLSVerify bool
 }
 
-func (b *baseRepo) setupDirs(baseDir string) error {
+func (b *baseRepo) setupDirs(ctx context.Context, baseDir string) error {
 	var err error
 	if b.homeDir, err = os.MkdirTemp(baseDir, "repo-"); err != nil {
 		return fmt.Errorf(
@@ -63,7 +73,9 @@ func (b *baseRepo) setupDirs(baseDir string) error {
 		return fmt.Errorf("error resolving symlinks in path %s: %w", b.homeDir, err)
 	}
 	b.dir = filepath.Join(b.homeDir, "repo")
-	cmd := b.buildGitCommand("config", "--global", "init.defaultBranch", "main")
+	cmd := b.buildGitCommand(
+		ctx, "config", "--global", "init.defaultBranch", "main",
+	)
 	// Override the cmd.Dir that's set by b.buildGitCommand(). It's normally the
 	// repository's path, but if this method was called as part of the cloning
 	// process, that path may not exist yet.
@@ -76,12 +88,12 @@ func (b *baseRepo) setupDirs(baseDir string) error {
 
 // setupClient sets up "global" git configuration with author and authentication
 // details in the specified virtual home directory.
-func (b *baseRepo) setupClient(opts *ClientOptions) error {
+func (b *baseRepo) setupClient(ctx context.Context, opts *ClientOptions) error {
 	if opts == nil {
 		opts = &ClientOptions{}
 	}
 
-	if err := b.setupUser(b.homeDir, opts.User); err != nil {
+	if err := b.setupUser(ctx, b.homeDir, opts.User); err != nil {
 		return fmt.Errorf("error configuring the author: %w", err)
 	}
 
@@ -90,7 +102,9 @@ func (b *baseRepo) setupClient(opts *ClientOptions) error {
 	}
 
 	if opts.InsecureSkipTLSVerify {
-		cmd := b.buildGitCommand("config", "--global", "http.sslVerify", "false")
+		cmd := b.buildGitCommand(
+			ctx, "config", "--global", "http.sslVerify", "false",
+		)
 		// Override the cmd.Dir that's set by b.buildGitCommand(). It's normally the
 		// repository's path, but if this method was called as part of the cloning
 		// process, that path may not exist yet.
@@ -124,7 +138,11 @@ type User struct {
 // signing, the name and email must match the GPG key identity. The directory
 // specified by homeDir is used as a virtual home directory for all commands
 // executed by this method.
-func (b *baseRepo) setupUser(homeDir string, user *User) error {
+func (b *baseRepo) setupUser(
+	ctx context.Context,
+	homeDir string,
+	user *User,
+) error {
 	if user == nil {
 		user = &User{}
 	}
@@ -133,7 +151,7 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 		user.Name = defaultUsername
 	}
 
-	cmd := b.buildGitCommand("config", "--global", "user.name", user.Name)
+	cmd := b.buildGitCommand(ctx, "config", "--global", "user.name", user.Name)
 	// Override cmd.Dir set by buildGitCommand(). The repo path may not exist
 	// yet if called during clone. homeDir is safe since we're only writing
 	// "global" git config for a synthetic user.
@@ -149,7 +167,7 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 		user.Email = defaultEmail
 	}
 
-	cmd = b.buildGitCommand("config", "--global", "user.email", user.Email)
+	cmd = b.buildGitCommand(ctx, "config", "--global", "user.email", user.Email)
 	// See justification for both of these overrides above.
 	cmd.Dir = homeDir
 	b.setCmdHome(cmd, homeDir)
@@ -172,7 +190,7 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 			}
 			defer func() {
 				if err := os.Remove(user.SigningKeyPath); err != nil {
-					logging.LoggerFromContext(context.TODO()).Error(
+					logging.LoggerFromContext(ctx).Error(
 						err,
 						"error removing file",
 						"file", user.SigningKeyPath,
@@ -182,7 +200,9 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 		}
 
 		if user.SigningKeyPath != "" {
-			cmd = b.buildGitCommand("config", "--global", "commit.gpgSign", "true")
+			cmd = b.buildGitCommand(
+				ctx, "config", "--global", "commit.gpgSign", "true",
+			)
 			// See justification for both of these overrides above.
 			cmd.Dir = homeDir
 			b.setCmdHome(cmd, homeDir)
@@ -191,14 +211,14 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 			}
 
 			// Enable signing for tags as well.
-			cmd = b.buildGitCommand("config", "--global", "tag.gpgSign", "true")
+			cmd = b.buildGitCommand(ctx, "config", "--global", "tag.gpgSign", "true")
 			cmd.Dir = homeDir
 			b.setCmdHome(cmd, homeDir)
 			if _, err := libExec.Exec(cmd); err != nil {
 				return fmt.Errorf("error configuring tag gpg signing: %w", err)
 			}
 
-			cmd = b.buildCommand("gpg", "--import", user.SigningKeyPath)
+			cmd = b.buildCommand(ctx, "gpg", "--import", user.SigningKeyPath)
 			// See justification for both of these overrides above.
 			cmd.Dir = homeDir
 			b.setCmdHome(cmd, homeDir)
@@ -209,7 +229,7 @@ func (b *baseRepo) setupUser(homeDir string, user *User) error {
 			// Set ultimate trust on the imported key so that commits signed
 			// by this key are considered trusted during signature
 			// verification (e.g. when deciding whether a rebase is safe).
-			if err := b.setUltimateTrust(homeDir, user.SigningKeyPath); err != nil {
+			if err := b.setUltimateTrust(ctx, homeDir, user.SigningKeyPath); err != nil {
 				return fmt.Errorf("error setting trust on gpg key: %w", err)
 			}
 		}
@@ -274,18 +294,14 @@ func (b *baseRepo) setupAuth(homeDir string) error {
 // repository's configuration. This is useful for reliably determining this
 // information later if an existing repository or working tree is loaded from
 // the file system.
-func (b *baseRepo) saveDirs() error {
+func (b *baseRepo) saveDirs(ctx context.Context) error {
 	if _, err := libExec.Exec(b.buildGitCommand(
-		"config",
-		repoDirConfigKey,
-		b.dir,
+		ctx, "config", repoDirConfigKey, b.dir,
 	)); err != nil {
 		return fmt.Errorf("error saving repo dir as config: %w", err)
 	}
 	if _, err := libExec.Exec(b.buildGitCommand(
-		"config",
-		repoHomeDirConfigKey,
-		b.homeDir,
+		ctx, "config", repoHomeDirConfigKey, b.homeDir,
 	)); err != nil {
 		return fmt.Errorf("error saving repo home dir as config: %w", err)
 	}
@@ -295,11 +311,9 @@ func (b *baseRepo) saveDirs() error {
 // saveOriginalURL saves the original URL of the repository to the repository's
 // configuration. This is useful for reliably determining this information when
 // an existing repository or working tree is loaded from the file system.
-func (b *baseRepo) saveOriginalURL() error {
+func (b *baseRepo) saveOriginalURL(ctx context.Context) error {
 	if _, err := libExec.Exec(b.buildGitCommand(
-		"config",
-		repoOriginalURLConfigKey,
-		b.originalURL,
+		ctx, "config", repoOriginalURLConfigKey, b.originalURL,
 	)); err != nil {
 		return fmt.Errorf("error saving original URL as config: %w", err)
 	}
@@ -312,16 +326,15 @@ func (b *baseRepo) saveOriginalURL() error {
 // also reconciles any residual GnuPG state in that home directory that may
 // have been left behind by a process in a different container sharing the
 // same underlying filesystem.
-func (b *baseRepo) loadHomeDir() error {
+func (b *baseRepo) loadHomeDir(ctx context.Context) error {
 	res, err := libExec.Exec(b.buildGitCommand(
-		"config",
-		repoHomeDirConfigKey,
+		ctx, "config", repoHomeDirConfigKey,
 	))
 	if err != nil {
 		return fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
 	b.homeDir = strings.TrimSpace(string(res))
-	b.reconcileGPGState()
+	b.reconcileGPGState(ctx)
 	return nil
 }
 
@@ -361,7 +374,7 @@ func (b *baseRepo) loadHomeDir() error {
 // Safe to call when no GnuPG state exists (no-op) and in traditional
 // single-process deployments where no cross-container state sharing occurs
 // (also effectively a no-op).
-func (b *baseRepo) reconcileGPGState() {
+func (b *baseRepo) reconcileGPGState(ctx context.Context) {
 	if b.homeDir == "" {
 		return
 	}
@@ -371,9 +384,9 @@ func (b *baseRepo) reconcileGPGState() {
 	}
 	// Must run before removing sockets: gpgconf finds the agent via its
 	// sockets and tells it to shut down cleanly.
-	_, _ = libExec.Exec(b.buildCommand("gpgconf", "--kill", "gpg-agent"))
+	_, _ = libExec.Exec(b.buildCommand(ctx, "gpgconf", "--kill", "gpg-agent"))
 
-	logger := logging.LoggerFromContext(context.TODO())
+	logger := logging.LoggerFromContext(ctx)
 	remove := func(path string) {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			logger.Error(
@@ -407,15 +420,16 @@ func (b *baseRepo) reconcileGPGState() {
 // repository's configuration. This is useful for reliably determining this
 // information when an existing repository or working tree is loaded from the
 // file system.
-func (b *baseRepo) loadURLs() error {
-	res, err := libExec.Exec(b.buildGitCommand("config", repoOriginalURLConfigKey))
+func (b *baseRepo) loadURLs(ctx context.Context) error {
+	res, err := libExec.Exec(b.buildGitCommand(
+		ctx, "config", repoOriginalURLConfigKey,
+	))
 	if err != nil {
 		return fmt.Errorf(`error getting original URL of remote "origin": %w`, err)
 	}
 	b.originalURL = strings.TrimSpace(string(res))
 	if res, err = libExec.Exec(b.buildGitCommand(
-		"config",
-		"remote.origin.url",
+		ctx, "config", "remote.origin.url",
 	)); err != nil {
 		return fmt.Errorf(`error getting URL of remote "origin": %w`, err)
 	}
@@ -423,8 +437,19 @@ func (b *baseRepo) loadURLs() error {
 	return nil
 }
 
-func (b *baseRepo) buildCommand(command string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(command, arg...)
+func (b *baseRepo) buildCommand(
+	ctx context.Context,
+	command string,
+	arg ...string,
+) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, command, arg...)
+	// On cancellation, send SIGTERM rather than the default SIGKILL so the
+	// command has a chance to clean up after itself (e.g. git removing lock
+	// files).
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = cmdWaitDelay
 	homeEnvVar := fmt.Sprintf("HOME=%s", b.homeDir)
 	if cmd.Env == nil {
 		cmd.Env = []string{homeEnvVar}
@@ -435,8 +460,11 @@ func (b *baseRepo) buildCommand(command string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-func (b *baseRepo) buildGitCommand(arg ...string) *exec.Cmd {
-	cmd := b.buildCommand("git", arg...)
+func (b *baseRepo) buildGitCommand(
+	ctx context.Context,
+	arg ...string,
+) *exec.Cmd {
+	cmd := b.buildCommand(ctx, "git", arg...)
 	// TODO(v1.13.0): Remove this line when SSH support is removed.
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_SSH_COMMAND=ssh -F %s/.ssh/config", b.homeDir))
 	if b.creds != nil && b.creds.Password != "" {
@@ -466,8 +494,12 @@ func (b *baseRepo) HomeDir() string {
 	return b.homeDir
 }
 
-func (b *baseRepo) RemoteBranchExists(branch string) (bool, error) {
+func (b *baseRepo) RemoteBranchExists(
+	ctx context.Context,
+	branch string,
+) (bool, error) {
 	_, err := libExec.Exec(b.buildGitCommand(
+		ctx,
 		"ls-remote",
 		"--heads",
 		"--exit-code", // Return 2 if not found
@@ -496,9 +528,14 @@ func (b *baseRepo) URL() string {
 
 // setUltimateTrust sets ultimate trust (level 6) on a GPG key so that
 // signatures made by this key are considered fully trusted during verification.
-func (b *baseRepo) setUltimateTrust(homeDir, keyPath string) error {
+func (b *baseRepo) setUltimateTrust(
+	ctx context.Context,
+	homeDir string,
+	keyPath string,
+) error {
 	// Get the fingerprint of the key.
 	cmd := b.buildCommand(
+		ctx,
 		"gpg",
 		"--with-colons",
 		"--fingerprint",
@@ -530,7 +567,7 @@ func (b *baseRepo) setUltimateTrust(homeDir, keyPath string) error {
 		return fmt.Errorf("could not determine fingerprint of gpg key %q", keyPath)
 	}
 	// Import owner trust: level 6 = ultimate trust.
-	cmd = b.buildCommand("gpg", "--import-ownertrust")
+	cmd = b.buildCommand(ctx, "gpg", "--import-ownertrust")
 	cmd.Dir = homeDir
 	b.setCmdHome(cmd, homeDir)
 	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s:6:\n", fingerprint))

--- a/pkg/controller/git/base_repo.go
+++ b/pkg/controller/git/base_repo.go
@@ -32,6 +32,16 @@ const (
 	// (e.g. ssh or an askpass helper) inherited the pipes and holds them
 	// open, so a non-zero WaitDelay is required to guarantee Wait returns.
 	cmdWaitDelay = 10 * time.Second
+
+	// gitHTTPLowSpeedLimit and gitHTTPLowSpeedTime together configure git's stall
+	// detector for HTTP(S) transfers: git aborts any transfer whose throughput
+	// stays below gitHTTPLowSpeedLimit (bytes per second) for gitHTTPLowSpeedTime
+	// (seconds). This detects connections that have effectively stopped moving
+	// data -- e.g. a connection severed at the network layer with no RST/FIN
+	// delivered -- without imposing any bound on the total duration of a healthy
+	// transfer, however large or slow.
+	gitHTTPLowSpeedLimit = "1024"
+	gitHTTPLowSpeedTime  = "30"
 )
 
 // baseRepo implements the common underpinnings of a Git repository with a
@@ -465,6 +475,11 @@ func (b *baseRepo) buildGitCommand(
 	arg ...string,
 ) *exec.Cmd {
 	cmd := b.buildCommand(ctx, "git", arg...)
+	cmd.Env = append(
+		cmd.Env,
+		"GIT_HTTP_LOW_SPEED_LIMIT="+gitHTTPLowSpeedLimit,
+		"GIT_HTTP_LOW_SPEED_TIME="+gitHTTPLowSpeedTime,
+	)
 	// TODO(v1.13.0): Remove this line when SSH support is removed.
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_SSH_COMMAND=ssh -F %s/.ssh/config", b.homeDir))
 	if b.creds != nil && b.creds.Password != "" {

--- a/pkg/controller/git/base_repo_test.go
+++ b/pkg/controller/git/base_repo_test.go
@@ -1,11 +1,15 @@
 package git
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	libExec "github.com/akuity/kargo/pkg/exec"
 )
 
 func TestSetupUser(t *testing.T) {
@@ -120,10 +124,33 @@ func TestSetupUser(t *testing.T) {
 				homeDir: repoHomeDir,
 			}
 
-			err := b.setupUser(homeDir, tc.author)
+			err := b.setupUser(t.Context(), homeDir, tc.author)
 			tc.assert(t, homeDir, repoHomeDir, err)
 		})
 	}
+}
+
+func TestBuildCommandCancellation(t *testing.T) {
+	t.Parallel()
+
+	b := &baseRepo{
+		dir:     t.TempDir(),
+		homeDir: t.TempDir(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	cmd := b.buildCommand(ctx, "sleep", "30")
+	start := time.Now()
+	_, err := libExec.Exec(cmd)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The command must be terminated promptly once the context expires rather
+	// than running to completion. The bound is generous to avoid flakes on
+	// slow machines, but far below the command's 30-second natural duration.
+	require.Less(t, elapsed, 10*time.Second)
 }
 
 // assertGitConfig verifies that a git config key has the expected value in

--- a/pkg/controller/git/base_repo_test.go
+++ b/pkg/controller/git/base_repo_test.go
@@ -2,8 +2,11 @@ package git
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,6 +131,68 @@ func TestSetupUser(t *testing.T) {
 			tc.assert(t, homeDir, repoHomeDir, err)
 		})
 	}
+}
+
+func TestBuildGitCommandStallDetection(t *testing.T) {
+	t.Parallel()
+
+	b := &baseRepo{
+		dir:     t.TempDir(),
+		homeDir: t.TempDir(),
+	}
+
+	cmd := b.buildGitCommand(t.Context(), "status")
+	require.Contains(t, cmd.Env, "GIT_HTTP_LOW_SPEED_LIMIT="+gitHTTPLowSpeedLimit)
+	require.Contains(t, cmd.Env, "GIT_HTTP_LOW_SPEED_TIME="+gitHTTPLowSpeedTime)
+}
+
+func TestGitAbortsStalledTransfer(t *testing.T) {
+	t.Parallel()
+
+	// A server that accepts git's initial request (GET .../info/refs) and then
+	// never sends a byte -- the same shape as a connection black-holed at the
+	// network layer.
+	blocked := make(chan struct{})
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			<-blocked
+		}),
+	)
+	t.Cleanup(func() {
+		close(blocked)
+		testServer.Close()
+	})
+
+	b := &baseRepo{
+		dir:     t.TempDir(),
+		homeDir: t.TempDir(),
+	}
+
+	cmd := b.buildGitCommand(
+		t.Context(),
+		"clone",
+		testServer.URL+"/repo.git",
+		filepath.Join(t.TempDir(), "repo"),
+	)
+	// Shrink the stall window so the test proves the mechanism -- git aborting
+	// a transfer that is moving no data -- without waiting out the full
+	// production window.
+	for i, v := range cmd.Env {
+		if strings.HasPrefix(v, "GIT_HTTP_LOW_SPEED_TIME=") {
+			cmd.Env[i] = "GIT_HTTP_LOW_SPEED_TIME=2"
+		}
+	}
+
+	start := time.Now()
+	_, err := libExec.Exec(cmd)
+	elapsed := time.Since(start)
+
+	// Without stall detection, the clone would block on the silent server
+	// indefinitely. With it, git aborts once throughput has stayed below the
+	// floor for the configured window.
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "too slow")
+	require.Less(t, elapsed, 30*time.Second)
 }
 
 func TestBuildCommandCancellation(t *testing.T) {

--- a/pkg/controller/git/commit/base_selector.go
+++ b/pkg/controller/git/commit/base_selector.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/expr-lang/expr"
@@ -25,12 +26,14 @@ type baseSelector struct {
 	discoveryLimit        int
 
 	gitCloneFn func(
+		ctx context.Context,
 		repoURL string,
 		clientOpts *git.ClientOptions,
 		cloneOpts *git.CloneOptions,
 	) (git.Repo, error)
 
 	lsRemoteFn func(
+		ctx context.Context,
 		repoURL string,
 		clientOpts *git.ClientOptions,
 		patterns ...string,

--- a/pkg/controller/git/commit/lexical_selector.go
+++ b/pkg/controller/git/commit/lexical_selector.go
@@ -56,10 +56,10 @@ func (l *lexicalSelector) Select(ctx context.Context) (
 		return nil, err
 	}
 	defer func() {
-		_ = repo.Close()
+		_ = repo.Close(ctx)
 	}()
 
-	tags, err := repo.ListTags()
+	tags, err := repo.ListTags(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (l *lexicalSelector) Select(ctx context.Context) (
 		return strings.Compare(j.Tag, i.Tag)
 	})
 
-	if tags, err = l.filterTagsByDiffPathsFn(repo, tags); err != nil {
+	if tags, err = l.filterTagsByDiffPathsFn(ctx, repo, tags); err != nil {
 		return nil, fmt.Errorf("error filtering tags by paths: %w", err)
 	}
 

--- a/pkg/controller/git/commit/lexical_selector_test.go
+++ b/pkg/controller/git/commit/lexical_selector_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -64,6 +65,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
@@ -83,12 +85,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return nil, errors.New("something went wrong")
 								},
 							}, nil
@@ -106,12 +109,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}}, nil
 								},
 							}, nil
@@ -130,18 +134,20 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}}, nil
 								},
 							}, nil
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						context.Context,
 						git.Repo,
 						[]git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -159,12 +165,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "123"},
 										{Tag: "abc"},
@@ -175,6 +182,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 					},
 					allowTagsRegexes: []*regexp.Regexp{allowAlphas},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -198,12 +206,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "123"},
 										{Tag: "abc"},
@@ -214,6 +223,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 					},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile("^123$")},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -237,12 +247,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "ABC"},
 										{Tag: "abc"},
@@ -254,6 +265,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 					allowTagsRegexes:  []*regexp.Regexp{allowAlphas},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile("^ABC$")},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -277,12 +289,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "Diana"},
 										{Tag: "Arthur"},
@@ -295,6 +308,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -322,12 +336,13 @@ func Test_lexicalSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "Diana"},
 										{Tag: "Arthur"},
@@ -341,6 +356,7 @@ func Test_lexicalSelector_Select(t *testing.T) {
 						discoveryLimit: 3,
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {

--- a/pkg/controller/git/commit/newest_from_branch_selector.go
+++ b/pkg/controller/git/commit/newest_from_branch_selector.go
@@ -42,12 +42,14 @@ type newestFromBranchSelector struct {
 	branch    string
 	sinceDate *time.Time
 
-	selectCommitsFn func(git.Repo) ([]git.CommitMetadata, error)
+	selectCommitsFn func(context.Context, git.Repo) ([]git.CommitMetadata, error)
 	listCommitsFn   func(
-		repo git.Repo,
-		opts *git.ListCommitsOptions,
+		context.Context,
+		git.Repo,
+		*git.ListCommitsOptions,
 	) ([]git.CommitMetadata, error)
 	getDiffPathsForCommitIDFn func(
+		ctx context.Context,
 		repo git.Repo,
 		commitID string,
 	) ([]string, error)
@@ -102,13 +104,13 @@ func (n *newestFromBranchSelector) MatchesRef(ref string) bool {
 // remote's HEAD, whose commit is the default branch tip whatever it is called --
 // the same branch Select clones via an empty CloneOptions.Branch.
 func (n *newestFromBranchSelector) ListRefs(
-	_ context.Context,
+	ctx context.Context,
 ) (*kargoapi.GitDiscoveryRefs, error) {
 	ref := headRef
 	if n.branch != "" {
 		ref = branchPrefix + n.branch
 	}
-	refs, err := n.lsRemoteFn(n.repoURL, n.clientOptions(), ref)
+	refs, err := n.lsRemoteFn(ctx, n.repoURL, n.clientOptions(), ref)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error listing branch refs in git repo %q: %w", n.repoURL, err,
@@ -143,6 +145,7 @@ func (n *newestFromBranchSelector) Select(ctx context.Context) (
 
 	logger.Debug("cloning repository")
 	repo, err := n.gitCloneFn(
+		ctx,
 		n.repoURL,
 		&git.ClientOptions{
 			Credentials:           n.creds,
@@ -158,10 +161,10 @@ func (n *newestFromBranchSelector) Select(ctx context.Context) (
 		return nil, fmt.Errorf("error cloning git repo %q: %w", n.repoURL, err)
 	}
 	defer func() {
-		_ = repo.Close()
+		_ = repo.Close(ctx)
 	}()
 
-	commits, err := n.selectCommitsFn(repo)
+	commits, err := n.selectCommitsFn(ctx, repo)
 	if err != nil {
 		return nil,
 			fmt.Errorf("error selecting relevant commits from branch: %w", err)
@@ -171,6 +174,7 @@ func (n *newestFromBranchSelector) Select(ctx context.Context) (
 }
 
 func (n *newestFromBranchSelector) selectCommits(
+	ctx context.Context,
 	repo git.Repo,
 ) ([]git.CommitMetadata, error) {
 	opts := &git.ListCommitsOptions{Since: n.sinceDate}
@@ -178,7 +182,7 @@ func (n *newestFromBranchSelector) selectCommits(
 	for skip, batch := uint(0), uint(n.discoveryLimit); ; skip, batch = skip+batch, min(batch*2, 1000) { // nolint: gosec
 		opts.Limit = batch // nolint: gosec
 		opts.Skip = skip   // nolint: gosec
-		commits, err := n.listCommitsFn(repo, opts)
+		commits, err := n.listCommitsFn(ctx, repo, opts)
 		if err != nil {
 			return nil,
 				fmt.Errorf("error listing commits from git repo %q: %w", n.repoURL, err)
@@ -205,7 +209,7 @@ func (n *newestFromBranchSelector) selectCommits(
 
 			// If include or exclude path selectors are specified, filter the commits.
 			if n.includePaths != nil || n.excludePaths != nil {
-				diffPaths, err := n.getDiffPathsForCommitIDFn(repo, commit.ID)
+				diffPaths, err := n.getDiffPathsForCommitIDFn(ctx, repo, commit.ID)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"error getting diff paths for commit %q in git repo %q: %w",
@@ -232,17 +236,19 @@ func (n *newestFromBranchSelector) selectCommits(
 }
 
 func (n *newestFromBranchSelector) listCommits(
+	ctx context.Context,
 	repo git.Repo,
 	opts *git.ListCommitsOptions,
 ) ([]git.CommitMetadata, error) {
-	return repo.ListCommits(opts)
+	return repo.ListCommits(ctx, opts)
 }
 
 func (n *newestFromBranchSelector) getDiffPathsForCommitID(
+	ctx context.Context,
 	repo git.Repo,
 	commitID string,
 ) ([]string, error) {
-	return repo.GetDiffPathsForCommitID(commitID)
+	return repo.GetDiffPathsForCommitID(ctx, commitID)
 }
 
 // evaluateCommitExpression evaluates the given commit expression against

--- a/pkg/controller/git/commit/newest_from_branch_selector_test.go
+++ b/pkg/controller/git/commit/newest_from_branch_selector_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -138,13 +139,23 @@ func Test_newestFromBranchSelector_ListRefs(t *testing.T) {
 	testCases := []struct {
 		name       string
 		branch     string
-		lsRemoteFn func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error)
+		lsRemoteFn func(
+			ctx context.Context,
+			repoURL string,
+			clientOpts *git.ClientOptions,
+			patterns ...string,
+		) ([]git.RemoteRef, error)
 		assertions func(*testing.T, *kargoapi.GitDiscoveryRefs, error)
 	}{
 		{
 			name:   "error listing refs",
 			branch: "main",
-			lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				context.Context,
+				string,
+				*git.ClientOptions,
+				...string,
+			) ([]git.RemoteRef, error) {
 				return nil, errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, refs *kargoapi.GitDiscoveryRefs, err error) {
@@ -155,7 +166,12 @@ func Test_newestFromBranchSelector_ListRefs(t *testing.T) {
 		{
 			name:   "records branch head",
 			branch: "main",
-			lsRemoteFn: func(_ string, _ *git.ClientOptions, patterns ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				_ context.Context,
+				_ string,
+				_ *git.ClientOptions,
+				patterns ...string,
+			) ([]git.RemoteRef, error) {
 				require.Equal(t, []string{"refs/heads/main"}, patterns)
 				return []git.RemoteRef{{Name: "refs/heads/main", ID: head}}, nil
 			},
@@ -170,7 +186,12 @@ func Test_newestFromBranchSelector_ListRefs(t *testing.T) {
 			// "develop", not just "main"/"master").
 			name:   "unspecified branch resolves HEAD",
 			branch: "",
-			lsRemoteFn: func(_ string, _ *git.ClientOptions, patterns ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				_ context.Context,
+				_ string,
+				_ *git.ClientOptions,
+				patterns ...string,
+			) ([]git.RemoteRef, error) {
 				require.Equal(t, []string{"HEAD"}, patterns)
 				return []git.RemoteRef{{Name: "HEAD", ID: head}}, nil
 			},
@@ -182,7 +203,12 @@ func Test_newestFromBranchSelector_ListRefs(t *testing.T) {
 		{
 			name:   "missing configured branch yields nil observation",
 			branch: "main",
-			lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				context.Context,
+				string,
+				*git.ClientOptions,
+				...string,
+			) ([]git.RemoteRef, error) {
 				return nil, nil
 			},
 			assertions: func(t *testing.T, refs *kargoapi.GitDiscoveryRefs, err error) {
@@ -196,7 +222,12 @@ func Test_newestFromBranchSelector_ListRefs(t *testing.T) {
 			// short-circuiting on a repeated empty observation.
 			name:   "unspecified branch with no HEAD yields nil observation",
 			branch: "",
-			lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				context.Context,
+				string,
+				*git.ClientOptions,
+				...string,
+			) ([]git.RemoteRef, error) {
 				return nil, nil
 			},
 			assertions: func(t *testing.T, refs *kargoapi.GitDiscoveryRefs, err error) {
@@ -228,6 +259,7 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 			selector: &newestFromBranchSelector{
 				baseSelector: &baseSelector{
 					gitCloneFn: func(
+						context.Context,
 						string,
 						*git.ClientOptions,
 						*git.CloneOptions,
@@ -245,6 +277,7 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 			selector: &newestFromBranchSelector{
 				baseSelector: &baseSelector{
 					gitCloneFn: func(
+						context.Context,
 						string,
 						*git.ClientOptions,
 						*git.CloneOptions,
@@ -252,7 +285,10 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 						return &git.MockRepo{}, nil
 					},
 				},
-				selectCommitsFn: func(git.Repo) ([]git.CommitMetadata, error) {
+				selectCommitsFn: func(
+					context.Context,
+					git.Repo,
+				) ([]git.CommitMetadata, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -265,6 +301,7 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 			selector: &newestFromBranchSelector{
 				baseSelector: &baseSelector{
 					gitCloneFn: func(
+						context.Context,
 						string,
 						*git.ClientOptions,
 						*git.CloneOptions,
@@ -272,7 +309,10 @@ func Test_newestFromBranchSelector_Select(t *testing.T) {
 						return &git.MockRepo{}, nil
 					},
 				},
-				selectCommitsFn: func(git.Repo) ([]git.CommitMetadata, error) {
+				selectCommitsFn: func(
+					context.Context,
+					git.Repo,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{{}, {}, {}, {}, {}}, nil
 				},
 			},
@@ -423,7 +463,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 			name: "error listing commits",
 			selector: &newestFromBranchSelector{
 				baseSelector: &baseSelector{},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -437,7 +481,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 				baseSelector: &baseSelector{
 					discoveryLimit: 3,
 				},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{{}, {}, {}, {}, {}}, nil
 				},
 			},
@@ -452,7 +500,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 				baseSelector: &baseSelector{
 					filterExpression: nonBoolExpression,
 				},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{{}}, nil
 				},
 			},
@@ -466,10 +518,18 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 				baseSelector: &baseSelector{
 					includePaths: includePaths,
 				},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{{}}, nil
 				},
-				getDiffPathsForCommitIDFn: func(git.Repo, string) ([]string, error) {
+				getDiffPathsForCommitIDFn: func(
+					context.Context,
+					git.Repo,
+					string,
+				) ([]string, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -484,7 +544,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 					filterExpression: idFilterExpression,
 					discoveryLimit:   3,
 				},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "A"},
 						{ID: "B"},
@@ -510,7 +574,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 					includePaths:   includePaths,
 					discoveryLimit: 3,
 				},
-				listCommitsFn: func(git.Repo, *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+				listCommitsFn: func(
+					context.Context,
+					git.Repo,
+					*git.ListCommitsOptions,
+				) ([]git.CommitMetadata, error) {
 					return []git.CommitMetadata{
 						{ID: "A"},
 						{ID: "B"},
@@ -520,6 +588,7 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 					}, nil
 				},
 				getDiffPathsForCommitIDFn: func(
+					_ context.Context,
 					_ git.Repo,
 					commitID string,
 				) ([]string, error) {
@@ -545,7 +614,11 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 				return &newestFromBranchSelector{
 					baseSelector: &baseSelector{discoveryLimit: 5},
 					sinceDate:    &cutoff,
-					listCommitsFn: func(_ git.Repo, opts *git.ListCommitsOptions) ([]git.CommitMetadata, error) {
+					listCommitsFn: func(
+						_ context.Context,
+						_ git.Repo,
+						opts *git.ListCommitsOptions,
+					) ([]git.CommitMetadata, error) {
 						// Simulate git filtering by date -- only return commits after cutoff.
 						require.NotNil(t, opts)
 						require.NotNil(t, opts.Since)
@@ -573,7 +646,7 @@ func Test_newestFromBranchSelector_selectCommits(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			commits, err := testCase.selector.selectCommits(nil)
+			commits, err := testCase.selector.selectCommits(t.Context(), nil)
 			testCase.assertions(t, commits, err)
 		})
 	}

--- a/pkg/controller/git/commit/newest_tag_selector.go
+++ b/pkg/controller/git/commit/newest_tag_selector.go
@@ -54,10 +54,10 @@ func (n *newestTagSelector) Select(ctx context.Context) (
 		return nil, err
 	}
 	defer func() {
-		_ = repo.Close()
+		_ = repo.Close(ctx)
 	}()
 
-	tags, err := repo.ListTags()
+	tags, err := repo.ListTags(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (n *newestTagSelector) Select(ctx context.Context) (
 	// Note: Tags are already sorted in descending order by creation date when
 	// retrieved. No further sorting is required.
 
-	if tags, err = n.filterTagsByDiffPathsFn(repo, tags); err != nil {
+	if tags, err = n.filterTagsByDiffPathsFn(ctx, repo, tags); err != nil {
 		return nil, fmt.Errorf("error filtering tags by paths: %w", err)
 	}
 

--- a/pkg/controller/git/commit/newest_tag_selector_test.go
+++ b/pkg/controller/git/commit/newest_tag_selector_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -64,6 +65,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
@@ -83,12 +85,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return nil, errors.New("something went wrong")
 								},
 							}, nil
@@ -106,12 +109,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}}, nil
 								},
 							}, nil
@@ -130,18 +134,20 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}}, nil
 								},
 							}, nil
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						context.Context,
 						git.Repo,
 						[]git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -159,12 +165,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "123"},
 										{Tag: "abc"},
@@ -175,6 +182,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 					},
 					allowTagsRegexes: []*regexp.Regexp{allowAlphas},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -198,12 +206,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "123"},
 										{Tag: "abc"},
@@ -214,6 +223,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 					},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile("^123$")},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -237,12 +247,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "ABC"},
 										{Tag: "abc"},
@@ -254,6 +265,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 					allowTagsRegexes:  []*regexp.Regexp{allowAlphas},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile("^ABC$")},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -277,12 +289,13 @@ func Test_newestTagSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}, {}, {}, {}, {}}, nil
 								},
 							}, nil
@@ -290,6 +303,7 @@ func Test_newestTagSelector_Select(t *testing.T) {
 						discoveryLimit: 3,
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {

--- a/pkg/controller/git/commit/semver_selector.go
+++ b/pkg/controller/git/commit/semver_selector.go
@@ -112,10 +112,10 @@ func (s *semverSelector) Select(ctx context.Context) (
 		return nil, err
 	}
 	defer func() {
-		_ = repo.Close()
+		_ = repo.Close(ctx)
 	}()
 
-	tags, err := repo.ListTags()
+	tags, err := repo.ListTags(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (s *semverSelector) Select(ctx context.Context) (
 
 	s.sort(tags)
 
-	if tags, err = s.filterTagsByDiffPathsFn(repo, tags); err != nil {
+	if tags, err = s.filterTagsByDiffPathsFn(ctx, repo, tags); err != nil {
 		return nil, fmt.Errorf("error filtering tags by paths: %w", err)
 	}
 

--- a/pkg/controller/git/commit/semver_selector_test.go
+++ b/pkg/controller/git/commit/semver_selector_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -19,7 +20,12 @@ func Test_semverSelector_ListRefs(t *testing.T) {
 	s := &semverSelector{
 		tagBasedSelector: &tagBasedSelector{
 			baseSelector: &baseSelector{
-				lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+				lsRemoteFn: func(
+					context.Context,
+					string,
+					*git.ClientOptions,
+					...string,
+				) ([]git.RemoteRef, error) {
 					return []git.RemoteRef{
 						{Name: tagPrefix + "v1.2.4", ID: "d"},
 						{Name: tagPrefix + "v1.1.0", ID: "a"},     // below constraint
@@ -200,6 +206,7 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
@@ -219,12 +226,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return nil, errors.New("something went wrong")
 								},
 							}, nil
@@ -242,12 +250,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{Tag: "v1.0.0"}}, nil
 								},
 							}, nil
@@ -266,18 +275,20 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{{}}, nil
 								},
 							}, nil
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						context.Context,
 						git.Repo,
 						[]git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -295,12 +306,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "foo"},
 										{Tag: "v1.2.3"},
@@ -311,6 +323,7 @@ func Test_semverSelector_Select(t *testing.T) {
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -334,12 +347,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "v1.0.0"},
 										{Tag: "v2.0.0"},
@@ -351,6 +365,7 @@ func Test_semverSelector_Select(t *testing.T) {
 					},
 					allowTagsRegexes: []*regexp.Regexp{allowMajorV1},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -374,12 +389,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "v1.0.0"},
 										{Tag: "v1.1.0"},
@@ -390,6 +406,7 @@ func Test_semverSelector_Select(t *testing.T) {
 					},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile(`^v1\.0\.0$`)},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -413,12 +430,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "v1.1.0"},
 										{Tag: "v1.0.0"},
@@ -430,6 +448,7 @@ func Test_semverSelector_Select(t *testing.T) {
 					allowTagsRegexes:  []*regexp.Regexp{allowMajorV1},
 					ignoreTagsRegexes: []*regexp.Regexp{regexp.MustCompile(`^v1\.0\.0$`)},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -453,12 +472,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "v3.0.0"},
 										{Tag: "v5.0.0"},
@@ -471,6 +491,7 @@ func Test_semverSelector_Select(t *testing.T) {
 						},
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {
@@ -501,12 +522,13 @@ func Test_semverSelector_Select(t *testing.T) {
 				tagBasedSelector: &tagBasedSelector{
 					baseSelector: &baseSelector{
 						gitCloneFn: func(
+							context.Context,
 							string,
 							*git.ClientOptions,
 							*git.CloneOptions,
 						) (git.Repo, error) {
 							return &git.MockRepo{
-								ListTagsFn: func() ([]git.TagMetadata, error) {
+								ListTagsFn: func(context.Context) ([]git.TagMetadata, error) {
 									return []git.TagMetadata{
 										{Tag: "v3.0.0"},
 										{Tag: "v5.0.0"},
@@ -520,6 +542,7 @@ func Test_semverSelector_Select(t *testing.T) {
 						discoveryLimit: 3,
 					},
 					filterTagsByDiffPathsFn: func(
+						_ context.Context,
 						_ git.Repo,
 						tags []git.TagMetadata,
 					) ([]git.TagMetadata, error) {

--- a/pkg/controller/git/commit/tag_based_selector.go
+++ b/pkg/controller/git/commit/tag_based_selector.go
@@ -35,6 +35,7 @@ type tagBasedSelector struct {
 	ignoreTagsRegexes []*regexp.Regexp
 
 	filterTagsByDiffPathsFn func(
+		context.Context,
 		git.Repo,
 		[]git.TagMetadata,
 	) ([]git.TagMetadata, error)
@@ -119,7 +120,7 @@ func (t *tagBasedSelector) listTagRefs(
 	ctx context.Context,
 	matches func(tag string) bool,
 ) (*kargoapi.GitDiscoveryRefs, error) {
-	refs, err := t.lsRemoteFn(t.repoURL, t.clientOptions(), tagPrefix+"*")
+	refs, err := t.lsRemoteFn(ctx, t.repoURL, t.clientOptions(), tagPrefix+"*")
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error listing tag refs in git repo %q: %w", t.repoURL, err,
@@ -197,6 +198,7 @@ func (t *tagBasedSelector) clone(ctx context.Context) (git.Repo, error) {
 		Blobless:     t.blobless,
 	}
 	repo, err := t.gitCloneFn(
+		ctx,
 		t.repoURL,
 		&git.ClientOptions{
 			Credentials:           t.creds,
@@ -275,6 +277,7 @@ func (t *tagBasedSelector) filterTagsByExpression(
 // those paths against user-defined path-selection criteria. Only tags pointing
 // to commits that satisfy those criteria are returned.
 func (t *tagBasedSelector) filterTagsByDiffPaths(
+	ctx context.Context,
 	repo git.Repo,
 	tags []git.TagMetadata,
 ) ([]git.TagMetadata, error) {
@@ -283,7 +286,7 @@ func (t *tagBasedSelector) filterTagsByDiffPaths(
 	}
 	filteredTags := make([]git.TagMetadata, 0, t.discoveryLimit)
 	for _, tag := range tags {
-		diffPaths, err := repo.GetDiffPathsForCommitID(tag.CommitID)
+		diffPaths, err := repo.GetDiffPathsForCommitID(ctx, tag.CommitID)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error getting diff paths for tag %q in git repo %q: %w",

--- a/pkg/controller/git/commit/tag_based_selector_test.go
+++ b/pkg/controller/git/commit/tag_based_selector_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strconv"
@@ -29,12 +30,22 @@ func Test_tagBasedSelector_ListRefs(t *testing.T) {
 	testCases := []struct {
 		name       string
 		selector   *tagBasedSelector
-		lsRemoteFn func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error)
+		lsRemoteFn func(
+			ctx context.Context,
+			repoURL string,
+			clientOpts *git.ClientOptions,
+			patterns ...string,
+		) ([]git.RemoteRef, error)
 		assertions func(*testing.T, *kargoapi.GitDiscoveryRefs, error)
 	}{
 		{
 			name: "error listing refs",
-			lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				context.Context,
+				string,
+				*git.ClientOptions,
+				...string,
+			) ([]git.RemoteRef, error) {
 				return nil, errors.New("something went wrong")
 			},
 			assertions: func(t *testing.T, refs *kargoapi.GitDiscoveryRefs, err error) {
@@ -47,7 +58,12 @@ func Test_tagBasedSelector_ListRefs(t *testing.T) {
 			selector: &tagBasedSelector{
 				allowTagsRegexes: []*regexp.Regexp{regexp.MustCompile(`^v1\.`)},
 			},
-			lsRemoteFn: func(_ string, _ *git.ClientOptions, patterns ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				_ context.Context,
+				_ string,
+				_ *git.ClientOptions,
+				patterns ...string,
+			) ([]git.RemoteRef, error) {
 				require.Equal(t, []string{tagPrefix + "*"}, patterns)
 				return []git.RemoteRef{
 					{Name: tagPrefix + "v1.2.0", ID: "b"},
@@ -68,7 +84,12 @@ func Test_tagBasedSelector_ListRefs(t *testing.T) {
 		{
 			name:     "tag count over cap suppresses observation",
 			selector: &tagBasedSelector{},
-			lsRemoteFn: func(string, *git.ClientOptions, ...string) ([]git.RemoteRef, error) {
+			lsRemoteFn: func(
+				context.Context,
+				string,
+				*git.ClientOptions,
+				...string,
+			) ([]git.RemoteRef, error) {
 				return makeRefs(maxObservedTags + 1), nil
 			},
 			assertions: func(t *testing.T, refs *kargoapi.GitDiscoveryRefs, err error) {

--- a/pkg/controller/git/common_test.go
+++ b/pkg/controller/git/common_test.go
@@ -50,10 +50,15 @@ func setupRemoteRepo(
 
 	testRepoURL := fmt.Sprintf("%s/test.git", server.URL)
 
-	repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &creds}, nil)
+	repo, err := Clone(
+		t.Context(),
+		testRepoURL,
+		&ClientOptions{Credentials: &creds},
+		nil,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, repo)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 
 	for _, initFn := range initFns {
 		initFn(t, repo)
@@ -69,9 +74,13 @@ func initialMainCommit(t *testing.T, rep WorkTree) {
 		0600,
 	)
 	require.NoError(t, err)
-	err = rep.AddAllAndCommit(fmt.Sprintf("initial commit %s", uuid.NewString()), nil)
+	err = rep.AddAllAndCommit(
+		t.Context(),
+		fmt.Sprintf("initial commit %s", uuid.NewString()),
+		nil,
+	)
 	require.NoError(t, err)
-	err = rep.Push(nil)
+	err = rep.Push(t.Context(), nil)
 	require.NoError(t, err)
 }
 
@@ -82,9 +91,9 @@ func commitAhead(t *testing.T, rep WorkTree) {
 		0o600,
 	)
 	require.NoError(t, err)
-	err = rep.AddAllAndCommit("remote commit", nil)
+	err = rep.AddAllAndCommit(t.Context(), "remote commit", nil)
 	require.NoError(t, err)
-	err = rep.Push(&PushOptions{TargetBranch: "ahead"})
+	err = rep.Push(t.Context(), &PushOptions{TargetBranch: "ahead"})
 	require.NoError(t, err)
 }
 
@@ -137,11 +146,11 @@ func enableFakeCommitSigning(t *testing.T, wt *workTree, trusted bool) {
 	err := os.WriteFile(fakeGPG, []byte(script), 0o755)
 	require.NoError(t, err)
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"config", "--global", "gpg.program", fakeGPG,
+		t.Context(), "config", "--global", "gpg.program", fakeGPG,
 	))
 	require.NoError(t, err)
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"config", "--global", "commit.gpgSign", "true",
+		t.Context(), "config", "--global", "commit.gpgSign", "true",
 	))
 	require.NoError(t, err)
 }
@@ -151,11 +160,11 @@ func enableFakeCommitSigning(t *testing.T, wt *workTree, trusted bool) {
 func disableFakeCommitSigning(t *testing.T, wt *workTree) {
 	t.Helper()
 	_, err := libExec.Exec(wt.buildGitCommand(
-		"config", "--unset", "--global", "commit.gpgSign",
+		t.Context(), "config", "--unset", "--global", "commit.gpgSign",
 	))
 	require.NoError(t, err)
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"config", "--global", "commit.gpgSign", "false",
+		t.Context(), "config", "--global", "commit.gpgSign", "false",
 	))
 	require.NoError(t, err)
 }

--- a/pkg/controller/git/gpg.go
+++ b/pkg/controller/git/gpg.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -38,11 +39,14 @@ type CommitSignatureInfo struct {
 // commit, including whether it is signed by a trusted key and the identity
 // of the signer.
 func (w *workTree) GetCommitSignatureInfo(
+	ctx context.Context,
 	commitID string,
 ) (*CommitSignatureInfo, error) {
 	// A single git log call retrieves trust status (%G?) and the signer
 	// identity (%GS, formatted as "Name <email>") separated by a tab.
-	cmd := w.buildGitCommand("log", "-1", "--format=%G?\t%GS", commitID, "--")
+	cmd := w.buildGitCommand(
+		ctx, "log", "-1", "--format=%G?\t%GS", commitID, "--",
+	)
 	res, err := libExec.Exec(cmd)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -86,9 +90,10 @@ func parseSignerIdentity(signer string) (string, string) {
 //   - E: signature cannot be checked (missing key)
 //   - N: no signature
 func (w *workTree) verifyCommitSignature(
+	ctx context.Context,
 	commitID string,
 ) (signatureStatus, error) {
-	cmd := w.buildGitCommand("log", "-1", "--format=%G?", commitID, "--")
+	cmd := w.buildGitCommand(ctx, "log", "-1", "--format=%G?", commitID, "--")
 	res, err := libExec.Exec(cmd)
 	if err != nil {
 		return signatureUnsigned, fmt.Errorf(
@@ -109,8 +114,8 @@ func (w *workTree) verifyCommitSignature(
 
 // isSigningConfigured returns true if GPG commit signing is enabled in the
 // git configuration for this repository.
-func (w *workTree) isSigningConfigured() (bool, error) {
-	cmd := w.buildGitCommand("config", "--get", "commit.gpgSign")
+func (w *workTree) isSigningConfigured(ctx context.Context) (bool, error) {
+	cmd := w.buildGitCommand(ctx, "config", "--get", "commit.gpgSign")
 	res, err := libExec.Exec(cmd)
 	if err != nil {
 		var exitErr *libExec.ExitError

--- a/pkg/controller/git/gpg_test.go
+++ b/pkg/controller/git/gpg_test.go
@@ -19,12 +19,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 
 	t.Run("unsigned commit is not trusted", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(
 			fmt.Sprintf("%s/test.txt", repo.Dir()),
@@ -32,13 +33,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("unsigned commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "unsigned commit", nil)
 		require.NoError(t, err)
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
-		info, err := repo.GetCommitSignatureInfo(commitID)
+		info, err := repo.GetCommitSignatureInfo(t.Context(), commitID)
 		require.NoError(t, err)
 		require.False(t, info.Trusted)
 		require.Empty(t, info.SignerName)
@@ -47,12 +48,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 
 	t.Run("commit signed by trusted key", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
@@ -63,13 +65,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("trusted commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "trusted commit", nil)
 		require.NoError(t, err)
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
-		info, err := repo.GetCommitSignatureInfo(commitID)
+		info, err := repo.GetCommitSignatureInfo(t.Context(), commitID)
 		require.NoError(t, err)
 		require.True(t, info.Trusted)
 		// Note: the fake GPG script used by enableFakeCommitSigning does
@@ -80,12 +82,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 
 	t.Run("commit signed by untrusted key is not trusted", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, false)
@@ -96,13 +99,13 @@ func Test_workTree_GetCommitSignatureInfo(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("untrusted commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "untrusted commit", nil)
 		require.NoError(t, err)
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
-		info, err := repo.GetCommitSignatureInfo(commitID)
+		info, err := repo.GetCommitSignatureInfo(t.Context(), commitID)
 		require.NoError(t, err)
 		require.False(t, info.Trusted)
 	})
@@ -116,30 +119,32 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 
 	t.Run("unsigned commit", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
 		wt := internalWorkTree(t, repo)
-		status, err := wt.verifyCommitSignature(commitID)
+		status, err := wt.verifyCommitSignature(t.Context(), commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureUnsigned, status)
 	})
 
 	t.Run("trusted signature", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
@@ -150,25 +155,26 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("signed commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "signed commit", nil)
 		require.NoError(t, err)
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
-		status, err := wt.verifyCommitSignature(commitID)
+		status, err := wt.verifyCommitSignature(t.Context(), commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureTrusted, status)
 	})
 
 	t.Run("untrusted signature", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, false)
@@ -179,13 +185,13 @@ func Test_workTree_verifyCommitSignature(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("signed commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "signed commit", nil)
 		require.NoError(t, err)
 
-		commitID, err := repo.LastCommitID()
+		commitID, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
-		status, err := wt.verifyCommitSignature(commitID)
+		status, err := wt.verifyCommitSignature(t.Context(), commitID)
 		require.NoError(t, err)
 		require.Equal(t, signatureUntrusted, status)
 	})
@@ -199,34 +205,36 @@ func Test_workTree_isSigningConfigured(t *testing.T) {
 
 	t.Run("not configured", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
-		configured, err := internalWorkTree(t, repo).isSigningConfigured()
+		configured, err := internalWorkTree(t, repo).isSigningConfigured(t.Context())
 		require.NoError(t, err)
 		require.False(t, configured)
 	})
 
 	t.Run("configured", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		_, err = libExec.Exec(wt.buildGitCommand(
-			"config", "--global", "commit.gpgSign", "true",
+			t.Context(), "config", "--global", "commit.gpgSign", "true",
 		))
 		require.NoError(t, err)
 
-		configured, err := wt.isSigningConfigured()
+		configured, err := wt.isSigningConfigured(t.Context())
 		require.NoError(t, err)
 		require.True(t, configured)
 	})

--- a/pkg/controller/git/ls_remote.go
+++ b/pkg/controller/git/ls_remote.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -34,6 +35,7 @@ type RemoteRef struct {
 // the tag is re-pointed, and results are only ever compared against other
 // LsRemote output produced the same way.
 func LsRemote(
+	ctx context.Context,
 	repoURL string,
 	clientOpts *ClientOptions,
 	patterns ...string,
@@ -50,13 +52,13 @@ func LsRemote(
 	// client configuration (and any SSH key material) needed to authenticate.
 	// There is no working tree or clone -- only the home directory -- so cleanup
 	// is a single RemoveAll.
-	if err := b.setupDirs(""); err != nil {
+	if err := b.setupDirs(ctx, ""); err != nil {
 		return nil, err
 	}
 	defer func() {
 		_ = os.RemoveAll(b.homeDir)
 	}()
-	if err := b.setupClient(clientOpts); err != nil {
+	if err := b.setupClient(ctx, clientOpts); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +67,7 @@ func LsRemote(
 	// branch. Annotated tags' peeled entries are instead dropped in
 	// parseLsRemoteOutput.
 	args := append([]string{"ls-remote", b.accessURL}, patterns...)
-	cmd := b.buildGitCommand(args...)
+	cmd := b.buildGitCommand(ctx, args...)
 	// Override the cmd.Dir that's set by buildGitCommand(). It's normally the
 	// repository's path, which does not exist here because nothing was cloned.
 	cmd.Dir = b.homeDir

--- a/pkg/controller/git/ls_remote_test.go
+++ b/pkg/controller/git/ls_remote_test.go
@@ -13,8 +13,11 @@ func Test_LsRemote(t *testing.T) {
 		func(t *testing.T, rep WorkTree) {
 			// Create and push an annotated tag so we can verify that its peeled
 			// "^{}" entry is dropped and only the tag object is reported.
-			require.NoError(t, rep.CreateTag("v1.0.0", "release v1.0.0", nil))
-			require.NoError(t, rep.Push(&PushOptions{Tag: "v1.0.0"}))
+			require.NoError(
+				t,
+				rep.CreateTag(t.Context(), "v1.0.0", "release v1.0.0", nil),
+			)
+			require.NoError(t, rep.Push(t.Context(), &PushOptions{Tag: "v1.0.0"}))
 		},
 	)
 	defer testServer.Close()
@@ -29,14 +32,16 @@ func Test_LsRemote(t *testing.T) {
 	// what these tests cover.
 
 	t.Run("branch ref is listed", func(t *testing.T) {
-		refs, err := LsRemote(testRepoURL, clientOpts, "refs/heads/main")
+		refs, err := LsRemote(
+			t.Context(), testRepoURL, clientOpts, "refs/heads/main",
+		)
 		require.NoError(t, err)
 		require.Len(t, refs, 1)
 		require.Equal(t, "refs/heads/main", refs[0].Name)
 	})
 
 	t.Run("annotated tag collapses to a single entry", func(t *testing.T) {
-		refs, err := LsRemote(testRepoURL, clientOpts, "refs/tags/*")
+		refs, err := LsRemote(t.Context(), testRepoURL, clientOpts, "refs/tags/*")
 		require.NoError(t, err)
 		// Despite the annotated tag's peeled entry on the wire, exactly one ref
 		// is reported for the tag.
@@ -45,7 +50,9 @@ func Test_LsRemote(t *testing.T) {
 	})
 
 	t.Run("absent ref yields no entries", func(t *testing.T) {
-		refs, err := LsRemote(testRepoURL, clientOpts, "refs/heads/nonexistent")
+		refs, err := LsRemote(
+			t.Context(), testRepoURL, clientOpts, "refs/heads/nonexistent",
+		)
 		require.NoError(t, err)
 		require.Empty(t, refs)
 	})

--- a/pkg/controller/git/mock_repo.go
+++ b/pkg/controller/git/mock_repo.go
@@ -1,107 +1,145 @@
 package git
 
+import "context"
+
 type MockRepo struct {
-	AddAllFn          func() error
+	AddAllFn          func(ctx context.Context) error
 	AddAllAndCommitFn func(
+		ctx context.Context,
 		message string,
 		commitOpts *CommitOptions,
 	) error
-	CleanFn                   func() error
-	ClearFn                   func() error
-	CloseFn                   func() error
-	CheckoutFn                func(branch string) error
-	CommitFn                  func(message string, opts *CommitOptions) error
-	CreateChildBranchFn       func(branch string) error
-	CreateOrphanedBranchFn    func(branch string) error
-	CreateTagFn               func(tag, msg string, opts *CreateTagOptions) error
-	CurrentBranchFn           func() (string, error)
-	DeleteBranchFn            func(branch string) error
+	CleanFn    func(ctx context.Context) error
+	ClearFn    func(ctx context.Context) error
+	CloseFn    func(ctx context.Context) error
+	CheckoutFn func(ctx context.Context, branch string) error
+	CommitFn   func(
+		ctx context.Context,
+		message string,
+		opts *CommitOptions,
+	) error
+	CreateChildBranchFn    func(ctx context.Context, branch string) error
+	CreateOrphanedBranchFn func(ctx context.Context, branch string) error
+	CreateTagFn            func(
+		ctx context.Context,
+		tag string,
+		msg string,
+		opts *CreateTagOptions,
+	) error
+	CurrentBranchFn           func(ctx context.Context) (string, error)
+	DeleteBranchFn            func(ctx context.Context, branch string) error
 	DirFn                     func() string
-	FetchFn                   func(opts *FetchOptions) error
-	HasDiffsFn                func() (bool, error)
+	FetchFn                   func(ctx context.Context, opts *FetchOptions) error
+	HasDiffsFn                func(ctx context.Context) (bool, error)
 	HomeDirFn                 func() string
-	GetDiffPathsForCommitIDFn func(commitID string) ([]string, error)
-	IsAncestorFn              func(parent string, child string) (bool, error)
-	IsRebasingFn              func() (bool, error)
-	LastCommitIDFn            func() (string, error)
-	ListTagsFn                func() ([]TagMetadata, error)
-	ListCommitsFn             func(opts *ListCommitsOptions) ([]CommitMetadata, error)
-	CommitMessageFn           func(id string) (string, error)
-	GetCommitSignatureInfoFn  func(string) (*CommitSignatureInfo, error)
-	IntegrateRemoteChangesFn  func(*IntegrationOptions) error
-	PullFn                    func(*PullOptions) error
-	PushFn                    func(*PushOptions) error
-	RefsHaveDiffsFn           func(commit1 string, commit2 string) (bool, error)
-	RemoteBranchExistsFn      func(branch string) (bool, error)
-	ResetHardFn               func() error
-	URLFn                     func() string
-	UpdateSubmodulesFn        func() error
+	GetDiffPathsForCommitIDFn func(
+		ctx context.Context,
+		commitID string,
+	) ([]string, error)
+	IsAncestorFn func(
+		ctx context.Context,
+		parent string,
+		child string,
+	) (bool, error)
+	IsRebasingFn   func(ctx context.Context) (bool, error)
+	LastCommitIDFn func(ctx context.Context) (string, error)
+	ListTagsFn     func(ctx context.Context) ([]TagMetadata, error)
+	ListCommitsFn  func(
+		ctx context.Context,
+		opts *ListCommitsOptions,
+	) ([]CommitMetadata, error)
+	CommitMessageFn          func(ctx context.Context, id string) (string, error)
+	GetCommitSignatureInfoFn func(
+		ctx context.Context,
+		commitID string,
+	) (*CommitSignatureInfo, error)
+	IntegrateRemoteChangesFn func(context.Context, *IntegrationOptions) error
+	PullFn                   func(context.Context, *PullOptions) error
+	PushFn                   func(context.Context, *PushOptions) error
+	RefsHaveDiffsFn          func(
+		ctx context.Context,
+		commit1 string,
+		commit2 string,
+	) (bool, error)
+	RemoteBranchExistsFn func(ctx context.Context, branch string) (bool, error)
+	ResetHardFn          func(ctx context.Context) error
+	URLFn                func() string
+	UpdateSubmodulesFn   func(ctx context.Context) error
 }
 
-func (m *MockRepo) AddAll() error {
-	return m.AddAllFn()
+func (m *MockRepo) AddAll(ctx context.Context) error {
+	return m.AddAllFn(ctx)
 }
 
 func (m *MockRepo) AddAllAndCommit(
+	ctx context.Context,
 	message string,
 	commitOpts *CommitOptions,
 ) error {
-	return m.AddAllAndCommitFn(message, commitOpts)
+	return m.AddAllAndCommitFn(ctx, message, commitOpts)
 }
 
-func (m *MockRepo) Clean() error {
-	return m.CleanFn()
+func (m *MockRepo) Clean(ctx context.Context) error {
+	return m.CleanFn(ctx)
 }
 
-func (m *MockRepo) Clear() error {
-	return m.ClearFn()
+func (m *MockRepo) Clear(ctx context.Context) error {
+	return m.ClearFn(ctx)
 }
 
-func (m *MockRepo) Close() error {
+func (m *MockRepo) Close(ctx context.Context) error {
 	if m.CloseFn == nil {
 		return nil
 	}
-	return m.CloseFn()
+	return m.CloseFn(ctx)
 }
 
-func (m *MockRepo) Checkout(branch string) error {
-	return m.CheckoutFn(branch)
+func (m *MockRepo) Checkout(ctx context.Context, branch string) error {
+	return m.CheckoutFn(ctx, branch)
 }
 
-func (m *MockRepo) Commit(message string, opts *CommitOptions) error {
-	return m.CommitFn(message, opts)
+func (m *MockRepo) Commit(
+	ctx context.Context,
+	message string,
+	opts *CommitOptions,
+) error {
+	return m.CommitFn(ctx, message, opts)
 }
 
-func (m *MockRepo) CreateChildBranch(branch string) error {
-	return m.CreateChildBranchFn(branch)
+func (m *MockRepo) CreateChildBranch(ctx context.Context, branch string) error {
+	return m.CreateChildBranchFn(ctx, branch)
 }
 
-func (m *MockRepo) CreateOrphanedBranch(branch string) error {
-	return m.CreateOrphanedBranchFn(branch)
+func (m *MockRepo) CreateOrphanedBranch(ctx context.Context, branch string) error {
+	return m.CreateOrphanedBranchFn(ctx, branch)
 }
 
-func (m *MockRepo) CreateTag(tag, msg string, opts *CreateTagOptions) error {
-	return m.CreateTagFn(tag, msg, opts)
+func (m *MockRepo) CreateTag(
+	ctx context.Context,
+	tag, msg string,
+	opts *CreateTagOptions,
+) error {
+	return m.CreateTagFn(ctx, tag, msg, opts)
 }
 
-func (m *MockRepo) CurrentBranch() (string, error) {
-	return m.CurrentBranchFn()
+func (m *MockRepo) CurrentBranch(ctx context.Context) (string, error) {
+	return m.CurrentBranchFn(ctx)
 }
 
-func (m *MockRepo) DeleteBranch(branch string) error {
-	return m.DeleteBranchFn(branch)
+func (m *MockRepo) DeleteBranch(ctx context.Context, branch string) error {
+	return m.DeleteBranchFn(ctx, branch)
 }
 
 func (m *MockRepo) Dir() string {
 	return m.DirFn()
 }
 
-func (m *MockRepo) Fetch(opts *FetchOptions) error {
-	return m.FetchFn(opts)
+func (m *MockRepo) Fetch(ctx context.Context, opts *FetchOptions) error {
+	return m.FetchFn(ctx, opts)
 }
 
-func (m *MockRepo) HasDiffs() (bool, error) {
-	return m.HasDiffsFn()
+func (m *MockRepo) HasDiffs(ctx context.Context) (bool, error) {
+	return m.HasDiffsFn(ctx)
 }
 
 func (m *MockRepo) HomeDir() string {
@@ -109,74 +147,91 @@ func (m *MockRepo) HomeDir() string {
 }
 
 func (m *MockRepo) GetDiffPathsForCommitID(
+	ctx context.Context,
 	commitID string,
 ) ([]string, error) {
-	return m.GetDiffPathsForCommitIDFn(commitID)
+	return m.GetDiffPathsForCommitIDFn(ctx, commitID)
 }
 
-func (m *MockRepo) IsAncestor(parent string, child string) (bool, error) {
-	return m.IsAncestorFn(parent, child)
+func (m *MockRepo) IsAncestor(
+	ctx context.Context,
+	parent string,
+	child string,
+) (bool, error) {
+	return m.IsAncestorFn(ctx, parent, child)
 }
 
-func (m *MockRepo) IsRebasing() (bool, error) {
-	return m.IsRebasingFn()
+func (m *MockRepo) IsRebasing(ctx context.Context) (bool, error) {
+	return m.IsRebasingFn(ctx)
 }
 
-func (m *MockRepo) LastCommitID() (string, error) {
-	return m.LastCommitIDFn()
+func (m *MockRepo) LastCommitID(ctx context.Context) (string, error) {
+	return m.LastCommitIDFn(ctx)
 }
 
-func (m *MockRepo) ListTags() ([]TagMetadata, error) {
-	return m.ListTagsFn()
+func (m *MockRepo) ListTags(ctx context.Context) ([]TagMetadata, error) {
+	return m.ListTagsFn(ctx)
 }
 
-func (m *MockRepo) ListCommits(opts *ListCommitsOptions) ([]CommitMetadata, error) {
-	return m.ListCommitsFn(opts)
+func (m *MockRepo) ListCommits(
+	ctx context.Context,
+	opts *ListCommitsOptions,
+) ([]CommitMetadata, error) {
+	return m.ListCommitsFn(ctx, opts)
 }
 
-func (m *MockRepo) CommitMessage(id string) (string, error) {
-	return m.CommitMessageFn(id)
+func (m *MockRepo) CommitMessage(
+	ctx context.Context,
+	id string,
+) (string, error) {
+	return m.CommitMessageFn(ctx, id)
 }
 
 func (m *MockRepo) GetCommitSignatureInfo(
+	ctx context.Context,
 	commitID string,
 ) (*CommitSignatureInfo, error) {
-	return m.GetCommitSignatureInfoFn(commitID)
+	return m.GetCommitSignatureInfoFn(ctx, commitID)
 }
 
 func (m *MockRepo) IntegrateRemoteChanges(
+	ctx context.Context,
 	opts *IntegrationOptions,
 ) error {
-	return m.IntegrateRemoteChangesFn(opts)
+	return m.IntegrateRemoteChangesFn(ctx, opts)
 }
 
-func (m *MockRepo) Pull(opts *PullOptions) error {
-	return m.PullFn(opts)
+func (m *MockRepo) Pull(ctx context.Context, opts *PullOptions) error {
+	return m.PullFn(ctx, opts)
 }
 
-func (m *MockRepo) Push(opts *PushOptions) error {
-	return m.PushFn(opts)
+func (m *MockRepo) Push(ctx context.Context, opts *PushOptions) error {
+	return m.PushFn(ctx, opts)
 }
 
 func (m *MockRepo) RefsHaveDiffs(
+	ctx context.Context,
 	commit1 string,
 	commit2 string,
 ) (bool, error) {
-	return m.RefsHaveDiffsFn(commit1, commit2)
+	return m.RefsHaveDiffsFn(ctx, commit1, commit2)
 }
 
-func (m *MockRepo) RemoteBranchExists(branch string) (bool, error) {
-	return m.RemoteBranchExistsFn(branch)
+func (m *MockRepo) RemoteBranchExists(
+	ctx context.Context,
+	branch string,
+) (bool, error) {
+	return m.RemoteBranchExistsFn(ctx, branch)
 }
 
-func (m *MockRepo) ResetHard() error {
-	return m.ResetHardFn()
+func (m *MockRepo) ResetHard(ctx context.Context) error {
+	return m.ResetHardFn(ctx)
 }
 
 func (m *MockRepo) URL() string {
 	return m.URLFn()
 }
 
-func (m *MockRepo) UpdateSubmodules() error {
-	return m.UpdateSubmodulesFn()
+func (m *MockRepo) UpdateSubmodules(ctx context.Context) error {
+	return m.UpdateSubmodulesFn(ctx)
 }

--- a/pkg/controller/git/remote_commit_integration.go
+++ b/pkg/controller/git/remote_commit_integration.go
@@ -20,7 +20,10 @@ type IntegrationOptions struct {
 	IntegrationPolicy PushIntegrationPolicy
 }
 
-func (w *workTree) IntegrateRemoteChanges(opts *IntegrationOptions) error {
+func (w *workTree) IntegrateRemoteChanges(
+	ctx context.Context,
+	opts *IntegrationOptions,
+) error {
 	if opts == nil {
 		opts = &IntegrationOptions{}
 	}
@@ -35,11 +38,11 @@ func (w *workTree) IntegrateRemoteChanges(opts *IntegrationOptions) error {
 	targetBranch := opts.TargetBranch
 	if targetBranch == "" {
 		var err error
-		if targetBranch, err = w.CurrentBranch(); err != nil {
+		if targetBranch, err = w.CurrentBranch(ctx); err != nil {
 			return err
 		}
 	}
-	exists, err := w.RemoteBranchExists(targetBranch)
+	exists, err := w.RemoteBranchExists(ctx, targetBranch)
 	if err != nil {
 		return err
 	}
@@ -47,7 +50,7 @@ func (w *workTree) IntegrateRemoteChanges(opts *IntegrationOptions) error {
 		return nil
 	}
 
-	logger := logging.LoggerFromContext(context.TODO()).WithValues(
+	logger := logging.LoggerFromContext(ctx).WithValues(
 		"remoteBranch", targetBranch,
 		"integrationPolicy", integrationPolicy,
 	)
@@ -55,18 +58,18 @@ func (w *workTree) IntegrateRemoteChanges(opts *IntegrationOptions) error {
 	switch integrationPolicy {
 	case PushIntegrationPolicyAlwaysRebase:
 		logger.Trace("integrating remote changes via rebase (always)")
-		return w.pullRebase(targetBranch)
+		return w.pullRebase(ctx, targetBranch)
 	case PushIntegrationPolicyAlwaysMerge:
 		logger.Trace("integrating remote changes via merge (always)")
-		return w.pullMerge(targetBranch)
+		return w.pullMerge(ctx, targetBranch)
 	case PushIntegrationPolicyRebaseOrMerge, PushIntegrationPolicyRebaseOrFail:
-		safe, err := w.canSafelyRebase(targetBranch)
+		safe, err := w.canSafelyRebase(ctx, targetBranch)
 		if err != nil {
 			return fmt.Errorf("error checking rebase safety: %w", err)
 		}
 		if safe {
 			logger.Trace("integrating remote changes via rebase")
-			return w.pullRebase(targetBranch)
+			return w.pullRebase(ctx, targetBranch)
 		}
 		if integrationPolicy == PushIntegrationPolicyRebaseOrFail {
 			logger.Trace(
@@ -75,17 +78,17 @@ func (w *workTree) IntegrateRemoteChanges(opts *IntegrationOptions) error {
 			return ErrRebaseUnsafe
 		}
 		logger.Trace("integrating remote changes via merge (rebase unsafe)")
-		return w.pullMerge(targetBranch)
+		return w.pullMerge(ctx, targetBranch)
 	default:
 		return fmt.Errorf("unknown push integration policy: %q", integrationPolicy)
 	}
 }
 
 // pullRebase performs a git pull --rebase against the specified remote branch.
-func (w *workTree) pullRebase(targetBranch string) error {
-	cmd := w.buildGitCommand("pull", "--rebase", "origin", targetBranch)
+func (w *workTree) pullRebase(ctx context.Context, targetBranch string) error {
+	cmd := w.buildGitCommand(ctx, "pull", "--rebase", "origin", targetBranch)
 	if _, err := libExec.Exec(cmd); err != nil {
-		if isRebasing, rbErr := w.IsRebasing(); rbErr == nil && isRebasing {
+		if isRebasing, rbErr := w.IsRebasing(ctx); rbErr == nil && isRebasing {
 			return ErrMergeConflict
 		}
 		return fmt.Errorf("error pulling and rebasing branch: %w", err)
@@ -94,13 +97,13 @@ func (w *workTree) pullRebase(targetBranch string) error {
 }
 
 // pullMerge performs a git pull (merge) against the specified remote branch.
-func (w *workTree) pullMerge(targetBranch string) error {
-	cmd := w.buildGitCommand("pull", "--no-rebase", "origin", targetBranch)
+func (w *workTree) pullMerge(ctx context.Context, targetBranch string) error {
+	cmd := w.buildGitCommand(ctx, "pull", "--no-rebase", "origin", targetBranch)
 	if _, err := libExec.Exec(cmd); err != nil {
 		// Check for merge conflicts — MERGE_HEAD exists when a merge is
 		// in progress and waiting for conflict resolution.
 		if _, statErr := libExec.Exec(w.buildGitCommand(
-			"rev-parse", "--verify", "MERGE_HEAD",
+			ctx, "rev-parse", "--verify", "MERGE_HEAD",
 		)); statErr == nil {
 			return ErrMergeConflict
 		}
@@ -119,8 +122,11 @@ func (w *workTree) pullMerge(targetBranch string) error {
 //   - Signed with untrusted key: always unsafe (Kargo can't vouch for it)
 //   - Unsigned + signing configured: unsafe (would fabricate a signature)
 //   - Unsigned + signing not configured: safe (stays unsigned)
-func (w *workTree) canSafelyRebase(targetBranch string) (bool, error) {
-	commits, err := w.commitsToReplay(targetBranch)
+func (w *workTree) canSafelyRebase(
+	ctx context.Context,
+	targetBranch string,
+) (bool, error) {
+	commits, err := w.commitsToReplay(ctx, targetBranch)
 	if err != nil {
 		return false, fmt.Errorf(
 			"error determining commits to replay: %w", err,
@@ -129,14 +135,14 @@ func (w *workTree) canSafelyRebase(targetBranch string) (bool, error) {
 	if len(commits) == 0 {
 		return true, nil
 	}
-	signing, err := w.isSigningConfigured()
+	signing, err := w.isSigningConfigured(ctx)
 	if err != nil {
 		return false, fmt.Errorf(
 			"error checking signing configuration: %w", err,
 		)
 	}
 	for _, commitID := range commits {
-		status, err := w.verifyCommitSignature(commitID)
+		status, err := w.verifyCommitSignature(ctx, commitID)
 		if err != nil {
 			return false, fmt.Errorf(
 				"error verifying signature of commit %s: %w",
@@ -153,17 +159,19 @@ func (w *workTree) canSafelyRebase(targetBranch string) (bool, error) {
 // commitsToReplay returns the SHAs of commits that would be replayed during
 // a rebase of the current branch on top of the specified remote branch.
 func (w *workTree) commitsToReplay(
+	ctx context.Context,
 	targetBranch string,
 ) ([]string, error) {
 	remoteRef := fmt.Sprintf("origin/%s", targetBranch)
 	// Always fetch the target branch to ensure the remote tracking ref
 	// exists and has full, up-to-date history for the git log range below.
-	if err := w.Fetch(&FetchOptions{Branch: targetBranch}); err != nil {
+	if err := w.Fetch(ctx, &FetchOptions{Branch: targetBranch}); err != nil {
 		return nil, fmt.Errorf(
 			"error fetching remote branch %q: %w", targetBranch, err,
 		)
 	}
 	res, err := libExec.Exec(w.buildGitCommand(
+		ctx,
 		"log",
 		"--format=%H",
 		fmt.Sprintf("%s..HEAD", remoteRef),

--- a/pkg/controller/git/remote_commit_integration_test.go
+++ b/pkg/controller/git/remote_commit_integration_test.go
@@ -20,13 +20,18 @@ func Test_workTree_IntegrateRemoteChanges(t *testing.T) {
 	defer testServer.Close()
 
 	t.Run("AlwaysRebase: rebases unconditionally", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		// Enable signing so that RebaseOrMerge would fall back to merge, but
@@ -34,7 +39,7 @@ func Test_workTree_IntegrateRemoteChanges(t *testing.T) {
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.IntegrateRemoteChanges(&IntegrationOptions{
+		err = wt.IntegrateRemoteChanges(t.Context(), &IntegrationOptions{
 			TargetBranch:      "ahead",
 			IntegrationPolicy: PushIntegrationPolicyAlwaysRebase,
 		})
@@ -42,96 +47,122 @@ func Test_workTree_IntegrateRemoteChanges(t *testing.T) {
 
 		// A rebase produces no merge commits:
 		// initial + remote + local = 3.
-		commits, err := repo.ListCommits(nil)
+		commits, err := repo.ListCommits(t.Context(), nil)
 		require.NoError(t, err)
 		require.Len(t, commits, 3)
 	})
 
 	t.Run("RebaseOrMerge: rebases when safe", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
-		err = internalWorkTree(t, repo).IntegrateRemoteChanges(&IntegrationOptions{
-			TargetBranch:      "ahead",
-			IntegrationPolicy: PushIntegrationPolicyRebaseOrMerge,
-		})
+		err = internalWorkTree(t, repo).IntegrateRemoteChanges(
+			t.Context(),
+			&IntegrationOptions{
+				TargetBranch:      "ahead",
+				IntegrationPolicy: PushIntegrationPolicyRebaseOrMerge,
+			},
+		)
 		require.NoError(t, err)
 
 		// All local commits are unsigned and signing is not configured, so
 		// rebase is safe. No merge commits: initial + remote + local = 3.
-		commits, err := repo.ListCommits(nil)
+		commits, err := repo.ListCommits(t.Context(), nil)
 		require.NoError(t, err)
 		require.Len(t, commits, 3)
 	})
 
 	t.Run("RebaseOrMerge: merges when rebase is unsafe", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		// Enable signing so that rebasing unsigned commits would be unsafe.
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.IntegrateRemoteChanges(&IntegrationOptions{
+		err = wt.IntegrateRemoteChanges(t.Context(), &IntegrationOptions{
 			TargetBranch:      "ahead",
 			IntegrationPolicy: PushIntegrationPolicyRebaseOrMerge,
 		})
 		require.NoError(t, err)
 
 		// Should have fallen back to merge.
-		msg, err := repo.CommitMessage("HEAD")
+		msg, err := repo.CommitMessage(t.Context(), "HEAD")
 		require.NoError(t, err)
 		require.Contains(t, msg, "Merge")
 	})
 
 	t.Run("RebaseOrFail: rebases when safe", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
-		err = internalWorkTree(t, repo).IntegrateRemoteChanges(&IntegrationOptions{
-			TargetBranch:      "ahead",
-			IntegrationPolicy: PushIntegrationPolicyRebaseOrFail,
-		})
+		err = internalWorkTree(t, repo).IntegrateRemoteChanges(
+			t.Context(),
+			&IntegrationOptions{
+				TargetBranch:      "ahead",
+				IntegrationPolicy: PushIntegrationPolicyRebaseOrFail,
+			},
+		)
 		require.NoError(t, err)
 
 		// Rebase is safe (unsigned, signing not configured).
-		commits, err := repo.ListCommits(nil)
+		commits, err := repo.ListCommits(t.Context(), nil)
 		require.NoError(t, err)
 		require.Len(t, commits, 3)
 	})
 
 	t.Run("RebaseOrFail: fails when rebase is unsafe", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
 
-		err = wt.IntegrateRemoteChanges(&IntegrationOptions{
+		err = wt.IntegrateRemoteChanges(t.Context(), &IntegrationOptions{
 			TargetBranch:      "ahead",
 			IntegrationPolicy: PushIntegrationPolicyRebaseOrFail,
 		})
@@ -139,24 +170,32 @@ func Test_workTree_IntegrateRemoteChanges(t *testing.T) {
 	})
 
 	t.Run("AlwaysMerge: merges unconditionally", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(fmt.Sprintf("%s/local.txt", repo.Dir()), []byte("local"), 0o600)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
-		err = internalWorkTree(t, repo).IntegrateRemoteChanges(&IntegrationOptions{
-			TargetBranch:      "ahead",
-			IntegrationPolicy: PushIntegrationPolicyAlwaysMerge,
-		})
+		err = internalWorkTree(t, repo).IntegrateRemoteChanges(
+			t.Context(),
+			&IntegrationOptions{
+				TargetBranch:      "ahead",
+				IntegrationPolicy: PushIntegrationPolicyAlwaysMerge,
+			},
+		)
 		require.NoError(t, err)
 
 		// Even though rebase would be safe (unsigned, no signing), the policy
 		// says always merge.
-		msg, err := repo.CommitMessage("HEAD")
+		msg, err := repo.CommitMessage(t.Context(), "HEAD")
 		require.NoError(t, err)
 		require.Contains(t, msg, "Merge")
 	})
@@ -172,9 +211,14 @@ func Test_workTree_pullRebase(t *testing.T) {
 	defer testServer.Close()
 
 	t.Run("rebase fails with merge conflicts", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Add a conflicting local commit.
 		err = os.WriteFile(
@@ -183,18 +227,23 @@ func Test_workTree_pullRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local conflict", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local conflict", nil)
 		require.NoError(t, err)
 
 		// With a conflict, the rebase should have failed.
-		err = internalWorkTree(t, repo).pullRebase("ahead")
+		err = internalWorkTree(t, repo).pullRebase(t.Context(), "ahead")
 		require.ErrorIs(t, err, ErrMergeConflict)
 	})
 
 	t.Run("rebases succeeds", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Add a non-conflicting local commit.
 		err = os.WriteFile(
@@ -203,16 +252,16 @@ func Test_workTree_pullRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		// With no conflicts, the rebase should have succeeded.
-		err = internalWorkTree(t, repo).pullRebase("ahead")
+		err = internalWorkTree(t, repo).pullRebase(t.Context(), "ahead")
 		require.NoError(t, err)
 
 		// The rebase should not have created any merge commits, so the commit count
 		// should be: initial + remote + local = 3.
-		commits, err := repo.ListCommits(nil)
+		commits, err := repo.ListCommits(t.Context(), nil)
 		require.NoError(t, err)
 		require.Len(t, commits, 3)
 	})
@@ -228,9 +277,14 @@ func Test_workTree_pullMerge(t *testing.T) {
 	defer testServer.Close()
 
 	t.Run("merge fails with merge conflicts", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Add a conflicting local commit.
 		err = os.WriteFile(
@@ -239,18 +293,23 @@ func Test_workTree_pullMerge(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local conflict", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local conflict", nil)
 		require.NoError(t, err)
 
 		// With a conflict, the merge should have failed.
-		err = internalWorkTree(t, repo).pullMerge("ahead")
+		err = internalWorkTree(t, repo).pullMerge(t.Context(), "ahead")
 		require.ErrorIs(t, err, ErrMergeConflict)
 	})
 
 	t.Run("merge succeeds", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Add a non-conflicting local commit.
 		err = os.WriteFile(
@@ -259,14 +318,17 @@ func Test_workTree_pullMerge(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		// With no conflicts, the merge should have succeeded.
-		require.NoError(t, internalWorkTree(t, repo).pullMerge("ahead"))
+		require.NoError(
+			t,
+			internalWorkTree(t, repo).pullMerge(t.Context(), "ahead"),
+		)
 
 		// After a merge, the head of the local branch should be a merge commit.
-		msg, err := repo.CommitMessage("HEAD")
+		msg, err := repo.CommitMessage(t.Context(), "HEAD")
 		require.NoError(t, err)
 		require.Contains(t, msg, "Merge")
 	})
@@ -277,19 +339,29 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 	defer testServer.Close()
 
 	t.Run("no commits to replay", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
-		safe, err := internalWorkTree(t, repo).canSafelyRebase("main")
+		safe, err := internalWorkTree(t, repo).canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		require.True(t, safe)
 	})
 
 	t.Run("unsigned local commits to replay; signing not configured", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Add an unsigned local commit.
 		err = os.WriteFile(
@@ -298,10 +370,10 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
-		safe, err := internalWorkTree(t, repo).canSafelyRebase("main")
+		safe, err := internalWorkTree(t, repo).canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		// This should be safe because rebasing won't lend Kargo's signature to
 		// commits that were previously unsigned.
@@ -309,26 +381,31 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 	})
 
 	t.Run("unsigned commits to replay; signing configured", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		require.NoError(t, os.WriteFile(
 			fmt.Sprintf("%s/file.txt", repo.Dir()),
 			[]byte("data"),
 			0o600,
 		))
-		err = repo.AddAllAndCommit("local commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local commit", nil)
 		require.NoError(t, err)
 
 		// Enable signing without actually importing a key.
 		wt := internalWorkTree(t, repo)
 		_, err = libExec.Exec(wt.buildGitCommand(
-			"config", "--global", "commit.gpgSign", "true",
+			t.Context(), "config", "--global", "commit.gpgSign", "true",
 		))
 		require.NoError(t, err)
 
-		safe, err := wt.canSafelyRebase("main")
+		safe, err := wt.canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		// This should be unsafe because rebasing would lend Kargo's signature to
 		// commits that were previously unsigned.
@@ -336,9 +413,14 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 	})
 
 	t.Run("trusted, signed local commits to replay; signing configured", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
@@ -349,10 +431,10 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("signed commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "signed commit", nil)
 		require.NoError(t, err)
 
-		safe, err := wt.canSafelyRebase("main")
+		safe, err := wt.canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		// This should be safe because Kargo trusted the signature on commits it
 		// will re-sign during the rebase.
@@ -360,9 +442,14 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 	})
 
 	t.Run("trusted, signed local commits to replay; signing not configured", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, true)
@@ -373,12 +460,12 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("signed commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "signed commit", nil)
 		require.NoError(t, err)
 
 		disableFakeCommitSigning(t, wt)
 
-		safe, err := wt.canSafelyRebase("main")
+		safe, err := wt.canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		// This should be unsafe because rebasing would strip trusted signatures
 		// from existing commits.
@@ -386,9 +473,14 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 	})
 
 	t.Run("untrusted, signed commits", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		wt := internalWorkTree(t, repo)
 		enableFakeCommitSigning(t, wt, false)
@@ -399,11 +491,11 @@ func Test_workTree_canSafelyRebase(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("untrusted signed commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "untrusted signed commit", nil)
 		require.NoError(t, err)
 
 		// Unsafe regardless — Kargo can't vouch for this commit.
-		safe, err := wt.canSafelyRebase("main")
+		safe, err := wt.canSafelyRebase(t.Context(), "main")
 		require.NoError(t, err)
 		// This should be unsafe, no matter what. If signing were not configured,
 		// rebasing would strip signatures from existing commits. Something
@@ -424,29 +516,45 @@ func Test_workTree_commitsToReplay(t *testing.T) {
 	defer testServer.Close()
 
 	t.Run("local branch and remote target branch are identical", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
-		commits, err := internalWorkTree(t, repo).commitsToReplay("main")
+		commits, err := internalWorkTree(t, repo).commitsToReplay(t.Context(), "main")
 		require.NoError(t, err)
 		require.Empty(t, commits)
 	})
 
 	t.Run("local branch is behind remote target branch", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
-		commits, err := internalWorkTree(t, repo).commitsToReplay("ahead")
+		commits, err := internalWorkTree(t, repo).
+			commitsToReplay(t.Context(), "ahead")
 		require.NoError(t, err)
 		require.Empty(t, commits)
 	})
 
 	t.Run("local branch is ahead of remote target branch", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(
 			fmt.Sprintf("%s/a.txt", repo.Dir()),
@@ -454,7 +562,7 @@ func Test_workTree_commitsToReplay(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("commit a", nil)
+		err = repo.AddAllAndCommit(t.Context(), "commit a", nil)
 		require.NoError(t, err)
 		err = os.WriteFile(
 			fmt.Sprintf("%s/b.txt", repo.Dir()),
@@ -462,19 +570,25 @@ func Test_workTree_commitsToReplay(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("commit b", nil)
+		err = repo.AddAllAndCommit(t.Context(), "commit b", nil)
 		require.NoError(t, err)
 
-		commits, err := internalWorkTree(t, repo).commitsToReplay("main")
+		commits, err := internalWorkTree(t, repo).
+			commitsToReplay(t.Context(), "main")
 		require.NoError(t, err)
 		// Two local commits should need to be replayed on main.
 		require.Len(t, commits, 2)
 	})
 
 	t.Run("local branch and remote target branch have diverged", func(t *testing.T) {
-		repo, err := Clone(testRepoURL, &ClientOptions{Credentials: &testRepoCreds}, nil)
+		repo, err := Clone(
+			t.Context(),
+			testRepoURL,
+			&ClientOptions{Credentials: &testRepoCreds},
+			nil,
+		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		err = os.WriteFile(
 			fmt.Sprintf("%s/a.txt", repo.Dir()),
@@ -482,7 +596,7 @@ func Test_workTree_commitsToReplay(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("commit a", nil)
+		err = repo.AddAllAndCommit(t.Context(), "commit a", nil)
 		require.NoError(t, err)
 		err = os.WriteFile(
 			fmt.Sprintf("%s/b.txt", repo.Dir()),
@@ -490,10 +604,11 @@ func Test_workTree_commitsToReplay(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("commit b", nil)
+		err = repo.AddAllAndCommit(t.Context(), "commit b", nil)
 		require.NoError(t, err)
 
-		commits, err := internalWorkTree(t, repo).commitsToReplay("ahead")
+		commits, err := internalWorkTree(t, repo).
+			commitsToReplay(t.Context(), "ahead")
 		// Two local commits should need to be replayed on ahead.
 		require.NoError(t, err)
 		require.Len(t, commits, 2)

--- a/pkg/controller/git/repo.go
+++ b/pkg/controller/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,7 +13,7 @@ import (
 type Repo interface {
 	// Close cleans up file system resources used by this repository. This should
 	// always be called before a repository goes out of scope.
-	Close() error
+	Close(ctx context.Context) error
 	// Dir returns an absolute path to the repository.
 	Dir() string
 	// HomeDir returns an absolute path to the home directory of the system user
@@ -62,6 +63,7 @@ type CloneOptions struct {
 // perform any setup that is required for successfully authenticating to the
 // remote repository.
 func Clone(
+	ctx context.Context,
 	repoURL string,
 	clientOpts *ClientOptions,
 	cloneOpts *CloneOptions,
@@ -83,25 +85,25 @@ func Clone(
 			baseRepo: baseRepo,
 		},
 	}
-	if err := r.setupDirs(cloneOpts.BaseDir); err != nil {
+	if err := r.setupDirs(ctx, cloneOpts.BaseDir); err != nil {
 		return nil, err
 	}
-	if err := r.setupClient(clientOpts); err != nil {
+	if err := r.setupClient(ctx, clientOpts); err != nil {
 		return nil, err
 	}
-	if err := r.clone(cloneOpts); err != nil {
+	if err := r.clone(ctx, cloneOpts); err != nil {
 		return nil, err
 	}
-	if err := r.saveDirs(); err != nil {
+	if err := r.saveDirs(ctx); err != nil {
 		return nil, err
 	}
-	if err := r.saveOriginalURL(); err != nil {
+	if err := r.saveOriginalURL(ctx); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-func (r *repo) clone(opts *CloneOptions) error {
+func (r *repo) clone(ctx context.Context, opts *CloneOptions) error {
 	if opts == nil {
 		opts = &CloneOptions{}
 	}
@@ -119,7 +121,7 @@ func (r *repo) clone(opts *CloneOptions) error {
 		args = append(args, "--filter", "blob:none")
 	}
 	args = append(args, r.accessURL, r.dir)
-	cmd := r.buildGitCommand(args...)
+	cmd := r.buildGitCommand(ctx, args...)
 	cmd.Dir = r.homeDir // Override the cmd.Dir that's set by r.buildGitCommand()
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf("error cloning repo %q into %q: %w", r.originalURL, r.dir, err)
@@ -131,7 +133,11 @@ type LoadRepoOptions struct {
 	Credentials *RepoCredentials
 }
 
-func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
+func LoadRepo(
+	ctx context.Context,
+	path string,
+	opts *LoadRepoOptions,
+) (Repo, error) {
 	if opts == nil {
 		opts = &LoadRepoOptions{}
 	}
@@ -145,10 +151,10 @@ func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
 			baseRepo: baseRepo,
 		},
 	}
-	if err := r.loadHomeDir(); err != nil {
+	if err := r.loadHomeDir(ctx); err != nil {
 		return nil, fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
-	if err := r.loadURLs(); err != nil {
+	if err := r.loadURLs(ctx); err != nil {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
@@ -158,6 +164,6 @@ func LoadRepo(path string, opts *LoadRepoOptions) (Repo, error) {
 	return r, nil
 }
 
-func (r *repo) Close() error {
+func (r *repo) Close(context.Context) error {
 	return os.RemoveAll(r.homeDir)
 }

--- a/pkg/controller/git/repo_test.go
+++ b/pkg/controller/git/repo_test.go
@@ -15,15 +15,14 @@ func TestRepo(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := Clone(
+		t.Context(),
 		testRepoURL,
-		&ClientOptions{
-			Credentials: &testRepoCreds,
-		},
+		&ClientOptions{Credentials: &testRepoCreds},
 		nil,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 	r, ok := rep.(*repo)
 	require.True(t, ok)
 
@@ -59,7 +58,7 @@ func TestRepo(t *testing.T) {
 
 	t.Run("can check for diffs -- negative result", func(t *testing.T) {
 		var hasDiffs bool
-		hasDiffs, err = rep.HasDiffs()
+		hasDiffs, err = rep.HasDiffs(t.Context())
 		require.NoError(t, err)
 		require.False(t, hasDiffs)
 	})
@@ -69,7 +68,7 @@ func TestRepo(t *testing.T) {
 
 	t.Run("can check for diffs -- positive result", func(t *testing.T) {
 		var hasDiffs bool
-		hasDiffs, err = rep.HasDiffs()
+		hasDiffs, err = rep.HasDiffs(t.Context())
 		require.NoError(t, err)
 		require.True(t, hasDiffs)
 	})
@@ -78,14 +77,14 @@ func TestRepo(t *testing.T) {
 
 with a body
 `, uuid.NewString())
-	err = rep.AddAllAndCommit(testCommitMessage, nil)
+	err = rep.AddAllAndCommit(t.Context(), testCommitMessage, nil)
 	require.NoError(t, err)
 
 	t.Run("can commit", func(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	lastCommitID, err := rep.LastCommitID()
+	lastCommitID, err := rep.LastCommitID(t.Context())
 	require.NoError(t, err)
 
 	t.Run("can get last commit id", func(t *testing.T) {
@@ -95,26 +94,26 @@ with a body
 
 	t.Run("can get commit message by id", func(t *testing.T) {
 		var msg string
-		msg, err = rep.CommitMessage(lastCommitID)
+		msg, err = rep.CommitMessage(t.Context(), lastCommitID)
 		require.NoError(t, err)
 		require.Equal(t, testCommitMessage, msg)
 	})
 
 	t.Run("can get diff paths", func(t *testing.T) {
 		var paths []string
-		paths, err = rep.GetDiffPathsForCommitID(lastCommitID)
+		paths, err = rep.GetDiffPathsForCommitID(t.Context(), lastCommitID)
 		require.NoError(t, err)
 		require.Len(t, paths, 1)
 	})
 
 	t.Run("can check if remote branch exists -- negative result", func(t *testing.T) {
 		var exists bool
-		exists, err = rep.RemoteBranchExists("main") // The remote repo is empty!
+		exists, err = rep.RemoteBranchExists(t.Context(), "main") // The remote repo is empty!
 		require.NoError(t, err)
 		require.False(t, exists)
 	})
 
-	err = rep.Push(nil)
+	err = rep.Push(t.Context(), nil)
 	require.NoError(t, err)
 
 	t.Run("can push", func(t *testing.T) {
@@ -123,13 +122,13 @@ with a body
 
 	t.Run("can check if remote branch exists -- positive result", func(t *testing.T) {
 		var exists bool
-		exists, err = rep.RemoteBranchExists("main")
+		exists, err = rep.RemoteBranchExists(t.Context(), "main")
 		require.NoError(t, err)
 		require.True(t, exists)
 	})
 
 	testBranch := fmt.Sprintf("test-branch-%s", uuid.NewString())
-	err = rep.CreateChildBranch(testBranch)
+	err = rep.CreateChildBranch(t.Context(), testBranch)
 	require.NoError(t, err)
 
 	t.Run("can create a child branch", func(t *testing.T) {
@@ -141,35 +140,34 @@ with a body
 
 	t.Run("can hard reset", func(t *testing.T) {
 		var hasDiffs bool
-		hasDiffs, err = rep.HasDiffs()
+		hasDiffs, err = rep.HasDiffs(t.Context())
 		require.NoError(t, err)
 		require.True(t, hasDiffs)
-		err = rep.ResetHard()
+		err = rep.ResetHard(t.Context())
 		require.NoError(t, err)
-		hasDiffs, err = rep.HasDiffs()
+		hasDiffs, err = rep.HasDiffs(t.Context())
 		require.NoError(t, err)
 		require.False(t, hasDiffs)
 	})
 
 	t.Run("can create an orphaned branch", func(t *testing.T) {
 		testBranch := fmt.Sprintf("test-branch-%s", uuid.NewString())
-		err = rep.CreateOrphanedBranch(testBranch)
+		err = rep.CreateOrphanedBranch(t.Context(), testBranch)
 		require.NoError(t, err)
 	})
 
 	t.Run("can load an existing repo", func(t *testing.T) {
 		existingRepo, err := LoadRepo(
+			t.Context(),
 			rep.Dir(),
-			&LoadRepoOptions{
-				Credentials: &testRepoCreds,
-			},
+			&LoadRepoOptions{Credentials: &testRepoCreds},
 		)
 		require.NoError(t, err)
 		require.Equal(t, rep, existingRepo)
 	})
 
 	t.Run("can close repo", func(t *testing.T) {
-		require.NoError(t, rep.Close())
+		require.NoError(t, rep.Close(t.Context()))
 		_, err := os.Stat(r.HomeDir())
 		require.Error(t, err)
 		require.True(t, os.IsNotExist(err))

--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -20,42 +20,46 @@ import (
 // repository.
 type WorkTree interface {
 	// AddAll stages pending changes for commit.
-	AddAll() error
+	AddAll(ctx context.Context) error
 	// AddAllAndCommit is a convenience function that stages pending changes for
 	// commit to the current branch and then commits them using the provided
 	// commit message.
-	AddAllAndCommit(message string, commitOpts *CommitOptions) error
+	AddAllAndCommit(
+		ctx context.Context,
+		message string,
+		commitOpts *CommitOptions,
+	) error
 	// Clean cleans the working tree.
-	Clean() error
+	Clean(ctx context.Context) error
 	// Clear executes `git rm -rf .` to remove all files from the working tree.
-	Clear() error
+	Clear(ctx context.Context) error
 	// Close cleans up file system resources used by this working tree. This
 	// should always be called before a WorkTree goes out of scope.
-	Close() error
+	Close(ctx context.Context) error
 	// Checkout checks out the specified branch.
-	Checkout(branch string) error
+	Checkout(ctx context.Context, branch string) error
 	// Commit commits staged changes to the current branch.
-	Commit(message string, opts *CommitOptions) error
+	Commit(ctx context.Context, message string, opts *CommitOptions) error
 	// CreateChildBranch creates a new branch that is a child of the current
 	// branch.
-	CreateChildBranch(branch string) error
+	CreateChildBranch(ctx context.Context, branch string) error
 	// CreateOrphanedBranch creates a new branch that shares no commit history
 	// with any other branch.
-	CreateOrphanedBranch(branch string) error
+	CreateOrphanedBranch(ctx context.Context, branch string) error
 	// CreateTag creates a new annotated tag with the specified name and message.
-	CreateTag(name, msg string, opts *CreateTagOptions) error
+	CreateTag(ctx context.Context, name, msg string, opts *CreateTagOptions) error
 	// CurrentBranch returns the current branch
-	CurrentBranch() (string, error)
+	CurrentBranch(ctx context.Context) (string, error)
 	// DeleteBranch deletes the specified branch
-	DeleteBranch(branch string) error
+	DeleteBranch(ctx context.Context, branch string) error
 	// Dir returns an absolute path to the working tree.
 	Dir() string
 	// Fetch fetches updates from the remote repository.
-	Fetch(opts *FetchOptions) error
+	Fetch(ctx context.Context, opts *FetchOptions) error
 	// HasDiffs returns a bool indicating whether the working tree currently
 	// contains any differences from what's already at the head of the current
 	// branch.
-	HasDiffs() (bool, error)
+	HasDiffs(ctx context.Context) (bool, error)
 	// HomeDir returns an absolute path to the home directory of the system user
 	// who cloned the repo associated with this working tree.
 	HomeDir() string
@@ -64,51 +68,64 @@ type WorkTree interface {
 	// commit with the given ID. For renamed or moved files, both the old and
 	// new paths are included so that path-based filters can match on either
 	// side of the move.
-	GetDiffPathsForCommitID(commitID string) ([]string, error)
+	GetDiffPathsForCommitID(
+		ctx context.Context,
+		commitID string,
+	) ([]string, error)
 	// IsAncestor returns true if parent branch is an ancestor of child
-	IsAncestor(parent string, child string) (bool, error)
+	IsAncestor(ctx context.Context, parent string, child string) (bool, error)
 	// IsRebasing returns a bool indicating whether the working tree is currently
 	// in the middle of a rebase operation.
-	IsRebasing() (bool, error)
+	IsRebasing(ctx context.Context) (bool, error)
 	// LastCommitID returns the ID (sha) of the most recent commit to the current
 	// branch.
-	LastCommitID() (string, error)
+	LastCommitID(ctx context.Context) (string, error)
 	// ListTags returns a slice of tags in the repository with metadata such as
 	// commit ID, creator date, and subject.
-	ListTags() ([]TagMetadata, error)
+	ListTags(ctx context.Context) ([]TagMetadata, error)
 	// ListCommits returns a slice of commits in the current branch with
 	// metadata such as commit ID, commit date, and subject.
-	ListCommits(opts *ListCommitsOptions) ([]CommitMetadata, error)
+	ListCommits(
+		ctx context.Context,
+		opts *ListCommitsOptions,
+	) ([]CommitMetadata, error)
 	// CommitMessage returns the text of the most recent commit message associated
 	// with the specified commit ID.
-	CommitMessage(id string) (string, error)
+	CommitMessage(ctx context.Context, id string) (string, error)
 	// GetCommitSignatureInfo returns signature information for the specified
 	// commit, including whether it is signed by a trusted key and the
 	// identity of the signer. If opts provides a SigningKey, a temporary
 	// keyring is created with that key imported at ultimate trust and used
 	// for verification.
-	GetCommitSignatureInfo(commitID string) (*CommitSignatureInfo, error)
+	GetCommitSignatureInfo(
+		ctx context.Context,
+		commitID string,
+	) (*CommitSignatureInfo, error)
 	// IntegrateRemoteChanges integrates remote changes into the local branch
 	// before pushing. This fetches the target branch and applies the operator-
 	// configured integration policy (rebase, merge, or fail). It is a no-op
 	// if the remote branch does not exist or the policy is None.
-	IntegrateRemoteChanges(*IntegrationOptions) error
+	IntegrateRemoteChanges(context.Context, *IntegrationOptions) error
 	// Pull fetches and integrates changes from a remote branch
 	// into the current local branch.
-	Pull(*PullOptions) error
+	Pull(context.Context, *PullOptions) error
 	// Push pushes from the local repository to the remote repository.
-	Push(*PushOptions) error
+	Push(context.Context, *PushOptions) error
 	// RefsHaveDiffs returns whether there is a diff between two commits/branches
-	RefsHaveDiffs(commit1 string, commit2 string) (bool, error)
+	RefsHaveDiffs(
+		ctx context.Context,
+		commit1 string,
+		commit2 string,
+	) (bool, error)
 	// RemoteBranchExists returns a bool indicating if the specified branch exists
 	// in the remote repository.
-	RemoteBranchExists(branch string) (bool, error)
+	RemoteBranchExists(ctx context.Context, branch string) (bool, error)
 	// ResetHard performs a hard reset on the working tree.
-	ResetHard() error
+	ResetHard(ctx context.Context) error
 	// URL returns the remote URL of the repository.
 	URL() string
 	// UpdateSubmodules updates the submodules in the working tree.
-	UpdateSubmodules() error
+	UpdateSubmodules(ctx context.Context) error
 }
 
 // ListCommitsOptions contains options for listing commits.
@@ -132,7 +149,11 @@ type LoadWorkTreeOptions struct {
 	Credentials *RepoCredentials
 }
 
-func LoadWorkTree(path string, opts *LoadWorkTreeOptions) (WorkTree, error) {
+func LoadWorkTree(
+	ctx context.Context,
+	path string,
+	opts *LoadWorkTreeOptions,
+) (WorkTree, error) {
 	if opts == nil {
 		opts = &LoadWorkTreeOptions{}
 	}
@@ -142,25 +163,22 @@ func LoadWorkTree(path string, opts *LoadWorkTreeOptions) (WorkTree, error) {
 			dir:   path,
 		},
 	}
-	res, err := libExec.Exec(w.buildGitCommand(
-		"config",
-		repoDirConfigKey,
-	))
+	res, err := libExec.Exec(w.buildGitCommand(ctx, "config", repoDirConfigKey))
 	if err != nil {
 		return nil, fmt.Errorf("error reading repo dir from config: %w", err)
 	}
 	repoPath := strings.TrimSpace(string(res))
-	if err = w.loadHomeDir(); err != nil {
+	if err = w.loadHomeDir(ctx); err != nil {
 		return nil, fmt.Errorf("error reading repo home dir from config: %w", err)
 	}
-	if err = w.loadURLs(); err != nil {
+	if err = w.loadURLs(ctx); err != nil {
 		return nil,
 			fmt.Errorf(`error reading URL of remote "origin" from config: %w`, err)
 	}
 	if err = w.setupAuth(w.homeDir); err != nil {
 		return nil, fmt.Errorf("error configuring the credentials: %w", err)
 	}
-	br, err := LoadBareRepo(repoPath, &LoadBareRepoOptions{
+	br, err := LoadBareRepo(ctx, repoPath, &LoadBareRepoOptions{
 		Credentials: opts.Credentials,
 	})
 	if err != nil {
@@ -170,39 +188,45 @@ func LoadWorkTree(path string, opts *LoadWorkTreeOptions) (WorkTree, error) {
 	return w, nil
 }
 
-func (w *workTree) AddAll() error {
-	if _, err := libExec.Exec(w.buildGitCommand("add", ".")); err != nil {
+func (w *workTree) AddAll(ctx context.Context) error {
+	if _, err := libExec.Exec(w.buildGitCommand(ctx, "add", ".")); err != nil {
 		return fmt.Errorf("error staging changes for commit: %w", err)
 	}
 	return nil
 }
 
-func (w *workTree) AddAllAndCommit(message string, commitOpts *CommitOptions) error {
-	if err := w.AddAll(); err != nil {
+func (w *workTree) AddAllAndCommit(
+	ctx context.Context,
+	message string,
+	commitOpts *CommitOptions,
+) error {
+	if err := w.AddAll(ctx); err != nil {
 		return err
 	}
-	return w.Commit(message, commitOpts)
+	return w.Commit(ctx, message, commitOpts)
 }
 
-func (w *workTree) Clean() error {
-	if _, err := libExec.Exec(w.buildGitCommand("clean", "-fd")); err != nil {
+func (w *workTree) Clean(ctx context.Context) error {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "clean", "-fd",
+	)); err != nil {
 		return fmt.Errorf("error cleaning worktree: %w", err)
 	}
 	return nil
 }
 
-func (w *workTree) Clear() error {
-	if _, err := libExec.Exec(
-		w.buildGitCommand("rm", "-rf", "--ignore-unmatch", "."),
-	); err != nil {
+func (w *workTree) Clear(ctx context.Context) error {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "rm", "-rf", "--ignore-unmatch", ".",
+	)); err != nil {
 		return fmt.Errorf("error clearing worktree: %w", err)
 	}
 	return nil
 }
 
-func (w *workTree) Close() error {
+func (w *workTree) Close(ctx context.Context) error {
 	if w.bareRepo != nil {
-		return w.bareRepo.RemoveWorkTree(w.dir)
+		return w.bareRepo.RemoveWorkTree(ctx, w.dir)
 	}
 	if err := os.RemoveAll(w.dir); err != nil {
 		return fmt.Errorf("error removing working tree at %q: %w", w.dir, err)
@@ -210,8 +234,9 @@ func (w *workTree) Close() error {
 	return nil
 }
 
-func (w *workTree) Checkout(branch string) error {
+func (w *workTree) Checkout(ctx context.Context, branch string) error {
 	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx,
 		"checkout",
 		branch,
 		// The next line makes it crystal clear to git that we're checking out
@@ -236,7 +261,11 @@ type CommitOptions struct {
 	Author *User
 }
 
-func (w *workTree) Commit(message string, opts *CommitOptions) error {
+func (w *workTree) Commit(
+	ctx context.Context,
+	message string,
+	opts *CommitOptions,
+) error {
 	if opts == nil {
 		opts = &CommitOptions{}
 	}
@@ -256,11 +285,11 @@ func (w *workTree) Commit(message string, opts *CommitOptions) error {
 		}
 		defer func() {
 			if cleanErr := os.RemoveAll(homeDir); cleanErr != nil {
-				logging.LoggerFromContext(context.TODO()).
+				logging.LoggerFromContext(ctx).
 					Error(cleanErr, "error removing virtual home directory", "path", homeDir)
 			}
 		}()
-		if err = w.setupUser(homeDir, opts.Author); err != nil {
+		if err = w.setupUser(ctx, homeDir, opts.Author); err != nil {
 			return fmt.Errorf(
 				"error setting up author + committer information for commit command: %w", err,
 			)
@@ -272,7 +301,7 @@ func (w *workTree) Commit(message string, opts *CommitOptions) error {
 		cmdTokens = append(cmdTokens, "--allow-empty")
 	}
 
-	cmd := w.buildGitCommand(cmdTokens...)
+	cmd := w.buildGitCommand(ctx, cmdTokens...)
 	if homeDir != "" {
 		// Override the home directory set by b.buildGitCommand().
 		w.setCmdHome(cmd, homeDir)
@@ -283,26 +312,29 @@ func (w *workTree) Commit(message string, opts *CommitOptions) error {
 	return nil
 }
 
-func (w *workTree) CommitMessage(id string) (string, error) {
-	msgBytes, err := libExec.Exec(
-		w.buildGitCommand(
-			"log",
-			"-n",
-			"1",
-			"--pretty=format:%B",
-			id,
-			// `--` clarifies that id is a branch name and not a file name
-			"--",
-		),
-	)
+func (w *workTree) CommitMessage(
+	ctx context.Context,
+	id string,
+) (string, error) {
+	msgBytes, err := libExec.Exec(w.buildGitCommand(
+		ctx,
+		"log",
+		"-n",
+		"1",
+		"--pretty=format:%B",
+		id,
+		// `--` clarifies that id is a branch name and not a file name
+		"--",
+	))
 	if err != nil {
 		return "", fmt.Errorf("error obtaining commit message for commit %q: %w", id, err)
 	}
 	return string(msgBytes), nil
 }
 
-func (w *workTree) CreateChildBranch(branch string) error {
+func (w *workTree) CreateChildBranch(ctx context.Context, branch string) error {
 	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx,
 		"checkout",
 		"-b",
 		branch,
@@ -319,19 +351,16 @@ func (w *workTree) CreateChildBranch(branch string) error {
 	return nil
 }
 
-func (w *workTree) CreateOrphanedBranch(branch string) error {
+func (w *workTree) CreateOrphanedBranch(ctx context.Context, branch string) error {
 	if _, err := libExec.Exec(w.buildGitCommand(
-		"switch",
-		"--orphan",
-		branch,
-		"--discard-changes",
+		ctx, "switch", "--orphan", branch, "--discard-changes",
 	)); err != nil {
 		return fmt.Errorf(
 			"error creating orphaned branch %q for repo %q: %w",
 			branch, w.originalURL, err,
 		)
 	}
-	return w.Clean()
+	return w.Clean(ctx)
 }
 
 // CreateTagOptions represents options for creating a tag.
@@ -340,7 +369,11 @@ type CreateTagOptions struct {
 	Force bool
 }
 
-func (w *workTree) CreateTag(tag, msg string, opts *CreateTagOptions) error {
+func (w *workTree) CreateTag(
+	ctx context.Context,
+	tag, msg string,
+	opts *CreateTagOptions,
+) error {
 	if opts == nil {
 		opts = &CreateTagOptions{}
 	}
@@ -348,15 +381,15 @@ func (w *workTree) CreateTag(tag, msg string, opts *CreateTagOptions) error {
 	if opts.Force {
 		args = append(args, "--force")
 	}
-	cmd := w.buildGitCommand(args...)
+	cmd := w.buildGitCommand(ctx, args...)
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf("error creating annotated tag %q: %w", tag, err)
 	}
 	return nil
 }
 
-func (w *workTree) CurrentBranch() (string, error) {
-	res, err := libExec.Exec(w.buildGitCommand("branch", "--show-current"))
+func (w *workTree) CurrentBranch(ctx context.Context) (string, error) {
+	res, err := libExec.Exec(w.buildGitCommand(ctx, "branch", "--show-current"))
 	if err != nil {
 		return "", fmt.Errorf(
 			"error checking current branch for repo %q: %w",
@@ -366,12 +399,9 @@ func (w *workTree) CurrentBranch() (string, error) {
 	return strings.TrimSpace(string(res)), nil
 }
 
-func (w *workTree) DeleteBranch(branch string) error {
+func (w *workTree) DeleteBranch(ctx context.Context, branch string) error {
 	if _, err := libExec.Exec(w.buildGitCommand(
-		"branch",
-		"--delete",
-		"--force",
-		branch,
+		ctx, "branch", "--delete", "--force", branch,
 	)); err != nil {
 		return fmt.Errorf("error deleting branch %q for repo %q: %w", branch, w.accessURL, err)
 	}
@@ -388,7 +418,7 @@ type FetchOptions struct {
 	Depth uint
 }
 
-func (w *workTree) Fetch(opts *FetchOptions) error {
+func (w *workTree) Fetch(ctx context.Context, opts *FetchOptions) error {
 	if opts == nil {
 		opts = &FetchOptions{}
 	}
@@ -405,7 +435,7 @@ func (w *workTree) Fetch(opts *FetchOptions) error {
 	if opts.Depth > 0 {
 		args = append(args, "--depth", fmt.Sprintf("%d", opts.Depth))
 	}
-	if _, err := libExec.Exec(w.buildGitCommand(args...)); err != nil {
+	if _, err := libExec.Exec(w.buildGitCommand(ctx, args...)); err != nil {
 		return fmt.Errorf(
 			"error fetching from repo %q: %w", w.originalURL, err,
 		)
@@ -413,8 +443,13 @@ func (w *workTree) Fetch(opts *FetchOptions) error {
 	return nil
 }
 
-func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(w.buildGitCommand("show", "--pretty=", "--name-status", "--first-parent", commitID))
+func (w *workTree) GetDiffPathsForCommitID(
+	ctx context.Context,
+	commitID string,
+) ([]string, error) {
+	resBytes, err := libExec.Exec(w.buildGitCommand(
+		ctx, "show", "--pretty=", "--name-status", "--first-parent", commitID,
+	))
 	if err != nil {
 		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}
@@ -448,16 +483,18 @@ func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
 	return paths, nil
 }
 
-func (w *workTree) HasDiffs() (bool, error) {
-	resBytes, err := libExec.Exec(w.buildGitCommand("status", "-s"))
+func (w *workTree) HasDiffs(ctx context.Context) (bool, error) {
+	resBytes, err := libExec.Exec(w.buildGitCommand(ctx, "status", "-s"))
 	if err != nil {
 		return false, fmt.Errorf("error checking status of branch: %w", err)
 	}
 	return len(resBytes) > 0, nil
 }
 
-func (w *workTree) IsAncestor(parent string, child string) (bool, error) {
-	_, err := libExec.Exec(w.buildGitCommand("merge-base", "--is-ancestor", parent, child))
+func (w *workTree) IsAncestor(ctx context.Context, parent string, child string) (bool, error) {
+	_, err := libExec.Exec(w.buildGitCommand(
+		ctx, "merge-base", "--is-ancestor", parent, child,
+	))
 	if err == nil {
 		return true, nil
 	}
@@ -470,8 +507,10 @@ func (w *workTree) IsAncestor(parent string, child string) (bool, error) {
 	return false, fmt.Errorf("error testing ancestry of branches %q, %q: %w", parent, child, err)
 }
 
-func (w *workTree) IsRebasing() (bool, error) {
-	res, err := libExec.Exec(w.buildGitCommand("rev-parse", "--git-path", "rebase-merge"))
+func (w *workTree) IsRebasing(ctx context.Context) (bool, error) {
+	res, err := libExec.Exec(w.buildGitCommand(
+		ctx, "rev-parse", "--git-path", "rebase-merge",
+	))
 	if err != nil {
 		return false, fmt.Errorf("error determining rebase status: %w", err)
 	}
@@ -482,7 +521,9 @@ func (w *workTree) IsRebasing() (bool, error) {
 		}
 		return true, nil
 	}
-	if res, err = libExec.Exec(w.buildGitCommand("rev-parse", "--git-path", "rebase-apply")); err != nil {
+	if res, err = libExec.Exec(w.buildGitCommand(
+		ctx, "rev-parse", "--git-path", "rebase-apply",
+	)); err != nil {
 		return false, fmt.Errorf("error determining rebase status: %w", err)
 	}
 	rebaseApply := filepath.Join(w.dir, strings.TrimSpace(string(res)))
@@ -495,8 +536,8 @@ func (w *workTree) IsRebasing() (bool, error) {
 	return false, nil
 }
 
-func (w *workTree) LastCommitID() (string, error) {
-	shaBytes, err := libExec.Exec(w.buildGitCommand("rev-parse", "HEAD"))
+func (w *workTree) LastCommitID(ctx context.Context) (string, error) {
+	shaBytes, err := libExec.Exec(w.buildGitCommand(ctx, "rev-parse", "HEAD"))
 	if err != nil {
 		return "", fmt.Errorf("error obtaining ID of last commit: %w", err)
 	}
@@ -517,7 +558,10 @@ type CommitMetadata struct {
 	Subject string
 }
 
-func (w *workTree) ListCommits(opts *ListCommitsOptions) ([]CommitMetadata, error) {
+func (w *workTree) ListCommits(
+	ctx context.Context,
+	opts *ListCommitsOptions,
+) ([]CommitMetadata, error) {
 	if opts == nil {
 		opts = &ListCommitsOptions{}
 	}
@@ -544,7 +588,7 @@ func (w *workTree) ListCommits(opts *ListCommitsOptions) ([]CommitMetadata, erro
 		args = append(args, fmt.Sprintf("--since=%s", opts.Since.Format(time.RFC3339)))
 	}
 
-	b, err := libExec.Exec(w.buildGitCommand(args...))
+	b, err := libExec.Exec(w.buildGitCommand(ctx, args...))
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error listing commits for repo %q: %w",
@@ -633,8 +677,10 @@ func parseTagMetadataLine(line []byte) (TagMetadata, error) {
 	return metadata, nil
 }
 
-func (w *workTree) ListTags() ([]TagMetadata, error) {
-	if _, err := libExec.Exec(w.buildGitCommand("fetch", "origin", "--tags")); err != nil {
+func (w *workTree) ListTags(ctx context.Context) ([]TagMetadata, error) {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "fetch", "origin", "--tags",
+	)); err != nil {
 		return nil, fmt.Errorf(
 			"error fetching tags from repo %q: %w",
 			w.originalURL, err,
@@ -668,6 +714,7 @@ func (w *workTree) ListTags() ([]TagMetadata, error) {
 	)
 
 	tagsBytes, err := libExec.Exec(w.buildGitCommand(
+		ctx,
 		"for-each-ref",
 		"--sort=-creatordate",
 		"--format="+tagFormat,
@@ -703,23 +750,23 @@ type PullOptions struct {
 	Force bool
 }
 
-func (w *workTree) Pull(opts *PullOptions) error {
+func (w *workTree) Pull(ctx context.Context, opts *PullOptions) error {
 	if opts == nil {
 		opts = &PullOptions{}
 	}
 	branch := opts.Branch
 	if branch == "" {
 		var err error
-		if branch, err = w.CurrentBranch(); err != nil {
+		if branch, err = w.CurrentBranch(ctx); err != nil {
 			return err
 		}
 	}
-	if err := w.Fetch(&FetchOptions{Branch: branch}); err != nil {
+	if err := w.Fetch(ctx, &FetchOptions{Branch: branch}); err != nil {
 		return fmt.Errorf("error fetching branch %q: %w", branch, err)
 	}
 	if opts.Force {
 		cmd := w.buildGitCommand(
-			"reset", "--hard", fmt.Sprintf("origin/%s", branch),
+			ctx, "reset", "--hard", fmt.Sprintf("origin/%s", branch),
 		)
 		if _, err := libExec.Exec(cmd); err != nil {
 			return fmt.Errorf(
@@ -728,7 +775,7 @@ func (w *workTree) Pull(opts *PullOptions) error {
 		}
 		return nil
 	}
-	cmd := w.buildGitCommand("merge", fmt.Sprintf("origin/%s", branch))
+	cmd := w.buildGitCommand(ctx, "merge", fmt.Sprintf("origin/%s", branch))
 	if _, err := libExec.Exec(cmd); err != nil {
 		return fmt.Errorf(
 			"error merging origin/%s: %w", branch, err,
@@ -763,7 +810,7 @@ type PushOptions struct {
 // nolint: lll
 var nonFastForwardRegex = regexp.MustCompile(`(?m)^\s*!\s+\[(?:remote )?rejected].+\((?:non-fast-forward|fetch first|cannot lock ref.*|incorrect old value provided)\)\s*$`)
 
-func (w *workTree) Push(opts *PushOptions) error {
+func (w *workTree) Push(ctx context.Context, opts *PushOptions) error {
 	if opts == nil {
 		opts = &PushOptions{}
 	}
@@ -774,7 +821,7 @@ func (w *workTree) Push(opts *PushOptions) error {
 	args := []string{"push", "origin"}
 	if opts.Tag != "" {
 		args = append(args, "tag", opts.Tag)
-		if _, err := libExec.Exec(w.buildGitCommand(args...)); err != nil {
+		if _, err := libExec.Exec(w.buildGitCommand(ctx, args...)); err != nil {
 			return fmt.Errorf("error pushing tag: %w", err)
 		}
 		return nil
@@ -783,13 +830,13 @@ func (w *workTree) Push(opts *PushOptions) error {
 	targetBranch := opts.TargetBranch
 	if targetBranch == "" {
 		var err error
-		if targetBranch, err = w.CurrentBranch(); err != nil {
+		if targetBranch, err = w.CurrentBranch(ctx); err != nil {
 			return err
 		}
 	}
 
 	args = append(args, fmt.Sprintf("HEAD:%s", targetBranch))
-	if err := w.IntegrateRemoteChanges(&IntegrationOptions{
+	if err := w.IntegrateRemoteChanges(ctx, &IntegrationOptions{
 		TargetBranch:      targetBranch,
 		IntegrationPolicy: opts.IntegrationPolicy,
 	}); err != nil {
@@ -800,7 +847,7 @@ func (w *workTree) Push(opts *PushOptions) error {
 		args = append(args, "--force")
 	}
 
-	if res, err := libExec.Exec(w.buildGitCommand(args...)); err != nil {
+	if res, err := libExec.Exec(w.buildGitCommand(ctx, args...)); err != nil {
 		if nonFastForwardRegex.MatchString(string(res)) {
 			return fmt.Errorf("error pushing branch: %w", ErrNonFastForward)
 		}
@@ -809,10 +856,15 @@ func (w *workTree) Push(opts *PushOptions) error {
 	return nil
 }
 
-func (w *workTree) RefsHaveDiffs(commit1 string, commit2 string) (bool, error) {
+func (w *workTree) RefsHaveDiffs(
+	ctx context.Context,
+	commit1 string,
+	commit2 string,
+) (bool, error) {
 	// `git diff --quiet` returns 0 if no diff, 1 if diff, and non-zero/one for any other error
 	_, err := libExec.Exec(w.buildGitCommand(
-		"diff", "--quiet", fmt.Sprintf("%s..%s", commit1, commit2), "--"))
+		ctx, "diff", "--quiet", fmt.Sprintf("%s..%s", commit1, commit2), "--",
+	))
 	if err == nil {
 		return false, nil
 	}
@@ -825,15 +877,19 @@ func (w *workTree) RefsHaveDiffs(commit1 string, commit2 string) (bool, error) {
 	return false, fmt.Errorf("error diffing commits %s..%s: %w", commit1, commit2, err)
 }
 
-func (w *workTree) ResetHard() error {
-	if _, err := libExec.Exec(w.buildGitCommand("reset", "--hard")); err != nil {
+func (w *workTree) ResetHard(ctx context.Context) error {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "reset", "--hard",
+	)); err != nil {
 		return fmt.Errorf("error resetting branch working tree: %w", err)
 	}
 	return nil
 }
 
-func (w *workTree) UpdateSubmodules() error {
-	if _, err := libExec.Exec(w.buildGitCommand("submodule", "update", "--init", "--recursive")); err != nil {
+func (w *workTree) UpdateSubmodules(ctx context.Context) error {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "submodule", "update", "--init", "--recursive",
+	)); err != nil {
 		return fmt.Errorf("error updating submodules: %w", err)
 	}
 	return nil
@@ -862,21 +918,24 @@ func validateSparsePatterns(patterns []string) error {
 
 // configureSparseCheckout configures sparse checkout in cone mode for the
 // working tree with the specified directory patterns.
-func (w *workTree) configureSparseCheckout(patterns []string) error {
+func (w *workTree) configureSparseCheckout(
+	ctx context.Context,
+	patterns []string,
+) error {
 	if err := validateSparsePatterns(patterns); err != nil {
 		return err
 	}
 
 	// Initialize sparse checkout in cone mode (fast, directory-based)
-	if _, err := libExec.Exec(
-		w.buildGitCommand("sparse-checkout", "init", "--cone"),
-	); err != nil {
+	if _, err := libExec.Exec(w.buildGitCommand(
+		ctx, "sparse-checkout", "init", "--cone",
+	)); err != nil {
 		return fmt.Errorf("error initializing sparse checkout: %w", err)
 	}
 
 	// Set the sparse checkout patterns
 	setArgs := append([]string{"sparse-checkout", "set"}, patterns...)
-	if _, err := libExec.Exec(w.buildGitCommand(setArgs...)); err != nil {
+	if _, err := libExec.Exec(w.buildGitCommand(ctx, setArgs...)); err != nil {
 		return fmt.Errorf("error setting sparse checkout patterns %v: %w", patterns, err)
 	}
 	return nil

--- a/pkg/controller/git/work_tree_test.go
+++ b/pkg/controller/git/work_tree_test.go
@@ -32,6 +32,7 @@ func TestWorkTree(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := CloneBare(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{
 			Credentials: &testRepoCreds,
@@ -40,18 +41,20 @@ func TestWorkTree(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	workingTreePath := filepath.Join(rep.HomeDir(), "working-tree")
 	workTree, err := rep.AddWorkTree(
+		t.Context(),
 		workingTreePath,
 		&AddWorkTreeOptions{Ref: "main"},
 	)
 	require.NoError(t, err)
-	defer workTree.Close()
+	defer workTree.Close(t.Context())
 
 	t.Run("can load an existing working tree", func(t *testing.T) {
 		existingWorkTree, err := LoadWorkTree(
+			t.Context(),
 			workTree.Dir(),
 			&LoadWorkTreeOptions{
 				Credentials: &testRepoCreds,
@@ -62,7 +65,7 @@ func TestWorkTree(t *testing.T) {
 	})
 
 	t.Run("can close working tree", func(t *testing.T) {
-		require.NoError(t, workTree.Close())
+		require.NoError(t, workTree.Close(t.Context()))
 		_, err := os.Stat(workTree.Dir())
 		require.Error(t, err)
 		require.True(t, os.IsNotExist(err))
@@ -78,12 +81,13 @@ func Test_workTree_Pull(t *testing.T) {
 
 	t.Run("force pull resets to remote", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Make a local commit that diverges from "ahead".
 		err = os.WriteFile(
@@ -92,17 +96,17 @@ func Test_workTree_Pull(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local divergent commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local divergent commit", nil)
 		require.NoError(t, err)
 
-		localCommit, err := repo.LastCommitID()
+		localCommit, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 
 		// Force pull from "ahead" should reset to the remote state.
-		err = repo.Pull(&PullOptions{Branch: "ahead", Force: true})
+		err = repo.Pull(t.Context(), &PullOptions{Branch: "ahead", Force: true})
 		require.NoError(t, err)
 
-		newCommit, err := repo.LastCommitID()
+		newCommit, err := repo.LastCommitID(t.Context())
 		require.NoError(t, err)
 		require.NotEqual(t, localCommit, newCommit)
 
@@ -121,12 +125,13 @@ func Test_workTree_Pull(t *testing.T) {
 
 	t.Run("non-force pull merges remote", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Make a local commit on a different file to avoid conflicts.
 		err = os.WriteFile(
@@ -135,11 +140,11 @@ func Test_workTree_Pull(t *testing.T) {
 			0o600,
 		)
 		require.NoError(t, err)
-		err = repo.AddAllAndCommit("local non-conflicting commit", nil)
+		err = repo.AddAllAndCommit(t.Context(), "local non-conflicting commit", nil)
 		require.NoError(t, err)
 
 		// Non-force pull from "ahead" should merge.
-		err = repo.Pull(&PullOptions{Branch: "ahead"})
+		err = repo.Pull(t.Context(), &PullOptions{Branch: "ahead"})
 		require.NoError(t, err)
 
 		// Both files should be present after merge.
@@ -153,22 +158,23 @@ func Test_workTree_Pull(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have a merge commit.
-		msg, err := repo.CommitMessage("HEAD")
+		msg, err := repo.CommitMessage(t.Context(), "HEAD")
 		require.NoError(t, err)
 		require.Contains(t, msg, "Merge")
 	})
 
 	t.Run("nil opts defaults to current branch", func(t *testing.T) {
 		repo, err := Clone(
+			t.Context(),
 			testRepoURL,
 			&ClientOptions{Credentials: &testRepoCreds},
 			nil,
 		)
 		require.NoError(t, err)
-		defer repo.Close()
+		defer repo.Close(t.Context())
 
 		// Pull with nil opts should not error (fetches current branch).
-		err = repo.Pull(nil)
+		err = repo.Pull(t.Context(), nil)
 		require.NoError(t, err)
 	})
 }
@@ -237,13 +243,14 @@ func TestListCommits(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := Clone(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{Credentials: &testRepoCreds},
 		nil,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	wt := internalWorkTree(t, rep)
 
@@ -256,10 +263,13 @@ func TestListCommits(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("main: initial commit", nil))
+	require.NoError(
+		t,
+		rep.AddAllAndCommit(t.Context(), "main: initial commit", nil),
+	)
 
 	// Create a feature branch from the initial commit
-	require.NoError(t, rep.CreateChildBranch("feature"))
+	require.NoError(t, rep.CreateChildBranch(t.Context(), "feature"))
 	require.NoError(
 		t,
 		os.WriteFile(
@@ -268,7 +278,7 @@ func TestListCommits(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("feature: work 1", nil))
+	require.NoError(t, rep.AddAllAndCommit(t.Context(), "feature: work 1", nil))
 	require.NoError(
 		t,
 		os.WriteFile(
@@ -277,10 +287,10 @@ func TestListCommits(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("feature: work 2", nil))
+	require.NoError(t, rep.AddAllAndCommit(t.Context(), "feature: work 2", nil))
 
 	// Back to main, add another commit
-	require.NoError(t, rep.Checkout("main"))
+	require.NoError(t, rep.Checkout(t.Context(), "main"))
 	require.NoError(
 		t,
 		os.WriteFile(
@@ -289,17 +299,20 @@ func TestListCommits(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("main: second commit", nil))
+	require.NoError(
+		t,
+		rep.AddAllAndCommit(t.Context(), "main: second commit", nil),
+	)
 
 	// Merge the feature branch into main
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"merge", "feature", "--no-ff", "-m", "main: merge feature",
+		t.Context(), "merge", "feature", "--no-ff", "-m", "main: merge feature",
 	))
 	require.NoError(t, err)
 
 	// ListCommits should only return first-parent commits (main line),
 	// not the individual feature branch commits.
-	commits, err := rep.ListCommits(nil)
+	commits, err := rep.ListCommits(t.Context(), nil)
 	require.NoError(t, err)
 
 	subjects := make([]string, len(commits))
@@ -322,13 +335,14 @@ func TestGetDiffPathsForMergeCommit(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := Clone(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{Credentials: &testRepoCreds},
 		nil,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	wt := internalWorkTree(t, rep)
 
@@ -350,10 +364,10 @@ func TestGetDiffPathsForMergeCommit(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("initial commit", nil))
+	require.NoError(t, rep.AddAllAndCommit(t.Context(), "initial commit", nil))
 
 	// Create branch-a and modify file1
-	require.NoError(t, rep.CreateChildBranch("branch-a"))
+	require.NoError(t, rep.CreateChildBranch(t.Context(), "branch-a"))
 	require.NoError(
 		t,
 		os.WriteFile(
@@ -362,11 +376,14 @@ func TestGetDiffPathsForMergeCommit(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("branch-a: modify file1", nil))
+	require.NoError(
+		t,
+		rep.AddAllAndCommit(t.Context(), "branch-a: modify file1", nil),
+	)
 
 	// Back to main, create branch-b, modify file2
-	require.NoError(t, rep.Checkout("main"))
-	require.NoError(t, rep.CreateChildBranch("branch-b"))
+	require.NoError(t, rep.Checkout(t.Context(), "main"))
+	require.NoError(t, rep.CreateChildBranch(t.Context(), "branch-b"))
 	require.NoError(
 		t,
 		os.WriteFile(
@@ -375,28 +392,31 @@ func TestGetDiffPathsForMergeCommit(t *testing.T) {
 			0o600,
 		),
 	)
-	require.NoError(t, rep.AddAllAndCommit("branch-b: modify file2", nil))
+	require.NoError(
+		t,
+		rep.AddAllAndCommit(t.Context(), "branch-b: modify file2", nil),
+	)
 
 	// Merge branch-b into main
-	require.NoError(t, rep.Checkout("main"))
+	require.NoError(t, rep.Checkout(t.Context(), "main"))
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"merge", "branch-b", "--no-ff", "-m", "merge branch-b",
+		t.Context(), "merge", "branch-b", "--no-ff", "-m", "merge branch-b",
 	))
 	require.NoError(t, err)
 
 	// Merge branch-a into main
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"merge", "branch-a", "--no-ff", "-m", "merge branch-a",
+		t.Context(), "merge", "branch-a", "--no-ff", "-m", "merge branch-a",
 	))
 	require.NoError(t, err)
 
-	mergeCommitID, err := rep.LastCommitID()
+	mergeCommitID, err := rep.LastCommitID(t.Context())
 	require.NoError(t, err)
 
 	// GetDiffPathsForCommitID on the merge commit should return only
 	// the file introduced by that merge (file1, from branch-a), not
 	// file2 which was already on main via the earlier merge of branch-b.
-	paths, err := rep.GetDiffPathsForCommitID(mergeCommitID)
+	paths, err := rep.GetDiffPathsForCommitID(t.Context(), mergeCommitID)
 	require.NoError(t, err)
 	require.Equal(t, []string{"foo/file1.txt"}, paths)
 }
@@ -406,13 +426,14 @@ func TestGetDiffPathsForMovedFile(t *testing.T) {
 	defer testServer.Close()
 
 	rep, err := Clone(
+		t.Context(),
 		testRepoURL,
 		&ClientOptions{Credentials: &testRepoCreds},
 		nil,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
-	defer rep.Close()
+	defer rep.Close(t.Context())
 
 	wt := internalWorkTree(t, rep)
 
@@ -423,22 +444,25 @@ func TestGetDiffPathsForMovedFile(t *testing.T) {
 		[]byte("kind: Pod"),
 		0o600,
 	))
-	require.NoError(t, rep.AddAllAndCommit("initial commit", nil))
+	require.NoError(t, rep.AddAllAndCommit(t.Context(), "initial commit", nil))
 
 	// Move the file to a different directory
 	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/different-app", rep.Dir()), 0o755))
 	_, err = libExec.Exec(wt.buildGitCommand(
-		"mv", "app/pod.yaml", "different-app/pod.yaml",
+		t.Context(), "mv", "app/pod.yaml", "different-app/pod.yaml",
 	))
 	require.NoError(t, err)
-	require.NoError(t, rep.AddAllAndCommit("move pod.yaml to different-app/", nil))
+	require.NoError(
+		t,
+		rep.AddAllAndCommit(t.Context(), "move pod.yaml to different-app/", nil),
+	)
 
-	moveCommitID, err := rep.LastCommitID()
+	moveCommitID, err := rep.LastCommitID(t.Context())
 	require.NoError(t, err)
 
 	// GetDiffPathsForCommitID should return both the old and new paths so
 	// that a warehouse watching app/ detects the removal.
-	paths, err := rep.GetDiffPathsForCommitID(moveCommitID)
+	paths, err := rep.GetDiffPathsForCommitID(t.Context(), moveCommitID)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"app/pod.yaml", "different-app/pod.yaml"}, paths)
 }

--- a/pkg/controller/warehouses/warehouses.go
+++ b/pkg/controller/warehouses/warehouses.go
@@ -595,6 +595,13 @@ func (r *reconciler) discoverArtifacts(
 			}
 			gitIdx++
 		}
+		// TODO(krancour): Discovery relies on stall detection in the underlying
+		// implementations (git's low-speed abort; ResponseHeaderTimeout on
+		// registry/repository HTTP transports) to keep a dead connection from
+		// hanging a reconcile indefinitely. Those measures bound "no progress," not
+		// total duration, so a healthy-but-slow transfer is never cut off. If they
+		// should ever prove insufficient, setting a per-subscription deadline from
+		// ctx here is the natural next step.
 		res, err := subscriber.DiscoverArtifacts(ctx, project, sub, lastResult)
 		if err != nil {
 			return nil, fmt.Errorf("error discovering artifacts: %w", err)

--- a/pkg/gitprovider/testing/helpers.go
+++ b/pkg/gitprovider/testing/helpers.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -153,6 +154,7 @@ func RunPRTests(
 func ensureMainBranch(t *testing.T, cfg RepoConfig) {
 	t.Helper()
 	if _, err := git.Clone(
+		t.Context(),
 		cfg.RepoURL,
 		cfg.clientOpts(),
 		&git.CloneOptions{Branch: "main", SingleBranch: true},
@@ -193,21 +195,22 @@ func cloneAndPush(
 ) git.Repo {
 	t.Helper()
 	repo, err := git.Clone(
+		t.Context(),
 		cfg.RepoURL,
 		cfg.clientOpts(),
 		&git.CloneOptions{Branch: "main", SingleBranch: true},
 	)
 	require.NoError(t, err)
-	require.NoError(t, repo.CreateChildBranch(branchName))
+	require.NoError(t, repo.CreateChildBranch(t.Context(), branchName))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo.Dir(), fmt.Sprintf("test-%s.txt", branchName)),
 		[]byte(fmt.Sprintf("test content %d", time.Now().UnixNano())),
 		0600,
 	))
 	require.NoError(t, repo.AddAllAndCommit(
-		fmt.Sprintf("test commit for %s", branchName), nil,
+		t.Context(), fmt.Sprintf("test commit for %s", branchName), nil,
 	))
-	require.NoError(t, repo.Push(nil))
+	require.NoError(t, repo.Push(t.Context(), nil))
 	return repo
 }
 
@@ -216,6 +219,7 @@ func cloneAndPush(
 func cloneMain(t *testing.T, cfg RepoConfig) git.Repo {
 	t.Helper()
 	repo, err := git.Clone(
+		t.Context(),
 		cfg.RepoURL,
 		cfg.clientOpts(),
 		&git.CloneOptions{Branch: "main", SingleBranch: true},
@@ -233,8 +237,8 @@ func commitFileAndPush(
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo.Dir(), name), []byte(content), 0600,
 	))
-	require.NoError(t, repo.AddAllAndCommit(message, nil))
-	require.NoError(t, repo.Push(nil))
+	require.NoError(t, repo.AddAllAndCommit(t.Context(), message, nil))
+	require.NoError(t, repo.Push(t.Context(), nil))
 }
 
 // openPR opens a pull request from headBranch into main and returns its number.
@@ -277,7 +281,7 @@ func deleteBranchAndClose(cfg RepoConfig, repo git.Repo, branchName string) {
 		"GIT_TERMINAL_PROMPT=0",
 	)
 	_ = cmd.Run()
-	repo.Close() // nolint: errcheck
+	repo.Close(context.Background()) // nolint: errcheck
 }
 
 // SetupCleanPR creates a PR with a single non-conflicting commit. It returns the
@@ -307,7 +311,7 @@ func SetupConflictingPR(
 
 	// Feature branch adds the file with one content.
 	featureRepo := cloneMain(t, cfg)
-	require.NoError(t, featureRepo.CreateChildBranch(branchName))
+	require.NoError(t, featureRepo.CreateChildBranch(t.Context(), branchName))
 	commitFileAndPush(
 		t, featureRepo, conflictFile, "feature content\n", "feature change",
 	)
@@ -315,7 +319,7 @@ func SetupConflictingPR(
 	// main adds the same file with different content, diverging from the feature
 	// branch.
 	mainRepo := cloneMain(t, cfg)
-	defer mainRepo.Close() // nolint: errcheck
+	defer mainRepo.Close(t.Context()) // nolint: errcheck
 	commitFileAndPush(
 		t, mainRepo, conflictFile, "main content\n", "conflicting main change",
 	)

--- a/pkg/helm/chart/http_selector.go
+++ b/pkg/helm/chart/http_selector.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-cleanhttp"
@@ -15,6 +16,13 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/helm"
 )
+
+// responseHeaderTimeout bounds how long a request to a chart repository may
+// wait for response headers after the request is fully written. Repositories
+// answer in milliseconds; prolonged header silence means the connection is
+// effectively dead. This bounds only time-to-first-header per request and
+// imposes no limit on the total duration of a response transfer.
+const responseHeaderTimeout = 30 * time.Second
 
 // httpSelector is an implementation of Selector that interacts with classic
 // (http/s-based) Helm chart repositories.
@@ -45,8 +53,8 @@ func newHTTPSelector(
 }
 
 // Select implements Selector.
-func (h *httpSelector) Select(context.Context) ([]string, error) {
-	req, err := http.NewRequest(http.MethodGet, h.indexURL, nil)
+func (h *httpSelector) Select(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.indexURL, nil)
 	if err != nil {
 		return nil,
 			fmt.Errorf("error preparing HTTP/S request to %q: %w", h.indexURL, err)
@@ -54,14 +62,14 @@ func (h *httpSelector) Select(context.Context) ([]string, error) {
 	if h.creds != nil {
 		req.SetBasicAuth(h.creds.Username, h.creds.Password)
 	}
-	httpClient := http.DefaultClient
+	httpTransport := cleanhttp.DefaultTransport()
+	httpTransport.ResponseHeaderTimeout = responseHeaderTimeout
 	if h.insecureSkipTLSVerify {
-		httpTransport := cleanhttp.DefaultTransport()
 		httpTransport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true, // #nosec G402 -- explicitly allowed by insecureSkipTLSVerify
 		}
-		httpClient = &http.Client{Transport: httpTransport}
 	}
+	httpClient := &http.Client{Transport: httpTransport}
 	res, err := httpClient.Do(req) // #nosec G704 -- SSRF mitigated: no method/header control, no response access
 	if err != nil {
 		return nil,

--- a/pkg/helm/chart/http_selector_test.go
+++ b/pkg/helm/chart/http_selector_test.go
@@ -1,6 +1,7 @@
 package chart
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -204,4 +205,29 @@ func Test_httpSelector_Select(t *testing.T) {
 			testCase.assertions(t, versions, err)
 		})
 	}
+}
+
+func Test_httpSelector_Select_honorsContext(t *testing.T) {
+	// A server that never responds within the test's lifetime.
+	blocked := make(chan struct{})
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			<-blocked
+		}),
+	)
+	t.Cleanup(func() {
+		close(blocked)
+		testServer.Close()
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	s := &httpSelector{
+		baseSelector: &baseSelector{repoURL: testServer.URL},
+		indexURL:     fmt.Sprintf("%s/index.yaml", testServer.URL),
+		chartName:    "fake-chart",
+	}
+	_, err := s.Select(ctx)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/helm/registry.go
+++ b/pkg/helm/registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"helm.sh/helm/v3/pkg/registry"
@@ -16,6 +17,13 @@ import (
 
 	"github.com/akuity/kargo/pkg/x/version"
 )
+
+// responseHeaderTimeout bounds how long a request to a registry may wait for
+// response headers after the request is fully written. Registries answer in
+// milliseconds; prolonged header silence means the connection is effectively
+// dead. This bounds only time-to-first-header per request and imposes no
+// limit on the total duration of a response transfer.
+const responseHeaderTimeout = 30 * time.Second
 
 // NewRegistryClient creates a new registry client using the provided authorizer.
 // This can be combined with an EphemeralAuthorizer to create a client that
@@ -105,6 +113,7 @@ func (a *EphemeralAuthorizer) Login(ctx context.Context, host, username, passwor
 // When insecure is true, TLS certificate verification is skipped.
 func newRegistryTransport(insecure bool) *http.Transport {
 	transport := cleanhttp.DefaultTransport()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
 	if insecure {
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true, // #nosec G402 -- explicitly allowed by insecureSkipTLSVerify

--- a/pkg/image/repository_client.go
+++ b/pkg/image/repository_client.go
@@ -39,6 +39,13 @@ const (
 	// legacyBuildDateAnnotation is the legacy Label Schema annotation for build date.
 	// See: http://label-schema.org/rc1/
 	legacyBuildDateAnnotation = "org.label-schema.build-date"
+
+	// responseHeaderTimeout bounds how long a request to a registry may wait for
+	// response headers after the request is fully written. Registries answer in
+	// milliseconds; prolonged header silence means the connection is effectively
+	// dead. This bounds only time-to-first-header per request and imposes no
+	// limit on the total duration of a response transfer.
+	responseHeaderTimeout = 30 * time.Second
 )
 
 var metaSem = semaphore.NewWeighted(maxMetadataConcurrency)
@@ -100,6 +107,7 @@ func newRepositoryClient(
 	reg := getRegistry(repoRef.Context().RegistryStr())
 
 	httpTransport := cleanhttp.DefaultTransport()
+	httpTransport.ResponseHeaderTimeout = responseHeaderTimeout
 	if insecureSkipTLSVerify {
 		httpTransport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: insecureSkipTLSVerify, // nolint: gosec

--- a/pkg/promotion/runner/builtin/git_cloner.go
+++ b/pkg/promotion/runner/builtin/git_cloner.go
@@ -140,6 +140,7 @@ func (g *gitCloner) run(
 	}
 
 	repo, err := git.CloneBare(
+		ctx,
 		cfg.RepoURL,
 		&git.ClientOptions{
 			User:                  &repoUser,
@@ -161,7 +162,7 @@ func (g *gitCloner) run(
 		switch {
 		case checkout.Branch != "":
 			ref = checkout.Branch
-			if err = ensureRemoteBranch(repo, ref, checkout.Create); err != nil {
+			if err = ensureRemoteBranch(ctx, repo, ref, checkout.Create); err != nil {
 				return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 					fmt.Errorf("error ensuring existence of remote branch %s: %w", ref, err)
 			}
@@ -178,6 +179,7 @@ func (g *gitCloner) run(
 			)
 		}
 		worktree, err := repo.AddWorkTree(
+			ctx,
 			path,
 			&git.AddWorkTreeOptions{
 				Ref:    ref,
@@ -192,7 +194,7 @@ func (g *gitCloner) run(
 				)
 		}
 		if cfg.RecurseSubmodules {
-			if err = worktree.UpdateSubmodules(); err != nil {
+			if err = worktree.UpdateSubmodules(ctx); err != nil {
 				return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 					fmt.Errorf("error updating submodules for worktree at %s: %w", path, err)
 			}
@@ -201,7 +203,7 @@ func (g *gitCloner) run(
 		if checkout.As != "" {
 			key = checkout.As
 		}
-		if commits[key], err = worktree.LastCommitID(); err != nil {
+		if commits[key], err = worktree.LastCommitID(ctx); err != nil {
 			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 				fmt.Errorf("error resolving HEAD for worktree at %s: %w", path, err)
 		}
@@ -220,8 +222,13 @@ func (g *gitCloner) run(
 // exist and create == true, an empty orphaned branch is created and pushed to
 // the remote. If the branch does not exist and create == false, an error is
 // returned.
-func ensureRemoteBranch(repo git.BareRepo, branch string, create bool) error {
-	exists, err := repo.RemoteBranchExists(branch)
+func ensureRemoteBranch(
+	ctx context.Context,
+	repo git.BareRepo,
+	branch string,
+	create bool,
+) error {
+	exists, err := repo.RemoteBranchExists(ctx, branch)
 	if err != nil {
 		return fmt.Errorf(
 			"error checking if remote branch %q of repo %s exists: %w",
@@ -244,24 +251,25 @@ func ensureRemoteBranch(repo git.BareRepo, branch string, create bool) error {
 	if err != nil {
 		return fmt.Errorf("error creating temporary directory: %w", err)
 	}
-	workTree, err := repo.AddWorkTree(tmpDir, &git.AddWorkTreeOptions{Orphan: true})
+	workTree, err := repo.AddWorkTree(ctx, tmpDir, &git.AddWorkTreeOptions{Orphan: true})
 	if err != nil {
 		return fmt.Errorf(
 			"error adding temporary working tree for branch %q of repo %s: %w",
 			branch, repo.URL(), err,
 		)
 	}
-	defer workTree.Close()
+	defer workTree.Close(ctx)
 	// `git worktree add --orphan some/path` (i.e. the preceding
 	// repo.AddWorkTree() call) creates a new orphaned branch named "path". We
 	// have no control over the branch name. It will always be equal to the last
 	// component of the path. So, we will immediately create _another_ orphaned
 	// branch with the name we really wanted before making an initial commit and
 	// pushing it to the remote.
-	if err = workTree.CreateOrphanedBranch(branch); err != nil {
+	if err = workTree.CreateOrphanedBranch(ctx, branch); err != nil {
 		return err
 	}
 	if err = workTree.Commit(
+		ctx,
 		"Initial commit",
 		&git.CommitOptions{AllowEmpty: true},
 	); err != nil {
@@ -270,7 +278,10 @@ func ensureRemoteBranch(repo git.BareRepo, branch string, create bool) error {
 			branch, repo.URL(), err,
 		)
 	}
-	if err = workTree.Push(&git.PushOptions{TargetBranch: branch}); err != nil {
+	if err = workTree.Push(
+		ctx,
+		&git.PushOptions{TargetBranch: branch},
+	); err != nil {
 		return fmt.Errorf(
 			"error pushing initial commit to new branch %q to repo %s: %w",
 			branch, repo.URL(), err,

--- a/pkg/promotion/runner/builtin/git_cloner_test.go
+++ b/pkg/promotion/runner/builtin/git_cloner_test.go
@@ -323,17 +323,17 @@ func Test_gitCloner_run(t *testing.T) {
 	testRepoURL := fmt.Sprintf("%s/test.git", server.URL)
 
 	// Create some content and push it to the remote repository's default branch
-	repo, err := git.Clone(testRepoURL, nil, nil)
+	repo, err := git.Clone(t.Context(), testRepoURL, nil, nil)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	err = os.WriteFile(filepath.Join(repo.Dir(), "test.txt"), []byte("foo"), 0600)
 	require.NoError(t, err)
-	err = repo.AddAllAndCommit("Initial commit", nil)
+	err = repo.AddAllAndCommit(t.Context(), "Initial commit", nil)
 	require.NoError(t, err)
-	err = repo.Push(nil)
+	err = repo.Push(t.Context(), nil)
 	require.NoError(t, err)
 
-	srcBranchCommitID, err := repo.LastCommitID()
+	srcBranchCommitID, err := repo.LastCommitID(t.Context())
 	require.NoError(t, err)
 
 	// Now we can proceed to test gitCloner...
@@ -382,9 +382,13 @@ func Test_gitCloner_run(t *testing.T) {
 	require.FileExists(t, filepath.Join(stepCtx.WorkDir, "out", ".git"))
 
 	// Assert output map contains the expected commit hashes for each checkout
-	outTree, err := git.LoadWorkTree(filepath.Join(stepCtx.WorkDir, "out"), nil)
+	outTree, err := git.LoadWorkTree(
+		t.Context(),
+		filepath.Join(stepCtx.WorkDir, "out"),
+		nil,
+	)
 	require.NoError(t, err)
-	outBranchCommitID, err := outTree.LastCommitID()
+	outBranchCommitID, err := outTree.LastCommitID(t.Context())
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -410,24 +414,24 @@ func Test_gitCloner_run_with_submodules(t *testing.T) {
 
 	// Create submodule remote repo and push a file
 	subRepoURL := fmt.Sprintf("%s/sub.git", server.URL)
-	subRepo, err := git.Clone(subRepoURL, nil, nil)
+	subRepo, err := git.Clone(t.Context(), subRepoURL, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = subRepo.Close()
+		_ = subRepo.Close(t.Context())
 	})
 	err = os.WriteFile(filepath.Join(subRepo.Dir(), "sub.txt"), []byte("sub"), 0o600)
 	require.NoError(t, err)
-	err = subRepo.AddAllAndCommit("Initial commit sub", nil)
+	err = subRepo.AddAllAndCommit(t.Context(), "Initial commit sub", nil)
 	require.NoError(t, err)
-	err = subRepo.Push(nil)
+	err = subRepo.Push(t.Context(), nil)
 	require.NoError(t, err)
 
 	// Create main repo and add the submodule
 	mainRepoURL := fmt.Sprintf("%s/main.git", server.URL)
-	mainRepo, err := git.Clone(mainRepoURL, nil, nil)
+	mainRepo, err := git.Clone(t.Context(), mainRepoURL, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = mainRepo.Close()
+		_ = mainRepo.Close(t.Context())
 	})
 
 	// Use git submodule add to create proper submodule metadata
@@ -437,12 +441,12 @@ func Test_gitCloner_run_with_submodules(t *testing.T) {
 	require.NoErrorf(t, err, "git submodule add failed: %s", string(out))
 
 	// Commit and push the submodule addition
-	err = mainRepo.AddAllAndCommit("Add submodule", nil)
+	err = mainRepo.AddAllAndCommit(t.Context(), "Add submodule", nil)
 	require.NoError(t, err)
-	err = mainRepo.Push(nil)
+	err = mainRepo.Push(t.Context(), nil)
 	require.NoError(t, err)
 
-	mainCommitID, err := mainRepo.LastCommitID()
+	mainCommitID, err := mainRepo.LastCommitID(t.Context())
 	require.NoError(t, err)
 
 	// Run git-cloner with recurseSubmodules = true

--- a/pkg/promotion/runner/builtin/git_commiter.go
+++ b/pkg/promotion/runner/builtin/git_commiter.go
@@ -62,7 +62,7 @@ func (g *gitCommitter) convert(cfg promotion.Config) (builtin.GitCommitConfig, e
 }
 
 func (g *gitCommitter) run(
-	_ context.Context,
+	ctx context.Context,
 	stepCtx *promotion.StepContext,
 	cfg builtin.GitCommitConfig,
 ) (promotion.StepResult, error) {
@@ -73,16 +73,16 @@ func (g *gitCommitter) run(
 			cfg.Path, stepCtx.WorkDir, err,
 		)
 	}
-	workTree, err := git.LoadWorkTree(path, nil)
+	workTree, err := git.LoadWorkTree(ctx, path, nil)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
-	if err = workTree.AddAll(); err != nil {
+	if err = workTree.AddAll(ctx); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error adding all changes to working tree: %w", err)
 	}
-	hasDiffs, err := workTree.HasDiffs()
+	hasDiffs, err := workTree.HasDiffs(ctx)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error checking for diffs in working tree: %w", err)
@@ -98,13 +98,13 @@ func (g *gitCommitter) run(
 				SigningKey: cfg.Author.SigningKey,
 			}
 		}
-		if err = workTree.Commit(cfg.Message, commitOpts); err != nil {
+		if err = workTree.Commit(ctx, cfg.Message, commitOpts); err != nil {
 			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 				fmt.Errorf("error committing to working tree: %w", err)
 		}
 	}
 
-	commitID, err := workTree.LastCommitID()
+	commitID, err := workTree.LastCommitID(ctx)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)

--- a/pkg/promotion/runner/builtin/git_commiter_test.go
+++ b/pkg/promotion/runner/builtin/git_commiter_test.go
@@ -183,6 +183,7 @@ func Test_gitCommitter_run(t *testing.T) {
 	// gitCloner might have so we can verify gitCommitter's ability to reload the
 	// working tree from the file system.
 	repo, err := git.CloneBare(
+		t.Context(),
 		testRepoURL,
 		nil,
 		&git.BareCloneOptions{
@@ -190,11 +191,12 @@ func Test_gitCommitter_run(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	// "master" is still the default branch name for a new repository
 	// unless you configure it otherwise.
 	workTreePath := filepath.Join(workDir, "master")
 	workTree, err := repo.AddWorkTree(
+		t.Context(),
 		workTreePath,
 		&git.AddWorkTreeOptions{Orphan: true},
 	)
@@ -203,7 +205,7 @@ func Test_gitCommitter_run(t *testing.T) {
 	// create an orphaned working tree, so we have to follow up with this to make
 	// the branch name look like what we wanted. gitCloner does this internally as
 	// well.
-	err = workTree.CreateOrphanedBranch("master")
+	err = workTree.CreateOrphanedBranch(t.Context(), "master")
 	require.NoError(t, err)
 
 	// Write a file. It will be gitCommitter's job to commit it.
@@ -230,12 +232,12 @@ func Test_gitCommitter_run(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
-	expectedCommit, err := workTree.LastCommitID()
+	expectedCommit, err := workTree.LastCommitID(t.Context())
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[stateKeyCommit]
 	require.True(t, ok)
 	require.Equal(t, expectedCommit, actualCommit)
-	lastCommitMsg, err := workTree.CommitMessage("HEAD")
+	lastCommitMsg, err := workTree.CommitMessage(t.Context(), "HEAD")
 	require.NoError(t, err)
 	require.Equal(t, "Initial commit\n", lastCommitMsg)
 

--- a/pkg/promotion/runner/builtin/git_pr_opener.go
+++ b/pkg/promotion/runner/builtin/git_pr_opener.go
@@ -121,6 +121,7 @@ func (g *gitPROpener) run(
 	}
 
 	repo, err := git.Clone(
+		ctx,
 		cfg.RepoURL,
 		&git.ClientOptions{
 			Credentials:           repoCreds,
@@ -135,7 +136,7 @@ func (g *gitPROpener) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error cloning %s: %w", cfg.RepoURL, err)
 	}
-	defer repo.Close()
+	defer repo.Close(ctx)
 
 	gpOpts := &gitprovider.Options{
 		InsecureSkipTLSVerify: cfg.InsecureSkipTLSVerify,
@@ -182,7 +183,7 @@ func (g *gitPROpener) run(
 	// we're free to create a new one.
 
 	// Get the title from the commit message of the head of the source branch
-	commitMsg, err := repo.CommitMessage(sourceBranch)
+	commitMsg, err := repo.CommitMessage(ctx, sourceBranch)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, fmt.Errorf(
 			"error getting commit message from head of branch %s: %w",
@@ -190,7 +191,7 @@ func (g *gitPROpener) run(
 		)
 	}
 
-	exists, err := repo.RemoteBranchExists(cfg.TargetBranch)
+	exists, err := repo.RemoteBranchExists(ctx, cfg.TargetBranch)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, fmt.Errorf(
 			"error checking if remote branch %q of repo %s exists: %w",
@@ -205,6 +206,7 @@ func (g *gitPROpener) run(
 
 	// Ensure we have the latest commits from the remote before checking for diffs.
 	err = repo.Fetch(
+		ctx,
 		&git.FetchOptions{
 			Branch: cfg.TargetBranch,
 			Depth:  1,
@@ -216,7 +218,7 @@ func (g *gitPROpener) run(
 
 	remoteSrc := fmt.Sprintf("origin/%s", sourceBranch)
 	remoteTarget := fmt.Sprintf("origin/%s", cfg.TargetBranch)
-	hasChanges, err := repo.RefsHaveDiffs(remoteSrc, remoteTarget)
+	hasChanges, err := repo.RefsHaveDiffs(ctx, remoteSrc, remoteTarget)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored}, fmt.Errorf(
 			"failed to check for changes between remote branches %s and %s: %w",
@@ -336,11 +338,11 @@ func (g *gitPROpener) getExistingPR(
 	gitProv gitprovider.Interface,
 	targetBranch string,
 ) (*gitprovider.PullRequest, error) {
-	commitID, err := repo.LastCommitID()
+	commitID, err := repo.LastCommitID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting last commit ID: %w", err)
 	}
-	sourceBranch, err := repo.CurrentBranch()
+	sourceBranch, err := repo.CurrentBranch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting current branch: %w", err)
 	}

--- a/pkg/promotion/runner/builtin/git_pr_opener_test.go
+++ b/pkg/promotion/runner/builtin/git_pr_opener_test.go
@@ -166,22 +166,22 @@ func Test_gitPROpener_run(t *testing.T) {
 
 	workDir := t.TempDir()
 
-	repo, err := git.Clone(testRepoURL, nil, nil)
+	repo, err := git.Clone(t.Context(), testRepoURL, nil, nil)
 	require.NoError(t, err)
-	defer repo.Close()
-	err = repo.CreateOrphanedBranch(testSourceBranch)
+	defer repo.Close(t.Context())
+	err = repo.CreateOrphanedBranch(t.Context(), testSourceBranch)
 	require.NoError(t, err)
 
 	// Make a file with the same name as the branch
 	err = os.WriteFile(filepath.Join(repo.Dir(), testSourceBranch), []byte("foo"), 0600)
 	require.NoError(t, err)
 
-	err = repo.AddAll()
+	err = repo.AddAll(t.Context())
 	require.NoError(t, err)
 
-	err = repo.Commit("Initial commit", &git.CommitOptions{AllowEmpty: true})
+	err = repo.Commit(t.Context(), "Initial commit", &git.CommitOptions{AllowEmpty: true})
 	require.NoError(t, err)
-	err = repo.Push(nil)
+	err = repo.Push(t.Context(), nil)
 	require.NoError(t, err)
 
 	// Set up a fake git provider
@@ -248,8 +248,8 @@ func Test_gitPROpener_run(t *testing.T) {
 
 	t.Run("skip when target branch exists but has no changes", func(t *testing.T) {
 		// push the target branch with no changes compared to the source branch
-		require.NoError(t, repo.CreateChildBranch(testTargetBranch))
-		require.NoError(t, repo.Push(nil))
+		require.NoError(t, repo.CreateChildBranch(t.Context(), testTargetBranch))
+		require.NoError(t, repo.Push(t.Context(), nil))
 
 		r := newGitPROpener(promotion.StepRunnerCapabilities{
 			CredsDB: &credentials.FakeDB{},
@@ -277,10 +277,10 @@ func Test_gitPROpener_run(t *testing.T) {
 
 	t.Run("successfully opens PR when target branch exists and has changes", func(t *testing.T) {
 		// ensure there is a change compared to the source branch by pushing a commit to the target branch
-		require.NoError(t, repo.Checkout(testTargetBranch))
+		require.NoError(t, repo.Checkout(t.Context(), testTargetBranch))
 		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/some-file.txt", repo.Dir()), []byte("some changes"), 0600))
-		require.NoError(t, repo.AddAllAndCommit("my commit msg", nil))
-		require.NoError(t, repo.Push(nil))
+		require.NoError(t, repo.AddAllAndCommit(t.Context(), "my commit msg", nil))
+		require.NoError(t, repo.Push(t.Context(), nil))
 
 		r := newGitPROpener(promotion.StepRunnerCapabilities{
 			CredsDB: &credentials.FakeDB{},

--- a/pkg/promotion/runner/builtin/git_pusher.go
+++ b/pkg/promotion/runner/builtin/git_pusher.go
@@ -132,7 +132,7 @@ func (g *gitPushPusher) run(
 		)
 	}
 	loadOpts := &git.LoadWorkTreeOptions{}
-	workTree, err := git.LoadWorkTree(path, loadOpts)
+	workTree, err := git.LoadWorkTree(ctx, path, loadOpts)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
@@ -154,7 +154,7 @@ func (g *gitPushPusher) run(
 			SSHPrivateKey: creds.SSHPrivateKey,
 		}
 	}
-	if workTree, err = git.LoadWorkTree(path, loadOpts); err != nil {
+	if workTree, err = git.LoadWorkTree(ctx, path, loadOpts); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
@@ -196,7 +196,7 @@ func (g *gitPushPusher) run(
 		// If targetBranch is still empty, we want to set it to the current branch
 		// because we will want to return the branch that was pushed to, but we
 		// don't want to mess with the options any further.
-		if pushOpts.TargetBranch, err = workTree.CurrentBranch(); err != nil {
+		if pushOpts.TargetBranch, err = workTree.CurrentBranch(ctx); err != nil {
 			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 				fmt.Errorf("error getting current branch: %w", err)
 		}
@@ -232,7 +232,7 @@ func (g *gitPushPusher) run(
 			// using the GitHub API. This means retries should only ever be necessary
 			// when there are multiple sharded controllers concurrently executing
 			// Promotions that push to the same branch.
-			return g.push(workTree, pushOpts)
+			return g.push(ctx, workTree, pushOpts)
 		},
 	); err != nil {
 		if git.IsMergeConflict(err) {
@@ -251,7 +251,7 @@ func (g *gitPushPusher) run(
 			fmt.Errorf("error pushing commits to remote: %w", err)
 	}
 
-	commitID, err := workTree.LastCommitID()
+	commitID, err := workTree.LastCommitID(ctx)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)
@@ -289,7 +289,11 @@ func (g *gitPushPusher) run(
 // local branch and pushing the branch to the remote using the GitHub API. This
 // helps reduce the likelihood of conflicts when multiple Promotions that push
 // to the same branch are running concurrently.
-func (g *gitPushPusher) push(workTree git.WorkTree, pushOpts *git.PushOptions) error {
+func (g *gitPushPusher) push(
+	ctx context.Context,
+	workTree git.WorkTree,
+	pushOpts *git.PushOptions,
+) error {
 	branchKey := g.getBranchKey(workTree.URL(), pushOpts.TargetBranch)
 	if _, exists := g.branchMus[branchKey]; !exists {
 		g.masterMu.Lock()
@@ -302,7 +306,7 @@ func (g *gitPushPusher) push(workTree git.WorkTree, pushOpts *git.PushOptions) e
 	}
 	g.branchMus[branchKey].Lock()
 	defer g.branchMus[branchKey].Unlock()
-	return workTree.Push(pushOpts)
+	return workTree.Push(ctx, pushOpts)
 }
 
 func (g *gitPushPusher) getBranchKey(repoURL, branch string) string {

--- a/pkg/promotion/runner/builtin/git_pusher_test.go
+++ b/pkg/promotion/runner/builtin/git_pusher_test.go
@@ -191,6 +191,7 @@ func Test_gitPusher_run(t *testing.T) {
 	// gitCloner might have so we can verify gitPusher's ability to reload the
 	// working tree from the file system.
 	repo, err := git.CloneBare(
+		t.Context(),
 		testRepoURL,
 		nil,
 		&git.BareCloneOptions{
@@ -198,11 +199,12 @@ func Test_gitPusher_run(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	// "master" is still the default branch name for a new repository
 	// unless you configure it otherwise.
 	workTreePath := filepath.Join(workDir, "master")
 	workTree, err := repo.AddWorkTree(
+		t.Context(),
 		workTreePath,
 		&git.AddWorkTreeOptions{Orphan: true},
 	)
@@ -211,7 +213,7 @@ func Test_gitPusher_run(t *testing.T) {
 	// create an orphaned working tree, so we have to follow up with this to make
 	// the branch name look like what we wanted. gitCloner does this internally as
 	// well.
-	err = workTree.CreateOrphanedBranch("master")
+	err = workTree.CreateOrphanedBranch(t.Context(), "master")
 	require.NoError(t, err)
 
 	// Write a file.
@@ -220,11 +222,11 @@ func Test_gitPusher_run(t *testing.T) {
 
 	// Commit the changes similarly to how gitCommitter would
 	// have. It will be gitPushStepRunner's job to push this commit.
-	err = workTree.AddAllAndCommit("Initial commit", nil)
+	err = workTree.AddAllAndCommit(t.Context(), "Initial commit", nil)
 	require.NoError(t, err)
 
 	// Tag the commit so we can also test pushing tags later.
-	require.NoError(t, workTree.CreateTag("v1.0.0", "hello", nil))
+	require.NoError(t, workTree.CreateTag(t.Context(), "v1.0.0", "hello", nil))
 
 	// Set up a fake git provider
 	// Cannot register multiple providers with the same name, so this takes
@@ -280,7 +282,7 @@ func Test_gitPusher_run(t *testing.T) {
 		branchName, ok := res.Output[stateKeyBranch]
 		require.True(t, ok)
 		require.Equal(t, "kargo/promotion/fake-promotion", branchName)
-		expectedCommit, err := workTree.LastCommitID()
+		expectedCommit, err := workTree.LastCommitID(t.Context())
 		require.NoError(t, err)
 		actualCommit, ok := res.Output[stateKeyCommit]
 		require.True(t, ok)
@@ -304,8 +306,8 @@ func Test_gitPusher_run(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.NoError(t, workTree.Checkout("v1.0.0"))
-		expectedCommit, err := workTree.LastCommitID()
+		require.NoError(t, workTree.Checkout(t.Context(), "v1.0.0"))
+		expectedCommit, err := workTree.LastCommitID(t.Context())
 		require.NoError(t, err)
 		actualCommit, ok := res.Output[stateKeyCommit]
 		require.True(t, ok)

--- a/pkg/promotion/runner/builtin/git_tagger.go
+++ b/pkg/promotion/runner/builtin/git_tagger.go
@@ -57,7 +57,7 @@ func (g *gitTagTagger) convert(cfg promotion.Config) (builtin.GitTagConfig, erro
 }
 
 func (g *gitTagTagger) run(
-	_ context.Context,
+	ctx context.Context,
 	stepCtx *promotion.StepContext,
 	cfg builtin.GitTagConfig,
 ) (promotion.StepResult, error) {
@@ -68,12 +68,13 @@ func (g *gitTagTagger) run(
 			cfg.Path, stepCtx.WorkDir, err,
 		)
 	}
-	workTree, err := git.LoadWorkTree(path, nil)
+	workTree, err := git.LoadWorkTree(ctx, path, nil)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
 	if err = workTree.CreateTag(
+		ctx,
 		cfg.Tag,
 		cfg.Message,
 		&git.CreateTagOptions{Force: cfg.Force},
@@ -81,7 +82,7 @@ func (g *gitTagTagger) run(
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error creating tag %s: %w", cfg.Tag, err)
 	}
-	commitID, err := workTree.LastCommitID()
+	commitID, err := workTree.LastCommitID(ctx)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)

--- a/pkg/promotion/runner/builtin/git_tagger_test.go
+++ b/pkg/promotion/runner/builtin/git_tagger_test.go
@@ -126,6 +126,7 @@ func Test_gitTagger_run(t *testing.T) {
 	// gitCloner might have so we can verify gitTagger's ability to reload the
 	// working tree from the file system.
 	repo, err := git.CloneBare(
+		t.Context(),
 		testRepoURL,
 		nil,
 		&git.BareCloneOptions{
@@ -133,12 +134,13 @@ func Test_gitTagger_run(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 
 	// "master" is still the default branch name for a new repository
 	// unless you configure it otherwise.
 	workTreePath := filepath.Join(workDir, "master")
 	workTree, err := repo.AddWorkTree(
+		t.Context(),
 		workTreePath,
 		&git.AddWorkTreeOptions{Orphan: true},
 	)
@@ -148,7 +150,7 @@ func Test_gitTagger_run(t *testing.T) {
 	// create an orphaned working tree, so we have to follow up with this to make
 	// the branch name look like what we wanted. gitCloner does this internally as
 	// well.
-	err = workTree.CreateOrphanedBranch("master")
+	err = workTree.CreateOrphanedBranch(t.Context(), "master")
 	require.NoError(t, err)
 
 	// Write a file. It will be gitTagger's job to tag the current commit.
@@ -159,9 +161,9 @@ func Test_gitTagger_run(t *testing.T) {
 	require.NoError(t, err)
 
 	// Commit the file
-	err = workTree.AddAll()
+	err = workTree.AddAll(t.Context())
 	require.NoError(t, err)
-	err = workTree.Commit("Initial commit", nil)
+	err = workTree.Commit(t.Context(), "Initial commit", nil)
 	require.NoError(t, err)
 
 	// Now we can proceed to test gitTagger...
@@ -181,8 +183,8 @@ func Test_gitTagger_run(t *testing.T) {
 	// Verify
 	require.NoError(t, err)
 	require.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
-	require.NoError(t, workTree.Checkout("v1.0.0"))
-	expectedCommit, err := workTree.LastCommitID()
+	require.NoError(t, workTree.Checkout(t.Context(), "v1.0.0"))
+	expectedCommit, err := workTree.LastCommitID(t.Context())
 	require.NoError(t, err)
 	actualCommit, ok := res.Output[stateKeyCommit]
 	require.True(t, ok)
@@ -190,13 +192,13 @@ func Test_gitTagger_run(t *testing.T) {
 
 	// Switch back to the branch and add another commit so the tag would need to
 	// move to a different commit.
-	require.NoError(t, workTree.Checkout("master"))
+	require.NoError(t, workTree.Checkout(t.Context(), "master"))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workTree.Dir(), "test.txt"),
 		[]byte("bar"), 0600,
 	))
-	require.NoError(t, workTree.AddAll())
-	require.NoError(t, workTree.Commit("Second commit", nil))
+	require.NoError(t, workTree.AddAll(t.Context()))
+	require.NoError(t, workTree.Commit(t.Context(), "Second commit", nil))
 
 	// Re-tagging without force should fail because the tag already exists.
 	res, err = runner.run(
@@ -222,8 +224,8 @@ func Test_gitTagger_run(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
-	require.NoError(t, workTree.Checkout("v1.0.0"))
-	expectedCommit, err = workTree.LastCommitID()
+	require.NoError(t, workTree.Checkout(t.Context(), "v1.0.0"))
+	expectedCommit, err = workTree.LastCommitID(t.Context())
 	require.NoError(t, err)
 	actualCommit, ok = res.Output[stateKeyCommit]
 	require.True(t, ok)

--- a/pkg/promotion/runner/builtin/git_tree_clearer.go
+++ b/pkg/promotion/runner/builtin/git_tree_clearer.go
@@ -57,7 +57,7 @@ func (g *gitTreeClearer) convert(cfg promotion.Config) (builtin.GitClearConfig, 
 }
 
 func (g *gitTreeClearer) run(
-	_ context.Context,
+	ctx context.Context,
 	stepCtx *promotion.StepContext,
 	cfg builtin.GitClearConfig,
 ) (promotion.StepResult, error) {
@@ -68,7 +68,7 @@ func (g *gitTreeClearer) run(
 			cfg.Path, stepCtx.WorkDir, err,
 		)
 	}
-	workTree, err := git.LoadWorkTree(p, nil)
+	workTree, err := git.LoadWorkTree(ctx, p, nil)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
@@ -76,11 +76,11 @@ func (g *gitTreeClearer) run(
 	// workTree.Clear() won't remove any files that aren't indexed. This is a bit
 	// of a hack to ensure that we don't have any untracked files in the working
 	// tree so that workTree.Clear() will remove everything.
-	if err = workTree.AddAll(); err != nil {
+	if err = workTree.AddAll(ctx); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error adding all files to working tree at %s: %w", cfg.Path, err)
 	}
-	if err = workTree.Clear(); err != nil {
+	if err = workTree.Clear(ctx); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error clearing working tree at %s: %w", cfg.Path, err)
 	}

--- a/pkg/promotion/runner/builtin/git_tree_clearer_test.go
+++ b/pkg/promotion/runner/builtin/git_tree_clearer_test.go
@@ -64,6 +64,7 @@ func Test_gitTreeOverwriter_run(t *testing.T) {
 	// gitCloner might have so we can verify gitPusher's ability to reload the
 	// working tree from the file system.
 	repo, err := git.CloneBare(
+		t.Context(),
 		testRepoURL,
 		nil,
 		&git.BareCloneOptions{
@@ -72,12 +73,13 @@ func Test_gitTreeOverwriter_run(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = repo.Close()
+		_ = repo.Close(t.Context())
 	})
 	// "master" is still the default branch name for a new repository
 	// unless you configure it otherwise.
 	workTreePath := filepath.Join(workDir, "master")
 	workTree, err := repo.AddWorkTree(
+		t.Context(),
 		workTreePath,
 		&git.AddWorkTreeOptions{Orphan: true},
 	)

--- a/pkg/promotion/runner/builtin/github_push_integration_test.go
+++ b/pkg/promotion/runner/builtin/github_push_integration_test.go
@@ -612,14 +612,16 @@ func TestGitHubPush_Integration(t *testing.T) {
 				User: gitUser,
 			}
 			bareRepo, err := git.CloneBare(
+				t.Context(),
 				repoURL,
 				clientOpts,
 				&git.BareCloneOptions{BaseDir: workDir},
 			)
 			require.NoError(t, err)
-			defer bareRepo.Close()
+			defer bareRepo.Close(t.Context())
 
 			workTree, err := bareRepo.AddWorkTree(
+				t.Context(),
 				filepath.Join(workDir, "main"),
 				&git.AddWorkTreeOptions{Ref: "main"},
 			)
@@ -652,6 +654,7 @@ func TestGitHubPush_Integration(t *testing.T) {
 			require.NoError(
 				t,
 				workTree.AddAllAndCommit(
+					t.Context(),
 					"commit A by someone else",
 					&git.CommitOptions{
 						Author: &git.User{
@@ -669,7 +672,7 @@ func TestGitHubPush_Integration(t *testing.T) {
 				0o600,
 			))
 			require.NoError(t, workTree.AddAllAndCommit(
-				"commit B by Kargo", nil,
+				t.Context(), "commit B by Kargo", nil,
 			))
 
 			// Set up target branch state if needed.
@@ -807,23 +810,23 @@ func ensureMainBranch(
 	}
 	// If main already exists, nothing to do.
 	if repo, err := git.Clone(
-		repoURL, clientOpts,
+		t.Context(), repoURL, clientOpts,
 		&git.CloneOptions{Branch: "main", SingleBranch: true},
 	); err == nil {
-		repo.Close()
+		repo.Close(t.Context())
 		return
 	}
 	// Create main with an initial commit.
-	repo, err := git.Clone(repoURL, clientOpts, nil)
+	repo, err := git.Clone(t.Context(), repoURL, clientOpts, nil)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo.Dir(), "README.md"),
 		[]byte("# integration test repo\n"),
 		0o600,
 	))
-	require.NoError(t, repo.AddAllAndCommit("initial commit", nil))
-	require.NoError(t, repo.Push(nil))
+	require.NoError(t, repo.AddAllAndCommit(t.Context(), "initial commit", nil))
+	require.NoError(t, repo.Push(t.Context(), nil))
 }
 
 func setupLocalBehindTarget(
@@ -835,14 +838,16 @@ func setupLocalBehindTarget(
 	t.Helper()
 	// Push the local branch (which has test commits A + B) to the target
 	// branch so that the target contains everything the local has.
-	require.NoError(t, workTree.CreateChildBranch(targetBranch))
+	require.NoError(t, workTree.CreateChildBranch(t.Context(), targetBranch))
 	require.NoError(t, workTree.Push(
+		t.Context(),
 		&git.PushOptions{TargetBranch: targetBranch},
 	))
 	// Switch back to main so the work tree is in the expected state.
-	require.NoError(t, workTree.Checkout("main"))
+	require.NoError(t, workTree.Checkout(t.Context(), "main"))
 	// Clone the target branch and add a commit so it's ahead of local.
 	repo, err := git.Clone(
+		t.Context(),
 		workTree.URL(),
 		&git.ClientOptions{
 			Credentials: &git.RepoCredentials{
@@ -854,15 +859,15 @@ func setupLocalBehindTarget(
 		&git.CloneOptions{Branch: targetBranch, SingleBranch: true},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo.Dir(),
 			fmt.Sprintf("remote-%d.txt", time.Now().UnixNano())),
 		[]byte("remote commit"),
 		0o600,
 	))
-	require.NoError(t, repo.AddAllAndCommit("remote commit ahead", nil))
-	require.NoError(t, repo.Push(nil))
+	require.NoError(t, repo.AddAllAndCommit(t.Context(), "remote commit ahead", nil))
+	require.NoError(t, repo.Push(t.Context(), nil))
 }
 
 func setupLocalAheadOfTarget(
@@ -875,6 +880,7 @@ func setupLocalAheadOfTarget(
 	// Clone main from the remote. This gets us a repo at the remote's
 	// current HEAD — before our test commits, which only exist locally.
 	repo, err := git.Clone(
+		t.Context(),
 		workTree.URL(),
 		&git.ClientOptions{
 			Credentials: &git.RepoCredentials{
@@ -886,10 +892,11 @@ func setupLocalAheadOfTarget(
 		&git.CloneOptions{Branch: "main", SingleBranch: true},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	// Create the target branch at this point and push it.
-	require.NoError(t, repo.CreateChildBranch(targetBranch))
+	require.NoError(t, repo.CreateChildBranch(t.Context(), targetBranch))
 	require.NoError(t, repo.Push(
+		t.Context(),
 		&git.PushOptions{TargetBranch: targetBranch},
 	))
 }
@@ -905,6 +912,7 @@ func setupLocalDivergedFromTarget(
 	setupLocalAheadOfTarget(t, workTree, targetBranch, token)
 	// Clone the target branch and add a commit.
 	repo, err := git.Clone(
+		t.Context(),
 		workTree.URL(),
 		&git.ClientOptions{
 			Credentials: &git.RepoCredentials{
@@ -916,15 +924,18 @@ func setupLocalDivergedFromTarget(
 		&git.CloneOptions{Branch: targetBranch, SingleBranch: true},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo.Dir(),
 			fmt.Sprintf("remote-%d.txt", time.Now().UnixNano())),
 		[]byte("remote commit"),
 		0o600,
 	))
-	require.NoError(t, repo.AddAllAndCommit("remote commit ahead", nil))
-	require.NoError(t, repo.Push(nil))
+	require.NoError(
+		t,
+		repo.AddAllAndCommit(t.Context(), "remote commit ahead", nil),
+	)
+	require.NoError(t, repo.Push(t.Context(), nil))
 }
 
 func fetchCommitChain(

--- a/pkg/promotion/runner/builtin/github_pusher.go
+++ b/pkg/promotion/runner/builtin/github_pusher.go
@@ -181,7 +181,7 @@ func (g *githubPusher) run(
 		)
 	}
 	loadOpts := &git.LoadWorkTreeOptions{}
-	workTree, err := git.LoadWorkTree(path, loadOpts)
+	workTree, err := git.LoadWorkTree(ctx, path, loadOpts)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
@@ -228,7 +228,7 @@ func (g *githubPusher) run(
 				"credentials for %s are missing a password/token", workTree.URL(),
 			)}
 	}
-	if workTree, err = git.LoadWorkTree(path, loadOpts); err != nil {
+	if workTree, err = git.LoadWorkTree(ctx, path, loadOpts); err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error loading working tree from %s: %w", cfg.Path, err)
 	}
@@ -274,7 +274,7 @@ func (g *githubPusher) run(
 		// If targetBranch is still empty, we want to set it to the current branch
 		// because we will want to return the branch that was pushed to, but we
 		// don't want to mess with the options any further.
-		if pushCfg.targetBranch, err = workTree.CurrentBranch(); err != nil {
+		if pushCfg.targetBranch, err = workTree.CurrentBranch(ctx); err != nil {
 			return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 				fmt.Errorf("error getting current branch: %w", err)
 		}
@@ -357,7 +357,7 @@ func (g *githubPusher) run(
 
 	// Sync the local branch with the remote after API replay, since the
 	// replayed commits have new SHAs.
-	if err = workTree.Pull(&git.PullOptions{
+	if err = workTree.Pull(ctx, &git.PullOptions{
 		Branch: pushCfg.targetBranch,
 		Force:  true,
 	}); err != nil {
@@ -365,7 +365,7 @@ func (g *githubPusher) run(
 			fmt.Errorf("error syncing local branch after push: %w", err)
 	}
 
-	commitID, err := workTree.LastCommitID()
+	commitID, err := workTree.LastCommitID(ctx)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			fmt.Errorf("error getting last commit ID: %w", err)
@@ -423,6 +423,7 @@ func (g *githubPusher) push(
 	// diverged from it. Start by integrating any remote changes we don't have
 	// locally.
 	if err := workTree.IntegrateRemoteChanges(
+		ctx,
 		&git.IntegrationOptions{
 			TargetBranch:      opts.targetBranch,
 			IntegrationPolicy: opts.integrationPolicy,
@@ -437,7 +438,7 @@ func (g *githubPusher) push(
 
 	// Force push the local branch to a staging ref. This gets all objects onto
 	// GitHub without creating a visible branch.
-	if err := workTree.Push(&git.PushOptions{
+	if err := workTree.Push(ctx, &git.PushOptions{
 		TargetBranch: opts.stagingRef,
 		Force:        true,
 	}); err != nil {
@@ -448,7 +449,7 @@ func (g *githubPusher) push(
 	// to be the same commit, so we can use the ID of the commit at the head of
 	// the local branch as the source commit for the upcoming comparison to the
 	// target branch.
-	sourceHead, err := workTree.LastCommitID()
+	sourceHead, err := workTree.LastCommitID(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting source HEAD: %w", err)
 	}
@@ -459,7 +460,7 @@ func (g *githubPusher) push(
 	)
 
 	// We need to know if the remote target branch exists.
-	targetBranchExists, err := workTree.RemoteBranchExists(opts.targetBranch)
+	targetBranchExists, err := workTree.RemoteBranchExists(ctx, opts.targetBranch)
 	if err != nil {
 		return fmt.Errorf(
 			"error checking if remote branch %s exists: %w",
@@ -476,7 +477,7 @@ func (g *githubPusher) push(
 	baseRefStr := "heads/" + opts.targetBranch
 	if !targetBranchExists {
 		var currentBranch string
-		if currentBranch, err = workTree.CurrentBranch(); err != nil {
+		if currentBranch, err = workTree.CurrentBranch(ctx); err != nil {
 			return fmt.Errorf("error getting current branch name: %w", err)
 		}
 		baseRefStr = "heads/" + currentBranch
@@ -615,7 +616,7 @@ func (g *githubPusher) replayCommits(
 		}
 
 		// Get signature info for trust evaluation.
-		sigInfo, err := workTree.GetCommitSignatureInfo(repoCommit.GetSHA())
+		sigInfo, err := workTree.GetCommitSignatureInfo(ctx, repoCommit.GetSHA())
 		if err != nil {
 			return "", fmt.Errorf(
 				"error getting signature info for commit %s: %w",

--- a/pkg/promotion/runner/builtin/github_pusher_test.go
+++ b/pkg/promotion/runner/builtin/github_pusher_test.go
@@ -127,25 +127,30 @@ func Test_githubPusher_run(t *testing.T) {
 	// Set up a real working tree that LoadWorkTree can load.
 	workDir := t.TempDir()
 	repo, err := git.CloneBare(
+		t.Context(),
 		testRepoURL,
 		nil,
 		&git.BareCloneOptions{BaseDir: workDir},
 	)
 	require.NoError(t, err)
-	defer repo.Close()
+	defer repo.Close(t.Context())
 	workTreePath := filepath.Join(workDir, "main")
 	workTree, err := repo.AddWorkTree(
+		t.Context(),
 		workTreePath,
 		&git.AddWorkTreeOptions{Orphan: true},
 	)
 	require.NoError(t, err)
-	require.NoError(t, workTree.CreateOrphanedBranch("main"))
+	require.NoError(t, workTree.CreateOrphanedBranch(t.Context(), "main"))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workTree.Dir(), "test.txt"),
 		[]byte("foo"),
 		0o600,
 	))
-	require.NoError(t, workTree.AddAllAndCommit("initial commit", nil))
+	require.NoError(
+		t,
+		workTree.AddAllAndCommit(t.Context(), "initial commit", nil),
+	)
 
 	stepCtx := &promotion.StepContext{WorkDir: workDir}
 
@@ -307,7 +312,10 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return errors.New("something went wrong")
 				},
 			},
@@ -322,10 +330,13 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return errors.New("something went wrong")
 				},
 			},
@@ -340,13 +351,16 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "", errors.New("something went wrong")
 				},
 			},
@@ -361,16 +375,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return false, errors.New("something went wrong")
 				},
 			},
@@ -385,19 +402,22 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return false, nil
 				},
-				CurrentBranchFn: func() (string, error) {
+				CurrentBranchFn: func(_ context.Context) (string, error) {
 					return "", errors.New("something went wrong")
 				},
 			},
@@ -412,16 +432,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -446,16 +469,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -490,16 +516,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -533,16 +562,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -589,16 +621,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -642,16 +677,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -686,16 +724,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -729,16 +770,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -778,16 +822,19 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
 			},
@@ -828,19 +875,22 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
-				GetCommitSignatureInfoFn: func(string) (*git.CommitSignatureInfo, error) {
+				GetCommitSignatureInfoFn: func(context.Context, string) (*git.CommitSignatureInfo, error) {
 					return &git.CommitSignatureInfo{}, nil
 				},
 			},
@@ -901,19 +951,25 @@ func Test_githubPusher_push(t *testing.T) {
 				URLFn: func() string {
 					return testRepoURL
 				},
-				IntegrateRemoteChangesFn: func(*git.IntegrationOptions) error {
+				IntegrateRemoteChangesFn: func(
+					context.Context,
+					*git.IntegrationOptions,
+				) error {
 					return nil
 				},
-				PushFn: func(*git.PushOptions) error {
+				PushFn: func(context.Context, *git.PushOptions) error {
 					return nil
 				},
-				LastCommitIDFn: func() (string, error) {
+				LastCommitIDFn: func(_ context.Context) (string, error) {
 					return "fake-source-head", nil
 				},
-				RemoteBranchExistsFn: func(string) (bool, error) {
+				RemoteBranchExistsFn: func(context.Context, string) (bool, error) {
 					return true, nil
 				},
-				GetCommitSignatureInfoFn: func(string) (*git.CommitSignatureInfo, error) {
+				GetCommitSignatureInfoFn: func(
+					context.Context,
+					string,
+				) (*git.CommitSignatureInfo, error) {
 					return &git.CommitSignatureInfo{}, nil
 				},
 			},
@@ -1008,7 +1064,10 @@ func Test_githubPusher_replayCommits(t *testing.T) {
 		{
 			name: "error getting signature info",
 			workTree: &git.MockRepo{
-				GetCommitSignatureInfoFn: func(string) (*git.CommitSignatureInfo, error) {
+				GetCommitSignatureInfoFn: func(
+					context.Context,
+					string,
+				) (*git.CommitSignatureInfo, error) {
 					return nil, errors.New("something went wrong")
 				},
 			},
@@ -1027,7 +1086,10 @@ func Test_githubPusher_replayCommits(t *testing.T) {
 		{
 			name: "error creating commit via API",
 			workTree: &git.MockRepo{
-				GetCommitSignatureInfoFn: func(string) (*git.CommitSignatureInfo, error) {
+				GetCommitSignatureInfoFn: func(
+					context.Context,
+					string,
+				) (*git.CommitSignatureInfo, error) {
 					return &git.CommitSignatureInfo{Trusted: false}, nil
 				},
 			},
@@ -1059,7 +1121,10 @@ func Test_githubPusher_replayCommits(t *testing.T) {
 		{
 			name: "success; SHA map chains parents across commits",
 			workTree: &git.MockRepo{
-				GetCommitSignatureInfoFn: func(string) (*git.CommitSignatureInfo, error) {
+				GetCommitSignatureInfoFn: func(
+					context.Context,
+					string,
+				) (*git.CommitSignatureInfo, error) {
 					return &git.CommitSignatureInfo{Trusted: false}, nil
 				},
 			},


### PR DESCRIPTION
Fixes #6651: a connection that went silent mid-discovery would park a Warehouse's reconcile goroutine until the controller was restarted.

- Git invocations now set `GIT_HTTP_LOW_SPEED_LIMIT/TIME`, aborting any transfer moving no data (test included: clone from a silent server).
- Image and OCI chart registry transports set a 30s `ResponseHeaderTimeout`.
- The classic chart repo selector now honors its context (previously discarded) and gets the same header bound instead of `http.DefaultClient`.

Stall detection was chosen over timeouts because it bounds lack of progress, not total duration: dead connections die in seconds while large, slow, healthy clones are never cut off. A comment in the reconciler marks where a deadline would go if this ever proves insufficient.

The context plumbing through `pkg/controller/git` is not strictly needed for this fix; it's kept as a general improvement (cancellable subprocesses, clean shutdown) that also positions us to add deadlines quickly if ever warranted.

Note to reviewers: Commit 4073dc1a6050c349668bc7072880d55f25ca79b9 is the largest, but also the most mechanical. It is nothing but plumbing of context throughout the various git interfaces and their consumers. The other commits are substantially smaller and more worthy of scrutiny.

Possibly makes it into v1.11.0, but will not block the release. Can be deferred to v1.11.1.