### PR TITLE
fix: prevent response body leak and propagate context to HTTP requests

### DIFF
--- a/pkg/helm/chart/http_selector.go
+++ b/pkg/helm/chart/http_selector.go
@@ -67,6 +67,7 @@ func (h *httpSelector) Select(context.Context) ([]string, error) {
 		return nil,
 			fmt.Errorf("error querying repository index at %q: %w", h.indexURL, err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"received unexpected HTTP %d when querying repository index at %q",
@@ -74,7 +75,6 @@ func (h *httpSelector) Select(context.Context) ([]string, error) {
 			h.indexURL,
 		)
 	}
-	defer res.Body.Close()
 	resBodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil,

--- a/pkg/promotion/runner/builtin/http_requester.go
+++ b/pkg/promotion/runner/builtin/http_requester.go
@@ -92,7 +92,7 @@ func (h *httpRequester) run(
 	_ *promotion.StepContext,
 	cfg builtin.HTTPConfig,
 ) (promotion.StepResult, error) {
-	req, err := h.buildRequest(cfg)
+	req, err := h.buildRequest(ctx, cfg)
 	if err != nil {
 		return promotion.StepResult{Status: kargoapi.PromotionStepStatusErrored},
 			&promotion.TerminalError{Err: fmt.Errorf("error building HTTP request: %w", err)}
@@ -297,12 +297,12 @@ func (h *httpRequester) extractErrorMessageFromResponse(
 	return errorMessage, nil
 }
 
-func (h *httpRequester) buildRequest(cfg builtin.HTTPConfig) (*http.Request, error) {
+func (h *httpRequester) buildRequest(ctx context.Context, cfg builtin.HTTPConfig) (*http.Request, error) {
 	method := cfg.Method
 	if method == "" {
 		method = http.MethodGet
 	}
-	req, err := http.NewRequest(method, cfg.URL, bytes.NewBufferString(cfg.Body))
+	req, err := http.NewRequestWithContext(ctx, method, cfg.URL, bytes.NewBufferString(cfg.Body))
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP request: %w", err)
 	}

--- a/pkg/promotion/runner/builtin/http_requester.go
+++ b/pkg/promotion/runner/builtin/http_requester.go
@@ -297,12 +297,20 @@ func (h *httpRequester) extractErrorMessageFromResponse(
 	return errorMessage, nil
 }
 
-func (h *httpRequester) buildRequest(ctx context.Context, cfg builtin.HTTPConfig) (*http.Request, error) {
+func (h *httpRequester) buildRequest(
+	ctx context.Context,
+	cfg builtin.HTTPConfig,
+) (*http.Request, error) {
 	method := cfg.Method
 	if method == "" {
 		method = http.MethodGet
 	}
-	req, err := http.NewRequestWithContext(ctx, method, cfg.URL, bytes.NewBufferString(cfg.Body))
+	req, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		cfg.URL,
+		bytes.NewBufferString(cfg.Body),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP request: %w", err)
 	}

--- a/pkg/promotion/runner/builtin/http_requester_test.go
+++ b/pkg/promotion/runner/builtin/http_requester_test.go
@@ -746,7 +746,8 @@ func Test_httpRequester_run(t *testing.T) {
 }
 
 func Test_httpRequester_buildRequest(t *testing.T) {
-	req, err := (&httpRequester{}).buildRequest(builtin.HTTPConfig{
+	ctx := t.Context()
+	req, err := (&httpRequester{}).buildRequest(ctx, builtin.HTTPConfig{
 		Method: "GET",
 		URL:    "http://example.com",
 		Headers: []builtin.HTTPConfigHeader{{
@@ -759,6 +760,7 @@ func Test_httpRequester_buildRequest(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
+	require.Equal(t, ctx, req.Context())
 	require.Equal(t, "GET", req.Method)
 	require.Equal(t, "http://example.com?param=some+value", req.URL.String())
 	require.Equal(t, "application/json", req.Header.Get("Content-Type"))


### PR DESCRIPTION
## Summary
- Fix response body leak in `http_selector.go` when non-200 status codes are received
- Propagate context to HTTP requests in `http_requester.go` for proper cancellation support

## Changes
- `pkg/helm/chart/http_selector.go`: Moved `defer res.Body.Close()` before the status code check so the response body is always closed, even on error responses
- `pkg/promotion/runner/builtin/http_requester.go`: Changed `http.NewRequest` to `http.NewRequestWithContext` and threaded the context parameter through `buildRequest`

## Impact
Without this fix, non-200 HTTP responses from Helm chart repositories leak response bodies. Additionally, HTTP promotion steps don't respect context cancellation, which can cause goroutine leaks during shutdown.

## Checklist
- [x] Code follows the project's coding style
- [x] Tests added if applicable