### PR TITLE
feat: freight status expression helper

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -520,6 +520,36 @@ features.
 
 :::
 
+### `freightStatus(freightName)`
+
+The `freightStatus()` function retrieves the entire `status` object of a
+`Freight` resource, including `currentlyIn`, `verifiedIn`, `approvedFor`, and
+`metadata`. This is a superset of what `freightMetadata()` exposes, and is
+useful when a promotion step needs to make decisions based on fields other
+than metadata e.g. checking whether a `Freight` was manually
+approved for a `Stage`. It has one required argument:
+
+- `freightName` (Required): The name of the `Freight` resource
+
+Example:
+
+```yaml
+config:
+  # Check whether the Freight has been manually approved for the "prod" Stage
+  wasManuallyApproved: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}
+
+  # Check whether the Freight is currently verified in the "staging" Stage
+  isVerifiedInStaging: ${{ freightStatus(ctx.targetFreight.name).verifiedIn?.staging != nil }}
+```
+:::info
+
+You can handle `nil` values gracefully in Expr using its
+[nil coalescing](https://expr-lang.org/docs/language-definition#nil-coalescing) and
+[optional chaining](https://expr-lang.org/docs/language-definition#optional-chaining)
+features.
+
+:::
+
 ### `stageMetadata(stageName)`
 
 The `stageMetadata()` function retrieves metadata stored in a `Stage` resource. It

--- a/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
+++ b/docs/docs/50-user-guide/60-reference-docs/40-expressions.md
@@ -534,12 +534,30 @@ approved for a `Stage`. It has one required argument:
 Example:
 
 ```yaml
-config:
-  # Check whether the Freight has been manually approved for the "prod" Stage
-  wasManuallyApproved: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: compose-output
+          as: freight-status
+          config:
+            all: ${{ freightStatus(ctx.targetFreight.name) }}
+            currentlyIn: ${{ freightStatus(ctx.targetFreight.name).currentlyIn }}
+            verifiedIn: ${{ freightStatus(ctx.targetFreight.name).verifiedIn }}
+            approvedFor: ${{ freightStatus(ctx.targetFreight.name).approvedFor }}
+            metadata: ${{ freightStatus(ctx.targetFreight.name).metadata }}
+            wasBypassed: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}
 
-  # Check whether the Freight is currently verified in the "staging" Stage
-  isVerifiedInStaging: ${{ freightStatus(ctx.targetFreight.name).verifiedIn?.staging != nil }}
+        # Automation flows freely when this promotion resulted from normal 
+        # verification, but an additional human gate is required when it resulted from a
+        # manual "Approve" bypass of this Stage.
+        - uses: fail
+          if: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}
+          config:
+            message: >-
+              Freight ${{ ctx.targetFreight.name }} was promoted to prod via a
+              manual approval bypass (approvedFor.prod.approvedAt =
+              ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt }}).
+              This requires additional human review before proceeding.
 ```
 :::info
 

--- a/pkg/expressions/function/functions.go
+++ b/pkg/expressions/function/functions.go
@@ -47,6 +47,7 @@ func FreightOperations(
 		ChartFromFreight(ctx, c, project, freightRequests, freightRefs),
 		ArtifactFromFreight(ctx, c, project, freightRequests, freightRefs),
 		FreightMetadata(ctx, c, project),
+		FreightStatus(ctx, c, project),
 	}
 }
 
@@ -82,6 +83,7 @@ func DataOperations(ctx context.Context, c client.Client, cache *gocache.Cache, 
 		Secret(ctx, c, cache, project),
 		SharedSecret(ctx, c, cache),
 		FreightMetadata(ctx, c, project),
+		FreightStatus(ctx, c, project),
 		StageMetadata(ctx, c, project),
 	}
 }
@@ -309,33 +311,12 @@ func freightMetadata(
 			return nil, fmt.Errorf("freight ref name must not be empty")
 		}
 
-		// Retrieve the Freight object as unstructured because it bypasses the
-		// client's cache. This is essential for cases where Freight metadata is
-		// being accessed very shortly after having been updated.
-		u := &unstructured.Unstructured{}
-		u.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   kargoapi.GroupVersion.Group,
-			Version: kargoapi.GroupVersion.Version,
-			Kind:    "Freight",
-		})
-		if err := c.Get(
-			ctx,
-			client.ObjectKey{Namespace: project, Name: freightRefName},
-			u,
-		); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to get freight %s: %w", freightRefName, err)
+		freight, err := getFreightForExpr(ctx, c, project, freightRefName)
+		if err != nil {
+			return nil, err
 		}
