### PR TITLE
feat(events): annotate promotion events with rollback status

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -20,6 +20,7 @@ const (
 	AnnotationKeyEventVerificationStartTime  = AnnotationKeyEventPrefix + "verification-start-time"
 	AnnotationKeyEventVerificationFinishTime = AnnotationKeyEventPrefix + "verification-finish-time"
 	AnnotationKeyEventApplications           = AnnotationKeyEventPrefix + "applications"
+	AnnotationKeyEventRollback               = AnnotationKeyEventPrefix + "rollback"
 )
 
 const (

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
@@ -112,6 +112,7 @@ Promotion payloads describe a promotion resource and the freight it targets.
 | `stageName`    | String                                                | Stage targeted by the promotion.                      | No               |
 | `createTime`   | String (RFC3339)                                      | Creation timestamp of the promotion resource.         | No               |
 | `applications` | Array\<[NamespacedName](#applications-entry-fields)\> | Argo CD applications resolved for the promotion step. | Yes              |
+| `rollback`     | Boolean                                               | Indicates whether the promotion is a rollback.        | Yes              |
 
 #### Applications Entry Fields
 

--- a/pkg/event/promotion.go
+++ b/pkg/event/promotion.go
@@ -26,6 +26,7 @@ type Promotion struct {
 	StageName    string                 `json:"stageName"`
 	CreateTime   time.Time              `json:"createTime"`
 	Applications []types.NamespacedName `json:"applications,omitempty"`
+	Rollback     bool                   `json:"rollback,omitempty"`
 }
 
 func (p Promotion) GetName() string {
@@ -180,6 +181,9 @@ func (p *Promotion) MarshalAnnotationsTo(annotations map[string]string) {
 	if p.Freight != nil {
 		p.Freight.MarshalAnnotationsTo(annotations)
 	}
+	if p.Rollback {
+		annotations[kargoapi.AnnotationKeyEventRollback] = kargoapi.AnnotationValueTrue
+	}
 }
 
 func (p *PromotionSucceeded) MarshalAnnotations() map[string]string {
@@ -245,6 +249,7 @@ func UnmarshalPromotionAnnotations(annotations map[string]string) (Promotion, er
 		Name:       annotations[kargoapi.AnnotationKeyEventPromotionName],
 		StageName:  annotations[kargoapi.AnnotationKeyEventStageName],
 		CreateTime: createTime,
+		Rollback:   annotations[kargoapi.AnnotationKeyEventRollback] == kargoapi.AnnotationValueTrue,
 	}
 
 	if applications, ok := annotations[kargoapi.AnnotationKeyEventApplications]; ok {
@@ -370,6 +375,7 @@ func newPromotion(
 		Name:       promotion.GetName(),
 		StageName:  promotion.Spec.Stage,
 		CreateTime: promotion.GetCreationTimestamp().Time,
+		Rollback:   promotion.Annotations[kargoapi.AnnotationKeyRollback] == kargoapi.AnnotationValueTrue,
 	}
 
 	if freight != nil {

--- a/pkg/event/promotion_test.go
+++ b/pkg/event/promotion_test.go
@@ -482,6 +482,74 @@ func TestPromotionSucceeded_UnmarshalVerificationPending(t *testing.T) {
 	}
 }
 
+func TestNewPromotion_Rollback(t *testing.T) {
+	testCases := map[string]struct {
+		annotations map[string]string
+		expected    bool
+	}{
+		"rollback annotation true": {
+			annotations: map[string]string{
+				kargoapi.AnnotationKeyRollback: "true",
+			},
+			expected: true,
+		},
+		"rollback annotation false": {
+			annotations: map[string]string{
+				kargoapi.AnnotationKeyRollback: "false",
+			},
+			expected: false,
+		},
+		"rollback annotation absent": {
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			promotion := &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-promotion",
+					Namespace:   "test-project",
+					Annotations: tc.annotations,
+				},
+				Spec: kargoapi.PromotionSpec{
+					Stage: "test-stage",
+				},
+			}
+			evt := newPromotion(promotion, nil)
+			require.Equal(t, tc.expected, evt.Rollback)
+		})
+	}
+}
+
+func TestPromotionEventMarshalAnnotations_Rollback(t *testing.T) {
+	promotion := Promotion{
+		Name:      "test-promotion",
+		StageName: "test-stage",
+		Rollback:  true,
+	}
+	annotations := map[string]string{}
+	promotion.MarshalAnnotationsTo(annotations)
+	require.Equal(t, kargoapi.AnnotationValueTrue, annotations[kargoapi.AnnotationKeyEventRollback])
+
+	promotion.Rollback = false
+	annotations = map[string]string{}
+	promotion.MarshalAnnotationsTo(annotations)
+	require.NotContains(t, annotations, kargoapi.AnnotationKeyEventRollback)
+}
+
+func TestUnmarshalPromotionAnnotations_Rollback(t *testing.T) {
+	annotations := map[string]string{
+		kargoapi.AnnotationKeyEventPromotionName:       "test-promotion",
+		kargoapi.AnnotationKeyEventStageName:           "test-stage",
+		kargoapi.AnnotationKeyEventPromotionCreateTime: "2024-01-01T12:00:00Z",
+		kargoapi.AnnotationKeyEventRollback:            "true",
+	}
+	evt, err := UnmarshalPromotionAnnotations(annotations)
+	require.NoError(t, err)
+	require.True(t, evt.Rollback)
+}
+
 func TestCalculatePromotionVars(t *testing.T) {
 	testCases := map[string]struct {
 		promotion *kargoapi.Promotion


### PR DESCRIPTION
## Description

Adds a new annotation to PromotionCreated events to discern if the Promotion was a rollback promotion.

```yaml
    event.kargo.akuity.io/rollback: "true"
```

## Checklist

### Eligibility

- [x] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
