### PR TITLE
fix(ui): open ArgoCD links in a new tab natively

### DIFF
--- a/ui/src/features/project/pipelines/nodes/argocd-link.tsx
+++ b/ui/src/features/project/pipelines/nodes/argocd-link.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import z from 'zod';
 
+import { withBasePath } from '@ui/config/base-path';
 import { ARGOCD_CONTEXT_KEY, SHARD_LABEL_KEY } from '@ui/config/labels';
 import { paths } from '@ui/config/paths';
 import { useExtensionsContext } from '@ui/extensions/extensions-context';
@@ -47,26 +48,43 @@ export const ArgoCDLink = ({
     }
   }, [stage]);
 
+  // Router-relative path for the in-app extension route (no basePath -- navigate
+  // prepends the router basename itself).
+  const extensionPath = React.useCallback(
+    (link: ArgoCDContext) =>
+      generatePath(paths.projectArgoCDExtension, {
+        name: projectName,
+        namespace: link.namespace,
+        appName: link.name,
+        stageName: stage.metadata?.name
+      }),
+    [projectName, stage]
+  );
+
+  // Browser href carrying the real destination, so cmd/ctrl-click and "open in
+  // new tab" work natively. withBasePath re-adds the prefix for the SPA route.
+  const argoCDHref = React.useCallback(
+    (link: ArgoCDContext) =>
+      isExtensionArgoCD
+        ? withBasePath(extensionPath(link))
+        : `${argoCDShardURL}/applications/${link.namespace}/${link.name}`,
+    [isExtensionArgoCD, extensionPath, argoCDShardURL]
+  );
+
+  // A plain click on the in-app extension route stays SPA navigation; modified
+  // clicks fall through to the browser's native new-tab handling.
   const openArgoCD = React.useCallback(
-    (link: ArgoCDContext) => {
-      if (isExtensionArgoCD) {
-        navigate(
-          generatePath(paths.projectArgoCDExtension, {
-            name: projectName,
-            namespace: link.namespace,
-            appName: link.name,
-            stageName: stage.metadata?.name
-          })
-        );
-      } else {
-        window.open(
-          `${argoCDShardURL}/applications/${link.namespace}/${link.name}`,
-          '_blank',
-          'noopener noreferrer'
-        );
+    (e: React.MouseEvent, link: ArgoCDContext) => {
+      if (!isExtensionArgoCD) {
+        return;
       }
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) {
+        return;
+      }
+      e.preventDefault();
+      navigate(extensionPath(link));
     },
-    [isExtensionArgoCD, navigate, projectName, argoCDShardURL]
+    [isExtensionArgoCD, navigate, extensionPath]
   );
 
   if (argoCDApps.length === 0 || !argoCDShardURL) {
@@ -75,7 +93,13 @@ export const ArgoCDLink = ({
 
   if (argoCDApps.length === 1) {
     return (
-      <Button onClick={() => openArgoCD(argoCDApps[0])} {...buttonProps}>
+      <Button
+        href={argoCDHref(argoCDApps[0])}
+        target={isExtensionArgoCD ? undefined : '_blank'}
+        rel={isExtensionArgoCD ? undefined : 'noopener noreferrer'}
+        onClick={(e) => openArgoCD(e, argoCDApps[0])}
+        {...buttonProps}
+      >
         {children}
       </Button>
     );
@@ -95,11 +119,10 @@ export const ArgoCDLink = ({
             key: idx,
             label: (
               <a
-                href='#'
-                onClick={(e) => {
-                  e.preventDefault();
-                  openArgoCD(app);
-                }}
+                href={argoCDHref(app)}
+                target={isExtensionArgoCD ? undefined : '_blank'}
+                rel={isExtensionArgoCD ? undefined : 'noopener noreferrer'}
+                onClick={(e) => openArgoCD(e, app)}
               >
                 {status && <HealthStatusIcon health={status} className='mr-2' />}
                 {`${app.name} - ${app.namespace}`}


### PR DESCRIPTION
Closes #6688

## Problem

In the pipeline view, the ArgoCD link on a Stage node can't be opened in a new tab. Cmd/ctrl-click and right-click → "Open in new tab" either open in the same tab or land on the current Kargo page instead of the ArgoCD app.

The dropdown renders each item as `<a href='#'>` with the real destination only in the `onClick` handler. Native new-tab actions follow the anchor's actual `href` — which is `#` — so the browser never sees where the link really points.

## Approach

Put the real destination in `href` and let the browser handle every click mode natively, rather than trying to intercept modifier keys in JS. That's what anchors are for, and it fixes plain click, cmd/ctrl-click, and right-click in one move.

## Implementation

- `argoCDHref()` computes the real destination per app:
  - external ArgoCD → the app URL, rendered with `target="_blank"`
  - in-app extension route → the SPA path, wrapped in `withBasePath` (a real `href` needs the full prefix that the router basename would otherwise add for `navigate`)
- `openArgoCD()` only intercepts the in-app extension route on a plain click, to keep SPA navigation. Modified clicks (cmd/ctrl/shift/middle) fall through to the browser's native new-tab handling.
- Applied the same treatment to the single-app case — antd's `Button` renders an `<a>` when given `href`, so it gets the same behavior.

## Validation

- `pnpm run typecheck` and `eslint` pass on the changed file.
- UI-only change; worth a manual check in a Tilt env that both the single-app link and the multi-app dropdown open ArgoCD in a new tab across click/cmd-click/right-click.

Ticket: None

