### PR TITLE
feat(stages): add pluggable PromotionDispatcher extension point

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -75,23 +75,70 @@ func ReconcilerConfigFromEnv() ReconcilerConfig {
 }
 
 type RegularStageReconciler struct {
-	cfg            ReconcilerConfig
-	client         client.Client
-	eventSender    kargoEvent.Sender
-	healthChecker  health.AggregatingChecker
-	shardPredicate controller.ResponsibleFor[kargoapi.Stage]
+	cfg                 ReconcilerConfig
+	client              client.Client
+	eventSender         kargoEvent.Sender
+	healthChecker       health.AggregatingChecker
+	shardPredicate      controller.ResponsibleFor[kargoapi.Stage]
+	promotionDispatcher PromotionDispatcher
 
 	backoffCfg wait.Backoff
+}
+
+// PromotionDispatcher selects which Promotion, from the set of eligible pending
+// Promotions for a Stage, should become the Stage's current (running)
+// Promotion. It is consulted only when no Promotion is currently Running for the
+// Stage and at least one Pending Promotion has passed the controller's
+// eligibility gates (verification and health). Implementations therefore never
+// need to preserve the invariant that a Running Promotion is not preempted, and
+// may reason about conflicts across the full set of pending Promotions.
+type PromotionDispatcher interface {
+	// Select returns the Promotion to start next, or nil to start none on this
+	// pass (the Stage is requeued while pending Promotions remain). The pending
+	// slice is non-empty and sorted by ULID, oldest first.
+	Select(
+		ctx context.Context,
+		stage *kargoapi.Stage,
+		pending []kargoapi.Promotion,
+	) (*kargoapi.Promotion, error)
+}
+
+// defaultPromotionDispatcher preserves Kargo's historical first-in, first-out
+// behavior: the oldest (lowest-ULID) eligible pending Promotion is selected.
+type defaultPromotionDispatcher struct{}
+
+func (defaultPromotionDispatcher) Select(
+	_ context.Context,
+	_ *kargoapi.Stage,
+	pending []kargoapi.Promotion,
+) (*kargoapi.Promotion, error) {
+	return &pending[0], nil
+}
+
+// RegularStageReconcilerOption configures a RegularStageReconciler.
+type RegularStageReconcilerOption func(*RegularStageReconciler)
+
+// WithPromotionDispatcher overrides the PromotionDispatcher used to select which
+// pending Promotion a Stage should run next. A nil dispatcher is ignored. When
+// unset, a default first-in, first-out dispatcher is used.
+func WithPromotionDispatcher(d PromotionDispatcher) RegularStageReconcilerOption {
+	return func(r *RegularStageReconciler) {
+		if d != nil {
+			r.promotionDispatcher = d
+		}
+	}
 }
 
 // NewRegularStageReconciler creates a new Stages reconciler.
 func NewRegularStageReconciler(
 	cfg ReconcilerConfig,
 	healthChecker health.AggregatingChecker,
+	opts ...RegularStageReconcilerOption,
 ) *RegularStageReconciler {
-	return &RegularStageReconciler{
-		cfg:           cfg,
-		healthChecker: healthChecker,
+	r := &RegularStageReconciler{
+		cfg:                 cfg,
+		healthChecker:       healthChecker,
+		promotionDispatcher: defaultPromotionDispatcher{},
 		shardPredicate: controller.ResponsibleFor[kargoapi.Stage]{
 			IsDefaultController: cfg.IsDefaultController,
 			ShardName:           cfg.ShardName,
@@ -104,6 +151,10 @@ func NewRegularStageReconciler(
 			Jitter:   0.1,
 		},
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // SetupWithManager sets up the Stage reconciler with the given controller
@@ -637,10 +688,23 @@ func (r *RegularStageReconciler) syncPromotions(
 		}
 	}
 
-	// If the current Promotion is not the highest priority Promotion, or the
-	// highest priority Promotion is in a terminal phase, then we must have
-	// finished promoting.
-	if currentPromo != nil && (currentPromo.Name != highestPrioPromo.Name || highestPrioPromo.Status.Phase.IsTerminal()) {
+	// Determine whether the Promotion currently recorded on the Stage has
+	// finished. It is finished when it has reached a terminal phase or is no
+	// longer present (e.g. garbage-collected). Basing this on the current
+	// Promotion's own phase — rather than on whether it is still the
+	// highest-priority Promotion — keeps the decision independent of the
+	// PromotionDispatcher's ordering policy, which may select a Promotion other
+	// than the oldest pending one.
+	currentPromoDone := currentPromo != nil
+	if currentPromo != nil {
+		if promo := findPromotion(promotions.Items, currentPromo.Name); promo != nil {
+			currentPromoDone = promo.Status.Phase.IsTerminal()
+		}
+	}
+
+	// If the current Promotion has finished, then we must have finished
+	// promoting and can free the slot for the next Promotion.
+	if currentPromo != nil && currentPromoDone {
 		// Update the conditions to reflect that we are no longer promoting.
 		conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
 		newStatus.CurrentPromotion = nil
@@ -792,21 +856,76 @@ func (r *RegularStageReconciler) syncPromotions(
 	// If the highest priority Promotion is not in a terminal phase, then we
 	// are promoting the Freight.
 	if !highestPrioPromo.Status.Phase.IsTerminal() {
+		// Decide which Promotion the Stage runs on this pass.
+		var selected *kargoapi.Promotion
+		switch {
+		case currentPromo != nil:
+			// A Promotion is already selected and, per the "finished promoting"
+			// check above, is still non-terminal. Keep it: a Running or
+			// already-dispatched Promotion is never preempted, and this also
+			// prevents the selection from flip-flopping when a custom dispatcher
+			// chooses a Promotion other than the oldest pending one.
+			selected = findPromotion(promotions.Items, currentPromo.Name)
+		case highestPrioPromo.Status.Phase == kargoapi.PromotionPhaseRunning:
+			// No current Promotion is recorded but one is Running (e.g. after a
+			// controller restart): adopt it. A Running Promotion always sorts
+			// first, preserving the invariant that it is never preempted.
+			selected = &highestPrioPromo
+		}
+
+		// With no Promotion running and the slot open, consult the
+		// PromotionDispatcher to decide which of the eligible pending Promotions
+		// should run next. This lets a custom policy reason about conflicts
+		// across the pending set. The default dispatcher reproduces the
+		// historical first-in, first-out selection.
+		if selected == nil {
+			pending := make([]kargoapi.Promotion, 0, len(promotions.Items))
+			for _, promo := range promotions.Items {
+				if !promo.Status.Phase.IsTerminal() {
+					pending = append(pending, promo)
+				}
+			}
+			sel, err := r.promotionDispatcher.Select(ctx, stage, pending)
+			if err != nil {
+				err = fmt.Errorf(
+					"failed to select next Promotion for Stage %q in namespace %q: %w",
+					stage.Name, stage.Namespace, err,
+				)
+				conditions.Set(&newStatus, &metav1.Condition{
+					Type:               kargoapi.ConditionTypePromoting,
+					Status:             metav1.ConditionUnknown,
+					Reason:             "PromotionDispatchFailed",
+					Message:            err.Error(),
+					ObservedGeneration: stage.Generation,
+				})
+				return newStatus, hasNonTerminalPromotions, err
+			}
+			if sel == nil {
+				// The dispatcher declined to start any Promotion on this pass.
+				// Leave the slot open; the Stage is requeued while pending
+				// Promotions remain.
+				conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
+				newStatus.CurrentPromotion = nil
+				return newStatus, hasNonTerminalPromotions, nil
+			}
+			selected = sel
+		}
+
 		conditions.Set(&newStatus, &metav1.Condition{
 			Type:   kargoapi.ConditionTypePromoting,
 			Status: metav1.ConditionTrue,
 			Reason: "ActivePromotion",
 			Message: fmt.Sprintf(
 				"Promotion %q is currently %s",
-				highestPrioPromo.Name, highestPrioPromo.Status.Phase,
+				selected.Name, selected.Status.Phase,
 			),
 			ObservedGeneration: stage.Generation,
 		})
 
 		newStatus.CurrentPromotion = &kargoapi.PromotionReference{
-			Name: highestPrioPromo.Name,
+			Name: selected.Name,
 		}
-		if freight := highestPrioPromo.Status.Freight; freight != nil {
+		if freight := selected.Status.Freight; freight != nil {
 			newStatus.CurrentPromotion.Freight = freight.DeepCopy()
 		}
 		return newStatus, hasNonTerminalPromotions, nil
@@ -816,6 +935,17 @@ func (r *RegularStageReconciler) syncPromotions(
 	// not promoting.
 	conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
 	return newStatus, hasNonTerminalPromotions, nil
+}
+
+// findPromotion returns a pointer to the Promotion in promos with the given
+// name, or nil if none matches.
+func findPromotion(promos []kargoapi.Promotion, name string) *kargoapi.Promotion {
+	for i := range promos {
+		if promos[i].Name == name {
+			return &promos[i]
+		}
+	}
+	return nil
 }
 
 // assessHealth assesses the health of a Stage based on the health checks from

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -96,23 +96,31 @@ type PromotionDispatcher interface {
 	// Select returns the Promotion to start next, or nil to start none on this
 	// pass (the Stage is requeued while pending Promotions remain). The pending
 	// slice is non-empty and sorted by ULID, oldest first.
+	//
+	// retryAfter is meaningful only when the returned Promotion is nil (a
+	// decline): it hints how long until conditions may allow a Promotion to
+	// start, e.g. the time until the next relevant transition. The reconciler
+	// requeues the Stage after min(retryAfter, defaultRequeueDelay) and treats a
+	// non-positive value as "use the default cadence". It is ignored when a
+	// Promotion is selected or an error is returned.
 	Select(
 		ctx context.Context,
 		stage *kargoapi.Stage,
 		pending []kargoapi.Promotion,
-	) (*kargoapi.Promotion, error)
+	) (selection *kargoapi.Promotion, retryAfter time.Duration, err error)
 }
 
 // defaultPromotionDispatcher preserves Kargo's historical first-in, first-out
-// behavior: the oldest (lowest-ULID) eligible pending Promotion is selected.
+// behavior: the oldest (lowest-ULID) eligible pending Promotion is selected. It
+// never declines, so it never returns a retryAfter hint.
 type defaultPromotionDispatcher struct{}
 
 func (defaultPromotionDispatcher) Select(
 	_ context.Context,
 	_ *kargoapi.Stage,
 	pending []kargoapi.Promotion,
-) (*kargoapi.Promotion, error) {
-	return &pending[0], nil
+) (*kargoapi.Promotion, time.Duration, error) {
+	return &pending[0], 0, nil
 }
 
 // RegularStageReconcilerOption configures a RegularStageReconciler.
@@ -377,6 +385,19 @@ func (r *RegularStageReconciler) SetupWithManager(
 	return nil
 }
 
+const (
+	// immediateRequeueDelay is the requeue delay used when a Stage should be
+	// reconciled again as soon as possible (e.g. a pending Promotion is waiting
+	// for a free slot).
+	immediateRequeueDelay = 100 * time.Millisecond
+	// defaultRequeueDelay is the steady-state requeue cadence for a Stage with no
+	// more urgent reason to be reconciled. It also caps the PromotionDispatcher's
+	// decline hint, bounding staleness after external changes the Stage does not
+	// watch.
+	// TODO: Make the requeue delay configurable.
+	defaultRequeueDelay = 5 * time.Minute
+)
+
 func (r *RegularStageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logging.LoggerFromContext(ctx).WithValues(
 		"namespace", req.Namespace,
@@ -410,12 +431,12 @@ func (r *RegularStageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// The reason to requeue is to ensure that a possible deletion of the Stage
 	// directly after the finalizer was added is handled without delay.
 	if ok, err := api.EnsureFinalizer(ctx, r.client, stage); ok || err != nil {
-		return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, err
+		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, err
 	}
 
 	// Reconcile the Stage.
 	logger.Debug("reconciling Stage")
-	newStatus, needsRequeue, reconcileErr := r.reconcile(ctx, stage, time.Now())
+	newStatus, requeueAfter, reconcileErr := r.reconcile(ctx, stage, time.Now())
 	logger.Debug("done reconciling Stage")
 
 	// Record the current refresh token as having been handled.
@@ -439,20 +460,15 @@ func (r *RegularStageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if reconcileErr != nil {
 		return ctrl.Result{}, reconcileErr
 	}
-	// Immediate requeue if needed.
-	if needsRequeue {
-		return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
-	}
-	// Otherwise, requeue after a delay.
-	// TODO: Make the requeue delay configurable.
-	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	// reconcile chose when the Stage should next be seen.
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *RegularStageReconciler) reconcile(
 	ctx context.Context,
 	stage *kargoapi.Stage,
 	startTime time.Time,
-) (kargoapi.StageStatus, bool, error) {
+) (kargoapi.StageStatus, time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 
 	// working is the Stage the sub-reconcilers operate on. Its status is
@@ -479,6 +495,11 @@ func (r *RegularStageReconciler) reconcile(
 	})
 
 	var requestRequeue bool
+	// declineRequeueAfter is set when the PromotionDispatcher declined to start a
+	// Promotion this pass and hinted when the Stage should be revisited. It takes
+	// the place of the immediate requeue so a Stage waiting on external
+	// conditions does not busy-loop.
+	var declineRequeueAfter time.Duration
 	subReconcilers := []struct {
 		name      string
 		reconcile func() (kargoapi.StageStatus, error)
@@ -486,14 +507,18 @@ func (r *RegularStageReconciler) reconcile(
 		{
 			name: "syncing Promotions",
 			reconcile: func() (kargoapi.StageStatus, error) {
-				status, hasPendingPromotions, err := r.syncPromotions(ctx, working)
+				status, hasPendingPromotions, retryAfter, err := r.syncPromotions(ctx, working)
 				if err != nil {
 					err = fmt.Errorf("failed to sync Promotions: %w", err)
 				}
-				// If we have no current Promotion and there are pending Promotions,
-				// then we should request an immediate requeue to ensure that we
-				// process the next Promotion as soon as possible.
-				if status.CurrentPromotion == nil && hasPendingPromotions {
+				switch {
+				case retryAfter > 0:
+					// The dispatcher declined and asked to be retried later. Requeue
+					// at the (capped) hint rather than via the immediate path.
+					declineRequeueAfter = retryAfter
+				case status.CurrentPromotion == nil && hasPendingPromotions:
+					// No current Promotion but pending ones remain: requeue promptly
+					// so the next Promotion is processed as soon as possible.
 					requestRequeue = true
 				}
 				return status, err
@@ -572,7 +597,7 @@ func (r *RegularStageReconciler) reconcile(
 		// If an error occurred during the sub-reconciler, then we should
 		// return the error which will cause the Stage to be requeued.
 		if err != nil {
-			return newStatus, false, err
+			return newStatus, 0, err
 		}
 
 		// Patch the status of the Stage after each sub-reconciler to show progress.
@@ -594,7 +619,18 @@ func (r *RegularStageReconciler) reconcile(
 		conditions.Delete(&newStatus, kargoapi.ConditionTypeReconciling)
 	}
 
-	return newStatus, requestRequeue, nil
+	// Decide when the Stage should next be reconciled: promptly on an immediate
+	// requeue, at the dispatcher's (capped) hint on a decline, or at the default
+	// cadence otherwise.
+	requeueAfter := defaultRequeueDelay
+	switch {
+	case requestRequeue:
+		requeueAfter = immediateRequeueDelay
+	case declineRequeueAfter > 0 && declineRequeueAfter < requeueAfter:
+		requeueAfter = declineRequeueAfter
+	}
+
+	return newStatus, requeueAfter, nil
 }
 
 // syncPromotions synchronizes the Promotions for a Stage. It determines the
@@ -603,7 +639,7 @@ func (r *RegularStageReconciler) reconcile(
 func (r *RegularStageReconciler) syncPromotions(
 	ctx context.Context,
 	stage *kargoapi.Stage,
-) (kargoapi.StageStatus, bool, error) {
+) (kargoapi.StageStatus, bool, time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 	newStatus := *stage.Status.DeepCopy()
 
@@ -630,7 +666,7 @@ func (r *RegularStageReconciler) syncPromotions(
 			ObservedGeneration: stage.Generation,
 		})
 
-		return newStatus, false, err
+		return newStatus, false, 0, err
 	}
 
 	// Build a map of origin keys that are currently requested by this Stage,
@@ -660,7 +696,7 @@ func (r *RegularStageReconciler) syncPromotions(
 		conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
 		newStatus.CurrentPromotion = nil
 
-		return newStatus, false, nil
+		return newStatus, false, 0, nil
 	}
 
 	// Sort the Promotions by phase and creation time to determine the current
@@ -822,7 +858,7 @@ func (r *RegularStageReconciler) syncPromotions(
 		}
 
 		// Return at this point to allow the new Freight to be verified.
-		return newStatus, hasNonTerminalPromotions, nil
+		return newStatus, hasNonTerminalPromotions, 0, nil
 	}
 
 	// If the current Freight exists and has a non-terminal verification, wait
@@ -835,7 +871,7 @@ func (r *RegularStageReconciler) syncPromotions(
 					"wait for it to complete before allowing new promotions to start",
 			)
 			conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
-			return newStatus, hasNonTerminalPromotions, nil
+			return newStatus, hasNonTerminalPromotions, 0, nil
 		}
 
 		// If we are in a healthy state, the current Freight needs to be verified
@@ -848,7 +884,7 @@ func (r *RegularStageReconciler) syncPromotions(
 			if curVI == nil || !curVI.Phase.IsTerminal() {
 				logger.Debug("current Freight needs to be verified before allowing new promotions to start")
 				conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
-				return newStatus, hasNonTerminalPromotions, nil
+				return newStatus, hasNonTerminalPromotions, 0, nil
 			}
 		}
 	}
@@ -887,7 +923,7 @@ func (r *RegularStageReconciler) syncPromotions(
 					pending = append(pending, promo)
 				}
 			}
-			sel, err := r.promotionDispatcher.Select(ctx, stage, pending)
+			sel, retryAfter, err := r.promotionDispatcher.Select(ctx, stage, pending)
 			if err != nil {
 				err = fmt.Errorf(
 					"failed to select next Promotion for Stage %q in namespace %q: %w",
@@ -900,15 +936,20 @@ func (r *RegularStageReconciler) syncPromotions(
 					Message:            err.Error(),
 					ObservedGeneration: stage.Generation,
 				})
-				return newStatus, hasNonTerminalPromotions, err
+				return newStatus, hasNonTerminalPromotions, 0, err
 			}
 			if sel == nil {
 				// The dispatcher declined to start any Promotion on this pass.
-				// Leave the slot open; the Stage is requeued while pending
-				// Promotions remain.
+				// Leave the slot open; the Stage is requeued at the dispatcher's
+				// hint (or the default cadence when it gives none) while pending
+				// Promotions remain. A positive value marks this return as a
+				// decline for the caller.
 				conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
 				newStatus.CurrentPromotion = nil
-				return newStatus, hasNonTerminalPromotions, nil
+				if retryAfter <= 0 {
+					retryAfter = defaultRequeueDelay
+				}
+				return newStatus, hasNonTerminalPromotions, retryAfter, nil
 			}
 			selected = sel
 		}
@@ -930,13 +971,13 @@ func (r *RegularStageReconciler) syncPromotions(
 		if freight := selected.Status.Freight; freight != nil {
 			newStatus.CurrentPromotion.Freight = freight.DeepCopy()
 		}
-		return newStatus, hasNonTerminalPromotions, nil
+		return newStatus, hasNonTerminalPromotions, 0, nil
 	}
 
 	// If the highest priority Promotion is in a terminal phase, then we are
 	// not promoting.
 	conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
-	return newStatus, hasNonTerminalPromotions, nil
+	return newStatus, hasNonTerminalPromotions, 0, nil
 }
 
 // findPromotion returns a pointer to the Promotion in promos with the given

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -853,8 +853,10 @@ func (r *RegularStageReconciler) syncPromotions(
 		}
 	}
 
-	// If the highest priority Promotion is not in a terminal phase, then we
-	// are promoting the Freight.
+	// Non-terminal Promotions always sort ahead of terminal ones, so a
+	// non-terminal highest-priority Promotion means the Stage still has a
+	// Running or Pending Promotion to account for. Determine which Promotion
+	// should be the Stage's current one on this pass.
 	if !highestPrioPromo.Status.Phase.IsTerminal() {
 		// Decide which Promotion the Stage runs on this pass.
 		var selected *kargoapi.Promotion

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -633,6 +633,27 @@ func (r *RegularStageReconciler) reconcile(
 	return newStatus, requeueAfter, nil
 }
 
+// comparePromotionCompletion orders two Promotions by the time they COMPLETED
+// (Status.FinishedAt), falling back to ULID name when either timestamp is
+// absent or the two are equal. Stage status advances in completion order, not
+// creation (ULID) order: because a PromotionDispatcher may select a non-oldest
+// pending Promotion, Promotions can finish out of ULID order, and an
+// out-of-order completion must not skip a Promotion's outcome during replay.
+func comparePromotionCompletion(
+	aName string, aFinishedAt *metav1.Time,
+	bName string, bFinishedAt *metav1.Time,
+) int {
+	if aFinishedAt != nil && bFinishedAt != nil {
+		switch {
+		case aFinishedAt.Before(bFinishedAt):
+			return -1
+		case bFinishedAt.Before(aFinishedAt):
+			return 1
+		}
+	}
+	return strings.Compare(aName, bName)
+}
+
 // syncPromotions synchronizes the Promotions for a Stage. It determines the
 // current state of the Stage based on the Promotions that are running or have
 // completed.
@@ -745,29 +766,35 @@ func (r *RegularStageReconciler) syncPromotions(
 		conditions.Delete(&newStatus, kargoapi.ConditionTypePromoting)
 		newStatus.CurrentPromotion = nil
 
-		// Gather terminal Promotions newer than the last processed one, sorted
-		// oldest-to-newest so holds are applied in chronological order and
-		// Freight history entries are appended oldest-first (GC removes oldest
-		// first).
+		// Gather terminal Promotions newer than the last recorded one BY
+		// COMPLETION TIME, sorted oldest-to-newest so holds are applied in
+		// chronological order and Freight history entries are appended
+		// oldest-first (GC removes oldest first). Completion order is not the
+		// list's ULID sort order, so we cannot early-break as we could when the
+		// watermark was ULID-based; we scan the whole (GC-bounded) terminal set
+		// instead. This is what lets an out-of-order dispatch (a higher-ULID
+		// Promotion finishing before a lower-ULID one) record both outcomes
+		// rather than dropping the later-completing, lower-ULID Promotion.
 		var newPromos []*kargoapi.Promotion
 		for i := range promotions.Items {
 			promo := &promotions.Items[i]
-			if lastPromo != nil {
-				// We can break here since we know that all subsequent Promotions
-				// will be older than the last Promotion we saw.
-				// NB: This makes use of the fact that Promotion names are
-				// generated, and contain a timestamp component which will ensure
-				// that they can be sorted in a consistent order.
-				if strings.Compare(promo.Name, lastPromo.Name) <= 0 {
-					break
-				}
+			if !promo.Status.Phase.IsTerminal() {
+				continue
 			}
-			if promo.Status.Phase.IsTerminal() {
-				newPromos = append(newPromos, promo)
+			// Record only Promotions that completed after the current watermark.
+			if lastPromo != nil && comparePromotionCompletion(
+				promo.Name, promo.Status.FinishedAt,
+				lastPromo.Name, lastPromo.FinishedAt,
+			) <= 0 {
+				continue
 			}
+			newPromos = append(newPromos, promo)
 		}
 		slices.SortFunc(newPromos, func(a, b *kargoapi.Promotion) int {
-			return strings.Compare(a.Name, b.Name)
+			return comparePromotionCompletion(
+				a.Name, a.Status.FinishedAt,
+				b.Name, b.Status.FinishedAt,
+			)
 		})
 
 		// Replay new Promotions in chronological order to update hold state and
@@ -2134,7 +2161,10 @@ func (r *RegularStageReconciler) unprocessedHoldIntentPromotionExistsForOrigin(
 		}
 		if !promo.Status.Phase.IsTerminal() ||
 			(promo.Status.Phase == kargoapi.PromotionPhaseSucceeded &&
-				(lastPromo == nil || strings.Compare(promo.Name, lastPromo.Name) > 0)) {
+				(lastPromo == nil || comparePromotionCompletion(
+					promo.Name, promo.Status.FinishedAt,
+					lastPromo.Name, lastPromo.FinishedAt,
+				) > 0)) {
 			return true, nil
 		}
 	}
@@ -2179,7 +2209,10 @@ func (r *RegularStageReconciler) unprocessedPromotionExistsForStageFreight(
 		promo := &promotions.Items[i]
 		if !promo.Status.Phase.IsTerminal() ||
 			(promo.Status.Phase == kargoapi.PromotionPhaseSucceeded &&
-				(lastPromo == nil || strings.Compare(promo.Name, lastPromo.Name) > 0)) {
+				(lastPromo == nil || comparePromotionCompletion(
+					promo.Name, promo.Status.FinishedAt,
+					lastPromo.Name, lastPromo.FinishedAt,
+				) > 0)) {
 			return true, nil
 		}
 	}

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -651,6 +651,24 @@ func releaseHoldAnnotations(origin kargoapi.FreightOrigin) map[string]string {
 	return promo.Annotations
 }
 
+// fakePromotionDispatcher is a test PromotionDispatcher whose Select behavior is
+// supplied by a function field.
+type fakePromotionDispatcher struct {
+	selectFn func(
+		ctx context.Context,
+		stage *kargoapi.Stage,
+		pending []kargoapi.Promotion,
+	) (*kargoapi.Promotion, error)
+}
+
+func (f fakePromotionDispatcher) Select(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+	pending []kargoapi.Promotion,
+) (*kargoapi.Promotion, error) {
+	return f.selectFn(ctx, stage, pending)
+}
+
 func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, kargoapi.AddToScheme(scheme))
@@ -668,6 +686,7 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 		stage       *kargoapi.Stage
 		objects     []client.Object
 		interceptor interceptor.Funcs
+		dispatcher  PromotionDispatcher
 		assertions  func(*testing.T, kargoapi.StageStatus, bool, error)
 	}{
 		{
@@ -1406,6 +1425,293 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 			},
 		},
 		{
+			name: "default dispatcher selects oldest pending promotion",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-b",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.True(t, hasPendingPromotions)
+				require.NotNil(t, status.CurrentPromotion)
+				assert.Equal(t, "promo-a", status.CurrentPromotion.Name)
+			},
+		},
+		{
+			name: "custom dispatcher selects a non-oldest pending promotion",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-b",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:   kargoapi.PromotionPhasePending,
+						Freight: &kargoapi.FreightReference{Name: "freight-b"},
+					},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					pending []kargoapi.Promotion,
+				) (*kargoapi.Promotion, error) {
+					// Select the last (newest) pending Promotion instead of the
+					// default oldest-first choice.
+					return &pending[len(pending)-1], nil
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.True(t, hasPendingPromotions)
+				require.NotNil(t, status.CurrentPromotion)
+				assert.Equal(t, "promo-b", status.CurrentPromotion.Name)
+				require.NotNil(t, status.CurrentPromotion.Freight)
+				assert.Equal(t, "freight-b", status.CurrentPromotion.Freight.Name)
+
+				promotingCond := conditions.Get(&status, kargoapi.ConditionTypePromoting)
+				require.NotNil(t, promotingCond)
+				assert.Equal(t, metav1.ConditionTrue, promotingCond.Status)
+			},
+		},
+		{
+			name: "dispatcher declines to start a promotion",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					_ []kargoapi.Promotion,
+				) (*kargoapi.Promotion, error) {
+					return nil, nil
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				// A pending Promotion remains, so the Stage is requeued.
+				assert.True(t, hasPendingPromotions)
+				// No Promotion is selected to run.
+				assert.Nil(t, status.CurrentPromotion)
+				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypePromoting))
+			},
+		},
+		{
+			name: "dispatcher never preempts a running promotion",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "running-promo",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseRunning},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pending-promo",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					pending []kargoapi.Promotion,
+				) (*kargoapi.Promotion, error) {
+					// If (incorrectly) consulted, this would preempt the running
+					// Promotion; the assertion below proves it is not consulted.
+					return &pending[len(pending)-1], nil
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.True(t, hasPendingPromotions)
+				require.NotNil(t, status.CurrentPromotion)
+				assert.Equal(t, "running-promo", status.CurrentPromotion.Name)
+			},
+		},
+		{
+			name: "dispatcher error surfaces as promoting unknown",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					_ []kargoapi.Promotion,
+				) (*kargoapi.Promotion, error) {
+					return nil, fmt.Errorf("boom")
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, _ bool, err error) {
+				require.ErrorContains(t, err, "failed to select next Promotion")
+				assert.Nil(t, status.CurrentPromotion)
+				promotingCond := conditions.Get(&status, kargoapi.ConditionTypePromoting)
+				require.NotNil(t, promotingCond)
+				assert.Equal(t, metav1.ConditionUnknown, promotingCond.Status)
+				assert.Equal(t, "PromotionDispatchFailed", promotingCond.Reason)
+			},
+		},
+		{
+			name: "keeps a non-oldest current selection sticky",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{Name: "promo-b"},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-b",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					pending []kargoapi.Promotion,
+				) (*kargoapi.Promotion, error) {
+					// Would pick the oldest; the sticky current selection must
+					// win instead, so this must not be consulted.
+					return &pending[0], nil
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.True(t, hasPendingPromotions)
+				require.NotNil(t, status.CurrentPromotion)
+				assert.Equal(t, "promo-b", status.CurrentPromotion.Name)
+			},
+		},
+		{
+			name: "frees slot when a non-oldest current selection is terminal",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{Name: "promo-b"},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-b",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseFailed},
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				// promo-a is still pending, so the Stage is requeued.
+				assert.True(t, hasPendingPromotions)
+				// The finished current selection frees the slot; the next
+				// selection happens on a subsequent pass.
+				assert.Nil(t, status.CurrentPromotion)
+			},
+		},
+		{
 			name: "blocks new promotion when current freight has running verification",
 			stage: &kargoapi.Stage{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1968,9 +2274,14 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 				WithInterceptorFuncs(tt.interceptor).
 				Build()
 
+			dispatcher := tt.dispatcher
+			if dispatcher == nil {
+				dispatcher = defaultPromotionDispatcher{}
+			}
 			r := &RegularStageReconciler{
-				client:      c,
-				eventSender: k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
+				client:              c,
+				eventSender:         k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
+				promotionDispatcher: dispatcher,
 			}
 
 			status, requeue, err := r.syncPromotions(t.Context(), tt.stage)

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -442,7 +442,8 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 		stage       *kargoapi.Stage
 		objects     []client.Object
 		interceptor interceptor.Funcs
-		assertions  func(*testing.T, kargoapi.StageStatus, bool, error)
+		dispatcher  PromotionDispatcher
+		assertions  func(*testing.T, kargoapi.StageStatus, time.Duration, error)
 	}{
 		{
 			name: "subreconciler error preserves reconciling condition",
@@ -458,9 +459,11 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 					return fmt.Errorf("forced error")
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeueAfter time.Duration, err error) {
 				require.Error(t, err)
-				require.False(t, requeue)
+				// On error the requeue delay is unset; the controller requeues via
+				// the returned error instead.
+				require.Zero(t, requeueAfter)
 
 				reconciling := conditions.Get(&status, kargoapi.ConditionTypeReconciling)
 				require.NotNil(t, reconciling)
@@ -477,9 +480,9 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 					Generation: 1,
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeueAfter time.Duration, err error) {
 				require.NoError(t, err)
-				require.False(t, requeue)
+				require.Equal(t, defaultRequeueDelay, requeueAfter)
 
 				// Each subreconciler should have updated conditions
 				healthyCond := conditions.Get(&status, kargoapi.ConditionTypeHealthy)
@@ -506,9 +509,9 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeueAfter time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, requeue)
+				assert.Equal(t, defaultRequeueDelay, requeueAfter)
 
 				reconciling := conditions.Get(&status, kargoapi.ConditionTypeReconciling)
 				assert.Nil(t, reconciling)
@@ -576,16 +579,51 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, requeue bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, requeueAfter time.Duration, err error) {
 				// Status update failures between sub-reconcilers are non-fatal.
 				require.NoError(t, err)
-				require.False(t, requeue)
+				require.Equal(t, defaultRequeueDelay, requeueAfter)
 
 				// The results of syncPromotions were carried through the rest
 				// of the pass despite never having been persisted.
 				require.NotNil(t, status.LastPromotion)
 				assert.Equal(t, "test-promotion", status.LastPromotion.Name)
 				require.Len(t, status.FreightHistory, 1)
+			},
+		},
+		{
+			// A declining dispatcher must not trigger the immediate-requeue path;
+			// the Stage requeues at min(hint, defaultRequeueDelay) instead.
+			name: "dispatcher decline drives the requeue delay",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "test-project",
+					Name:       "test-stage",
+					Generation: 1,
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-project",
+						Name:      "test-promotion",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					_ []kargoapi.Promotion,
+				) (*kargoapi.Promotion, time.Duration, error) {
+					return nil, 90 * time.Second, nil
+				},
+			},
+			assertions: func(t *testing.T, _ kargoapi.StageStatus, requeueAfter time.Duration, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, 90*time.Second, requeueAfter)
 			},
 		},
 	}