-		freight := &kargoapi.Freight{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
-			u.Object,
-			freight,
-		); err != nil {
-			return nil, fmt.Errorf(
-				"error converting unstructured object to Freight: %w", err,
-			)
+		if freight == nil {
+			return nil, nil
 		}
 
 		if freight.Status.Metadata == nil {
@@ -352,6 +333,99 @@ func freightMetadata(
 		}
 		return decoded, nil
 	}
+}
+
+// FreightStatus returns an expr.Option that provides a `freightStatus()`
+// function for use in expressions; returning the entire status object of the
+// Freight.
+func FreightStatus(
+	ctx context.Context,
+	c client.Client,
+	project string,
+) expr.Option {
+	return expr.Function(
+		"freightStatus",
+		freightStatus(ctx, c, project),
+		new(func(freightRefName string) map[string]any),
+	)
+}
+
+func freightStatus(
+	ctx context.Context,
+	c client.Client,
+	project string,
+) exprFn {
+	return func(a ...any) (any, error) {
+		if len(a) != 1 {
+			return nil, fmt.Errorf("expected 1 argument, got %d", len(a))
+		}
+
+		freightRefName, ok := a[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("first argument must be string, got %T", a[0])
+		}
+		if freightRefName == "" {
+			return nil, fmt.Errorf("freight ref name must not be empty")
+		}
+		freight, err := getFreightForExpr(ctx, c, project, freightRefName)
+		if err != nil {
+			return nil, err
+		}
+		if freight == nil {
+			return nil, nil
+		}
+
+		raw, err := json.Marshal(freight.Status)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling freight status: %w", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return nil, fmt.Errorf("error unmarshaling freight status: %w", err)
+		}
+		return decoded, nil
+	}
+}
+
+// getFreightForExpr retrieves the named Freight resource within the given
+// project for use by expression functions. It returns a nil Freight and nil
+// error if the Freight does not exist.
+//
+// The Freight is retrieved as unstructured because it bypasses the client's
+// cache. This is essential for cases where Freight status is being accessed
+// very shortly after having been updated.
+func getFreightForExpr(
+	ctx context.Context,
+	c client.Client,
+	project string,
+	freightRefName string,
+) (*kargoapi.Freight, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   kargoapi.GroupVersion.Group,
+		Version: kargoapi.GroupVersion.Version,
+		Kind:    "Freight",
+	})
+	if err := c.Get(
+		ctx,
+		client.ObjectKey{Namespace: project, Name: freightRefName},
+		u,
+	); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get freight %s: %w", freightRefName, err)
+	}
+	freight := &kargoapi.Freight{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		u.Object,
+		freight,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"error converting unstructured object to Freight: %w", err,
+		)
+	}
+	return freight, nil
 }
 
 // StageMetadata returns an expr.Option that provides a `stageMetadata()` function

--- a/pkg/expressions/function/functions.go
+++ b/pkg/expressions/function/functions.go
@@ -416,16 +416,16 @@ func getFreightForExpr(
 		}
 		return nil, fmt.Errorf("failed to get freight %s: %w", freightRefName, err)
 	}
-	freight := &kargoapi.Freight{}
+	f := &kargoapi.Freight{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
 		u.Object,
-		freight,
+		f,
 	); err != nil {
 		return nil, fmt.Errorf(
 			"error converting unstructured object to Freight: %w", err,
 		)
 	}
-	return freight, nil
+	return f, nil
 }
 
 // StageMetadata returns an expr.Option that provides a `stageMetadata()` function

--- a/pkg/expressions/function/functions_test.go
+++ b/pkg/expressions/function/functions_test.go
@@ -1779,6 +1779,139 @@ func Test_freightMetadata(t *testing.T) {
 	}
 }
 
