### PR TITLE
fix: Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,13 +2,6 @@ FROM golang:1.26.5-trixie
 
 ARG TARGETARCH
 
-ARG NODE_MAJOR=22
-ARG PNPM_VERSION=11.13.0
-
-RUN apt update && apt install -y ca-certificates curl gnupg unzip \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
 ARG JAVA_MAJOR=21
 ARG NODE_MAJOR=22
 ARG PNPM_VERSION=11.13.0


### PR DESCRIPTION
#6647 broke `Dockerfile.dev` in a way CI did not catch. CI doesn't _use_ the image described by that file, the whole point of which is to be an approximation of the environment CI _does_ use, which is only used locally.