@@ -632,14 +670,19 @@ func TestRegularStagesReconciler_reconcile(t *testing.T) {
 				WithInterceptorFuncs(tt.interceptor).
 				Build()
 
+			dispatcher := tt.dispatcher
+			if dispatcher == nil {
+				dispatcher = defaultPromotionDispatcher{}
+			}
 			r := &RegularStageReconciler{
-				client:        c,
-				eventSender:   k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
-				healthChecker: &health.MockAggregatingChecker{},
+				client:              c,
+				eventSender:         k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
+				healthChecker:       &health.MockAggregatingChecker{},
+				promotionDispatcher: dispatcher,
 			}
 
-			status, requeue, err := r.reconcile(t.Context(), tt.stage, now)
-			tt.assertions(t, status, requeue, err)
+			status, requeueAfter, err := r.reconcile(t.Context(), tt.stage, now)
+			tt.assertions(t, status, requeueAfter, err)
 		})
 	}
 }
@@ -658,14 +701,14 @@ type fakePromotionDispatcher struct {
 		ctx context.Context,
 		stage *kargoapi.Stage,
 		pending []kargoapi.Promotion,
-	) (*kargoapi.Promotion, error)
+	) (*kargoapi.Promotion, time.Duration, error)
 }
 
 func (f fakePromotionDispatcher) Select(
 	ctx context.Context,
 	stage *kargoapi.Stage,
 	pending []kargoapi.Promotion,
-) (*kargoapi.Promotion, error) {
+) (*kargoapi.Promotion, time.Duration, error) {
 	return f.selectFn(ctx, stage, pending)
 }
 