+func Test_freightStatus(t *testing.T) {
+	const testProject = "fake-project"
+	const testFreightName = "fake-freight"
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, kargoapi.AddToScheme(scheme))
+
+	approvedAt := metav1.NewTime(time.Date(2026, 7, 24, 23, 11, 1, 0, time.UTC))
+	since := metav1.NewTime(time.Date(2026, 5, 13, 14, 42, 47, 0, time.UTC))
+
+	testFreight := &kargoapi.Freight{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testFreightName,
+			Namespace: testProject,
+		},
+		Status: kargoapi.FreightStatus{
+			CurrentlyIn: map[string]kargoapi.CurrentStage{
+				"staging": {Since: &since},
+			},
+			ApprovedFor: map[string]kargoapi.ApprovedStage{
+				"prod": {ApprovedAt: &approvedAt},
+			},
+			Metadata: map[string]apiextensionsv1.JSON{
+				"snow-id": {Raw: []byte(`"c2d4dd08833503d4b6207e95eeaad316"`)},
+			},
+		},
+	}
+
+	expectedStatus := map[string]any{
+		"currentlyIn": map[string]any{
+			"staging": map[string]any{
+				"since": since.Format(time.RFC3339),
+			},
+		},
+		"approvedFor": map[string]any{
+			"prod": map[string]any{
+				"approvedAt": approvedAt.Format(time.RFC3339),
+			},
+		},
+		"metadata": map[string]any{
+			"snow-id": "c2d4dd08833503d4b6207e95eeaad316",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		objects    []client.Object
+		args       []any
+		assertions func(t *testing.T, result any, err error)
+	}{
+		{
+			name: "no arguments",
+			args: []any{},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "expected 1 argument")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "too many arguments",
+			args: []any{testFreightName, "extra"},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "expected 1 argument")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "invalid argument type",
+			args: []any{123},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "argument must be string")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "empty freight ref name",
+			args: []any{""},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.ErrorContains(t, err, "freight ref name must not be empty")
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name:    "freight not found",
+			objects: []client.Object{}, // No freight objects
+			args:    []any{testFreightName},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "freight exists with empty status",
+			objects: []client.Object{
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testFreightName,
+						Namespace: testProject,
+					},
+					Status: kargoapi.FreightStatus{},
+				},
+			},
+			args: []any{testFreightName},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]any{}, result)
+			},
+		},
+		{
+			name:    "successful status retrieval",
+			objects: []client.Object{testFreight},
+			args:    []any{testFreightName},
+			assertions: func(t *testing.T, result any, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, expectedStatus, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				Build()
+
+			fn := freightStatus(t.Context(), c, testProject)
+			result, err := fn(tt.args...)
+			tt.assertions(t, result, err)
+		})
+	}
+}
+
 func Test_stageMetadata(t *testing.T) {
 	const testProject = "fake-project"
 	const testStageName = "fake-stage"


### PR DESCRIPTION
### Config
<img width="515" height="398" alt="config" src="https://github.com/user-attachments/assets/867911d3-5919-4986-8114-fdca68cb21fb" />

### Output

<img width="500" height="479" alt="output" src="https://github.com/user-attachments/assets/2666345b-22cd-4b23-8f99-cae9a21f16f5" />

### Resources used


```yaml
apiVersion: argoproj.io/v1alpha1
kind: AnalysisTemplate
metadata:
  name: always-pass
  namespace: kargo-demo
spec:
  metrics:
    - name: always-pass
      provider:
        job:
          spec:
            template:
              spec:
                containers:
                  - name: always-pass
                    image: alpine:3
                    command: [sh, -c, "exit 0"]
                restartPolicy: Never
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: test
  namespace: kargo-demo
spec:
  requestedFreight:
    - origin:
        kind: Warehouse
        name: my-warehouse
      sources:
        direct: true
        autoPromotionOptions:
          selectionPolicy: NewestFreight
  verification:
    analysisTemplates:
      - name: always-pass
  promotionTemplate:
    spec:
      steps:
        - uses: compose-output
          as: freight-status
          config:
            all: ${{ freightStatus(ctx.targetFreight.name) }}
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: uat
  namespace: kargo-demo
spec:
  requestedFreight:
    - origin:
        kind: Warehouse
        name: my-warehouse
      sources:
        stages:
          - test
        autoPromotionOptions:
          selectionPolicy: NewestFreight
  verification:
    analysisTemplates:
      - name: always-pass
  promotionTemplate:
    spec:
      steps:
        - uses: compose-output
          as: freight-status
          config:
            all: ${{ freightStatus(ctx.targetFreight.name) }}
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: prod
  namespace: kargo-demo
spec:
  requestedFreight:
    - origin:
        kind: Warehouse
        name: my-warehouse
      sources:
        stages:
          - uat
  promotionTemplate:
    spec:
      steps:
        # Dump the full freightStatus() object, plus the individual fields
        # called out in the issue, so the resolved values are visible in
        # `kubectl get promotion <name> -n kargo-demo -o yaml` under this
        # step's output.
        - uses: compose-output
          as: freight-status
          config:
            all: ${{ freightStatus(ctx.targetFreight.name) }}
            currentlyIn: ${{ freightStatus(ctx.targetFreight.name).currentlyIn }}
            verifiedIn: ${{ freightStatus(ctx.targetFreight.name).verifiedIn }}
            approvedFor: ${{ freightStatus(ctx.targetFreight.name).approvedFor }}
            metadata: ${{ freightStatus(ctx.targetFreight.name).metadata }}
            wasBypassed: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}

        # Reproduces the exact use case from the issue: automation flows
        # freely when this promotion resulted from normal verification, but
        # an additional human gate is required when it resulted from a
        # manual "Approve" bypass of this Stage.
        - uses: fail
          if: ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt != nil }}
          config:
            message: >-
              Freight ${{ ctx.targetFreight.name }} was promoted to prod via a
              manual approval bypass (approvedFor.prod.approvedAt =
              ${{ freightStatus(ctx.targetFreight.name).approvedFor?.prod?.approvedAt }}).
              This requires additional human review before proceeding.
---
apiVersion: kargo.akuity.io/v1alpha1
kind: ProjectConfig
metadata:
  name: kargo-demo
  namespace: kargo-demo
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Warehouse
metadata:
  name: my-warehouse
  namespace: kargo-demo
spec:
  interval: 30m
  subscriptions:
  - git:
      repoURL: git@github.com:fuskovic/testrepo.git
      branch: main
      strictSemvers: false
      includePaths:
      - files2/
---
apiVersion: v1
kind: Secret
metadata:
  name: warehouse-secret
  namespace: kargo-shared-resources
  labels:
    kargo.akuity.io/cred-type: git
stringData:
  repoURL: git@github.com:fuskovic/testrepo.git
  sshPrivateKey: redacted
 ```