### PR TITLE
fix(stages): tolerate admission denial of auto-promotion creates

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -1994,6 +1994,25 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 		// PromotionTemplate.
 		promotion := api.NewMinimalPromotion(stage, candidate.Name)
 		if err = r.client.Create(ctx, promotion); err != nil {
+			// An admission webhook may deny the create. Tolerate this as a
+			// non-error: nothing is persisted, so this reconcile moves on, and a
+			// later one re-derives and re-attempts the auto-promotion once the
+			// denying policy no longer applies. Any other error is still fatal to
+			// the reconcile.
+			//
+			// Deliberately not recorded as an event. A policy that holds keeps
+			// denying, so this branch is taken on every reconcile for as long as
+			// it does; an event per occurrence would report one unchanging
+			// condition thousands of times and bury the Project's event feed. A
+			// condition belongs in status, and Kargo Enterprise reports the one
+			// it knows about in Stage.status.promotionSchedule.
+			if apierrors.IsForbidden(err) {
+				freightLogger.Debug(
+					"auto-promotion was denied by an admission webhook",
+					"error", err.Error(),
+				)
+				continue
+			}
 			return newStatus, fmt.Errorf(
 				"error creating Promotion for Freight %q in namespace %q: %w",
 				candidate.Name, stage.Namespace, err,

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -7546,6 +7546,93 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 			},
 		},
 		{
+			// A Forbidden error from an admission webhook must not fail the
+			// reconcile: nothing is persisted and the pass continues, so a later
+			// reconcile can re-attempt once the denying policy no longer applies.
+			name:                 "tolerates a forbidden Promotion create",
+			autoPromotionEnabled: true,
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{
+						{
+							Origin: kargoapi.FreightOrigin{
+								Kind: kargoapi.FreightOriginKindWarehouse,
+								Name: "test-warehouse",
+							},
+							Sources: kargoapi.FreightSources{
+								Direct: true,
+							},
+						},
+					},
+					PromotionTemplate: &kargoapi.PromotionTemplate{
+						Spec: kargoapi.PromotionTemplateSpec{
+							Steps: []kargoapi.PromotionStep{
+								{
+									Uses: "fake-step",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "fake-project",
+						Name:              "test-freight",
+						CreationTimestamp: metav1.Time{Time: now},
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+			},
+			interceptor: interceptor.Funcs{
+				Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+					return &apierrors.StatusError{ErrStatus: metav1.Status{
+						Status: metav1.StatusFailure,
+						Reason: metav1.StatusReasonForbidden,
+						// Shaped like a real denial: the API server's wrapper around
+						// what a webhook returned via apierrors.NewForbidden, naming
+						// the Promotion the mutating webhook had just generated.
+						Message: `admission webhook "fake-webhook" denied the request: ` +
+							`promotions.kargo.akuity.io "test-stage.01jzzz.abc1234" is forbidden: ` +
+							`promotion of Stage "test-stage" is not permitted at this time`,
+					}}
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				recorder *fakeevent.EventRecorder,
+				c client.Client,
+				_ kargoapi.StageStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+
+				// No Promotion is persisted when the create is denied.
+				promoList := &kargoapi.PromotionList{}
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
+				assert.Empty(t, promoList.Items)
+
+				// Nor is anything recorded. A denial is a condition that persists
+				// across reconciles, not an occurrence, so an event per attempt
+				// would report the same thing indefinitely.
+				assert.Empty(t, recorder.Events)
+			},
+		},
+		{
 			name:                 "skips promotion when origin is in the effective hold map",
 			autoPromotionEnabled: true,
 			stage: &kargoapi.Stage{


### PR DESCRIPTION
When auto-promotion creates a Promotion, any error from `r.client.Create` is treated as fatal to the reconcile. An admission webhook denial is therefore indistinguishable from a genuine failure.

The consequence: a cluster running any admission policy that rejects Promotion creates — Kyverno, Gatekeeper, OPA, or any other validating webhook — drives every affected Stage into error-backoff for as long as the policy applies, with a `Reconciling` condition and a steady stream of reconcile errors in the logs. Nothing recovers until the policy is removed.

## The fix

A denial is a decision, not a failure. The API server persists nothing when a create is denied, so the reconcile has no partial state to unwind and nothing to retry imperatively.

`autoPromoteFreight` now treats `apierrors.IsForbidden` as non-fatal: it logs the denial and continues to the next requested Freight instead of returning an error. This is level-triggered — each subsequent reconcile re-derives the candidate and re-attempts the create, so promotion resumes on its own once the denying policy no longer applies. Any other create error remains fatal.

## Why no event

An earlier revision of this PR recorded an `AutoPromotionDenied` event here. That was wrong, and the type is gone.

A policy that denies keeps denying, so this branch is taken on every reconcile for as long as it holds — roughly every five minutes per affected Stage per blocked origin. An event per occurrence reports one unchanging fact indefinitely: a multi-hour freeze over a handful of Stages is thousands of Event writes, and `GET /v1beta1/projects/{project}/events` returns nothing but denials, which is worse than silence for the operator trying to see what actually happened.

Kargo's recorder is deliberately non-aggregating (`pkg/kubernetes/event`: "records all events without aggregation… without throttling / spam filtering"), because each event is meant to be one entry in an audit trail. That is the right default and this is simply not an event: it is a persistent condition, and a condition belongs in status. Kargo Enterprise, where promotion windows deny on purpose, reports it in `Stage.status.promotionSchedule` (#6737) — open or closed, why, and when it next changes.

## Testing

An `autoPromoteFreight` case returns a `Forbidden` `StatusError` from a create interceptor and asserts the reconcile succeeds, no Promotion is persisted, and nothing is recorded.

Verified end to end against a live cluster (Kargo Enterprise promotion windows, which deny Promotion creates through a validating webhook): with a Stage under an active Deny window and auto-promotion enabled, the Stage stays out of error-backoff, its conditions read `NoFreight` rather than `LastPromotionErrored`, and auto-promotion resumes unattended within the reconciler's 5-minute resync once the window reopens.

No API or CRD change; no codegen; no docs change.