@@ -687,7 +730,7 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 		objects     []client.Object
 		interceptor interceptor.Funcs
 		dispatcher  PromotionDispatcher
-		assertions  func(*testing.T, kargoapi.StageStatus, bool, error)
+		assertions  func(*testing.T, kargoapi.StageStatus, bool, time.Duration, error)
 	}{
 		{
 			name: "list promotions error",
@@ -703,9 +746,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					return fmt.Errorf("list error")
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.ErrorContains(t, err, "failed to list Promotions")
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 
 				assert.Len(t, status.Conditions, 1)
 				assert.Equal(t, kargoapi.ConditionTypePromoting, status.Conditions[0].Type)
@@ -731,9 +774,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Nil(t, status.CurrentPromotion)
 				assert.Empty(t, status.Conditions)
 			},
@@ -772,9 +815,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				require.Len(t, status.AutoPromotionHolds, 1)
 				hold := status.AutoPromotionHolds[origin.String()]
 				assert.Equal(t, "older-freight", hold.FreightName)
@@ -831,9 +874,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Empty(t, status.AutoPromotionHolds)
 			},
 		},
@@ -885,9 +928,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Empty(t, status.AutoPromotionHolds)
 			},
 		},
@@ -939,9 +982,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				require.Len(t, status.AutoPromotionHolds, 1)
 				hold := status.AutoPromotionHolds[origin.String()]
 				assert.Equal(t, "b-hold-promo", hold.PromotionName)
