### PR TITLE
fix: exhaustive rename detection was skipped due to too many files

### DIFF
--- a/pkg/controller/git/work_tree.go
+++ b/pkg/controller/git/work_tree.go
@@ -414,7 +414,9 @@ func (w *workTree) Fetch(opts *FetchOptions) error {
 }
 
 func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
-	resBytes, err := libExec.Exec(w.buildGitCommand("show", "--pretty=", "--name-status", "--first-parent", commitID))
+	resBytes, err := libExec.Exec(w.buildGitCommand(
+		"show", "--pretty=", "--name-status", "--no-renames", "--first-parent", commitID,
+	))
 	if err != nil {
 		return nil, fmt.Errorf("error getting diff paths for commit %q: %w", commitID, err)
 	}
@@ -425,25 +427,20 @@ func (w *workTree) GetDiffPathsForCommitID(commitID string) ([]string, error) {
 		if line == "" {
 			continue
 		}
-		// --name-status output is tab-separated: <status>\t<path> for most
-		// changes, or <status>\t<old-path>\t<new-path> for renames and copies.
-		// The status field for renames and copies includes a similarity score
-		// (e.g. R100, C85), so we use HasPrefix rather than exact equality.
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) < 2 {
+		// With --no-renames, a moved file is reported as a delete of the old
+		// path and an add of the new path rather than a single rename record,
+		// so --name-status output is always tab-separated as <status>\t<path>.
+		// This naturally surfaces both sides of a move without invoking git's
+		// rename detection, which can warn and fail on commits that change too
+		// many files at once.
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
 			return nil, fmt.Errorf(
 				"unexpected output from git show for commit %q: %q",
 				commitID, line,
 			)
 		}
-		// For renames (R), include both old and new paths so that a path filter
-		// matching the source directory detects the removal. Copies (C) leave
-		// the source unchanged, so only the destination path is relevant.
-		if len(parts) == 3 && strings.HasPrefix(parts[0], "R") {
-			paths = append(paths, parts[1], parts[2])
-		} else {
-			paths = append(paths, parts[1])
-		}
+		paths = append(paths, parts[1])
 	}
 	return paths, nil
 }

--- a/pkg/controller/git/work_tree_test.go
+++ b/pkg/controller/git/work_tree_test.go
@@ -442,3 +442,53 @@ func TestGetDiffPathsForMovedFile(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"app/pod.yaml", "different-app/pod.yaml"}, paths)
 }
+
+func TestGetDiffPathsForCommitWithManyModifiedRenames(t *testing.T) {
+	testServer, testRepoURL, testRepoCreds := setupRemoteRepo(t)
+	defer testServer.Close()
+
+	rep, err := Clone(
+		testRepoURL,
+		&ClientOptions{Credentials: &testRepoCreds},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rep)
+	defer rep.Close()
+
+	const fileCount = 2000
+
+	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/old", rep.Dir()), 0o755))
+	for i := range fileCount {
+		require.NoError(t, os.WriteFile(
+			fmt.Sprintf("%s/old/file%d.txt", rep.Dir(), i),
+			[]byte(fmt.Sprintf("content %d", i)),
+			0o600,
+		))
+	}
+	require.NoError(t, rep.AddAllAndCommit("initial commit", nil))
+
+	// Move every file to a new directory and slightly modify its content, so
+	// git can't pair renames using a cheap exact-content match and instead
+	// falls back to similarity-based rename detection. Once a commit changes
+	// enough files at once, git skips that detection and prints a warning to
+	// stderr rather than failing -- GetDiffPathsForCommitID must not treat
+	// that warning as a fatal error.
+	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/new", rep.Dir()), 0o755))
+	for i := range fileCount {
+		require.NoError(t, os.Remove(fmt.Sprintf("%s/old/file%d.txt", rep.Dir(), i)))
+		require.NoError(t, os.WriteFile(
+			fmt.Sprintf("%s/new/file%d.txt", rep.Dir(), i),
+			[]byte(fmt.Sprintf("content %d, modified", i)),
+			0o600,
+		))
+	}
+	require.NoError(t, rep.AddAllAndCommit("move and modify many files", nil))
+
+	commitID, err := rep.LastCommitID()
+	require.NoError(t, err)
+
+	paths, err := rep.GetDiffPathsForCommitID(commitID)
+	require.NoError(t, err)
+	require.Len(t, paths, fileCount*2)
+}


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/6675

Commit https://github.com/fuskovic/testrepo/commit/80cfadef602049715a99e97c95779731c7e48f37 from [my test repo](https://github.com/fuskovic/testrepo) successfully created freight after implementing this fix:

<img width="1006" height="293" alt="test-commit" src="https://github.com/user-attachments/assets/a32f8d1e-dd28-4c2c-a7e2-a5e3c23676c5" />


<img width="673" height="316" alt="freight-created" src="https://github.com/user-attachments/assets/a788ba14-e3fc-40c0-a3db-2caf2b8d8d9c" />




