### PR TITLE
fix(ui): show Progressing instead of Failed while Stage health is progressing

### DIFF
--- a/ui/src/features/common/stage-status/stage-condition-icon.tsx
+++ b/ui/src/features/common/stage-status/stage-condition-icon.tsx
@@ -1,6 +1,7 @@
 import {
   faCircle,
   faCircleMinus,
+  faCircleNotch,
   faMagnifyingGlass,
   faTimesCircle,
   faSync,
@@ -11,7 +12,11 @@ import { Tooltip } from 'antd';
 import classNames from 'classnames';
 import { memo, useMemo } from 'react';
 
-import { StageConditionType, StageConditionStatus } from '@ui/features/common/stage-status/utils';
+import {
+  StageConditionType,
+  StageConditionStatus,
+  isTransientNotReadyReason
+} from '@ui/features/common/stage-status/utils';
 import { V1Condition } from '@ui/gen/api/v2/models';
 
 import styles from './styles.module.less';
@@ -19,6 +24,7 @@ import { TruckIcon } from './truck-icon/truck-icon';
 
 interface IconState {
   icon: IconDefinition;
+  iconSpin?: boolean;
   tooltipTitle: string;
   tooltipMessage: string;
   iconClass: string;
@@ -83,7 +89,12 @@ export const StageConditionIcon = memo(
         StageConditionStatus.True
       );
 
-      const isFailed = readyCondition?.status === StageConditionStatus.False;
+      const isNotReady = readyCondition?.status === StageConditionStatus.False;
+
+      // Not Ready for a transient reason (e.g. a rollout still in progress)
+      // is not a failure.
+      const isProgressing = isNotReady && isTransientNotReadyReason(readyCondition?.reason);
+      const isFailed = isNotReady && !isProgressing;
 
       const { condition: verifiedCondition, isActive: isVerifying } = hasCondition(
         StageConditionType.Verified,
@@ -98,7 +109,7 @@ export const StageConditionIcon = memo(
         iconClass: 'text-gray-400'
       };
 
-      // Priority: Promoting > Verifying > Reconciling > Failed > Ready
+      // Priority: Promoting > Verifying > Reconciling > Progressing > Failed > Ready
       if (isPromoting && promotingCondition?.reason !== 'NoFreight') {
         iconState = {
           icon: faCircleMinus,
@@ -119,6 +130,15 @@ export const StageConditionIcon = memo(
           tooltipTitle: 'Reconciling',
           tooltipMessage: reconcilingCondition?.message ?? '',
           iconClass: `text-yellow-500 ${styles.rotate}`
+        };
+      } else if (isProgressing) {
+        iconState = {
+          icon: faCircleNotch,
+          iconSpin: true,
+          tooltipTitle: 'Progressing',
+          tooltipMessage:
+            readyCondition?.message || 'Waiting for the Stage to reach a healthy state',
+          iconClass: 'text-blue-500'
         };
       } else if (isFailed && readyCondition.reason !== 'NoFreight') {
         iconState = {
@@ -158,6 +178,7 @@ export const StageConditionIcon = memo(
     ) : (
       <FontAwesomeIcon
         icon={iconState.icon}
+        spin={iconState.iconSpin}
         className={classNames(className, iconState.iconClass)}
       />
     );

--- a/ui/src/features/common/stage-status/utils.test.ts
+++ b/ui/src/features/common/stage-status/utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Stage, V1Condition } from '@ui/gen/api/v2/models';
+
+import { getStagePhase } from './utils';
+
+const condition = (type: string, status: string, reason: string): V1Condition => ({
+  type,
+  status,
+  reason,
+  message: '',
+  lastTransitionTime: ''
+});
+
+const stage = (conditions: V1Condition[]): Stage => ({ status: { conditions } }) as Stage;
+
+describe('getStagePhase', () => {
+  test('Failed when the controller is dead', () => {
+    expect(getStagePhase(stage([]), true)).toEqual('Failed');
+  });
+
+  test('Promoting when a promotion is in progress', () => {
+    expect(getStagePhase(stage([condition('Promoting', 'True', 'ActivePromotion')]))).toEqual(
+      'Promoting'
+    );
+  });
+
+  test('Verifying when verification is in progress', () => {
+    expect(getStagePhase(stage([condition('Verified', 'Unknown', 'VerificationRunning')]))).toEqual(
+      'Verifying'
+    );
+  });
+
+  test('Reconciling when the controller is retrying after an error', () => {
+    expect(getStagePhase(stage([condition('Reconciling', 'True', 'RetryAfterError')]))).toEqual(
+      'Reconciling'
+    );
+  });
+
+  test('Progressing, not Failed, when not Ready because health is progressing', () => {
+    expect(
+      getStagePhase(
+        stage([
+          condition('Ready', 'False', 'Progressing'),
+          condition('Healthy', 'Unknown', 'Progressing'),
+          condition('Verified', 'True', 'Verified')
+        ])
+      )
+    ).toEqual('Progressing');
+  });
+
+  test('Progressing when waiting for a post-promotion health check', () => {
+    expect(getStagePhase(stage([condition('Ready', 'False', 'WaitingForHealthCheck')]))).toEqual(
+      'Progressing'
+    );
+  });
+
+  test('Failed when not Ready because the Stage is unhealthy', () => {
+    expect(getStagePhase(stage([condition('Ready', 'False', 'Unhealthy')]))).toEqual('Failed');
+  });
+
+  test('Failed when not Ready because the last promotion failed', () => {
+    expect(getStagePhase(stage([condition('Ready', 'False', 'LastPromotionFailed')]))).toEqual(
+      'Failed'
+    );
+  });
+
+  test('Unknown when not Ready due to having no Freight', () => {
+    expect(getStagePhase(stage([condition('Ready', 'False', 'NoFreight')]))).toEqual('Unknown');
+  });
+
+  test('Ready when the Ready condition is True', () => {
+    expect(getStagePhase(stage([condition('Ready', 'True', 'Verified')]))).toEqual('Ready');
+  });
+
+  test('Unknown when there are no conditions', () => {
+    expect(getStagePhase(stage([]))).toEqual('Unknown');
+  });
+});

--- a/ui/src/features/common/stage-status/utils.ts
+++ b/ui/src/features/common/stage-status/utils.ts
@@ -13,6 +13,15 @@ export const enum StageConditionStatus {
   Unknown = 'Unknown'
 }
 
+// Ready=False reasons that describe a transient, self-resolving state (e.g. an
+// Argo CD Application still rolling out after a successful promotion) rather
+// than an actual failure. The controller copies the Healthy condition's reason
+// onto the Ready condition, so these mirror the non-terminal health states.
+const transientNotReadyReasons = ['Progressing', 'WaitingForHealthCheck'];
+
+export const isTransientNotReadyReason = (reason?: string) =>
+  !!reason && transientNotReadyReasons.includes(reason);
+
 export const hasCondition = (
   type: StageConditionType,
   status: StageConditionStatus,
@@ -67,9 +76,13 @@ export const getStagePhase = (stage: Stage, isControllerDead?: boolean) => {
 
   const ready = hasCondition(StageConditionType.Ready, StageConditionStatus.True, conditions);
 
-  const failed = ready.condition?.status === StageConditionStatus.False;
+  const notReady = ready.condition?.status === StageConditionStatus.False;
 
-  if (failed && ready.condition?.reason !== 'NoFreight') {
+  if (notReady && isTransientNotReadyReason(ready.condition?.reason)) {
+    return 'Progressing';
+  }
+
+  if (notReady && ready.condition?.reason !== 'NoFreight') {
     return 'Failed';
   }
 


### PR DESCRIPTION
## Description

A Stage whose `Ready` condition is `False` for a transient reason was presented as **Failed** in the UI, even though nothing had failed (Kargo is just waiting for ArgoCD sync progression).

This is most visible after a successful promotion using the `argocd-update` step: while the Argo CD Application is still rolling out (health `Progressing`):
1. the Stage controller sets `Healthy: Unknown` with reason `Progressing`
2. copies that reason onto `Ready: False`, and
3. the UI renders any non-`NoFreight` `Ready: False` as Failed. 
 
For large Applications with sync measured in hours, this presents a red "Failed" badge on every promotion (and again whenever autoscaling or node churn briefly returns the App to `Progressing`), which reads as a false alarm to anyone babysitting a Freight promotion.

This PR introduces a distinct **Progressing** phase for the transient `Ready: False` reasons (`Progressing`, `WaitingForHealthCheck`), rendered as a spinning blue circle-notch icon -- matching how the adjacent health-status badge already renders the `Progressing` health state. 

Genuine failure reasons (`Unhealthy`, `LastPromotionFailed`, `ReconcileError`, etc.) continue to present as Failed, and the priority order becomes Promoting > Verifying > Reconciling > Progressing > Failed > Ready.

Closes https://github.com/akuity/kargo/issues/4951

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**