@@ -979,9 +1022,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Empty(t, status.AutoPromotionHolds)
 			},
 		},
@@ -1005,9 +1048,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				require.Len(t, status.AutoPromotionHolds, 1)
 				assert.Equal(
 					t,
@@ -1078,9 +1121,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Empty(
 					t,
 					status.AutoPromotionHolds,
@@ -1181,9 +1224,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseSucceeded},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 
 				// Origin A's hold must be cleared.
 				_, hasHoldA := status.AutoPromotionHolds["Warehouse/warehouse-a"]
@@ -1220,9 +1263,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Empty(t, status.AutoPromotionHolds)
 			},
 		},
@@ -1289,9 +1332,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				require.NotNil(t, status.CurrentPromotion)
 				assert.Equal(t, "auto-promotion", status.CurrentPromotion.Name)
 				require.Len(t, status.AutoPromotionHolds, 1)
@@ -1341,10 +1384,10 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
 
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 
 				assert.Nil(t, status.CurrentPromotion)
 
@@ -1405,10 +1448,10 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
 
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				assert.Equal(t, &kargoapi.PromotionReference{
 					Name: "active-promotion",
@@ -1450,9 +1493,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				require.NotNil(t, status.CurrentPromotion)
 				assert.Equal(t, "promo-a", status.CurrentPromotion.Name)
 			},
@@ -1491,15 +1534,15 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					_ context.Context,
 					_ *kargoapi.Stage,
 					pending []kargoapi.Promotion,
-				) (*kargoapi.Promotion, error) {
+				) (*kargoapi.Promotion, time.Duration, error) {
 					// Select the last (newest) pending Promotion instead of the
 					// default oldest-first choice.
-					return &pending[len(pending)-1], nil
+					return &pending[len(pending)-1], 0, nil
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				require.NotNil(t, status.CurrentPromotion)
 				assert.Equal(t, "promo-b", status.CurrentPromotion.Name)
 				require.NotNil(t, status.CurrentPromotion.Freight)
@@ -1511,7 +1554,7 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 			},
 		},
 		{
-			name: "dispatcher declines to start a promotion",
+			name: "dispatcher declines with a requeue hint",
 			stage: &kargoapi.Stage{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "fake-project",
@@ -1533,14 +1576,68 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					_ context.Context,
 					_ *kargoapi.Stage,
 					_ []kargoapi.Promotion,
-				) (*kargoapi.Promotion, error) {
-					return nil, nil
+				) (*kargoapi.Promotion, time.Duration, error) {
+					return nil, 90 * time.Second, nil
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(
+				t *testing.T,
+				status kargoapi.StageStatus,
+				hasPending bool,
+				retryAfter time.Duration,
+				err error,
+			) {
 				require.NoError(t, err)
 				// A pending Promotion remains, so the Stage is requeued.
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
+				// The dispatcher's hint is surfaced so the Stage sleeps until then
+				// rather than busy-looping.
+				assert.Equal(t, 90*time.Second, retryAfter)
+				// No Promotion is selected to run.
+				assert.Nil(t, status.CurrentPromotion)
+				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypePromoting))
+			},
+		},
+		{
+			name: "dispatcher declines without a requeue hint",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "promo-a",
+						Namespace: "fake-project",
+					},
+					Spec:   kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			dispatcher: fakePromotionDispatcher{
+				selectFn: func(
+					_ context.Context,
+					_ *kargoapi.Stage,
+					_ []kargoapi.Promotion,
+				) (*kargoapi.Promotion, time.Duration, error) {
+					return nil, 0, nil
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				status kargoapi.StageStatus,
+				hasPending bool,
+				retryAfter time.Duration,
+				err error,
+			) {
+				require.NoError(t, err)
+				// A pending Promotion remains, so the Stage is requeued.
+				assert.True(t, hasPending)
+				// A decline without a hint falls back to the default cadence
+				// rather than an immediate busy-loop.
+				assert.Equal(t, defaultRequeueDelay, retryAfter)
 				// No Promotion is selected to run.
 				assert.Nil(t, status.CurrentPromotion)
 				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypePromoting))
