### PR TITLE
feat(events): add a PromotionDiscarded event type

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -29,6 +29,7 @@ const (
 	EventTypePromotionFailed                 EventType = "PromotionFailed"
 	EventTypePromotionErrored                EventType = "PromotionErrored"
 	EventTypePromotionAborted                EventType = "PromotionAborted"
+	EventTypePromotionDiscarded              EventType = "PromotionDiscarded"
 	EventTypeFreightCreated                  EventType = "FreightCreated"
 	EventTypeFreightApproved                 EventType = "FreightApproved"
 	EventTypeFreightVerificationSucceeded    EventType = "FreightVerificationSucceeded"

--- a/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
+++ b/docs/docs/50-user-guide/60-reference-docs/90-events/10-event-reference.md
@@ -132,6 +132,7 @@ The complete list of built-in Kargo event types is provided below:
 - `PromotionFailed`
 - `PromotionErrored`
 - `PromotionAborted`
+- `PromotionDiscarded`
 - `FreightCreated`
 - `FreightApproved`
 - `FreightVerificationSucceeded`
@@ -190,6 +191,18 @@ This event is emitted when a promotion encounters an unexpected error.
 ### `PromotionAborted`
 
 This event is emitted when a promotion run is aborted before completion.
+
+**Payload Includes**
+
+- [Common event fields](#common-event-fields)
+- [Promotion fields](#promotion-fields)
+
+### `PromotionDiscarded`
+
+This event is emitted when the control plane removes a promotion that never started running, so
+that the reason it will not run is not lost along with it. Routine deletions by the garbage
+collector do not emit this event; those promotions already reached a terminal phase and reported
+an outcome of their own.
 
 **Payload Includes**
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -14,6 +14,7 @@ var KnownEventTypes = []kargoapi.EventType{
 	kargoapi.EventTypePromotionFailed,
 	kargoapi.EventTypePromotionErrored,
 	kargoapi.EventTypePromotionAborted,
+	kargoapi.EventTypePromotionDiscarded,
 	kargoapi.EventTypeFreightCreated,
 	kargoapi.EventTypeFreightApproved,
 	kargoapi.EventTypeFreightVerificationSucceeded,

--- a/pkg/event/kubernetes/kubernetes.go
+++ b/pkg/event/kubernetes/kubernetes.go
@@ -27,6 +27,8 @@ func FromKubernetesEvent(evt corev1.Event) (event.Meta, error) {
 		parsedEvent, err = event.UnmarshalPromotionErroredAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypePromotionAborted:
 		parsedEvent, err = event.UnmarshalPromotionAbortedAnnotations(id, evt.Annotations)
+	case kargoapi.EventTypePromotionDiscarded:
+		parsedEvent, err = event.UnmarshalPromotionDiscardedAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypeFreightCreated:
 		parsedEvent, err = event.UnmarshalFreightCreatedAnnotations(id, evt.Annotations)
 	case kargoapi.EventTypeFreightApproved:

--- a/pkg/event/kubernetes/kubernetes_test.go
+++ b/pkg/event/kubernetes/kubernetes_test.go
@@ -489,7 +489,8 @@ func isPromotionEvent(eventType kargoapi.EventType) bool {
 		kargoapi.EventTypePromotionSucceeded,
 		kargoapi.EventTypePromotionFailed,
 		kargoapi.EventTypePromotionErrored,
-		kargoapi.EventTypePromotionAborted:
+		kargoapi.EventTypePromotionAborted,
+		kargoapi.EventTypePromotionDiscarded:
 		return true
 	default:
 		return false

--- a/pkg/event/promotion.go
+++ b/pkg/event/promotion.go
@@ -82,6 +82,29 @@ func (p *PromotionAborted) Type() kargoapi.EventType {
 	return kargoapi.EventTypePromotionAborted
 }
 
+// PromotionDiscarded is event data recorded when the control plane removes a
+// Promotion that never ran. Every other way a Promotion can end reports an
+// outcome of its own; this covers the case where the removal *is* the outcome,
+// and the message is the only surviving record of why.
+//
+// Discarding is narrower than deleting. The garbage collector's retention
+// deletes stay silent, because those Promotions already reached a terminal
+// phase and already reported what happened.
+//
+// Nothing in OSS discards a Promotion today. Kargo Enterprise does, when a
+// promotion window closes while a Promotion is still Pending. The type is
+// registered here because registration is what gives the event an
+// involvedObject apiVersion, without which it never reaches the project event
+// stream or the UI.
+type PromotionDiscarded struct {
+	Common
+	Promotion
+}
+
+func (p *PromotionDiscarded) Type() kargoapi.EventType {
+	return kargoapi.EventTypePromotionDiscarded
+}
+
 // PromotionCreated is event data related to a created promotion.
 type PromotionCreated struct {
 	Common
@@ -156,6 +179,20 @@ func NewPromotionAborted(
 	}
 }
 
+// NewPromotionDiscarded creates a new PromotionDiscarded event from the given promotion and freight
+// data. The message should say why the Promotion was discarded, since that is the only record left
+// of it. The given actor will be used if it is not empty, but it will be overridden if the
+// promotion has an actor annotation.
+func NewPromotionDiscarded(
+	message, actor string, promotion *kargoapi.Promotion, freight *kargoapi.Freight,
+) *PromotionDiscarded {
+	common, promo := NewPromotionCommon(message, actor, promotion, freight)
+	return &PromotionDiscarded{
+		Common:    common,
+		Promotion: promo,
+	}
+}
+
 // NewPromotionCreated creates a new PromotionCreated event from the given promotion and freight data.
 // The given actor will be used if it is not empty, but it will be overridden if the promotion has
 // an actor annotation.
@@ -214,6 +251,14 @@ func (p *PromotionErrored) MarshalAnnotations() map[string]string {
 }
 
 func (p *PromotionAborted) MarshalAnnotations() map[string]string {
+	// Note that we skip message here, as it is not used in the annotations.
+	annotations := map[string]string{}
+	p.Common.MarshalAnnotationsTo(annotations)
+	p.Promotion.MarshalAnnotationsTo(annotations)
+	return annotations
+}
+
+func (p *PromotionDiscarded) MarshalAnnotations() map[string]string {
 	// Note that we skip message here, as it is not used in the annotations.
 	annotations := map[string]string{}
 	p.Common.MarshalAnnotationsTo(annotations)
@@ -341,6 +386,26 @@ func UnmarshalPromotionAbortedAnnotations(
 		return nil, err
 	}
 	evt := PromotionAborted{
+		Common:    common,
+		Promotion: promotion,
+	}
+	return &evt, nil
+}
+
+// UnmarshalPromotionDiscardedAnnotations converts the given annotations into a PromotionDiscarded. This is used by the
+// main event handler to convert the data into a normal structured event, but is exposed for convenience.
+func UnmarshalPromotionDiscardedAnnotations(
+	eventID string, annotations map[string]string,
+) (*PromotionDiscarded, error) {
+	common, err := UnmarshalCommonAnnotations(eventID, annotations)
+	if err != nil {
+		return nil, err
+	}
+	promotion, err := UnmarshalPromotionAnnotations(annotations)
+	if err != nil {
+		return nil, err
+	}
+	evt := PromotionDiscarded{
 		Common:    common,
 		Promotion: promotion,
 	}

--- a/pkg/event/promotion_test.go
+++ b/pkg/event/promotion_test.go
@@ -33,6 +33,11 @@ func TestPromotionAborted(t *testing.T) {
 	require.Equal(t, kargoapi.EventTypePromotionAborted, evt.Type())
 }
 
+func TestPromotionDiscarded(t *testing.T) {
+	evt := &PromotionDiscarded{}
+	require.Equal(t, kargoapi.EventTypePromotionDiscarded, evt.Type())
+}
+
 func TestPromotionCreated(t *testing.T) {
 	evt := &PromotionCreated{}
 	require.Equal(t, kargoapi.EventTypePromotionCreated, evt.Type())
@@ -176,6 +181,12 @@ func TestPromotionConstructors(t *testing.T) {
 				return NewPromotionAborted("Aborted message", "test-actor", promotion, freight)
 			},
 			expectedType: kargoapi.EventTypePromotionAborted,
+		},
+		"discarded": {
+			constructor: func() Meta {
+				return NewPromotionDiscarded("Discarded message", "test-actor", promotion, freight)
+			},
+			expectedType: kargoapi.EventTypePromotionDiscarded,
 		},
 		"created": {
 			constructor: func() Meta {
@@ -375,6 +386,28 @@ func TestPromotionEventUnmarshalAnnotations(t *testing.T) {
 				return UnmarshalPromotionAbortedAnnotations("event-id", annotations)
 			},
 			expectedType: &PromotionAborted{
+				Common: Common{
+					Project: "test-project",
+					ID:      "event-id",
+				},
+				Promotion: Promotion{
+					Name:       "test-promotion",
+					StageName:  "test-stage",
+					CreateTime: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+		"promotion discarded": {
+			annotations: map[string]string{
+				kargoapi.AnnotationKeyEventProject:             "test-project",
+				kargoapi.AnnotationKeyEventPromotionName:       "test-promotion",
+				kargoapi.AnnotationKeyEventStageName:           "test-stage",
+				kargoapi.AnnotationKeyEventPromotionCreateTime: "2024-01-01T12:00:00Z",
+			},
+			unmarshalFunc: func(annotations map[string]string) (Meta, error) {
+				return UnmarshalPromotionDiscardedAnnotations("event-id", annotations)
+			},
+			expectedType: &PromotionDiscarded{
 				Common: Common{
 					Project: "test-project",
 					ID:      "event-id",


### PR DESCRIPTION
Adds a `PromotionDiscarded` event type for a Promotion removed before it ever ran.

Every other way a Promotion can end — succeeded, failed, errored, aborted — records an event explaining itself. A Promotion removed while still `Pending` simply stops existing, and nothing distinguishes that from one that was never created. The person most likely to go looking is whoever requested it a few minutes earlier.

## Discarded, not deleted

The event names the outcome rather than the mechanism. The garbage collector's retention deletes stay silent on purpose: those Promotions already reached a terminal phase and already reported what happened, so an event would be noise about an object nobody is waiting on. A mechanism name would promise a report for every deletion — including a user's own — and leave anyone filtering on the type quietly missing most of them.

`PromotionDiscarded` means specifically *removed before it ever ran, where the removal is the outcome*.

## Registered but not emitted here

Nothing in OSS discards a Promotion today. Kargo Enterprise does, when a promotion window closes while a Promotion is still `Pending` — removing it rather than aborting it, because an aborted Promotion is terminal and unsuccessful and would trip the Stage controller's guard against re-promoting Freight whose last Promotion failed, suppressing that Freight long after the window reopened.

Registration is what makes such an event reachable at all, which is why the type belongs here rather than downstream:

- `EventSender.Send` stamps `involvedObject.apiVersion` only for types in `KnownEventTypes`.
- `indexer.EventsByInvolvedObjectAPIGroup` skips events without it.
- `listProjectEvents` selects on that index.

So an unregistered type is written to the cluster but never reaches `GET /v1beta1/projects/{project}/events` or the UI. 

## Shape

`Common` + `Promotion`, identical to the other five promotion events — no new marshalling machinery, reusing `NewPromotionCommon`. `TestFromKubernetesEvent_AllEventTypes` enumerates `KnownEventTypes`, so adding the constant is what forced the decode case to exist.

## Testing

Type, constructor, and annotation round-trip tests, plus the type's addition to the promotion-event set in the `pkg/event/kubernetes` tests. No API or CRD change; no codegen. The event reference doc enumerates types by hand with nothing to enforce it, so it is updated too.