@@ -1577,15 +1674,15 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					_ context.Context,
 					_ *kargoapi.Stage,
 					pending []kargoapi.Promotion,
-				) (*kargoapi.Promotion, error) {
+				) (*kargoapi.Promotion, time.Duration, error) {
 					// If (incorrectly) consulted, this would preempt the running
 					// Promotion; the assertion below proves it is not consulted.
-					return &pending[len(pending)-1], nil
+					return &pending[len(pending)-1], 0, nil
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				require.NotNil(t, status.CurrentPromotion)
 				assert.Equal(t, "running-promo", status.CurrentPromotion.Name)
 			},
@@ -1613,12 +1710,14 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					_ context.Context,
 					_ *kargoapi.Stage,
 					_ []kargoapi.Promotion,
-				) (*kargoapi.Promotion, error) {
-					return nil, fmt.Errorf("boom")
+				) (*kargoapi.Promotion, time.Duration, error) {
+					return nil, 0, fmt.Errorf("boom")
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, _ bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, _ bool, retryAfter time.Duration, err error) {
 				require.ErrorContains(t, err, "failed to select next Promotion")
+				// An error is not a decline, so no requeue hint is returned.
+				assert.Zero(t, retryAfter)
 				assert.Nil(t, status.CurrentPromotion)
 				promotingCond := conditions.Get(&status, kargoapi.ConditionTypePromoting)
 				require.NotNil(t, promotingCond)
@@ -1660,15 +1759,15 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					_ context.Context,
 					_ *kargoapi.Stage,
 					pending []kargoapi.Promotion,
-				) (*kargoapi.Promotion, error) {
+				) (*kargoapi.Promotion, time.Duration, error) {
 					// Would pick the oldest; the sticky current selection must
 					// win instead, so this must not be consulted.
-					return &pending[0], nil
+					return &pending[0], 0, nil
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				require.NotNil(t, status.CurrentPromotion)
 				assert.Equal(t, "promo-b", status.CurrentPromotion.Name)
 			},
@@ -1702,10 +1801,10 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhaseFailed},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
 				// promo-a is still pending, so the Stage is requeued.
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				// The finished current selection frees the slot; the next
 				// selection happens on a subsequent pass.
 				assert.Nil(t, status.CurrentPromotion)
@@ -1750,9 +1849,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				assert.Nil(t, status.CurrentPromotion)
 				assert.Empty(t, status.Conditions)
 			},
@@ -1795,9 +1894,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				// Should not have current promotion since verification is running
 				assert.Nil(t, status.CurrentPromotion)
@@ -1847,9 +1946,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				// Should allow promotion after verification is complete
 				require.NotNil(t, status.CurrentPromotion)
@@ -1896,9 +1995,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 				assert.Nil(t, status.CurrentPromotion)
 
 				promotingCond := conditions.Get(&status, kargoapi.ConditionTypePromoting)
@@ -1945,9 +2044,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				// Should allow promotion since there's no verification to wait for
 				require.NotNil(t, status.CurrentPromotion)
@@ -2002,9 +2101,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				// Should allow promotion since there's no verification to wait for
 				require.NotNil(t, status.CurrentPromotion)
@@ -2061,9 +2160,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				// Should allow promotion since there's no verification to wait for
 				require.NotNil(t, status.CurrentPromotion)
@@ -2120,9 +2219,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 
 				assert.Equal(t, "promotion-2", status.LastPromotion.Name)
 				assert.Empty(t, status.FreightHistory)
@@ -2163,9 +2262,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Nil(t, status.CurrentPromotion)
 
 				require.NotNil(t, status.LastPromotion)
@@ -2206,9 +2305,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.True(t, hasPendingPromotions)
+				assert.True(t, hasPending)
 
 				assert.Equal(t, "transitioning-promotion", status.CurrentPromotion.Name)
 
@@ -2247,9 +2346,9 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPending bool, _ time.Duration, err error) {
 				require.NoError(t, err)
-				assert.False(t, hasPendingPromotions)
+				assert.False(t, hasPending)
 				assert.Nil(t, status.CurrentPromotion)
 
 				promotingCond := conditions.Get(&status, kargoapi.ConditionTypePromoting)
@@ -2284,8 +2383,8 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 				promotionDispatcher: dispatcher,
 			}
 
-			status, requeue, err := r.syncPromotions(t.Context(), tt.stage)
-			tt.assertions(t, status, requeue, err)
+			status, requeue, retryAfter, err := r.syncPromotions(t.Context(), tt.stage)
+			tt.assertions(t, status, requeue, retryAfter, err)
 		})
 	}
 }

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -712,6 +712,55 @@ func (f fakePromotionDispatcher) Select(
 	return f.selectFn(ctx, stage, pending)
 }
 
+func TestComparePromotionCompletion(t *testing.T) {
+	earlier := metav1.Now()
+	later := metav1.NewTime(earlier.Add(time.Hour))
+	tests := []struct {
+		name   string
+		aName  string
+		aFin   *metav1.Time
+		bName  string
+		bFin   *metav1.Time
+		assert func(*testing.T, int)
+	}{
+		{
+			name:  "earlier completion sorts before later",
+			aName: "z", aFin: &earlier,
+			bName: "a", bFin: &later,
+			assert: func(t *testing.T, r int) { assert.Negative(t, r) },
+		},
+		{
+			name:  "later completion sorts after earlier",
+			aName: "a", aFin: &later,
+			bName: "z", bFin: &earlier,
+			assert: func(t *testing.T, r int) { assert.Positive(t, r) },
+		},
+		{
+			name:  "equal completion falls back to name",
+			aName: "a", aFin: &earlier,
+			bName: "b", bFin: &earlier,
+			assert: func(t *testing.T, r int) { assert.Negative(t, r) },
+		},
+		{
+			name:  "nil completion falls back to name",
+			aName: "b", aFin: nil,
+			bName: "a", bFin: &earlier,
+			assert: func(t *testing.T, r int) { assert.Positive(t, r) },
+		},
+		{
+			name:  "both nil and equal names compare equal",
+			aName: "a", aFin: nil,
+			bName: "a", bFin: nil,
+			assert: func(t *testing.T, r int) { assert.Zero(t, r) },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t, comparePromotionCompletion(tt.aName, tt.aFin, tt.bName, tt.bFin))
+		})
+	}
+}
+
 func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, kargoapi.AddToScheme(scheme))
@@ -732,6 +781,160 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 		dispatcher  PromotionDispatcher
 		assertions  func(*testing.T, kargoapi.StageStatus, bool, time.Duration, error)
 	}{
+		{
+			// AX9 / T1: the dispatcher can run a higher-ULID Promotion (e.g. a
+			// rollback) before a lower-ULID one (a frozen forward), so the
+			// lower-ULID Promotion completes LATER. The watermark is advanced by
+			// completion time, not ULID, so the later-completing lower-ULID
+			// Promotion is still recorded rather than skipped.
+			name: "records out-of-order completion below the ULID watermark",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Status: kargoapi.StageStatus{
+					// The higher-ULID Promotion ran and completed first
+					// (hourAgo), advancing the watermark.
+					CurrentPromotion: &kargoapi.PromotionReference{
+						Name: "test-stage.01",
+					},
+					LastPromotion: &kargoapi.PromotionReference{
+						Name:       "test-stage.02",
+						FinishedAt: &metav1.Time{Time: hourAgo},
+					},
+				},
+			},
+			objects: []client.Object{
+				// Lower-ULID forward that completed LATER than the watermark.
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-stage.01",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "forward-collection",
+							Freight: map[string]kargoapi.FreightReference{
+								"warehouse-1": {Name: "forward-freight"},
+							},
+						},
+					},
+				},
+				// Higher-ULID Promotion already recorded (completion equals the
+				// watermark), so it must not be replayed again.
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-stage.02",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: hourAgo},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "rollback-collection",
+							Freight: map[string]kargoapi.FreightReference{
+								"warehouse-1": {Name: "rollback-freight"},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				status kargoapi.StageStatus,
+				hasPending bool,
+				_ time.Duration,
+				err error,
+			) {
+				require.NoError(t, err)
+				assert.False(t, hasPending)
+
+				// The later-completing, lower-ULID forward is recorded and the
+				// watermark advances to it. (The old ULID break dropped it.)
+				require.NotNil(t, status.LastPromotion)
+				assert.Equal(t, "test-stage.01", status.LastPromotion.Name)
+
+				// Only the forward is newly recorded; the already-recorded
+				// Promotion (completion equals watermark) is not replayed.
+				require.Len(t, status.FreightHistory, 1)
+				assert.Equal(t, "forward-collection", status.FreightHistory[0].ID)
+			},
+		},
+		{
+			// Timestamps are second-granular after a round-trip, so ties are
+			// possible; the watermark comparator falls back to ULID name to keep
+			// replay deterministic.
+			name: "same-second completions replay in ULID-name order",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{
+						Name: "test-stage.bb",
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-stage.aa",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "aa-collection",
+							Freight: map[string]kargoapi.FreightReference{
+								"warehouse-1": {Name: "aa-freight"},
+							},
+						},
+					},
+				},
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-stage.bb",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.PromotionSpec{Stage: "test-stage"},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+						FreightCollection: &kargoapi.FreightCollection{
+							ID: "bb-collection",
+							Freight: map[string]kargoapi.FreightReference{
+								"warehouse-1": {Name: "bb-freight"},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				status kargoapi.StageStatus,
+				_ bool,
+				_ time.Duration,
+				err error,
+			) {
+				require.NoError(t, err)
+
+				// Both are recorded; "bb" sorts last by name, so it is the final
+				// watermark and (Record prepends) history[0].
+				require.Len(t, status.FreightHistory, 2)
+				assert.Equal(t, "bb-collection", status.FreightHistory[0].ID)
+				assert.Equal(t, "aa-collection", status.FreightHistory[1].ID)
+				require.NotNil(t, status.LastPromotion)
+				assert.Equal(t, "test-stage.bb", status.LastPromotion.Name)
+			},
+		},
 		{
 			name: "list promotions error",
 			stage: &kargoapi.Stage{
@@ -8351,6 +8554,112 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 					}
 				}
 				assert.Equal(t, 1, created)
+			},
+		},
+		{
+			// AX9 consistency: out-of-order completion. A hold-intent Promotion
+			// has a LOWER ULID than the watermark but completed LATER, so
+			// syncPromotions has not recorded its outcome yet and auto-promotion
+			// must stand down. A ULID-name check would wrongly treat it as
+			// recorded (lower name) and supersede the Freight it just held --
+			// the #3016 loop.
+			name: "skips promotion when a hold-intent Promotion completed after the watermark despite a lower ULID",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: "test-warehouse",
+						},
+						Sources: kargoapi.FreightSources{Direct: true},
+					}},
+					PromotionTemplate: &kargoapi.PromotionTemplate{
+						Spec: kargoapi.PromotionTemplateSpec{
+							Steps: []kargoapi.PromotionStep{{Uses: "fake-step"}},
+						},
+					},
+				},
+				Status: kargoapi.StageStatus{
+					// The watermark points at a higher-ULID Promotion that
+					// completed EARLIER (hourAgo). No hold is recorded yet.
+					LastPromotion: &kargoapi.PromotionReference{
+						Name:       "test-stage.2-forward-promo",
+						FinishedAt: &metav1.Time{Time: hourAgo},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.ProjectConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-project",
+						Namespace: "fake-project",
+					},
+					Spec: kargoapi.ProjectConfigSpec{
+						PromotionPolicies: []kargoapi.PromotionPolicy{{
+							Stage:                "test-stage",
+							AutoPromotionEnabled: true,
+						}},
+					},
+				},
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "fake-project",
+						Name:              "test-freight-new",
+						CreationTimestamp: metav1.Time{Time: now},
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+				// Hold-intent Promotion: lower ULID than the watermark, but it
+				// completed LATER (now > hourAgo), so its outcome is not yet
+				// recorded and auto-promotion must stand down for the origin.
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-stage.1-hold-promo",
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyAutoPromotionHold: "Warehouse/test-warehouse",
+						},
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage:   "test-stage",
+						Freight: "test-freight-old",
+					},
+					Status: kargoapi.PromotionStatus{
+						Phase:      kargoapi.PromotionPhaseSucceeded,
+						FinishedAt: &metav1.Time{Time: now},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				_ *fakeevent.EventRecorder,
+				c client.Client,
+				status kargoapi.StageStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+				assert.True(t, status.AutoPromotionEnabled)
+
+				// Auto-promotion stood down: no new Promotion was created.
+				promoList := &kargoapi.PromotionList{}
+				require.NoError(t, c.List(
+					t.Context(), promoList, client.InNamespace("fake-project"),
+				))
+				require.Len(t, promoList.Items, 1)
+				assert.Equal(t, "test-stage.1-hold-promo", promoList.Items[0].Name)
 			},
 		},
 		{


### PR DESCRIPTION
## What

Introduces a `PromotionDispatcher` extension point in the regular Stage
reconciler, controlling which of a Stage's eligible **pending** Promotions is
selected to run next.

## Why

Today `RegularStageReconciler.syncPromotions` sorts a Stage's Promotions and
records the highest-priority one as `Stage.Status.CurrentPromotion` (the
Promotion reconciler then flips it `Pending → Running`). The ordering is
hard-coded FIFO (oldest ULID) with a Running-first invariant. Making the
selection pluggable lets alternative strategies (e.g. priority or fairness
between pending Promotions) be introduced without changing the reconciler, and
makes the selection logic easier to test in isolation. The default keeps the
current behavior.

## What changed

- New `PromotionDispatcher` interface with
  `Select(ctx, stage, pending) (*Promotion, error)`. The full eligible-pending
  slice is passed so an implementation can consider the pending Promotions
  relative to one another.
- `defaultPromotionDispatcher` preserves the historical FIFO behavior, so this
  change is **behavior-preserving** by default.
- Supplied via a new variadic `WithPromotionDispatcher(...)` option on
  `NewRegularStageReconciler` (existing call sites are unaffected).
- The dispatcher is consulted only when the `CurrentPromotion` slot is open and
  no Promotion is Running — the reconciler keeps ownership of the Running-first
  invariant and the verification/health gates, so a dispatcher can never
  preempt a mid-flight Promotion.
- The "finished promoting" check and the current selection now key off the
  current Promotion's own terminal status rather than whether it remains the
  highest-priority Promotion. This keeps a non-oldest selection **sticky**
  instead of flip-flopping `CurrentPromotion` each pass.

## Tests

Extended `TestRegularStageReconciler_syncPromotions` with cases for: default ==
FIFO parity, a custom dispatcher selecting a non-oldest pending Promotion, the
dispatcher declining (slot stays open, Stage requeued), a Running Promotion
never being preempted, dispatcher error surfacing as `Promoting=Unknown`, a
non-oldest selection remaining sticky, and freeing the slot once the current
selection is terminal.

---

> Draft: opened for early feedback on the interface shape and the
> selection/guard refactor in `syncPromotions`.