### PR TITLE
fix(credentials): coalesce concurrent credential cache misses

### DIFF
--- a/pkg/cache/coalescing/cache.go
+++ b/pkg/cache/coalescing/cache.go
@@ -1,0 +1,255 @@
+package coalescing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/akuity/kargo/pkg/logging"
+)
+
+const (
+	// defaultCleanupInterval is how often a Cache evicts expired entries when no
+	// CacheOptions.CleanupInterval is provided. Eviction reclaims only what no
+	// caller asks for again, so this is not urgent work, but a coarse interval
+	// would retain such entries for many multiples of a short TTL. The cost of a
+	// finer one grows with the number of entries, and a Cache holding enough of
+	// them for that to matter is one whose CleanupInterval was chosen
+	// deliberately.
+	defaultCleanupInterval = time.Minute
+	// defaultLoadTimeout is the default timeout for a Loader function when no
+	// CacheOptions.LoadTimeout is provided.
+	defaultLoadTimeout = time.Minute
+	// defaultTTL is how long a Cache retains a value whose Loader function
+	// deferred that decision, when no CacheOptions.DefaultTTL is provided.
+	defaultTTL = time.Hour
+)
+
+// Loader is the signature for any function that, given implementation-specific
+// input, returns a value for a Cache to cache, along with the TTL to cache it
+// for, and if applicable, an error. A nil TTL signals that the value is not to
+// be cached. TTL of zero implicitly defers to associated
+// CacheOptions.DefaultTTL. A negative duration signals that the value is to be
+// cached indefinitely. Implementations are required to honor the context
+// argument and return promptly when it is canceled, timed out, or otherwise
+// ended.
+type Loader[I, T any] func(
+	ctx context.Context,
+	input I,
+) (T, *time.Duration, error)
+
+// CacheOptions are passed to NewCache() to configure the returned Cache.
+// NewCache() will accept a nil CacheOptions pointer and create its own
+// CacheOptions instead. Whether CacheOptions are passed in or created,
+// NewCache() works from a copy, populating any nil fields of that copy with
+// sensible defaults. A Cache's configuration is therefore fixed at the moment
+// it is built and unaffected by any later change to the CacheOptions the caller
+// retains.
+type CacheOptions struct {
+	// CleanupInterval is how often to evict expired entries from the Cache. When
+	// nil, NewCache() substitutes a default of 1m. A zero or negative duration is
+	// invalid and will cause NewCache() to return an error. This field is ignored
+	// entirely when CacheNothing is true, there being nothing to evict.
+	CleanupInterval *time.Duration
+	// DefaultTTL specifies how long to cache values obtained from a Loader
+	// function when the TTL also returned from that Loader function is zero. When
+	// nil, NewCache() substitutes a default of 1h. A zero or negative duration is
+	// valid and indicates the effective DefaultTTL is indefinite.
+	DefaultTTL *time.Duration
+	// LoadTimeout bounds execution of a Loader function. When nil, NewCache()
+	// substitutes a default of 1m. A zero or negative duration is invalid and
+	// will cause NewCache() to return an error.
+	LoadTimeout *time.Duration
+	// CacheNothing, when true, effectively disables all internal caching. When
+	// true, DefaultTTL and CleanupInterval have no effect, regardless of their
+	// values. This option is useful primarily for tests that wish to
+	// deterministically avoid all caching and ensure every call to Cache.Get()
+	// executes a Loader function or waits on one already in-flight.
+	CacheNothing bool
+}
+
+// Cache is an interface for a load-through cache.
+type Cache[I, T any] interface {
+	// Get returns the value cached under the given key, if one exists. On a miss,
+	// it returns the value a Loader function obtains using the given input, and
+	// caches that value unless the Loader function or this Cache's own
+	// configuration directs otherwise. Crucially, implementations MUST coalesce
+	// concurrent loads for a single key such that potentially expensive work is
+	// done only once, with all applicable, concurrent callers receiving the same
+	// result when loading completes. Subsequent callers presenting that key MUST
+	// receive the cached value, where one was cached, until it expires.
+	//
+	// A key and an input are separate arguments because the caller often will
+	// have derived the key from the input using a transformation (like a hash,
+	// for instance) that cannot be reversed, yet the original input will
+	// typically be required by an underlying Loader function in the event of a
+	// cache miss.
+	//
+	// A caller whose own context ends before a load completes stops waiting and
+	// receives an error saying so. The load itself carries on, belonging as it
+	// does to no one caller, so that those still waiting on it are served.
+	Get(ctx context.Context, key string, input I) (T, error)
+}
+
+// entry wraps a value on its way into and out of a cache that holds values of
+// any type, so that recovering the value again does not depend on the value's
+// own type. Stored bare, a nil value of an interface type T comes back as a nil
+// any, which no assertion to T can succeed against, so the value would be
+// retained and yet never served and every caller would load anew.
+type entry[T any] struct {
+	value T
+}
+
+// cache is an implementation of the Cache interface.
+type cache[I, T any] struct {
+	// loader is the function that will be called to load a value when a cache
+	// miss occurs.
+	loader Loader[I, T]
+
+	// loadTimeout bounds execution of loader.
+	loadTimeout time.Duration
+
+	// values is this component's INTERNAL cache. When nil, it stands down with
+	// all calls to Get() executing a Loader function or waiting on one already
+	// in-flight.
+	values *gocache.Cache
+
+	// group coalesces concurrent loads for any given key into a single load whose
+	// result is shared by all callers.
+	group singleflight.Group
+}
+
+// NewCache returns a Cache that fills misses using the given Loader function.
+// It returns an error if the given CacheOptions are invalid.
+func NewCache[I, T any](
+	loader Loader[I, T],
+	opts *CacheOptions,
+) (Cache[I, T], error) {
+	// Defaults are applied to a copy, leaving the caller's CacheOptions as they
+	// were found. The durations they name are dereferenced below, so nothing the
+	// caller still holds a pointer to can alter this Cache after the fact.
+	var effectiveOpts CacheOptions
+	if opts != nil {
+		effectiveOpts = *opts
+	}
+	if effectiveOpts.CleanupInterval == nil {
+		effectiveOpts.CleanupInterval = new(defaultCleanupInterval)
+	}
+	if effectiveOpts.DefaultTTL == nil {
+		effectiveOpts.DefaultTTL = new(defaultTTL)
+	}
+	if effectiveOpts.LoadTimeout == nil {
+		effectiveOpts.LoadTimeout = new(defaultLoadTimeout)
+	}
+	if *effectiveOpts.LoadTimeout <= 0 {
+		return nil,
+			errors.New("invalid CacheOptions: LoadTimeout must be positive")
+	}
+	c := &cache[I, T]{
+		loader:      loader,
+		loadTimeout: *effectiveOpts.LoadTimeout,
+	}
+	if !effectiveOpts.CacheNothing {
+		if *effectiveOpts.CleanupInterval <= 0 {
+			return nil,
+				errors.New("invalid CacheOptions: CleanupInterval must be positive")
+		}
+		c.values = gocache.New(
+			*effectiveOpts.DefaultTTL,
+			*effectiveOpts.CleanupInterval,
+		)
+	}
+	return c, nil
+}
+
+// Get implements the Cache interface.
+func (c *cache[I, T]) Get(
+	ctx context.Context,
+	key string,
+	input I,
+) (T, error) {
+	var zero T
+
+	logger := logging.LoggerFromContext(ctx).WithValues("key", key)
+
+	if c.values != nil {
+		if cached, exists := c.values.Get(key); exists {
+			if e, ok := cached.(entry[T]); ok {
+				logger.Debug("cache hit")
+				return e.value, nil
+			}
+		}
+		logger.Debug("cache miss")
+	} else {
+		logger.Debug("internal cache disabled; skipping cache lookup")
+	}
+
+	ch := c.group.DoChan(key, func() (val any, err error) {
+		// A panic escaping into singleflight is re-raised on a goroutine of its
+		// own, where no recovery a caller has in place can reach it, and takes the
+		// process down. Reporting it as an error instead keeps a defective Loader
+		// function from doing that, at the cost of the panic's own stack trace,
+		// which is logged here since it will not appear anywhere else.
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error(
+					nil, "recovered from panic in Loader function",
+					"panic", r,
+					"stack", string(debug.Stack()),
+				)
+				err = fmt.Errorf("Loader function panicked: %v", r)
+			}
+		}()
+		return c.loadAndCache(ctx, key, input)
+	})
+
+	select {
+	case <-ctx.Done():
+		return zero, fmt.Errorf(
+			"load interrupted; loading will continue in the background: %w",
+			ctx.Err(),
+		)
+	case res := <-ch:
+		if res.Err != nil {
+			return zero, res.Err
+		}
+		loaded, _ := res.Val.(entry[T])
+		return loaded.value, nil
+	}
+}
+
+// loadAndCache detaches the load from the calling context, runs it, and caches
+// what it produced, if that value is to be cached. It is intended to be
+// executed within the Cache's singleflight group.
+func (c *cache[I, T]) loadAndCache(
+	ctx context.Context,
+	key string,
+	input I,
+) (entry[T], error) {
+	logger := logging.LoggerFromContext(ctx).WithValues("key", key)
+
+	// Since no caller's cancellation bounds this work, it carries its own
+	// timeout. Nothing else of the calling context survives but its logger,
+	// carried over so that what the load logs remains attributable to the call
+	// that began it.
+	orphanedCtx, cancel := context.WithTimeout(
+		logging.ContextWithLogger(context.Background(), logger),
+		c.loadTimeout,
+	)
+	defer cancel()
+
+	value, ttl, err := c.loader(orphanedCtx, input)
+	if err != nil {
+		return entry[T]{}, err
+	}
+	loaded := entry[T]{value: value}
+	if c.values != nil && ttl != nil {
+		c.values.Set(key, loaded, *ttl)
+	}
+	return loaded, nil
+}

--- a/pkg/cache/coalescing/cache_test.go
+++ b/pkg/cache/coalescing/cache_test.go
@@ -1,0 +1,703 @@
+package coalescing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKey         = "test-key"
+	testInput       = "test-input"
+	testValue       = "test-value"
+	testLoadTimeout = 30 * time.Second
+)
+
+func TestNewCache(t *testing.T) {
+	t.Parallel()
+
+	zero := time.Duration(0)
+	negative := -1 * time.Minute
+	tenMinutes := 10 * time.Minute
+
+	testCases := []struct {
+		name       string
+		opts       *CacheOptions
+		assertions func(*testing.T, *CacheOptions, Cache[string, string], error)
+	}{
+		{
+			name: "nil CacheOptions",
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, defaultLoadTimeout, loadTimeoutOf(c))
+				require.NotNil(t, internalValues(c))
+			},
+		},
+		{
+			name: "caller's CacheOptions are left as they were found",
+			opts: &CacheOptions{},
+			assertions: func(
+				t *testing.T,
+				opts *CacheOptions,
+				_ Cache[string, string],
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Nil(t, opts.CleanupInterval)
+				require.Nil(t, opts.DefaultTTL)
+				require.Nil(t, opts.LoadTimeout)
+			},
+		},
+		{
+			name: "explicit LoadTimeout",
+			opts: &CacheOptions{LoadTimeout: &tenMinutes},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, tenMinutes, loadTimeoutOf(c))
+			},
+		},
+		{
+			name: "zero LoadTimeout",
+			opts: &CacheOptions{LoadTimeout: &zero},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.ErrorContains(t, err, "LoadTimeout must be positive")
+				require.Nil(t, c)
+			},
+		},
+		{
+			name: "negative LoadTimeout",
+			opts: &CacheOptions{LoadTimeout: &negative},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.ErrorContains(t, err, "LoadTimeout must be positive")
+				require.Nil(t, c)
+			},
+		},
+		{
+			name: "zero CleanupInterval",
+			opts: &CacheOptions{CleanupInterval: &zero},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.ErrorContains(t, err, "CleanupInterval must be positive")
+				require.Nil(t, c)
+			},
+		},
+		{
+			name: "negative CleanupInterval",
+			opts: &CacheOptions{CleanupInterval: &negative},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.ErrorContains(t, err, "CleanupInterval must be positive")
+				require.Nil(t, c)
+			},
+		},
+		{
+			name: "CacheNothing",
+			opts: &CacheOptions{CacheNothing: true},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Nil(t, internalValues(c))
+			},
+		},
+		{
+			// CleanupInterval governs eviction from a cache that CacheNothing keeps
+			// from being created at all, so no value for it can be wrong here.
+			name: "zero CleanupInterval with CacheNothing",
+			opts: &CacheOptions{CleanupInterval: &zero, CacheNothing: true},
+			assertions: func(
+				t *testing.T,
+				_ *CacheOptions,
+				c Cache[string, string],
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Nil(t, internalValues(c))
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewCache(noopLoader, testCase.opts)
+			testCase.assertions(t, testCase.opts, c, err)
+		})
+	}
+}
+
+func TestCache_Get_cacheHit(t *testing.T) {
+	t.Parallel()
+
+	// A retained value is served to subsequent callers without loading again.
+	var runs atomic.Int32
+	c := newTestCache(t, countingLoader(&runs, new(time.Hour)), nil)
+
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.NoError(t, err)
+		require.Equal(t, testValue, value)
+	}
+	require.Equal(t, int32(1), runs.Load())
+}
+
+func TestCache_Get_uncachedValue(t *testing.T) {
+	t.Parallel()
+
+	// A Loader function returning a nil TTL leaves nothing for the next caller to
+	// be served, so every caller loads.
+	var runs atomic.Int32
+	c := newTestCache(t, countingLoader(&runs, nil), nil)
+
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.NoError(t, err)
+		require.Equal(t, testValue, value)
+	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Empty(t, internalValues(c).Items())
+}
+
+func TestCache_Get_cacheNothing(t *testing.T) {
+	t.Parallel()
+
+	// A Cache that caches nothing loads for every caller, whatever TTL its Loader
+	// function returns.
+	var runs atomic.Int32
+	c := newTestCache(
+		t,
+		countingLoader(&runs, new(time.Hour)),
+		&CacheOptions{CacheNothing: true},
+	)
+
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.NoError(t, err)
+		require.Equal(t, testValue, value)
+	}
+	require.Equal(t, int32(2), runs.Load())
+}
+
+func TestCache_Get_loadError(t *testing.T) {
+	t.Parallel()
+
+	// A failed load is reported to the caller and caches nothing, so the next
+	// caller tries again. The TTL returned alongside the error is deliberately
+	// one that would otherwise have been honored.
+	var runs atomic.Int32
+	c := newTestCache(
+		t,
+		func(context.Context, string) (string, *time.Duration, error) {
+			runs.Add(1)
+			return testValue, new(time.Hour), errors.New("something went wrong")
+		},
+		nil,
+	)
+
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.ErrorContains(t, err, "something went wrong")
+		require.Empty(t, value)
+	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Empty(t, internalValues(c).Items())
+}
+
+func TestCache_Get_loaderPanics(t *testing.T) {
+	t.Parallel()
+
+	// A panic escaping a Loader function into singleflight would be re-raised on a
+	// goroutine of its own and take the process down with it. Every caller waiting
+	// on that load is told about it as an error instead, and this test's own
+	// survival is the evidence that the process was not lost.
+	var runs atomic.Int32
+	c := newTestCache(
+		t,
+		func(context.Context, string) (string, *time.Duration, error) {
+			runs.Add(1)
+			panic("something went wrong")
+		},
+		nil,
+	)
+
+	// A panicking load caches nothing, so a subsequent caller tries again.
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.ErrorContains(t, err, "something went wrong")
+		require.Empty(t, value)
+	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Empty(t, internalValues(c).Items())
+}
+
+func TestCache_Get_nilValueOfAnInterfaceType(t *testing.T) {
+	t.Parallel()
+
+	// A value is wrapped on its way into the internal cache so that recovering it
+	// again does not depend on its own type. Stored bare, a nil value of an
+	// interface type comes back as a nil any, which no assertion to that type can
+	// succeed against, so every caller would load anew.
+	var runs atomic.Int32
+	c, err := NewCache(
+		func(context.Context, string) (any, *time.Duration, error) {
+			runs.Add(1)
+			return nil, new(time.Hour), nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	for range 2 {
+		value, err := c.Get(t.Context(), testKey, testInput)
+		require.NoError(t, err)
+		require.Nil(t, value)
+	}
+	require.Equal(t, int32(1), runs.Load())
+}
+
+func TestCache_Get_ttl(t *testing.T) {
+	t.Parallel()
+
+	zero := time.Duration(0)
+	negative := -1 * time.Minute
+	tenMinutes := 10 * time.Minute
+	twoHours := 2 * time.Hour
+
+	testCases := []struct {
+		name string
+		// ttl is what the Loader function returns.
+		ttl *time.Duration
+		// optsDefaultTTL is what the Cache is configured with.
+		optsDefaultTTL *time.Duration
+		assertions     func(t *testing.T, item gocache.Item, retained bool)
+	}{
+		{
+			name: "nil TTL leaves the value uncached",
+			assertions: func(t *testing.T, _ gocache.Item, retained bool) {
+				require.False(t, retained)
+			},
+		},
+		{
+			name: "positive TTL is used as given",
+			ttl:  &tenMinutes,
+			assertions: func(t *testing.T, item gocache.Item, retained bool) {
+				require.True(t, retained)
+				requireExpiresIn(t, item, tenMinutes)
+			},
+		},
+		{
+			// go-cache records an entry that never expires as one whose expiration
+			// is zero.
+			name: "negative TTL retains the value indefinitely",
+			ttl:  &negative,
+			assertions: func(t *testing.T, item gocache.Item, retained bool) {
+				require.True(t, retained)
+				require.Zero(t, item.Expiration)
+			},
+		},
+		{
+			name:           "zero TTL defers to DefaultTTL",
+			ttl:            &zero,
+			optsDefaultTTL: &twoHours,
+			assertions: func(t *testing.T, item gocache.Item, retained bool) {
+				require.True(t, retained)
+				requireExpiresIn(t, item, twoHours)
+			},
+		},
+		{
+			name: "zero TTL defers to the default DefaultTTL",
+			ttl:  &zero,
+			assertions: func(t *testing.T, item gocache.Item, retained bool) {
+				require.True(t, retained)
+				requireExpiresIn(t, item, defaultTTL)
+			},
+		},
+		{
+			name:           "zero TTL defers to a DefaultTTL that is not positive",
+			ttl:            &zero,
+			optsDefaultTTL: &zero,
+			assertions: func(t *testing.T, item gocache.Item, retained bool) {
+				require.True(t, retained)
+				require.Zero(t, item.Expiration)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			c := newTestCache(
+				t,
+				func(context.Context, string) (string, *time.Duration, error) {
+					return testValue, testCase.ttl, nil
+				},
+				&CacheOptions{DefaultTTL: testCase.optsDefaultTTL},
+			)
+
+			value, err := c.Get(t.Context(), testKey, testInput)
+			require.NoError(t, err)
+			require.Equal(t, testValue, value)
+
+			item, retained := internalValues(c).Items()[testKey]
+			testCase.assertions(t, item, retained)
+		})
+	}
+}
+
+func TestCache_Get_coalescing(t *testing.T) {
+	t.Parallel()
+
+	const concurrency = 10
+
+	// Callers are split evenly between two keys. Each key must be loaded exactly
+	// once, which makes this sensitive both to callers failing to share a load
+	// and to callers for different keys sharing one.
+	keys := []string{"key-a", "key-b"}
+
+	// synctest.Test() runs a function in a "bubble": that function and every
+	// goroutine it starts form a group the runtime tracks. Inside the bubble,
+	// synctest.Wait() calls block until every other goroutine in the group is
+	// durably blocked -- parked on something only another member of the group can
+	// release. That is what lets this test observe the moment when every caller
+	// is waiting on a load, rather than guess at it with a sleep.
+	synctest.Test(t, func(t *testing.T) {
+		var runs atomic.Int32
+
+		// This channel will be used to unblock the goroutines that are parked
+		// inside the Loader function, but only after every caller is durably
+		// blocked on a singleflight.
+		release := make(chan struct{})
+
+		// A Cache that caches nothing leaves loading as the only way any caller can
+		// obtain a value. It also runs no janitor, a goroutine that would never
+		// exit, and a bubble does not close until every goroutine within it has.
+		c := newTestCache(
+			t,
+			func(_ context.Context, input string) (string, *time.Duration, error) {
+				runs.Add(1)
+				<-release
+				// The value identifies the input it was loaded from, so a caller served
+				// by another key's load is detectable.
+				return "value-for-" + input, nil, nil
+			},
+			&CacheOptions{CacheNothing: true},
+		)
+
+		values := make([]string, concurrency)
+		errs := make([]error, concurrency)
+		var wg sync.WaitGroup
+		for i := range concurrency {
+			wg.Go(func() {
+				key := keys[i%len(keys)]
+				values[i], errs[i] = c.Get(t.Context(), key, key)
+			})
+		}
+
+		// Returns only once every caller is durably blocked. The Cache retains
+		// nothing, so the only place they can be is waiting on a load.
+		// Specifically, singleflight has started one goroutine per key and each is
+		// parked inside the Loader function, with every caller waiting on the load
+		// it joined.
+		synctest.Wait()
+
+		// Allows the loads to complete.
+		close(release)
+
+		// Wait for all of the callers to finish.
+		wg.Wait()
+
+		// Since we forced the callers for each key to join one singleflight, there
+		// should have been exactly one load per key -- no more, which would mean
+		// callers failed to coalesce, and no fewer, which would mean callers for
+		// different keys shared a load.
+		require.Equal(t, int32(len(keys)), runs.Load())
+
+		// Verify that every caller received the value for its own key and no
+		// errors.
+		for i := range concurrency {
+			require.NoError(t, errs[i])
+			require.Equal(t, "value-for-"+keys[i%len(keys)], values[i])
+		}
+	})
+}
+
+func TestCache_Get_coalescingIsKeyedOnTheKey(t *testing.T) {
+	t.Parallel()
+
+	const concurrency = 4
+
+	// A key is what identifies work to be shared, so concurrent callers
+	// presenting one key join a single load even where the inputs they present
+	// differ. Every other test pairs one key with one input, which cannot tell
+	// coalescing by key apart from coalescing by input.
+	synctest.Test(t, func(t *testing.T) {
+		var runs atomic.Int32
+
+		release := make(chan struct{})
+		c := newTestCache(
+			t,
+			func(_ context.Context, input string) (string, *time.Duration, error) {
+				runs.Add(1)
+				<-release
+				return "value-for-" + input, nil, nil
+			},
+			&CacheOptions{CacheNothing: true},
+		)
+
+		var wg sync.WaitGroup
+		for i := range concurrency {
+			wg.Go(func() {
+				_, _ = c.Get(t.Context(), testKey, fmt.Sprintf("%s-%d", testInput, i))
+			})
+		}
+
+		// Returns once every caller is durably blocked on the load it joined.
+		synctest.Wait()
+		close(release)
+		wg.Wait()
+
+		require.Equal(t, int32(1), runs.Load())
+	})
+}
+
+func TestCache_Get_winnerCanceled(t *testing.T) {
+	t.Parallel()
+
+	// We will test the scenario where the caller whose call began a load abandons
+	// it mid-flight. Because a load runs under a context detached from any
+	// caller's, it must survive that and still serve the remaining callers
+	// waiting on it.
+
+	const numWaiters = 3
+
+	// The phased launch below relies on synctest.Wait(), which returns only once
+	// every other goroutine in the bubble is durably blocked. That is what lets
+	// this test know with certainty which caller began the load and which merely
+	// joined it, and then know that all of them are waiting before the winner
+	// walks away.
+	synctest.Test(t, func(t *testing.T) {
+		// This channel will be used to unblock the goroutine that is parked inside
+		// the Loader function, but only after the winner has abandoned it.
+		release := make(chan struct{})
+
+		c := newTestCache(
+			t,
+			func(ctx context.Context, _ string) (string, *time.Duration, error) {
+				// Honoring the context is what gives this test its teeth. Were the load
+				// running under the winner's context instead of a detached one,
+				// canceling the winner would land in the first case below and every
+				// waiter would receive that error.
+				select {
+				case <-ctx.Done():
+					return "", nil, ctx.Err()
+				case <-release:
+					return testValue, nil, nil
+				}
+			},
+			&CacheOptions{CacheNothing: true},
+		)
+
+		// The winner is launched alone, and with a context only it holds.
+		winnerCtx, cancel := context.WithCancel(t.Context())
+		winnerErr := make(chan error, 1)
+		go func() {
+			_, err := c.Get(winnerCtx, testKey, testInput)
+			winnerErr <- err
+		}()
+
+		// Returns once the winner and the goroutine singleflight started on its
+		// behalf are both durably blocked: the latter parked inside the Loader
+		// function, the former waiting on it. The load therefore exists and belongs
+		// to the winner. Launching the waiters any earlier would leave ownership of
+		// the load to the scheduler, and canceling a caller that does not own it
+		// proves nothing.
+		synctest.Wait()
+
+		type result struct {
+			value string
+			err   error
+		}
+		waiterRes := make(chan result, numWaiters)
+		for range numWaiters {
+			go func() {
+				value, err := c.Get(t.Context(), testKey, testInput)
+				waiterRes <- result{value: value, err: err}
+			}()
+		}
+
+		// Returns once the waiters have joined the winner's load, leaving the
+		// goroutine singleflight started parked inside the Loader function and
+		// every caller waiting on that load.
+		synctest.Wait()
+
+		// The winner abandons the load. The waiters' contexts stay live, so they
+		// keep waiting.
+		cancel()
+
+		// The winner reports that it stopped waiting, rather than reporting a
+		// failed load.
+		winErr := <-winnerErr
+		require.ErrorIs(t, winErr, context.Canceled)
+		require.ErrorContains(t, winErr, "loading will continue in the background")
+
+		// Because the load's context is detached, the winner's cancellation should
+		// not have halted it. Closing the release channel unblocks the load. Doing
+		// so before collecting the waiters' results below matters. If every
+		// goroutine in the bubble were parked, the fake clock would advance to the
+		// load's own deadline and fail it for reasons having nothing to do with
+		// what is under test.
+		close(release)
+
+		// Verify that every waiter received the loaded value and no errors, meaning
+		// the load outlived the caller that started it.
+		for range numWaiters {
+			res := <-waiterRes
+			require.NoError(t, res.err)
+			require.Equal(t, testValue, res.value)
+		}
+	})
+}
+
+func TestCache_Get_loadTimeout(t *testing.T) {
+	t.Parallel()
+
+	// A load runs under a context detached from every caller's, so a caller
+	// giving up cannot end it. Its own deadline is the only thing that can.
+
+	// A bubble has a fake clock that advances only when every goroutine in the
+	// group is durably blocked, and then only as far as the next pending timer.
+	// Here that timer is the load's own deadline, so this test reaches it
+	// instantly and measures it exactly, instead of waiting thirty seconds for
+	// it.
+	synctest.Test(t, func(t *testing.T) {
+		loadTimeout := testLoadTimeout
+		c := newTestCache(t, hangingLoader, &CacheOptions{
+			LoadTimeout:  &loadTimeout,
+			CacheNothing: true,
+		})
+
+		start := time.Now()
+		value, err := c.Get(t.Context(), testKey, testInput)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Empty(t, value)
+		require.Equal(t, testLoadTimeout, time.Since(start))
+	})
+}
+
+func TestCache_Get_defaultLoadTimeout(t *testing.T) {
+	t.Parallel()
+
+	// CacheOptions naming no LoadTimeout leave a load bounded by
+	// defaultLoadTimeout rather than unbounded.
+	synctest.Test(t, func(t *testing.T) {
+		c := newTestCache(t, hangingLoader, &CacheOptions{CacheNothing: true})
+
+		start := time.Now()
+		value, err := c.Get(t.Context(), testKey, testInput)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Empty(t, value)
+		require.Equal(t, defaultLoadTimeout, time.Since(start))
+	})
+}
+
+// noopLoader suits tests concerned with a Cache's construction rather than with
+// anything it loads.
+func noopLoader(context.Context, string) (string, *time.Duration, error) {
+	return testValue, nil, nil
+}
+
+// countingLoader returns a Loader function that records how many times it has
+// run and returns testValue with the given TTL.
+func countingLoader(
+	runs *atomic.Int32,
+	ttl *time.Duration,
+) Loader[string, string] {
+	return func(context.Context, string) (string, *time.Duration, error) {
+		runs.Add(1)
+		return testValue, ttl, nil
+	}
+}
+
+// hangingLoader never returns on its own, so only its context ending can end it.
+func hangingLoader(
+	ctx context.Context,
+	_ string,
+) (string, *time.Duration, error) {
+	<-ctx.Done()
+	return "", nil, ctx.Err()
+}
+
+// newTestCache returns a Cache built from the given Loader function and
+// CacheOptions, failing the test if those CacheOptions are rejected.
+func newTestCache(
+	t *testing.T,
+	loader Loader[string, string],
+	opts *CacheOptions,
+) Cache[string, string] {
+	t.Helper()
+	c, err := NewCache(loader, opts)
+	require.NoError(t, err)
+	return c
+}
+
+// loadTimeoutOf returns the timeout a Cache will bound its loads by.
+func loadTimeoutOf(c Cache[string, string]) time.Duration {
+	return c.(*cache[string, string]).loadTimeout // nolint: forcetypeassert
+}
+
+// internalValues returns a Cache's internal cache, which tests concerned with
+// what was retained, and for how long, inspect directly.
+func internalValues(c Cache[string, string]) *gocache.Cache {
+	return c.(*cache[string, string]).values // nolint: forcetypeassert
+}
+
+// requireExpiresIn asserts that a retained entry expires approximately the
+// given duration from now.
+func requireExpiresIn(t *testing.T, item gocache.Item, ttl time.Duration) {
+	t.Helper()
+	require.InDelta(
+		t,
+		ttl.Seconds(),
+		time.Until(time.Unix(0, item.Expiration)).Seconds(),
+		5,
+	)
+}

--- a/pkg/credentials/acr/workload_identity.go
+++ b/pkg/credentials/acr/workload_identity.go
@@ -2,6 +2,7 @@ package acr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -10,22 +11,30 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
-	"github.com/patrickmn/go-cache"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/logging"
 )
 
 const (
-	// cacheTTLMinutes is how long we cache ACR tokens before refreshing them.
-	// Set to 2.5 hours to ensure we refresh before the 3-hour token expiry.
-	cacheTTLMinutes = 150
-	// cleanupIntervalMinutes is how often the cache cleanup runs
-	cleanupIntervalMinutes = 30
+	// cacheTTL is how long an ACR token is cached for. ACR refresh tokens expire
+	// after three hours and the exchange API does not report a token's actual
+	// expiry, so no TTL can be derived from one and this is used for all of them.
+	cacheTTL = 150 * time.Minute
+	// cleanupInterval is how often expired tokens are evicted from the cache.
+	cleanupInterval = 30 * time.Minute
 	// acrTokenUsername is the fixed username used for ACR token authentication
 	acrTokenUsername = "00000000-0000-0000-0000-000000000000"
 	// acrScope is the Azure AD scope required for ACR authentication
 	acrScope = "https://containerregistry.azure.net/.default"
+	// tokenAcquisitionTimeout bounds a single token acquisition. Because an
+	// acquisition executes under a context detached from any caller's, this is
+	// the only thing bounding its duration. It is generous because it serves only
+	// as a fail-safe: exceeding it fails every caller waiting on that
+	// acquisition, and no fresh acquisition for the same registry can begin until
+	// it returns.
+	tokenAcquisitionTimeout = 30 * time.Second
 )
 
 // acrURLRegex matches Azure Container Registry URLs.
@@ -47,8 +56,10 @@ func init() {
 // Registry Workload Identity.
 type WorkloadIdentityProvider struct {
 	// tokenCache is an in-memory cache of ACR registry access tokens keyed by
-	// registry name.
-	tokenCache *cache.Cache
+	// registry name. It fills its own misses, coalescing concurrent loads for any
+	// given registry.
+	tokenCache coalescing.Cache[string, string]
+
 	credential azcore.TokenCredential
 
 	getAccessTokenFn func(ctx context.Context, registryName string) (string, error)
@@ -68,17 +79,23 @@ func NewWorkloadIdentityProvider(ctx context.Context) credentials.Provider {
 
 	logger.Info("Azure workload identity credential provider initialized")
 
-	p := &WorkloadIdentityProvider{
-		tokenCache: cache.New(
-			// ACR refresh tokens expire in 3 hours. We'll hang on to them for
-			// 2.5 hours. The ACR refresh token exchange API does not expose
-			// actual token expiry, so a dynamic TTL is not possible here.
-			cacheTTLMinutes*time.Minute,        // Default ttl for each entry
-			cleanupIntervalMinutes*time.Minute, // Cleanup interval
-		),
-		credential: credential,
-	}
+	p := &WorkloadIdentityProvider{credential: credential}
 	p.getAccessTokenFn = p.getAccessToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout:     new(tokenAcquisitionTimeout),
+			DefaultTTL:      new(cacheTTL),
+			CleanupInterval: new(cleanupInterval),
+		},
+	)
+	if err != nil {
+		logger.Error(
+			err, "error creating token cache; ACR credentials integration will be disabled",
+		)
+		return nil
+	}
+	p.tokenCache = tokenCache
 	return p
 }
 
@@ -108,41 +125,52 @@ func (p *WorkloadIdentityProvider) GetCredentials(
 		"provider", "acrWorkloadIdentity",
 		"repoURL", req.RepoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the cache for the token
-	if entry, exists := p.tokenCache.Get(registryName); exists {
-		logger.Debug("access token cache hit")
-		return &credentials.Credentials{
-			Username: acrTokenUsername,
-			Password: entry.(string), // nolint: forcetypeassert
-		}, nil
-	}
-	logger.Debug("access token cache miss")
-
-	// Cache miss, get a new token
-	accessToken, err := p.getAccessTokenFn(ctx, registryName)
+	accessToken, err := p.tokenCache.Get(ctx, registryName, registryName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting ACR access token: %w", err)
+		return nil, err
 	}
 
 	// If we didn't get a token, we'll treat this as no credentials found
 	if accessToken == "" {
 		return nil, nil
 	}
-	logger.Debug("obtained new access token")
-
-	// Cache the token using the default TTL. The ACR refresh token exchange API
-	// does not expose token expiry, so a dynamic TTL is not possible here.
-	logger.Debug(
-		"caching access token",
-		"ttl", cache.DefaultExpiration,
-	)
-	p.tokenCache.Set(registryName, accessToken, cache.DefaultExpiration)
 
 	return &credentials.Credentials{
 		Username: acrTokenUsername,
 		Password: accessToken,
 	}, nil
+}
+
+// loadAccessToken obtains an ACR access token for the given registry. It is the
+// Loader for this provider's token cache.
+func (p *WorkloadIdentityProvider) loadAccessToken(
+	ctx context.Context,
+	registryName string,
+) (string, *time.Duration, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	accessToken, err := p.getAccessTokenFn(ctx, registryName)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting ACR access token: %w", err)
+	}
+
+	// If we didn't get a token, we'll treat this as no credentials found
+	if accessToken == "" {
+		return "", nil, nil
+	}
+	logger.Debug("obtained new access token")
+
+	// The ACR refresh token exchange API does not expose token expiry, so no TTL
+	// of the token's own can be computed. A TTL of zero defers to the cache's
+	// default.
+	var ttl time.Duration
+	logger.Debug(
+		"caching access token",
+		"ttl", cacheTTL,
+	)
+	return accessToken, &ttl, nil
 }
 
 // getAccessToken returns an ACR refresh token using Azure workload identity.
@@ -185,7 +213,7 @@ func (p *WorkloadIdentityProvider) getAccessToken(
 	}
 
 	if refreshTokenResp.RefreshToken == nil {
-		return "", fmt.Errorf("received empty ACR refresh token")
+		return "", errors.New("received empty ACR refresh token")
 	}
 
 	return *refreshTokenResp.RefreshToken, nil

--- a/pkg/credentials/acr/workload_identity.go
+++ b/pkg/credentials/acr/workload_identity.go
@@ -24,10 +24,12 @@ const (
 	cacheTTL = 150 * time.Minute
 	// cleanupInterval is how often expired tokens are evicted from the cache.
 	cleanupInterval = 30 * time.Minute
+
 	// acrTokenUsername is the fixed username used for ACR token authentication
 	acrTokenUsername = "00000000-0000-0000-0000-000000000000"
 	// acrScope is the Azure AD scope required for ACR authentication
 	acrScope = "https://containerregistry.azure.net/.default"
+
 	// tokenAcquisitionTimeout bounds a single token acquisition. Because an
 	// acquisition executes under a context detached from any caller's, this is
 	// the only thing bounding its duration. It is generous because it serves only
@@ -165,12 +167,13 @@ func (p *WorkloadIdentityProvider) loadAccessToken(
 	// The ACR refresh token exchange API does not expose token expiry, so no TTL
 	// of the token's own can be computed. A TTL of zero defers to the cache's
 	// default.
-	var ttl time.Duration
 	logger.Debug(
 		"caching access token",
-		"ttl", cacheTTL,
+		"ttl", cacheTTL, // This is the default TTL the cache is actually using
 	)
-	return accessToken, &ttl, nil
+	return accessToken,
+		new(time.Duration), // zero TTL defers to the cache's default TTL
+		nil
 }
 
 // getAccessToken returns an ACR refresh token using Azure workload identity.

--- a/pkg/credentials/acr/workload_identity_test.go
+++ b/pkg/credentials/acr/workload_identity_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -103,7 +103,6 @@ func TestWorkloadIdentityProvider_Supports(t *testing.T) {
 
 func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 	const testRepoURL = "myregistry.azurecr.io/repo"
-	const testRegistryName = "myregistry"
 	const testToken = "fake-access-token"
 
 	testCases := []struct {
@@ -111,20 +110,14 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 		provider   *WorkloadIdentityProvider
 		credType   credentials.Type
 		repoURL    string
-		setupCache func(cache *cache.Cache)
-		assertions func(*testing.T, *cache.Cache, *credentials.Credentials, error)
+		assertions func(*testing.T, *credentials.Credentials, error)
 	}{
 		{
 			name:     "not supported",
 			provider: &WorkloadIdentityProvider{},
 			credType: credentials.TypeGit,
 			repoURL:  "git://repo",
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.Nil(t, creds)
 			},
@@ -134,38 +127,13 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 			provider: &WorkloadIdentityProvider{},
 			credType: credentials.TypeImage,
 			repoURL:  "not-an-acr-url",
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.Nil(t, creds)
 			},
 		},
 		{
-			name:     "cache hit",
-			provider: &WorkloadIdentityProvider{},
-			credType: credentials.TypeImage,
-			repoURL:  testRepoURL,
-			setupCache: func(c *cache.Cache) {
-				c.Set(testRegistryName, testToken, cache.DefaultExpiration)
-			},
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, acrTokenUsername, creds.Username)
-				assert.Equal(t, testToken, creds.Password)
-			},
-		},
-		{
-			name: "cache miss, successful token fetch",
+			name: "token obtained",
 			provider: &WorkloadIdentityProvider{
 				getAccessTokenFn: func(_ context.Context, _ string) (string, error) {
 					return testToken, nil
@@ -173,21 +141,11 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 			},
 			credType: credentials.TypeImage,
 			repoURL:  testRepoURL,
-			assertions: func(
-				t *testing.T,
-				c *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, acrTokenUsername, creds.Username)
 				assert.Equal(t, testToken, creds.Password)
-
-				// Verify the token was cached
-				cachedToken, found := c.Get(testRegistryName)
-				assert.True(t, found)
-				assert.Equal(t, testToken, cachedToken)
 			},
 		},
 		{
@@ -199,12 +157,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 			},
 			credType: credentials.TypeImage,
 			repoURL:  testRepoURL,
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.ErrorContains(t, err, "error getting ACR access token")
 				assert.Nil(t, creds)
 			},
@@ -218,7 +171,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 			},
 			credType: credentials.TypeImage,
 			repoURL:  testRepoURL,
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.Nil(t, creds)
 			},
@@ -227,10 +180,19 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.provider.credential = &mockCredential{}
-			testCase.provider.tokenCache = cache.New(10*time.Hour, time.Hour)
-			if testCase.setupCache != nil {
-				testCase.setupCache(testCase.provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's.
+			tokenCache, err := coalescing.NewCache(
+				testCase.provider.loadAccessToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(tokenAcquisitionTimeout),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			testCase.provider.tokenCache = tokenCache
 			creds, err := testCase.provider.GetCredentials(
 				t.Context(),
 				credentials.Request{
@@ -238,7 +200,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 					RepoURL: testCase.repoURL,
 				},
 			)
-			testCase.assertions(t, testCase.provider.tokenCache, creds, err)
+			testCase.assertions(t, creds, err)
 		})
 	}
 }
@@ -301,4 +263,48 @@ func (m *mockCredential) GetToken(_ context.Context, _ policy.TokenRequestOption
 		Token:     "mock-access-token",
 		ExpiresOn: time.Now().Add(time.Hour),
 	}, nil
+}
+
+func TestWorkloadIdentityProvider_GetCredentials_perRegistry(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the load deadline all belong to the cache this
+	// provider delegates to, and are covered by that package's tests. What remains
+	// this provider's own responsibility is that the key it caches under and the
+	// input it loads from describe the same registry, so that no registry is ever
+	// served another's token.
+
+	provider := &WorkloadIdentityProvider{
+		credential: &mockCredential{},
+		getAccessTokenFn: func(
+			_ context.Context,
+			registryName string,
+		) (string, error) {
+			// The token identifies the registry it was obtained for.
+			return "token-for-" + registryName, nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	for _, registry := range []string{"registry-a", "registry-b", "registry-a"} {
+		creds, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				RepoURL: registry + ".azurecr.io/repo",
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(t, acrTokenUsername, creds.Username)
+		require.Equal(t, "token-for-"+registry, creds.Password)
+	}
 }

--- a/pkg/credentials/ecr/access_key.go
+++ b/pkg/credentials/ecr/access_key.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
-	"github.com/patrickmn/go-cache"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/logging"
 )
@@ -33,8 +34,19 @@ func init() {
 	}
 }
 
+// accessKeyInput identifies the token a load should obtain. The cache key is a
+// hash of these values, so they cannot be recovered from it.
+type accessKeyInput struct {
+	region          string
+	accessKeyID     string
+	secretAccessKey string
+}
+
 type AccessKeyProvider struct {
-	tokenCache *cache.Cache
+	// tokenCache holds authorization tokens keyed by a hash of the credentials
+	// they were obtained with. It fills its own misses, coalescing concurrent
+	// loads for any given key.
+	tokenCache coalescing.Cache[accessKeyInput, string]
 
 	getAuthTokenFn func(
 		ctx context.Context,
@@ -45,16 +57,26 @@ type AccessKeyProvider struct {
 }
 
 func NewAccessKeyProvider() credentials.Provider {
-	p := &AccessKeyProvider{
-		tokenCache: cache.New(
+	p := &AccessKeyProvider{}
+	p.getAuthTokenFn = p.getAuthToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAuthToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
 			// Tokens live for 12 hours. We'll hang on to them for 10 by default.
 			// When the actual token expiry is available, it is used (minus a
 			// safety margin) instead of this default.
-			10*time.Hour, // Default ttl for each entry
-			time.Hour,    // Cleanup interval
-		),
+			DefaultTTL:      new(10 * time.Hour),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	if err != nil {
+		logging.LoggerFromContext(context.Background()).Error(
+			err, "error creating token cache; this provider will not be registered",
+		)
+		return nil
 	}
-	p.getAuthTokenFn = p.getAuthToken
+	p.tokenCache = tokenCache
 	return p
 }
 
@@ -87,38 +109,64 @@ func (p *AccessKeyProvider) GetCredentials(
 		"provider", "ecrAccessKey",
 		"repoURL", req.RepoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the cache for the token
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("auth token cache hit")
-		return decodeAuthToken(entry.(string)) // nolint: forcetypeassert
+	encodedToken, err := p.tokenCache.Get(
+		ctx,
+		cacheKey,
+		accessKeyInput{
+			region:          region,
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
-	logger.Debug("auth token cache miss")
 
-	// Cache miss, get a new token
+	// If we didn't get a token, we'll treat this as no credentials found
+	if encodedToken == "" {
+		return nil, nil
+	}
+
+	return decodeAuthToken(encodedToken)
+}
+
+// loadAuthToken obtains a new ECR authorization token using the given
+// credentials. It is the Loader for this provider's token cache.
+func (p *AccessKeyProvider) loadAuthToken(
+	ctx context.Context,
+	input accessKeyInput,
+) (string, *time.Duration, error) {
+	logger := logging.LoggerFromContext(ctx)
+
 	encodedToken, expiry, err := p.getAuthTokenFn(
 		ctx,
-		region,
-		accessKeyID,
-		secretAccessKey,
+		input.region,
+		input.accessKeyID,
+		input.secretAccessKey,
 	)
-	if err != nil || encodedToken == "" {
-		if err != nil {
-			err = fmt.Errorf("error getting ECR auth token: %w", err)
-		}
-		return nil, err
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting ECR auth token: %w", err)
+	}
+
+	// If we didn't get a token, we'll treat this as no credentials found
+	if encodedToken == "" {
+		return "", nil, nil
 	}
 	logger.Debug("obtained new auth token")
 
 	ttl := credentials.CalculateCacheTTL(expiry, tokenCacheExpiryMargin)
+	if ttl == nil {
+		logger.Debug("token expires too soon to be worth caching", "expiry", expiry)
+		return encodedToken, nil, nil
+	}
 	logger.Debug(
 		"caching auth token",
 		"expiry", expiry,
-		"ttl", ttl,
+		"ttl", *ttl,
 	)
-	p.tokenCache.Set(cacheKey, encodedToken, ttl)
-
-	return decodeAuthToken(encodedToken)
+	return encodedToken, ttl, nil
 }
 
 // getAuthToken gets an ECR authorization token using the provided access key ID
@@ -138,7 +186,7 @@ func (p *AccessKeyProvider) getAuthToken(
 	}
 
 	if output == nil || len(output.AuthorizationData) == 0 {
-		return "", time.Time{}, fmt.Errorf("no authorization data returned")
+		return "", time.Time{}, errors.New("no authorization data returned")
 	}
 
 	var expiry time.Time
@@ -150,7 +198,7 @@ func (p *AccessKeyProvider) getAuthToken(
 		return *token, expiry, nil
 	}
 
-	return "", time.Time{}, fmt.Errorf("no authorization token returned")
+	return "", time.Time{}, errors.New("no authorization token returned")
 }
 
 // decodeAuthToken decodes an ECR authorization token by base64 decoding it and
@@ -163,7 +211,7 @@ func decodeAuthToken(token string) (*credentials.Credentials, error) {
 	tokenParts := strings.SplitN(string(decodedToken), ":", 2)
 	if len(tokenParts) != 2 {
 		// This shouldn't ever happen
-		return nil, fmt.Errorf("invalid token format")
+		return nil, errors.New("invalid token format")
 	}
 	return &credentials.Credentials{
 		Username: tokenParts[0],

--- a/pkg/credentials/ecr/access_key_test.go
+++ b/pkg/credentials/ecr/access_key_test.go
@@ -2,14 +2,15 @@ package ecr
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -170,8 +171,7 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			accessKeyID string,
 			secretAccessKey string,
 		) (string, time.Time, error)
-		setupCache func(cache *cache.Cache)
-		assertions func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error)
+		assertions func(t *testing.T, creds *credentials.Credentials, err error)
 	}{
 		{
 			name:     "unsupported credentials",
@@ -186,36 +186,13 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			) (string, time.Time, error) {
 				return "", time.Time{}, nil
 			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
 			},
 		},
 		{
-			name:     "cache hit",
-			credType: credentials.TypeImage,
-			repoURL:  fakeRepoURL,
-			data: map[string][]byte{
-				regionKey: []byte(fakeRegion),
-				idKey:     []byte(fakeID),
-				secretKey: []byte(fakeSecret),
-			},
-			setupCache: func(c *cache.Cache) {
-				c.Set(
-					tokenCacheKey(fakeRegion, fakeID, fakeSecret),
-					fakeToken, // base64 of "AWS:password"
-					cache.DefaultExpiration,
-				)
-			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, "AWS", creds.Username)
-				assert.Equal(t, "password", creds.Password)
-			},
-		},
-		{
-			name:     "cache miss, successful token fetch",
+			name:     "token obtained",
 			credType: credentials.TypeImage,
 			repoURL:  fakeRepoURL,
 			data: map[string][]byte{
@@ -231,20 +208,34 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			) (string, time.Time, error) {
 				return fakeToken, time.Now().Add(12 * time.Hour), nil
 			},
-			assertions: func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, "AWS", creds.Username)
 				assert.Equal(t, "password", creds.Password)
-
-				// Verify the token was cached with a TTL based on the
-				// token's actual expiry
-				items := c.Items()
-				item, found := items[tokenCacheKey(fakeRegion, fakeID, fakeSecret)]
-				assert.True(t, found)
-				expectedTTL := 12*time.Hour - 5*time.Minute // 12h expiry - 5m margin
-				actualTTL := time.Until(time.Unix(0, item.Expiration))
-				assert.InDelta(t, expectedTTL.Seconds(), actualTTL.Seconds(), 5)
+			},
+		},
+		{
+			name:     "token obtained, but too near expiry to cache",
+			credType: credentials.TypeImage,
+			repoURL:  fakeRepoURL,
+			data: map[string][]byte{
+				regionKey: []byte(fakeRegion),
+				idKey:     []byte(fakeID),
+				secretKey: []byte(fakeSecret),
+			},
+			getAuthTokenFn: func(
+				context.Context,
+				string,
+				string,
+				string,
+			) (string, time.Time, error) {
+				return fakeToken, time.Now().Add(-time.Hour), nil
+			},
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, creds)
+				assert.Equal(t, "password", creds.Password)
 			},
 		},
 		{
@@ -264,7 +255,7 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			) (string, time.Time, error) {
 				return "", time.Time{}, errors.New("auth token error")
 			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.ErrorContains(t, err, "error getting ECR auth token")
 				assert.Nil(t, creds)
 			},
@@ -286,13 +277,9 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			) (string, time.Time, error) {
 				return "", time.Time{}, nil
 			},
-			assertions: func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
-
-				// Verify the token was not cached
-				_, found := c.Get(tokenCacheKey(fakeRegion, fakeID, fakeSecret))
-				assert.False(t, found)
 			},
 		},
 	}
@@ -302,9 +289,19 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 			provider := NewAccessKeyProvider().(*AccessKeyProvider) // nolint:forcetypeassert
 			provider.getAuthTokenFn = testCase.getAuthTokenFn
 
-			if testCase.setupCache != nil {
-				testCase.setupCache(provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's.
+			tokenCache, err := coalescing.NewCache(
+				provider.loadAuthToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(tokenAcquisitionTimeout),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			provider.tokenCache = tokenCache
 
 			creds, err := provider.GetCredentials(
 				t.Context(),
@@ -314,7 +311,7 @@ func TestAccessKeyProvider_GetCredentials(t *testing.T) {
 					Data:    testCase.data,
 				},
 			)
-			testCase.assertions(t, provider.tokenCache, creds, err)
+			testCase.assertions(t, creds, err)
 		})
 	}
 }
@@ -358,5 +355,76 @@ func Test_decodeAuthToken(t *testing.T) {
 			creds, err := decodeAuthToken(testCase.token)
 			testCase.assertions(t, creds, err)
 		})
+	}
+}
+
+func TestAccessKeyProvider_GetCredentials_perCredentials(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the load deadline all belong to the cache this
+	// provider delegates to, and are covered by that package's tests. What remains
+	// this provider's own responsibility is that the key it caches under and the
+	// input it loads from describe the same credentials, so that no set of
+	// credentials is ever served another's token.
+
+	const (
+		fakeRepoURL = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repo"
+		fakeRegion  = "us-west-2"
+		fakeID      = "AKIAIOSFODNN7EXAMPLE"                     // nolint:gosec
+		fakeOtherID = "AKIAI44QH8DHBEXAMPLE"                     // nolint:gosec
+		fakeSecret  = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" // nolint:gosec
+		fakeRotated = "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY" // nolint:gosec
+	)
+
+	provider := &AccessKeyProvider{
+		getAuthTokenFn: func(
+			_ context.Context,
+			_ string,
+			accessKeyID string,
+			secretAccessKey string,
+		) (string, time.Time, error) {
+			// The token identifies the credentials it was obtained with.
+			return base64.StdEncoding.EncodeToString(
+				[]byte("AWS:" + accessKeyID + "|" + secretAccessKey),
+			), time.Now().Add(12 * time.Hour), nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAuthToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	// Each dimension of the credentials varies in turn, and the first pair
+	// repeats at the end to confirm it is still served its own token.
+	for _, creds := range []struct {
+		id     string
+		secret string
+	}{
+		{fakeID, fakeSecret},
+		{fakeOtherID, fakeSecret},
+		{fakeID, fakeRotated},
+		{fakeID, fakeSecret},
+	} {
+		got, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				RepoURL: fakeRepoURL,
+				Data: map[string][]byte{
+					regionKey: []byte(fakeRegion),
+					idKey:     []byte(creds.id),
+					secretKey: []byte(creds.secret),
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, "AWS", got.Username)
+		require.Equal(t, creds.id+"|"+creds.secret, got.Password)
 	}
 }

--- a/pkg/credentials/ecr/common.go
+++ b/pkg/credentials/ecr/common.go
@@ -7,7 +7,17 @@ import (
 	"time"
 )
 
-const tokenCacheExpiryMargin = 5 * time.Minute
+const (
+	tokenCacheExpiryMargin = 5 * time.Minute
+
+	// tokenAcquisitionTimeout bounds a single token acquisition. Because an
+	// acquisition executes under a context detached from any caller's, this is
+	// the only thing bounding its duration. It is generous because it serves only
+	// as a fail-safe: exceeding it fails every caller waiting on that
+	// acquisition, and no fresh acquisition for the same key can begin until it
+	// returns.
+	tokenAcquisitionTimeout = 30 * time.Second
+)
 
 // ecrURLRegex is a regex that matches ECR URLs.
 var ecrURLRegex = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr\.(.+)\.amazonaws\.com/`)

--- a/pkg/credentials/ecr/managed_identity.go
+++ b/pkg/credentials/ecr/managed_identity.go
@@ -15,8 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/patrickmn/go-cache"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/logging"
 )
@@ -34,8 +34,18 @@ func init() {
 	}
 }
 
+// managedIdentityInput identifies the token a load should obtain. The cache key
+// is a hash of these values, so they cannot be recovered from it.
+type managedIdentityInput struct {
+	region  string
+	project string
+}
+
 type ManagedIdentityProvider struct {
-	tokenCache *cache.Cache
+	// tokenCache holds authorization tokens keyed by a hash of the region and
+	// Kargo Project they were obtained for. It fills its own misses, coalescing
+	// concurrent loads for any given key.
+	tokenCache coalescing.Cache[managedIdentityInput, string]
 
 	accountID string
 
@@ -79,20 +89,37 @@ func NewManagedIdentityProvider(ctx context.Context) credentials.Provider {
 		return nil
 	}
 
+	// A response carrying no account would be a surprise, but this runs at
+	// startup, where a panic takes the whole process with it.
+	if res.Account == nil {
+		logger.Error(
+			nil, "no account ID returned; AWS credentials integration will be disabled",
+		)
+		return nil
+	}
 	logger.Debug("got AWS account ID", "account", *res.Account)
 	awsAccountID = *res.Account
 
-	p := &ManagedIdentityProvider{
-		tokenCache: cache.New(
+	p := &ManagedIdentityProvider{accountID: awsAccountID}
+	p.getAuthTokenFn = p.getAuthToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAuthToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
 			// Tokens live for 12 hours. We'll hang on to them for 10 by default.
 			// When the actual token expiry is available, it is used (minus a
 			// safety margin) instead of this default.
-			10*time.Hour, // Default ttl for each entry
-			time.Hour,    // Cleanup interval
-		),
-		accountID: awsAccountID,
+			DefaultTTL:      new(10 * time.Hour),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	if err != nil {
+		logger.Error(
+			err, "error creating token cache; AWS credentials integration will be disabled",
+		)
+		return nil
 	}
-	p.getAuthTokenFn = p.getAuthToken
+	p.tokenCache = tokenCache
 	return p
 }
 
@@ -126,40 +153,59 @@ func (p *ManagedIdentityProvider) GetCredentials(
 		"provider", "ecrManagedIdentity",
 		"repoURL", req.RepoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the cache for the token
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("auth token cache hit")
-		return decodeAuthToken(entry.(string)) // nolint: forcetypeassert
-	}
-	logger.Debug("auth token cache miss")
-
-	// Cache miss, get a new token
-	encodedToken, expiry, err := p.getAuthTokenFn(ctx, region, req.Project)
+	encodedToken, err := p.tokenCache.Get(
+		ctx,
+		cacheKey,
+		managedIdentityInput{region: region, project: req.Project},
+	)
 	if err != nil {
-		// This might mean the controller's IAM role isn't authorized to assume the
-		// project-specific IAM role, or that the project-specific IAM role doesn't
-		// have the necessary permissions to get an ECR auth token. We're making
-		// a choice to consider this the will of the AWS admins and not a controller
-		// error. We'll just log it and move on as if we found no credentials.
-		return nil, fmt.Errorf("error getting ECR auth token: %w", err)
+		return nil, err
 	}
 
 	// If we didn't get a token, we'll treat this as no credentials found
 	if encodedToken == "" {
 		return nil, nil
 	}
+
+	return decodeAuthToken(encodedToken)
+}
+
+// loadAuthToken obtains a new ECR authorization token for the given region and
+// Kargo Project. It is the Loader for this provider's token cache.
+func (p *ManagedIdentityProvider) loadAuthToken(
+	ctx context.Context,
+	input managedIdentityInput,
+) (string, *time.Duration, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	encodedToken, expiry, err := p.getAuthTokenFn(ctx, input.region, input.project)
+	if err != nil {
+		// An IAM role not authorized to assume the project-specific role, or a
+		// project-specific role not authorized to obtain an ECR auth token, is
+		// taken to be the will of the AWS admins rather than an error, and reaches
+		// here as an empty token rather than as this error. See getAuthToken.
+		return "", nil, fmt.Errorf("error getting ECR auth token: %w", err)
+	}
+
+	// If we didn't get a token, we'll treat this as no credentials found
+	if encodedToken == "" {
+		return "", nil, nil
+	}
 	logger.Debug("obtained new auth token")
 
 	ttl := credentials.CalculateCacheTTL(expiry, tokenCacheExpiryMargin)
+	if ttl == nil {
+		logger.Debug("token expires too soon to be worth caching", "expiry", expiry)
+		return encodedToken, nil, nil
+	}
 	logger.Debug(
 		"caching auth token",
 		"expiry", expiry,
-		"ttl", ttl,
+		"ttl", *ttl,
 	)
-	p.tokenCache.Set(cacheKey, encodedToken, ttl)
-
-	return decodeAuthToken(encodedToken)
+	return encodedToken, ttl, nil
 }
 
 // getAuthToken returns an ECR authorization token obtained by assuming a
@@ -224,9 +270,21 @@ func (p *ManagedIdentityProvider) getAuthToken(
 		}
 	}
 
+	// A response carrying no authorization data would be a surprise, but indexing
+	// into it regardless is not worth the consequence: the cache this runs under
+	// would report the panic to every caller waiting on this key as an error
+	// saying nothing about what actually went wrong.
+	if output == nil || len(output.AuthorizationData) == 0 {
+		return "", time.Time{}, errors.New("no authorization data returned")
+	}
+
 	var expiry time.Time
 	if output.AuthorizationData[0].ExpiresAt != nil {
 		expiry = *output.AuthorizationData[0].ExpiresAt
+	}
+
+	if output.AuthorizationData[0].AuthorizationToken == nil {
+		return "", time.Time{}, errors.New("no authorization token returned")
 	}
 
 	logger.Debug("got ECR authorization token")

--- a/pkg/credentials/ecr/managed_identity_test.go
+++ b/pkg/credentials/ecr/managed_identity_test.go
@@ -2,14 +2,15 @@ package ecr
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -102,7 +103,6 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 		fakeAccountID = "123456789012"
 		fakeProject   = "fake-project"
 		fakeRepoURL   = "123456789012.dkr.ecr.us-west-2.amazonaws.com/repo"
-		fakeRegion    = "us-west-2"
 		// base64 of "AWS:password"
 		fakeToken = "QVdTOnBhc3N3b3Jk" // nolint:gosec
 	)
@@ -113,19 +113,17 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 		project    string
 		credType   credentials.Type
 		repoURL    string
-		setupCache func(cache *cache.Cache)
-		assertions func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error)
+		assertions func(t *testing.T, creds *credentials.Credentials, err error)
 	}{
 		{
 			name: "not supported",
 			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
+				accountID: fakeAccountID,
 			},
 			project:  fakeProject,
 			credType: credentials.TypeGit,
 			repoURL:  "git://repo",
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
 			},
@@ -133,42 +131,20 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 		{
 			name: "non-ECR URL",
 			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
+				accountID: fakeAccountID,
 			},
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  "not-an-ecr-url",
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
 			},
 		},
 		{
-			name: "cache hit",
+			name: "token obtained",
 			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
-			},
-			project:  fakeProject,
-			credType: credentials.TypeImage,
-			repoURL:  fakeRepoURL,
-			setupCache: func(c *cache.Cache) {
-				cacheKey := tokenCacheKey(fakeRegion, fakeProject)
-				c.Set(cacheKey, fakeToken, cache.DefaultExpiration)
-			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, "AWS", creds.Username)
-				assert.Equal(t, "password", creds.Password)
-			},
-		},
-		{
-			name: "cache miss, successful token fetch",
-			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
+				accountID: fakeAccountID,
 				getAuthTokenFn: func(
 					context.Context,
 					string,
@@ -180,27 +156,38 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeRepoURL,
-			assertions: func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, "AWS", creds.Username)
 				assert.Equal(t, "password", creds.Password)
-
-				// Verify the token was cached with a TTL based on the
-				// token's actual expiry
-				items := c.Items()
-				item, found := items[tokenCacheKey(fakeRegion, fakeProject)]
-				assert.True(t, found)
-				expectedTTL := 12*time.Hour - 5*time.Minute // 12h expiry - 5m margin
-				actualTTL := time.Until(time.Unix(0, item.Expiration))
-				assert.InDelta(t, expectedTTL.Seconds(), actualTTL.Seconds(), 5)
+			},
+		},
+		{
+			name: "token obtained, but too near expiry to cache",
+			provider: &ManagedIdentityProvider{
+				accountID: fakeAccountID,
+				getAuthTokenFn: func(
+					context.Context,
+					string,
+					string,
+				) (string, time.Time, error) {
+					return fakeToken, time.Now().Add(-time.Hour), nil
+				},
+			},
+			project:  fakeProject,
+			credType: credentials.TypeImage,
+			repoURL:  fakeRepoURL,
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, creds)
+				assert.Equal(t, "password", creds.Password)
 			},
 		},
 		{
 			name: "error in getAuthToken",
 			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
+				accountID: fakeAccountID,
 				getAuthTokenFn: func(
 					context.Context,
 					string,
@@ -212,7 +199,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeRepoURL,
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.ErrorContains(t, err, "error getting ECR auth token")
 				assert.Nil(t, creds)
 			},
@@ -220,8 +207,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 		{
 			name: "empty token from getAuthToken",
 			provider: &ManagedIdentityProvider{
-				accountID:  fakeAccountID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
+				accountID: fakeAccountID,
 				getAuthTokenFn: func(
 					context.Context,
 					string,
@@ -233,7 +219,7 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeRepoURL,
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
 			},
@@ -242,9 +228,20 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.setupCache != nil {
-				testCase.setupCache(testCase.provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's.
+			tokenCache, err := coalescing.NewCache(
+				testCase.provider.loadAuthToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(tokenAcquisitionTimeout),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			testCase.provider.tokenCache = tokenCache
+
 			creds, err := testCase.provider.GetCredentials(
 				t.Context(),
 				credentials.Request{
@@ -253,7 +250,68 @@ func TestManagedIdentityProvider_GetCredentials(t *testing.T) {
 					RepoURL: testCase.repoURL,
 				},
 			)
-			testCase.assertions(t, testCase.provider.tokenCache, creds, err)
+			testCase.assertions(t, creds, err)
 		})
+	}
+}
+
+func TestManagedIdentityProvider_GetCredentials_perProject(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the load deadline all belong to the cache this
+	// provider delegates to, and are covered by that package's tests. What remains
+	// this provider's own responsibility is that the key it caches under and the
+	// input it loads from describe the same region and Kargo Project, so that no
+	// Project is ever served another's token.
+
+	const fakeAccountID = "123456789012"
+
+	provider := &ManagedIdentityProvider{
+		accountID: fakeAccountID,
+		getAuthTokenFn: func(
+			_ context.Context,
+			region string,
+			project string,
+		) (string, time.Time, error) {
+			// The token identifies the region and Project it was obtained for.
+			return base64.StdEncoding.EncodeToString(
+				[]byte("AWS:" + region + "/" + project),
+			), time.Now().Add(12 * time.Hour), nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAuthToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	// Each dimension of the key varies in turn, and the first pair repeats at the
+	// end to confirm it is still served its own token.
+	for _, request := range []struct {
+		region  string
+		project string
+	}{
+		{"us-west-2", "project-a"},
+		{"us-west-2", "project-b"},
+		{"eu-west-1", "project-a"},
+		{"us-west-2", "project-a"},
+	} {
+		creds, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				Project: request.project,
+				RepoURL: fakeAccountID + ".dkr.ecr." + request.region +
+					".amazonaws.com/repo",
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(t, "AWS", creds.Username)
+		require.Equal(t, request.region+"/"+request.project, creds.Password)
 	}
 }

--- a/pkg/credentials/expiry.go
+++ b/pkg/credentials/expiry.go
@@ -1,22 +1,21 @@
 package credentials
 
-import (
-	"time"
+import "time"
 
-	"github.com/patrickmn/go-cache"
-)
-
-// CalculateCacheTTL calculates the time-to-live for a cached credential based
-// on the credential's expiry time and a safety margin. If the expiry time is
-// zero (unknown) or the remaining time after subtracting the margin is not
-// positive, it returns cache.DefaultExpiration, deferring to the cache's own
-// default TTL.
-func CalculateCacheTTL(expiry time.Time, margin time.Duration) time.Duration {
-	ttl := cache.DefaultExpiration
-	if !expiry.IsZero() {
-		if remaining := time.Until(expiry) - margin; remaining > 0 {
-			ttl = remaining
-		}
+// CalculateCacheTTL calculates how long a credential may be cached for, given
+// the credential's own expiry time and a safety margin. It returns nil when the
+// credential expires within that margin, caching one that is spent, or nearly
+// so, being how a caller comes to be handed a credential that has stopped
+// working. A zero expiry time means the credential's lifetime is unknown, for
+// which it returns a zero duration, deferring to whatever default TTL the cache
+// was configured with.
+func CalculateCacheTTL(expiry time.Time, margin time.Duration) *time.Duration {
+	if expiry.IsZero() {
+		return new(time.Duration)
 	}
-	return ttl
+	remaining := time.Until(expiry) - margin
+	if remaining <= 0 {
+		return nil
+	}
+	return &remaining
 }

--- a/pkg/credentials/expiry_test.go
+++ b/pkg/credentials/expiry_test.go
@@ -4,63 +4,72 @@ import (
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateCacheTTL(t *testing.T) {
+	t.Parallel()
+
 	const margin = 5 * time.Minute
 
-	tests := []struct {
-		name     string
-		expiry   time.Time
-		margin   time.Duration
-		expected time.Duration
+	testCases := []struct {
+		name   string
+		expiry time.Time
+		margin time.Duration
+		// expected is the duration the credential may be cached for, or nil where
+		// it is not to be cached at all.
+		expected *time.Duration
 	}{
 		{
-			name:     "zero expiry returns default",
-			expiry:   time.Time{},
-			margin:   margin,
-			expected: cache.DefaultExpiration,
+			name:   "unknown expiry defers to the cache's default",
+			expiry: time.Time{},
+			margin: margin,
+			// A zero duration is what defers to that default, and is distinct from
+			// declining to cache.
+			expected: new(time.Duration),
 		},
 		{
 			name:     "expiry far in the future returns remaining minus margin",
 			expiry:   time.Now().Add(time.Hour),
 			margin:   margin,
-			expected: 55 * time.Minute,
+			expected: new(55 * time.Minute),
 		},
 		{
-			name:     "expiry in the past returns default",
-			expiry:   time.Now().Add(-time.Hour),
-			margin:   margin,
-			expected: cache.DefaultExpiration,
-		},
-		{
-			name:     "remaining equals margin returns default",
-			expiry:   time.Now().Add(margin),
-			margin:   margin,
-			expected: cache.DefaultExpiration,
-		},
-		{
-			name:     "remaining less than margin returns default",
-			expiry:   time.Now().Add(margin - time.Second),
-			margin:   margin,
-			expected: cache.DefaultExpiration,
-		},
-		{
-			name:     "zero margin returns full remaining time",
+			name:     "zero margin returns the whole remaining time",
 			expiry:   time.Now().Add(30 * time.Minute),
 			margin:   0,
-			expected: 30 * time.Minute,
+			expected: new(30 * time.Minute),
+		},
+		{
+			name:   "expiry already past is not cached",
+			expiry: time.Now().Add(-time.Hour),
+			margin: margin,
+		},
+		{
+			name:   "expiry exactly at the margin is not cached",
+			expiry: time.Now().Add(margin),
+			margin: margin,
+		},
+		{
+			name:   "expiry inside the margin is not cached",
+			expiry: time.Now().Add(margin - time.Second),
+			margin: margin,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := CalculateCacheTTL(tt.expiry, tt.margin)
-			// Allow 1 second of tolerance since time.Now() is called in both
-			// the test setup and the function under test.
-			assert.InDelta(t, tt.expected, result, float64(time.Second))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ttl := CalculateCacheTTL(testCase.expiry, testCase.margin)
+			if testCase.expected == nil {
+				require.Nil(t, ttl)
+				return
+			}
+			require.NotNil(t, ttl)
+			// Allow a second of tolerance, time.Now() being called both in this
+			// test's setup and in the function under test.
+			assert.InDelta(t, *testCase.expected, *ttl, float64(time.Second))
 		})
 	}
 }

--- a/pkg/credentials/gar/common.go
+++ b/pkg/credentials/gar/common.go
@@ -10,6 +10,23 @@ import (
 const (
 	accessTokenUsername    = "oauth2accesstoken"
 	tokenCacheExpiryMargin = 5 * time.Minute
+
+	// tokenAcquisitionTimeout bounds a single token acquisition. Because an
+	// acquisition executes under a context detached from any caller's, nothing
+	// but this bounds how long one may run overall. It is generous because it
+	// serves only as a fail-safe: exceeding it fails every caller waiting on that
+	// acquisition, and no fresh acquisition for the same key can begin until it
+	// returns. It cannot bound an individual request that ignores its context,
+	// which is what tokenRequestTimeout is for.
+	tokenAcquisitionTimeout = 30 * time.Second
+
+	// tokenRequestTimeout bounds an individual HTTP request made while acquiring
+	// a token. It exists because oauth2 resolves its HTTP client from a context
+	// but then issues the request without one, leaving the acquisition's own
+	// deadline with nothing to act on. A request that is never answered would
+	// otherwise keep the acquisition running, and with it the singleflight key it
+	// occupies, failing every later caller for that key.
+	tokenRequestTimeout = 30 * time.Second
 )
 
 var (

--- a/pkg/credentials/gar/service_account_key.go
+++ b/pkg/credentials/gar/service_account_key.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"time"
 
-	"github.com/patrickmn/go-cache"
+	"github.com/hashicorp/go-cleanhttp"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/logging"
 )
@@ -31,7 +33,10 @@ func init() {
 }
 
 type ServiceAccountKeyProvider struct {
-	tokenCache *cache.Cache
+	// tokenCache holds access tokens keyed by a hash of the service account key
+	// they were obtained with. It fills its own misses, coalescing concurrent
+	// loads for any given service account key.
+	tokenCache coalescing.Cache[string, string]
 
 	getAccessTokenFn func(
 		ctx context.Context,
@@ -40,16 +45,26 @@ type ServiceAccountKeyProvider struct {
 }
 
 func NewServiceAccountKeyProvider() credentials.Provider {
-	p := &ServiceAccountKeyProvider{
-		tokenCache: cache.New(
+	p := &ServiceAccountKeyProvider{}
+	p.getAccessTokenFn = p.getAccessToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
 			// Access tokens live for one hour. We'll hang on to them for 40
 			// minutes by default. When the actual token expiry is available, it
 			// is used (minus a safety margin) instead of this default.
-			40*time.Minute, // Default ttl for each entry
-			time.Hour,      // Cleanup interval
-		),
+			DefaultTTL:      new(40 * time.Minute),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	if err != nil {
+		logging.LoggerFromContext(context.Background()).Error(
+			err, "error creating token cache; this provider will not be registered",
+		)
+		return nil
 	}
-	p.getAccessTokenFn = p.getAccessToken
+	p.tokenCache = tokenCache
 	return p
 }
 
@@ -80,41 +95,56 @@ func (p *ServiceAccountKeyProvider) GetCredentials(
 		"provider", "garServiceAccountKey",
 		"repoURL", req.RepoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the cache for the token
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("access token cache hit")
-		return &credentials.Credentials{
-			Username: accessTokenUsername,
-			Password: entry.(string), // nolint: forcetypeassert
-		}, nil
+	accessToken, err := p.tokenCache.Get(ctx, cacheKey, encodedServiceAccountKey)
+	if err != nil {
+		return nil, err
 	}
-	logger.Debug("access token cache miss")
 
-	// Cache miss, get a new token
+	// If we didn't get a token, we'll treat this as no credentials found
+	if accessToken == "" {
+		return nil, nil
+	}
+
+	return &credentials.Credentials{
+		Username: accessTokenUsername,
+		Password: accessToken,
+	}, nil
+}
+
+// loadAccessToken obtains a GCP access token using the given base64 encoded
+// service account key. It is the Loader for this provider's token cache.
+func (p *ServiceAccountKeyProvider) loadAccessToken(
+	ctx context.Context,
+	encodedServiceAccountKey string,
+) (string, *time.Duration, error) {
+	logger := logging.LoggerFromContext(ctx)
+
 	token, err := p.getAccessTokenFn(ctx, encodedServiceAccountKey)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP access token: %w", err)
+		return "", nil, fmt.Errorf("error getting GCP access token: %w", err)
 	}
 
 	// If we didn't get a token, we'll treat this as no credentials found
 	if token == nil || token.AccessToken == "" {
-		return nil, nil
+		return "", nil, nil
 	}
 	logger.Debug("obtained new access token")
 
 	ttl := credentials.CalculateCacheTTL(token.Expiry, tokenCacheExpiryMargin)
+	if ttl == nil {
+		logger.Debug(
+			"token expires too soon to be worth caching", "expiry", token.Expiry,
+		)
+		return token.AccessToken, nil, nil
+	}
 	logger.Debug(
 		"caching access token",
 		"expiry", token.Expiry,
-		"ttl", ttl,
+		"ttl", *ttl,
 	)
-	p.tokenCache.Set(cacheKey, token.AccessToken, ttl)
-
-	return &credentials.Credentials{
-		Username: accessTokenUsername,
-		Password: token.AccessToken,
-	}, nil
+	return token.AccessToken, ttl, nil
 }
 
 // getAccessToken returns a GCP access token retrieved using the provided base64
@@ -132,6 +162,13 @@ func (p *ServiceAccountKeyProvider) getAccessToken(
 	if err != nil {
 		return nil, fmt.Errorf("error parsing service account key: %w", err)
 	}
+
+	// oauth2 takes its HTTP client from the context but issues the token request
+	// without the context, so a client timeout is the only available bound.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: cleanhttp.DefaultTransport(),
+		Timeout:   tokenRequestTimeout,
+	})
 
 	tokenSource := config.TokenSource(ctx)
 	token, err := tokenSource.Token()

--- a/pkg/credentials/gar/service_account_key_test.go
+++ b/pkg/credentials/gar/service_account_key_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -157,29 +157,10 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 			ctx context.Context,
 			encodedServiceAccountKey string,
 		) (*oauth2.Token, error)
-		setupCache func(c *cache.Cache)
-		assertions func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error)
+		assertions func(t *testing.T, creds *credentials.Credentials, err error)
 	}{
 		{
-			name:     "cache hit",
-			credType: credentials.TypeImage,
-			repoURL:  fakeGARRepoURL,
-			data: map[string][]byte{
-				serviceAccountKeyKey: []byte(fakeServiceAccountKey),
-			},
-			setupCache: func(c *cache.Cache) {
-				cacheKey := tokenCacheKey(fakeServiceAccountKey)
-				c.Set(cacheKey, fakeAccessToken, cache.DefaultExpiration)
-			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, accessTokenUsername, creds.Username)
-				assert.Equal(t, fakeAccessToken, creds.Password)
-			},
-		},
-		{
-			name:     "cache miss, successful token fetch",
+			name:     "token obtained",
 			credType: credentials.TypeImage,
 			repoURL:  fakeGARRepoURL,
 			data: map[string][]byte{
@@ -191,20 +172,30 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 					Expiry:      time.Now().Add(time.Hour),
 				}, nil
 			},
-			assertions: func(t *testing.T, c *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
 				assert.Equal(t, fakeAccessToken, creds.Password)
-
-				// Verify the token was cached with a TTL based on the
-				// token's actual expiry
-				items := c.Items()
-				item, found := items[tokenCacheKey(fakeServiceAccountKey)]
-				assert.True(t, found)
-				expectedTTL := 55 * time.Minute // 1h expiry - 5m margin
-				actualTTL := time.Until(time.Unix(0, item.Expiration))
-				assert.InDelta(t, expectedTTL.Seconds(), actualTTL.Seconds(), 5)
+			},
+		},
+		{
+			name:     "token obtained, but too near expiry to cache",
+			credType: credentials.TypeImage,
+			repoURL:  fakeGARRepoURL,
+			data: map[string][]byte{
+				serviceAccountKeyKey: []byte(fakeServiceAccountKey),
+			},
+			getAccessTokenFn: func(context.Context, string) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken: fakeAccessToken,
+					Expiry:      time.Now().Add(-time.Hour),
+				}, nil
+			},
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, creds)
+				assert.Equal(t, fakeAccessToken, creds.Password)
 			},
 		},
 		{
@@ -217,7 +208,7 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 			getAccessTokenFn: func(context.Context, string) (*oauth2.Token, error) {
 				return nil, errors.New("access token error")
 			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.ErrorContains(t, err, "error getting GCP access token")
 				assert.Nil(t, creds)
 			},
@@ -232,7 +223,7 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 			getAccessTokenFn: func(context.Context, string) (*oauth2.Token, error) {
 				return nil, nil
 			},
-			assertions: func(t *testing.T, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.NoError(t, err)
 			},
@@ -244,9 +235,19 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 			provider := NewServiceAccountKeyProvider().(*ServiceAccountKeyProvider) // nolint:forcetypeassert
 			provider.getAccessTokenFn = testCase.getAccessTokenFn
 
-			if testCase.setupCache != nil {
-				testCase.setupCache(provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's.
+			tokenCache, err := coalescing.NewCache(
+				provider.loadAccessToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(tokenAcquisitionTimeout),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			provider.tokenCache = tokenCache
 
 			creds, err := provider.GetCredentials(
 				t.Context(),
@@ -256,7 +257,56 @@ func TestServiceAccountKeyProvider_GetCredentials(t *testing.T) {
 					Data:    testCase.data,
 				},
 			)
-			testCase.assertions(t, provider.tokenCache, creds, err)
+			testCase.assertions(t, creds, err)
 		})
+	}
+}
+
+func TestServiceAccountKeyProvider_GetCredentials_perKey(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the load deadline all belong to the cache this
+	// provider delegates to, and are covered by that package's tests. What remains
+	// this provider's own responsibility is that the key it caches under and the
+	// input it loads from describe the same service account key, so that no set of
+	// credentials is ever served another's token.
+
+	const fakeRepoURL = "us-central1-docker.pkg.dev/my-project/my-repo"
+
+	provider := &ServiceAccountKeyProvider{
+		getAccessTokenFn: func(
+			_ context.Context,
+			encodedServiceAccountKey string,
+		) (*oauth2.Token, error) {
+			// The token identifies the key it was obtained with.
+			return &oauth2.Token{
+				AccessToken: "token-for-" + encodedServiceAccountKey,
+				Expiry:      time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	for _, key := range []string{"key-a", "key-b", "key-a"} {
+		creds, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				RepoURL: fakeRepoURL,
+				Data:    map[string][]byte{serviceAccountKeyKey: []byte(key)},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(t, accessTokenUsername, creds.Username)
+		require.Equal(t, "token-for-"+key, creds.Password)
 	}
 }

--- a/pkg/credentials/gar/workload_identity_federation.go
+++ b/pkg/credentials/gar/workload_identity_federation.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/logging"
 )
@@ -46,6 +48,20 @@ func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentit
 		logger.Info("not running on GCP; skipping initialization of GCP Workload Identity Federation provider")
 		return nil
 	}
+
+	// The token source built below refreshes itself by issuing an HTTP request,
+	// and depending on which credentials Application Default Credentials
+	// resolves to, nothing may bound that request: a service account key routes
+	// through oauth2's JWT source, which takes its client from this context but
+	// issues the request without it. Since a refresh can occur inside a
+	// singleflight group, an unanswered request would occupy that group's key for
+	// the life of the process. Worse, a token source serializes refreshes behind
+	// a mutex, so every caller sharing this one would block, not merely those
+	// waiting on the key. A client timeout is the only bound available here.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: cleanhttp.DefaultTransport(),
+		Timeout:   tokenRequestTimeout,
+	})
 
 	var projectID string
 	var tokenSource oauth2.TokenSource
@@ -79,13 +95,6 @@ func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentit
 	p := &WorkloadIdentityFederationProvider{
 		projectID:   projectID,
 		tokenSource: tokenSource,
-		tokenCache: cache.New(
-			// Access tokens live for one hour. We'll hang on to them for 40
-			// minutes by default. When the actual token expiry is available, it
-			// is used (minus a safety margin) instead of this default.
-			40*time.Minute, // Default ttl for each entry
-			time.Hour,      // Cleanup interval
-		),
 		tokenSourceCache: cache.New(
 			// Token sources are long-lived. We could hang on to them indefinitely,
 			// but we'll cap it at 12 hours to prevent memory leaks.
@@ -94,12 +103,36 @@ func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentit
 		),
 	}
 	p.getAccessTokenFn = p.getAccessToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			// Access tokens live for one hour. We'll hang on to them for 40
+			// minutes by default. When the actual token expiry is available, it
+			// is used (minus a safety margin) instead of this default.
+			DefaultTTL:      new(40 * time.Minute),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	if err != nil {
+		logger.Error(
+			err,
+			"error creating token cache; GCP Workload Identity Federation "+
+				"provider could not be initialized",
+		)
+		return nil
+	}
+	p.tokenCache = tokenCache
 	return p
 }
 
 type WorkloadIdentityFederationProvider struct {
-	tokenCache       *cache.Cache // For short-lived Project-specific tokens
-	tokenSourceCache *cache.Cache // For long-lived token sources
+	// tokenCache holds short-lived Project-specific tokens and fills its own
+	// misses, coalescing concurrent loads for any given Project.
+	tokenCache coalescing.Cache[string, string]
+	// tokenSourceCache holds long-lived token sources for Projects that have no
+	// Project-specific token to be had.
+	tokenSourceCache *cache.Cache
 
 	projectID   string
 	tokenSource oauth2.TokenSource
@@ -130,17 +163,12 @@ func (p *WorkloadIdentityFederationProvider) GetCredentials(
 		"provider", "garWorkloadIdentityFederation",
 		"repoURL", req.RepoURL,
 	)
+	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the token cache for a Project-specific token
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("access token cache hit")
-		return &credentials.Credentials{
-			Username: accessTokenUsername,
-			Password: entry.(string), // nolint: forcetypeassert
-		}, nil
-	}
-
-	// Check the token source cache for a long-lived token source
+	// Check the token source cache for a long-lived token source. At most one of
+	// this provider's two caches holds an entry for any given key, since a load
+	// populates whichever of them applies and never both, so the order in which
+	// they are consulted does not matter.
 	if entry, exists := p.tokenSourceCache.Get(cacheKey); exists {
 		logger.Debug("token source cache hit")
 		tokenSource := entry.(oauth2.TokenSource) // nolint: forcetypeassert
@@ -153,41 +181,63 @@ func (p *WorkloadIdentityFederationProvider) GetCredentials(
 			Password: token.AccessToken,
 		}, nil
 	}
-	logger.Debug("access token cache miss")
 
-	// We had a miss in both caches, so we'll try to get a new Project-specific
-	// token.
-	accessToken, expiry, err := p.getAccessTokenFn(ctx, req.Project)
+	accessToken, err := p.tokenCache.Get(ctx, cacheKey, req.Project)
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP access token: %w", err)
+		return nil, err
+	}
+
+	// If we didn't get a token, we'll treat this as no credentials found
+	if accessToken == "" {
+		return nil, nil
+	}
+
+	return &credentials.Credentials{
+		Username: accessTokenUsername,
+		Password: accessToken,
+	}, nil
+}
+
+// loadAccessToken obtains a GCP access token scoped to the given Kargo Project.
+// If no Project-specific token is available, it caches the controller's own
+// token source and returns a token from that instead. It is the Loader for this
+// provider's token cache.
+func (p *WorkloadIdentityFederationProvider) loadAccessToken(
+	ctx context.Context,
+	project string,
+) (string, *time.Duration, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	accessToken, expiry, err := p.getAccessTokenFn(ctx, project)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting GCP access token: %w", err)
 	}
 	if accessToken != "" {
 		logger.Debug("obtained new access token")
 		ttl := credentials.CalculateCacheTTL(expiry, tokenCacheExpiryMargin)
+		if ttl == nil {
+			logger.Debug("token expires too soon to be worth caching", "expiry", expiry)
+			return accessToken, nil, nil
+		}
 		logger.Debug(
 			"caching access token",
 			"expiry", expiry,
-			"ttl", ttl,
+			"ttl", *ttl,
 		)
-		p.tokenCache.Set(cacheKey, accessToken, ttl)
-		return &credentials.Credentials{
-			Username: accessTokenUsername,
-			Password: accessToken,
-		}, nil
+		return accessToken, ttl, nil
 	}
 
 	// If we get to here, we found no Project-specific token and we'll cache the
-	// token source instead.
+	// token source instead. The token it yields is deliberately left uncached:
+	// the source refreshes itself, so caching the source is what spares future
+	// callers this work.
 	logger.Debug("no project-specific token found; caching default token source")
-	p.tokenSourceCache.Set(cacheKey, p.tokenSource, cache.DefaultExpiration)
+	p.tokenSourceCache.Set(tokenCacheKey(project), p.tokenSource, cache.DefaultExpiration)
 	token, err := p.tokenSource.Token()
 	if err != nil {
-		return nil, fmt.Errorf("error getting GCP access token: %w", err)
+		return "", nil, fmt.Errorf("error getting GCP access token: %w", err)
 	}
-	return &credentials.Credentials{
-		Username: accessTokenUsername,
-		Password: token.AccessToken,
-	}, nil
+	return token.AccessToken, nil, nil
 }
 
 // getAccessToken attempts to get a GCP access token scoped to the given Kargo
@@ -219,7 +269,7 @@ func (p *WorkloadIdentityFederationProvider) getAccessToken(
 				iamcredentials.CloudPlatformScope,
 			},
 		},
-	).Do()
+	).Context(ctx).Do()
 	if err != nil {
 		var googleErr *googleapi.Error
 		if errors.As(err, &googleErr) && googleErr.Code == http.StatusNotFound {
@@ -227,6 +277,18 @@ func (p *WorkloadIdentityFederationProvider) getAccessToken(
 			return "", time.Time{}, nil
 		}
 		logger.Error(err, "error generating access token")
+		return "", time.Time{}, nil
+	}
+
+	// A nil response alongside a nil error would be a surprise, but it is
+	// reachable: the generated client decodes into a pointer to the response
+	// pointer, so a success carrying a JSON null body nils the response and
+	// reports no error. Dereferencing it regardless is not worth the
+	// consequence: the cache this runs under would report the panic to every
+	// caller waiting on this key as an error saying nothing about what actually
+	// went wrong.
+	if resp == nil {
+		logger.Error(nil, "no response generating access token")
 		return "", time.Time{}, nil
 	}
 

--- a/pkg/credentials/gar/workload_identity_federation.go
+++ b/pkg/credentials/gar/workload_identity_federation.go
@@ -9,7 +9,6 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/patrickmn/go-cache"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
@@ -25,6 +24,14 @@ import (
 const (
 	initMaxAttempts   = 5
 	initRetryInterval = time.Second
+
+	// noProjectTokenTTL is how long the absence of a Project-specific service
+	// account is remembered. Nothing about that determination expires, so it is
+	// held for a good while: a shorter TTL would buy only a sooner discovery of a
+	// service account created after the fact, at the cost of repeating the lookup
+	// for every Project that will never have one. It is bounded at all only so
+	// that Projects that have come and gone do not accumulate.
+	noProjectTokenTTL = 12 * time.Hour
 )
 
 func init() {
@@ -36,6 +43,14 @@ func init() {
 			},
 		)
 	}
+}
+
+// projectToken is what this provider's token cache holds: either an access
+// token scoped to a Kargo Project, or a signal that the Project has no service
+// account of its own and the controller's identity is to be used instead.
+type projectToken struct {
+	accessToken string
+	useDefault  bool
 }
 
 // NewWorkloadIdentityFederationProvider returns a fully initialized
@@ -95,12 +110,6 @@ func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentit
 	p := &WorkloadIdentityFederationProvider{
 		projectID:   projectID,
 		tokenSource: tokenSource,
-		tokenSourceCache: cache.New(
-			// Token sources are long-lived. We could hang on to them indefinitely,
-			// but we'll cap it at 12 hours to prevent memory leaks.
-			12*time.Hour, // Default ttl for each entry
-			time.Hour,    // Cleanup interval
-		),
 	}
 	p.getAccessTokenFn = p.getAccessToken
 	tokenCache, err := coalescing.NewCache(
@@ -127,14 +136,18 @@ func NewWorkloadIdentityFederationProvider(ctx context.Context) *WorkloadIdentit
 }
 
 type WorkloadIdentityFederationProvider struct {
-	// tokenCache holds short-lived Project-specific tokens and fills its own
-	// misses, coalescing concurrent loads for any given Project.
-	tokenCache coalescing.Cache[string, string]
-	// tokenSourceCache holds long-lived token sources for Projects that have no
-	// Project-specific token to be had.
-	tokenSourceCache *cache.Cache
+	// tokenCache holds what is known about each Kargo Project's access to
+	// Artifact Registry. It fills its own misses, coalescing concurrent loads for
+	// any given Project.
+	tokenCache coalescing.Cache[string, projectToken]
 
-	projectID   string
+	projectID string
+
+	// tokenSource is the controller's own identity, used on behalf of Projects
+	// having no service account of their own. It is a cache in its own right,
+	// holding the token it last obtained and refreshing it as expiry nears, so
+	// what it yields is never cached here. What is worth remembering about such a
+	// Project is only that it has nothing better than this.
 	tokenSource oauth2.TokenSource
 
 	getAccessTokenFn func(
@@ -157,34 +170,30 @@ func (p *WorkloadIdentityFederationProvider) GetCredentials(
 	ctx context.Context,
 	req credentials.Request,
 ) (*credentials.Credentials, error) {
-	cacheKey := tokenCacheKey(req.Project)
-
 	logger := logging.LoggerFromContext(ctx).WithValues(
 		"provider", "garWorkloadIdentityFederation",
 		"repoURL", req.RepoURL,
 	)
 	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the token source cache for a long-lived token source. At most one of
-	// this provider's two caches holds an entry for any given key, since a load
-	// populates whichever of them applies and never both, so the order in which
-	// they are consulted does not matter.
-	if entry, exists := p.tokenSourceCache.Get(cacheKey); exists {
-		logger.Debug("token source cache hit")
-		tokenSource := entry.(oauth2.TokenSource) // nolint: forcetypeassert
-		token, err := tokenSource.Token()
-		if err != nil {
-			return nil, fmt.Errorf("error getting GCP access token: %w", err)
-		}
-		return &credentials.Credentials{
-			Username: accessTokenUsername,
-			Password: token.AccessToken,
-		}, nil
-	}
-
-	accessToken, err := p.tokenCache.Get(ctx, cacheKey, req.Project)
+	cachedToken, err := p.tokenCache.Get(
+		ctx,
+		tokenCacheKey(req.Project),
+		req.Project,
+	)
 	if err != nil {
 		return nil, err
+	}
+
+	accessToken := cachedToken.accessToken
+	if cachedToken.useDefault {
+		// Obtained anew on every call, for the reason given where tokenSource is
+		// declared.
+		var defaultToken *oauth2.Token
+		if defaultToken, err = p.tokenSource.Token(); err != nil {
+			return nil, fmt.Errorf("error getting GCP access token: %w", err)
+		}
+		accessToken = defaultToken.AccessToken
 	}
 
 	// If we didn't get a token, we'll treat this as no credentials found
@@ -199,45 +208,37 @@ func (p *WorkloadIdentityFederationProvider) GetCredentials(
 }
 
 // loadAccessToken obtains a GCP access token scoped to the given Kargo Project.
-// If no Project-specific token is available, it caches the controller's own
-// token source and returns a token from that instead. It is the Loader for this
-// provider's token cache.
+// If the Project has no service account of its own, what is returned says so
+// instead of carrying a token. It is the Loader for this provider's token
+// cache.
 func (p *WorkloadIdentityFederationProvider) loadAccessToken(
 	ctx context.Context,
 	project string,
-) (string, *time.Duration, error) {
+) (projectToken, *time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 
 	accessToken, expiry, err := p.getAccessTokenFn(ctx, project)
 	if err != nil {
-		return "", nil, fmt.Errorf("error getting GCP access token: %w", err)
-	}
-	if accessToken != "" {
-		logger.Debug("obtained new access token")
-		ttl := credentials.CalculateCacheTTL(expiry, tokenCacheExpiryMargin)
-		if ttl == nil {
-			logger.Debug("token expires too soon to be worth caching", "expiry", expiry)
-			return accessToken, nil, nil
-		}
-		logger.Debug(
-			"caching access token",
-			"expiry", expiry,
-			"ttl", *ttl,
-		)
-		return accessToken, ttl, nil
+		return projectToken{}, nil, fmt.Errorf("error getting GCP access token: %w", err)
 	}
 
-	// If we get to here, we found no Project-specific token and we'll cache the
-	// token source instead. The token it yields is deliberately left uncached:
-	// the source refreshes itself, so caching the source is what spares future
-	// callers this work.
-	logger.Debug("no project-specific token found; caching default token source")
-	p.tokenSourceCache.Set(tokenCacheKey(project), p.tokenSource, cache.DefaultExpiration)
-	token, err := p.tokenSource.Token()
-	if err != nil {
-		return "", nil, fmt.Errorf("error getting GCP access token: %w", err)
+	if accessToken == "" {
+		logger.Debug("no Project-specific token found; will use default token source")
+		return projectToken{useDefault: true}, new(noProjectTokenTTL), nil
 	}
-	return token.AccessToken, nil, nil
+	logger.Debug("obtained new access token")
+
+	ttl := credentials.CalculateCacheTTL(expiry, tokenCacheExpiryMargin)
+	if ttl == nil {
+		logger.Debug("token expires too soon to be worth caching", "expiry", expiry)
+		return projectToken{accessToken: accessToken}, nil, nil
+	}
+	logger.Debug(
+		"caching access token",
+		"expiry", expiry,
+		"ttl", *ttl,
+	)
+	return projectToken{accessToken: accessToken}, ttl, nil
 }
 
 // getAccessToken attempts to get a GCP access token scoped to the given Kargo

--- a/pkg/credentials/gar/workload_identity_federation_test.go
+++ b/pkg/credentials/gar/workload_identity_federation_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -124,53 +123,21 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name                  string
-		provider              *WorkloadIdentityFederationProvider
-		setupTokenSourceCache func(c *cache.Cache)
-		project               string
-		credType              credentials.Type
-		repoURL               string
-		assertions            func(
+		name       string
+		provider   *WorkloadIdentityFederationProvider
+		project    string
+		credType   credentials.Type
+		repoURL    string
+		assertions func(
 			t *testing.T,
-			tokenSourceCache *cache.Cache,
 			creds *credentials.Credentials,
 			err error,
 		)
 	}{
 		{
-			name: "token source cache hit",
-			provider: &WorkloadIdentityFederationProvider{
-				projectID:        fakeProjectID,
-				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
-				// A token distinct from the cached token source's, so that skipping
-				// the token source cache and acquiring one instead is detectable.
-				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
-					return "token-from-an-acquisition", time.Now().Add(time.Hour), nil
-				},
-			},
-			setupTokenSourceCache: func(c *cache.Cache) {
-				c.Set(tokenCacheKey(fakeProject), newFakeTokenSource(fakeToken), cache.DefaultExpiration)
-			},
-			project:  fakeProject,
-			credType: credentials.TypeImage,
-			repoURL:  fakeGCRRepoURL,
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, accessTokenUsername, creds.Username)
-				assert.Equal(t, fakeToken, creds.Password)
-			},
-		},
-		{
 			name: "token obtained",
 			provider: &WorkloadIdentityFederationProvider{
-				projectID:        fakeProjectID,
-				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				projectID: fakeProjectID,
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return fakeToken, time.Now().Add(time.Hour), nil
 				},
@@ -180,7 +147,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			repoURL:  fakeGCRRepoURL,
 			assertions: func(
 				t *testing.T,
-				_ *cache.Cache,
 				creds *credentials.Credentials,
 				err error,
 			) {
@@ -193,8 +159,7 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 		{
 			name: "token obtained, but too near expiry to cache",
 			provider: &WorkloadIdentityFederationProvider{
-				projectID:        fakeProjectID,
-				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				projectID: fakeProjectID,
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return fakeToken, time.Now().Add(-time.Hour), nil
 				},
@@ -204,7 +169,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			repoURL:  fakeGCRRepoURL,
 			assertions: func(
 				t *testing.T,
-				_ *cache.Cache,
 				creds *credentials.Credentials,
 				err error,
 			) {
@@ -216,8 +180,7 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 		{
 			name: "error in getAccessToken",
 			provider: &WorkloadIdentityFederationProvider{
-				projectID:        fakeProjectID,
-				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				projectID: fakeProjectID,
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return "", time.Time{}, fmt.Errorf("token fetch error")
 				},
@@ -227,7 +190,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			repoURL:  fakeGCRRepoURL,
 			assertions: func(
 				t *testing.T,
-				_ *cache.Cache,
 				creds *credentials.Credentials,
 				err error,
 			) {
@@ -239,8 +201,7 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 		{
 			name: "empty token from getAccessToken falls back to default token source",
 			provider: &WorkloadIdentityFederationProvider{
-				projectID:        fakeProjectID,
-				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				projectID: fakeProjectID,
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return "", time.Time{}, nil
 				},
@@ -251,7 +212,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			repoURL:  fakeGCRRepoURL,
 			assertions: func(
 				t *testing.T,
-				tokenSourceCache *cache.Cache,
 				creds *credentials.Credentials,
 				err error,
 			) {
@@ -259,15 +219,28 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
 				assert.Equal(t, fakeToken, creds.Password)
-
-				// Verify the token source was cached
-				tokenSource, found := tokenSourceCache.Get(tokenCacheKey(fakeProject))
-				assert.True(t, found)
-				ts, ok := tokenSource.(oauth2.TokenSource)
-				assert.True(t, ok)
-				token, err := ts.Token()
-				assert.NoError(t, err)
-				assert.Equal(t, fakeToken, token.AccessToken)
+			},
+		},
+		{
+			name: "error from default token source",
+			provider: &WorkloadIdentityFederationProvider{
+				projectID: fakeProjectID,
+				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
+					return "", time.Time{}, nil
+				},
+				tokenSource: newFailingTokenSource(fmt.Errorf("token source error")),
+			},
+			project:  fakeProject,
+			credType: credentials.TypeImage,
+			repoURL:  fakeGCRRepoURL,
+			assertions: func(
+				t *testing.T,
+				creds *credentials.Credentials,
+				err error,
+			) {
+				assert.ErrorContains(t, err, "error getting GCP access token")
+				assert.ErrorContains(t, err, "token source error")
+				assert.Nil(t, creds)
 			},
 		},
 	}
@@ -279,8 +252,7 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			// A cache that caches nothing leaves loading as the only way a caller
 			// can obtain a token, so every case exercises the load. Whether a hit is
 			// served from the cache instead is the cache's concern, not this
-			// provider's. The token source cache is this provider's own, and stays
-			// real.
+			// provider's.
 			tokenCache, err := coalescing.NewCache(
 				testCase.provider.loadAccessToken,
 				&coalescing.CacheOptions{
@@ -291,9 +263,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			require.NoError(t, err)
 			testCase.provider.tokenCache = tokenCache
 
-			if testCase.setupTokenSourceCache != nil {
-				testCase.setupTokenSourceCache(testCase.provider.tokenSourceCache)
-			}
 			creds, err := testCase.provider.GetCredentials(
 				t.Context(),
 				credentials.Request{
@@ -302,26 +271,54 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 					RepoURL: testCase.repoURL,
 				},
 			)
-			testCase.assertions(
-				t,
-				testCase.provider.tokenSourceCache,
-				creds,
-				err,
-			)
+			testCase.assertions(t, creds, err)
 		})
 	}
 }
 
-type fakeTokenSource struct {
-	token string
-}
+func TestWorkloadIdentityFederationProvider_GetCredentials_noProjectToken(t *testing.T) {
+	t.Parallel()
 
-func newFakeTokenSource(token string) oauth2.TokenSource {
-	return &fakeTokenSource{token: token}
-}
+	// A Project with no service account of its own has that fact cached in place
+	// of a token, so the lookup that established it is not repeated. The token
+	// itself cannot be cached in its stead, the controller's own token source
+	// being what refreshes it.
 
-func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{AccessToken: f.token}, nil
+	const fakeRepoURL = "us-central1-docker.pkg.dev/my-project/my-repo"
+
+	var lookups int
+	provider := &WorkloadIdentityFederationProvider{
+		tokenSource: newFakeTokenSource("token-from-default-source"),
+		getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
+			lookups++
+			return "", time.Time{}, nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout:     new(tokenAcquisitionTimeout),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	for range 2 {
+		creds, credsErr := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				Project: "project-without-a-service-account",
+				RepoURL: fakeRepoURL,
+			},
+		)
+		require.NoError(t, credsErr)
+		require.NotNil(t, creds)
+		require.Equal(t, accessTokenUsername, creds.Username)
+		require.Equal(t, "token-from-default-source", creds.Password)
+	}
+	require.Equal(t, 1, lookups)
 }
 
 func TestWorkloadIdentityFederationProvider_GetCredentials_perProject(t *testing.T) {
@@ -336,7 +333,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials_perProject(t *testing
 	const fakeRepoURL = "us-central1-docker.pkg.dev/my-project/my-repo"
 
 	provider := &WorkloadIdentityFederationProvider{
-		tokenSourceCache: cache.New(time.Hour, 0),
 		getAccessTokenFn: func(
 			_ context.Context,
 			project string,
@@ -369,4 +365,28 @@ func TestWorkloadIdentityFederationProvider_GetCredentials_perProject(t *testing
 		require.Equal(t, accessTokenUsername, creds.Username)
 		require.Equal(t, "token-for-"+project, creds.Password)
 	}
+}
+
+type fakeTokenSource struct {
+	token string
+}
+
+func newFakeTokenSource(token string) oauth2.TokenSource {
+	return &fakeTokenSource{token: token}
+}
+
+func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: f.token}, nil
+}
+
+type failingTokenSource struct {
+	err error
+}
+
+func newFailingTokenSource(err error) oauth2.TokenSource {
+	return &failingTokenSource{err: err}
+}
+
+func (f *failingTokenSource) Token() (*oauth2.Token, error) {
+	return nil, f.err
 }

--- a/pkg/credentials/gar/workload_identity_federation_test.go
+++ b/pkg/credentials/gar/workload_identity_federation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -24,18 +25,18 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name     string
-		provider *WorkloadIdentityFederationProvider
-		credType credentials.Type
-		repoURL  string
-		assert   func(t *testing.T, result bool)
+		name       string
+		provider   *WorkloadIdentityFederationProvider
+		credType   credentials.Type
+		repoURL    string
+		assertions func(t *testing.T, result bool)
 	}{
 		{
 			name:     "supports image credentials for GAR URL",
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeImage,
 			repoURL:  fakeGARRepoURL,
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.True(t, result)
 			},
 		},
@@ -44,7 +45,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeImage,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.True(t, result)
 			},
 		},
@@ -53,7 +54,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeHelm,
 			repoURL:  fakeGARRepoURL,
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.True(t, result)
 			},
 		},
@@ -62,7 +63,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeHelm,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.True(t, result)
 			},
 		},
@@ -71,7 +72,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeGit,
 			repoURL:  fakeGARRepoURL,
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.False(t, result)
 			},
 		},
@@ -80,7 +81,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeImage,
 			repoURL:  "docker.io/library/alpine",
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.False(t, result)
 			},
 		},
@@ -89,7 +90,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 			provider: &WorkloadIdentityFederationProvider{projectID: fakeProjectID},
 			credType: credentials.TypeHelm,
 			repoURL:  "docker.io/library/alpine",
-			assert: func(t *testing.T, result bool) {
+			assertions: func(t *testing.T, result bool) {
 				assert.False(t, result)
 			},
 		},
@@ -107,7 +108,7 @@ func TestWorkloadIdentityFederationProvider_Supports(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			testCase.assert(t, supports)
+			testCase.assertions(t, supports)
 		})
 	}
 }
@@ -125,46 +126,26 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		provider              *WorkloadIdentityFederationProvider
-		setupTokenCache       func(c *cache.Cache)
 		setupTokenSourceCache func(c *cache.Cache)
 		project               string
 		credType              credentials.Type
 		repoURL               string
-		assert                func(
+		assertions            func(
 			t *testing.T,
-			tokenCache *cache.Cache,
 			tokenSourceCache *cache.Cache,
 			creds *credentials.Credentials,
 			err error,
 		)
 	}{
 		{
-			name: "token cache hit",
-			provider: &WorkloadIdentityFederationProvider{
-				projectID:  fakeProjectID,
-				tokenCache: cache.New(10*time.Hour, time.Hour),
-			},
-			setupTokenCache: func(c *cache.Cache) {
-				c.Set(tokenCacheKey(fakeProject), fakeToken, cache.DefaultExpiration)
-			},
-			project:  fakeProject,
-			credType: credentials.TypeImage,
-			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, _, _ *cache.Cache, creds *credentials.Credentials, err error) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, accessTokenUsername, creds.Username)
-				assert.Equal(t, fakeToken, creds.Password)
-			},
-		},
-		{
-			name: "token cache miss, token source cache hit",
+			name: "token source cache hit",
 			provider: &WorkloadIdentityFederationProvider{
 				projectID:        fakeProjectID,
-				tokenCache:       cache.New(10*time.Hour, time.Hour),
 				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				// A token distinct from the cached token source's, so that skipping
+				// the token source cache and acquiring one instead is detectable.
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
-					return fakeToken, time.Now().Add(time.Hour), nil
+					return "token-from-an-acquisition", time.Now().Add(time.Hour), nil
 				},
 			},
 			setupTokenSourceCache: func(c *cache.Cache) {
@@ -173,7 +154,12 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, _, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(
+				t *testing.T,
+				_ *cache.Cache,
+				creds *credentials.Credentials,
+				err error,
+			) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
@@ -181,10 +167,9 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			},
 		},
 		{
-			name: "miss in both caches, successful token fetch",
+			name: "token obtained",
 			provider: &WorkloadIdentityFederationProvider{
 				projectID:        fakeProjectID,
-				tokenCache:       cache.New(10*time.Hour, time.Hour),
 				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return fakeToken, time.Now().Add(time.Hour), nil
@@ -193,26 +178,45 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, tokenCache, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(
+				t *testing.T,
+				_ *cache.Cache,
+				creds *credentials.Credentials,
+				err error,
+			) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
 				assert.Equal(t, fakeToken, creds.Password)
-
-				// Verify the token was cached with a TTL based on the token's actual expiry
-				items := tokenCache.Items()
-				item, found := items[tokenCacheKey(fakeProject)]
-				assert.True(t, found)
-				expectedTTL := 55 * time.Minute // 1h expiry - 5m margin
-				actualTTL := time.Until(time.Unix(0, item.Expiration))
-				assert.InDelta(t, expectedTTL.Seconds(), actualTTL.Seconds(), 5)
+			},
+		},
+		{
+			name: "token obtained, but too near expiry to cache",
+			provider: &WorkloadIdentityFederationProvider{
+				projectID:        fakeProjectID,
+				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
+				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
+					return fakeToken, time.Now().Add(-time.Hour), nil
+				},
+			},
+			project:  fakeProject,
+			credType: credentials.TypeImage,
+			repoURL:  fakeGCRRepoURL,
+			assertions: func(
+				t *testing.T,
+				_ *cache.Cache,
+				creds *credentials.Credentials,
+				err error,
+			) {
+				assert.NoError(t, err)
+				assert.NotNil(t, creds)
+				assert.Equal(t, fakeToken, creds.Password)
 			},
 		},
 		{
 			name: "error in getAccessToken",
 			provider: &WorkloadIdentityFederationProvider{
 				projectID:        fakeProjectID,
-				tokenCache:       cache.New(10*time.Hour, time.Hour),
 				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return "", time.Time{}, fmt.Errorf("token fetch error")
@@ -221,7 +225,13 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, _, _ *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(
+				t *testing.T,
+				_ *cache.Cache,
+				creds *credentials.Credentials,
+				err error,
+			) {
+				assert.ErrorContains(t, err, "error getting GCP access token")
 				assert.ErrorContains(t, err, "token fetch error")
 				assert.Nil(t, creds)
 			},
@@ -230,7 +240,6 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			name: "empty token from getAccessToken falls back to default token source",
 			provider: &WorkloadIdentityFederationProvider{
 				projectID:        fakeProjectID,
-				tokenCache:       cache.New(10*time.Hour, time.Hour),
 				tokenSourceCache: cache.New(10*time.Hour, time.Hour),
 				getAccessTokenFn: func(context.Context, string) (string, time.Time, error) {
 					return "", time.Time{}, nil
@@ -240,7 +249,12 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 			project:  fakeProject,
 			credType: credentials.TypeImage,
 			repoURL:  fakeGCRRepoURL,
-			assert: func(t *testing.T, _, tokenSourceCache *cache.Cache, creds *credentials.Credentials, err error) {
+			assertions: func(
+				t *testing.T,
+				tokenSourceCache *cache.Cache,
+				creds *credentials.Credentials,
+				err error,
+			) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
@@ -262,9 +276,21 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if testCase.setupTokenCache != nil {
-				testCase.setupTokenCache(testCase.provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's. The token source cache is this provider's own, and stays
+			// real.
+			tokenCache, err := coalescing.NewCache(
+				testCase.provider.loadAccessToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(tokenAcquisitionTimeout),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			testCase.provider.tokenCache = tokenCache
+
 			if testCase.setupTokenSourceCache != nil {
 				testCase.setupTokenSourceCache(testCase.provider.tokenSourceCache)
 			}
@@ -276,9 +302,8 @@ func TestWorkloadIdentityFederationProvider_GetCredentials(t *testing.T) {
 					RepoURL: testCase.repoURL,
 				},
 			)
-			testCase.assert(
+			testCase.assertions(
 				t,
-				testCase.provider.tokenCache,
 				testCase.provider.tokenSourceCache,
 				creds,
 				err,
@@ -297,4 +322,51 @@ func newFakeTokenSource(token string) oauth2.TokenSource {
 
 func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: f.token}, nil
+}
+
+func TestWorkloadIdentityFederationProvider_GetCredentials_perProject(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the load deadline all belong to the cache this
+	// provider delegates to, and are covered by that package's tests. What remains
+	// this provider's own responsibility is that the key it caches under and the
+	// input it loads from describe the same Project, so that no Project is ever
+	// served another's token.
+
+	const fakeRepoURL = "us-central1-docker.pkg.dev/my-project/my-repo"
+
+	provider := &WorkloadIdentityFederationProvider{
+		tokenSourceCache: cache.New(time.Hour, 0),
+		getAccessTokenFn: func(
+			_ context.Context,
+			project string,
+		) (string, time.Time, error) {
+			// The token identifies the Project it was obtained for.
+			return "token-for-" + project, time.Now().Add(time.Hour), nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	for _, project := range []string{"project-a", "project-b", "project-a"} {
+		creds, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Type:    credentials.TypeImage,
+				Project: project,
+				RepoURL: fakeRepoURL,
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(t, accessTokenUsername, creds.Username)
+		require.Equal(t, "token-for-"+project, creds.Password)
+	}
 }

--- a/pkg/credentials/github/app.go
+++ b/pkg/credentials/github/app.go
@@ -17,11 +17,10 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/jferrl/go-githubauth"
-	"github.com/patrickmn/go-cache"
 	"golang.org/x/oauth2"
-	"golang.org/x/sync/singleflight"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 	ghutil "github.com/akuity/kargo/pkg/github"
 	"github.com/akuity/kargo/pkg/logging"
@@ -55,25 +54,34 @@ func init() {
 	}
 }
 
-type AppCredentialProvider struct {
-	tokenCache *cache.Cache
+// appInput identifies the installation access token a load should mint. The
+// cache key is a hash of these values, so they cannot be recovered from it.
+type appInput struct {
+	appOrClientID     string
+	installationID    int64
+	encodedPrivateKey string
+	repoURL           string
+}
 
-	// mintGroup coalesces concurrent mints of the token for any given cache
-	// key into a single mint whose result is shared by all callers.
-	mintGroup singleflight.Group
+type AppCredentialProvider struct {
+	// tokenCache holds installation access tokens keyed by a hash of the App and
+	// repository they were minted for. It fills its own misses, coalescing
+	// concurrent mints for any given key.
+	tokenCache coalescing.Cache[appInput, string]
 
 	// validationBackoff is the schedule of waits between successive attempts to validate a newly
 	// minted installation access token. This is set as a field so that it can be overridden in
 	// tests to avoid long waits.
 	validationBackoff []time.Duration
 
-	// mintTimeoutBuffer is added to the sum of validationBackoff when computing the maximum time to
-	// wait for a token to be minted and validated. It accounts for network round-trips that are not
-	// captured by the backoff schedule. This is set as a field so that it can be overridden in tests
-	// to avoid long waits.
+	// mintTimeoutBuffer is added to the waits and validation requests accounted
+	// for in mintTimeout(). It covers the request that mints the token, which has
+	// no timeout of its own. This is set as a field so that it can be overridden
+	// in tests to avoid long waits.
 	mintTimeoutBuffer time.Duration
 
 	getAccessTokenFn func(
+		ctx context.Context,
 		appOrClientID string,
 		installationID int64,
 		encodedPrivateKey string,
@@ -90,13 +98,6 @@ type AppCredentialProvider struct {
 // NewAppCredentialProvider returns an implementation of credentials.Provider.
 func NewAppCredentialProvider() credentials.Provider {
 	p := &AppCredentialProvider{
-		tokenCache: cache.New(
-			// Access tokens live for one hour. We'll hang on to them for 40
-			// minutes by default. When the actual token expiry is available, it
-			// is used (minus a safety margin) instead of this default.
-			40*time.Minute, // Default ttl for each entry
-			time.Hour,      // Cleanup interval
-		),
 		// GitHub's own recommendation for retrying use of a newly minted token that has not yet
 		// replicated to all of their edge caches. See the Github support response in
 		// https://github.com/aws-amplify/amplify-hosting/issues/4080
@@ -112,6 +113,24 @@ func NewAppCredentialProvider() credentials.Provider {
 	}
 	p.getAccessTokenFn = p.getAccessToken
 	p.validateAccessTokenFn = p.validateAccessToken
+	tokenCache, err := coalescing.NewCache(
+		p.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(p.mintTimeout()),
+			// Access tokens live for one hour. We'll hang on to them for 40
+			// minutes by default. When the actual token expiry is available, it
+			// is used (minus a safety margin) instead of this default.
+			DefaultTTL:      new(40 * time.Minute),
+			CleanupInterval: new(time.Hour),
+		},
+	)
+	if err != nil {
+		logging.LoggerFromContext(context.Background()).Error(
+			err, "error creating token cache; this provider will not be registered",
+		)
+		return nil
+	}
+	p.tokenCache = tokenCache
 	return p
 }
 
@@ -200,105 +219,61 @@ func (p *AppCredentialProvider) getUsernameAndPassword(
 	)
 	ctx = logging.ContextWithLogger(ctx, logger)
 
-	// Check the cache for the token
-	if entry, exists := p.tokenCache.Get(cacheKey); exists {
-		logger.Debug("installation access token cache hit")
-		return &credentials.Credentials{
-			Username: accessTokenUsername,
-			Password: entry.(string), // nolint: forcetypeassert
-		}, nil
-	}
-	logger.Debug("installation access token cache miss")
-
-	// Cache miss, get a new token. All consumers of any given repository share one cache entry, so
-	// they miss the cache in unison when that entry expires and, without coordination, would each
-	// mint their own token. Coalescing concurrent mints for the same cache key avoids that
-	// thundering herd.
-	var accessToken any
-	var err error
-
-	// maxWait bounds how long the mint may run. Because the mint executes under an orphaned context
-	// (see mintAndCacheToken) rather than any caller's context, this is the only thing bounding its
-	// duration. It is the sum of the validation backoff schedule plus a buffer for network
-	// round-trips.
-	maxWait := p.mintTimeoutBuffer
-	for _, d := range p.validationBackoff {
-		maxWait += d
-	}
-
-	// NOTE(thomastaylor312): Right now if there is a single error that isn't a context error, it
-	// will fail all of the other requests as well. This _could_ end up biting us if we have a
-	// transient error. If that ever becomes the case, we can add an OR to this that uses the
-	// `shared` return value from the singleflight `DoChan` channel and then re-enqueue here as
-	// well, but for now we'll let real errors fall through to everyone.
-	ch := p.mintGroup.DoChan(cacheKey, func() (any, error) {
-		return p.mintAndCacheToken(
-			ctx,
-			appOrClientID,
-			installationID,
-			encodedPrivateKey,
-			repoURL,
-			cacheKey,
-			maxWait,
-		)
+	accessToken, err := p.tokenCache.Get(ctx, cacheKey, appInput{
+		appOrClientID:     appOrClientID,
+		installationID:    installationID,
+		encodedPrivateKey: encodedPrivateKey,
+		repoURL:           repoURL,
 	})
-	select {
-	case <-ctx.Done():
-		// See the comment in mintAndCacheToken for why we don't cancel the minting process here.
-		return nil, fmt.Errorf(
-			"mint token process interrupted, cache refresh will continue in the background: %w",
-			ctx.Err(),
-		)
-	case result := <-ch:
-		accessToken, err = result.Val, result.Err
-	}
-
 	if err != nil {
-		return nil, fmt.Errorf("error minting installation access token: %w", err)
+		return nil, err
 	}
 
 	return &credentials.Credentials{
 		Username: accessTokenUsername,
-		// We know the type is string so we're not checking the assertion here
-		Password: accessToken.(string), // nolint: forcetypeassert
+		Password: accessToken,
 	}, nil
 }
 
-// mintAndCacheToken mints a new installation access token, waits for it to
-// become usable, caches it, and returns it. It is intended to be executed
-// within the provider's singleflight group.
-func (p *AppCredentialProvider) mintAndCacheToken(
+// mintTimeout bounds how long a mint may run. Because a mint executes under a
+// context detached from any caller's, this is the only thing bounding its
+// duration, and exceeding it discards a token that was successfully minted. It
+// therefore has to cover everything a mint does: the request that mints the
+// token, every wait in the validation backoff schedule, and a validation
+// request after each of those waits as well as before the first.
+func (p *AppCredentialProvider) mintTimeout() time.Duration {
+	// One validation attempt precedes the first wait, so there is always one more
+	// attempt than there are waits.
+	maxWait := p.mintTimeoutBuffer +
+		time.Duration(len(p.validationBackoff)+1)*tokenValidationRequestTimeout
+	for _, d := range p.validationBackoff {
+		maxWait += d
+	}
+	return maxWait
+}
+
+// loadAccessToken mints a new installation access token, waits for it to become
+// usable, and returns it. It is the Loader for this provider's token cache.
+func (p *AppCredentialProvider) loadAccessToken(
 	ctx context.Context,
-	appOrClientID string,
-	installationID int64,
-	encodedPrivateKey string,
-	repoURL string,
-	cacheKey string,
-	maxWait time.Duration,
-) (string, error) {
+	input appInput,
+) (string, *time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 
-	// NOTE(thomastaylor312): We use a separate, orphaned context for running this function so that
-	// we can control timeout for the entire operation here. This function is only called from
-	// within a singleflight group, and if we have the "winner" of the first goroutine to execute
-	// this function get canceled, it cancels it for everyone. Initially, I had plumbed through
-	// handling for this, but it was a bunch of logic that, ultimately, is unnecessary. Even if all
-	// callers cancel, (essentially orphaning the function from an "owning" goroutine entirely), we
-	// still want to finish the work of minting and caching the token so that future callers can get
-	// it from the cache. So, we just use a separate context here that is not tied to any caller's
-	// context. We _do_, reattach the current logger so we have all its current context (and also
-	// helps us trace back where it was called from if needed)
-	orphanedCtx, cancel := context.WithTimeout(logging.ContextWithLogger(context.Background(), logger), maxWait)
-	defer cancel()
-
 	token, err := p.getAccessTokenFn(
-		appOrClientID,
-		installationID,
-		encodedPrivateKey,
-		repoURL,
+		ctx,
+		input.appOrClientID,
+		input.installationID,
+		input.encodedPrivateKey,
+		input.repoURL,
 	)
 	if err != nil {
-		return "", fmt.Errorf("error getting installation access token: %w", err)
+		return "", nil,
+			fmt.Errorf("error minting installation access token: %w", err)
+	}
+	// If we didn't get a token, we'll treat this as no credentials found
+	if token == nil || token.AccessToken == "" {
+		return "", nil, nil
 	}
 	logger.Debug("obtained new installation access token")
 
@@ -309,19 +284,24 @@ func (p *AppCredentialProvider) mintAndCacheToken(
 	// difficult-to-diagnose "repository not found" errors. Waiting until the
 	// token demonstrably works before releasing it to the caller prevents
 	// this.
-	if err = p.waitForTokenUsable(orphanedCtx, token.AccessToken, repoURL); err != nil {
-		return "", err
+	if err = p.waitForTokenUsable(ctx, token.AccessToken, input.repoURL); err != nil {
+		return "", nil,
+			fmt.Errorf("error minting installation access token: %w", err)
 	}
 
 	ttl := credentials.CalculateCacheTTL(token.Expiry, tokenCacheExpiryMargin)
+	if ttl == nil {
+		logger.Debug(
+			"token expires too soon to be worth caching", "expiry", token.Expiry,
+		)
+		return token.AccessToken, nil, nil
+	}
 	logger.Debug(
 		"caching installation access token",
 		"expiry", token.Expiry,
-		"ttl", ttl,
+		"ttl", *ttl,
 	)
-	p.tokenCache.Set(cacheKey, token.AccessToken, ttl)
-
-	return token.AccessToken, nil
+	return token.AccessToken, ttl, nil
 }
 
 // waitForTokenUsable checks that a newly minted installation access token is actually usable,
@@ -418,6 +398,7 @@ func (p *AppCredentialProvider) validateAccessToken(
 // getAccessToken gets an installation access token for the given app/client ID,
 // installation ID, PEM-encoded GitHub App private key, and repo URL.
 func (p *AppCredentialProvider) getAccessToken(
+	ctx context.Context,
 	appOrClientID string,
 	installationID int64,
 	encodedPrivateKey string,
@@ -435,6 +416,11 @@ func (p *AppCredentialProvider) getAccessToken(
 
 	installationOpts := []githubauth.InstallationTokenSourceOpt{
 		githubauth.WithHTTPClient(cleanhttp.DefaultClient()),
+		// Without this the token source falls back to context.Background(), which
+		// would leave the request unbounded. Minting is coalesced, so a request
+		// GitHub never answers would keep the singleflight key occupied and fail
+		// every later caller for this repository.
+		githubauth.WithContext(ctx),
 		// In all cases, the access token is scoped only to the repo specified by
 		// repoURL.
 		githubauth.WithInstallationTokenOptions(

--- a/pkg/credentials/github/app_test.go
+++ b/pkg/credentials/github/app_test.go
@@ -8,17 +8,16 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
 
@@ -222,6 +221,7 @@ func TestAppCredentialProvider_GetCredentials(t *testing.T) {
 		data             map[string][]byte
 		metadata         map[string]string
 		getAccessTokenFn func(
+			ctx context.Context,
 			appOrClientID string,
 			installationID int64,
 			encodedPrivateKey string,
@@ -319,12 +319,15 @@ func TestAppCredentialProvider_GetCredentials(t *testing.T) {
 			credType: credentials.TypeGit,
 			repoURL:  testRepoURL,
 			data:     testData,
-			getAccessTokenFn: func(string, int64, string, string) (*oauth2.Token, error) {
+			getAccessTokenFn: func(
+				context.Context, string, int64, string, string,
+			) (*oauth2.Token, error) {
 				return nil, errors.New("token error")
 			},
 			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.Nil(t, creds)
 				assert.Error(t, err)
+				assert.ErrorContains(t, err, "error minting installation access token")
 				assert.ErrorContains(t, err, "token error")
 			},
 		},
@@ -333,7 +336,9 @@ func TestAppCredentialProvider_GetCredentials(t *testing.T) {
 			credType: credentials.TypeGit,
 			repoURL:  testRepoURL,
 			data:     testData,
-			getAccessTokenFn: func(string, int64, string, string) (*oauth2.Token, error) {
+			getAccessTokenFn: func(
+				context.Context, string, int64, string, string,
+			) (*oauth2.Token, error) {
 				return &oauth2.Token{
 					AccessToken: "test-token",
 					Expiry:      time.Now().Add(time.Hour),
@@ -386,89 +391,61 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 		fakeAccessToken    = "test-token"
 	)
 
-	p := &AppCredentialProvider{}
-
-	testTokenCacheKey := p.tokenCacheKey(
-		fakeAppOrClientID,
-		fakeInstallationID,
-		fakePrivateKey,
-		fakeRepoURL,
-	)
-
 	testCases := []struct {
 		name             string
-		setupCache       func(c *cache.Cache)
 		getAccessTokenFn func(
+			ctx context.Context,
 			appOrClientID string,
 			installationID int64,
 			encodedPrivateKey string,
 			repoURL string,
 		) (*oauth2.Token, error)
-		assertions func(*testing.T, *cache.Cache, *credentials.Credentials, error)
+		assertions func(*testing.T, *credentials.Credentials, error)
 	}{
 		{
-			name: "cache hit",
-			setupCache: func(c *cache.Cache) {
-				c.Set(testTokenCacheKey, fakeAccessToken, cache.DefaultExpiration)
-			},
-			assertions: func(
-				t *testing.T,
-				_ *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
-				assert.NoError(t, err)
-				assert.NotNil(t, creds)
-				assert.Equal(t, accessTokenUsername, creds.Username)
-				assert.Equal(t, fakeAccessToken, creds.Password)
-			},
-		},
-		{
-			name: "cache miss, successful token fetch",
-			getAccessTokenFn: func(string, int64, string, string) (*oauth2.Token, error) {
+			name: "token obtained",
+			getAccessTokenFn: func(
+				context.Context, string, int64, string, string,
+			) (*oauth2.Token, error) {
 				return &oauth2.Token{
 					AccessToken: fakeAccessToken,
 					Expiry:      time.Now().Add(time.Hour),
 				}, nil
 			},
-			assertions: func(
-				t *testing.T,
-				c *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, creds)
 				assert.Equal(t, accessTokenUsername, creds.Username)
 				assert.Equal(t, fakeAccessToken, creds.Password)
-
-				// Verify the token was cached with a TTL based on the
-				// token's actual expiry
-				items := c.Items()
-				item, found := items[testTokenCacheKey]
-				assert.True(t, found)
-				expectedTTL := 55 * time.Minute // 1h expiry - 5m margin
-				actualTTL := time.Until(time.Unix(0, item.Expiration))
-				assert.InDelta(t, expectedTTL.Seconds(), actualTTL.Seconds(), 5)
+			},
+		},
+		{
+			name: "token obtained, but too near expiry to cache",
+			getAccessTokenFn: func(
+				context.Context, string, int64, string, string,
+			) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken: fakeAccessToken,
+					Expiry:      time.Now().Add(-time.Hour),
+				}, nil
+			},
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, creds)
+				assert.Equal(t, fakeAccessToken, creds.Password)
 			},
 		},
 		{
 			name: "error in getAccessToken",
-			getAccessTokenFn: func(string, int64, string, string) (*oauth2.Token, error) {
+			getAccessTokenFn: func(
+				context.Context, string, int64, string, string,
+			) (*oauth2.Token, error) {
 				return nil, errors.New("token error")
 			},
-			assertions: func(
-				t *testing.T,
-				c *cache.Cache,
-				creds *credentials.Credentials,
-				err error,
-			) {
+			assertions: func(t *testing.T, creds *credentials.Credentials, err error) {
+				assert.ErrorContains(t, err, "error minting installation access token")
 				assert.ErrorContains(t, err, "token error")
 				assert.Nil(t, creds)
-
-				// Verify the token was not cached
-				_, found := c.Get(testTokenCacheKey)
-				assert.False(t, found)
 			},
 		},
 	}
@@ -482,9 +459,19 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 				return true, nil
 			}
 
-			if testCase.setupCache != nil {
-				testCase.setupCache(provider.tokenCache)
-			}
+			// A cache that caches nothing leaves loading as the only way a caller
+			// can obtain a token, so every case exercises the load. Whether a hit is
+			// served from the cache instead is the cache's concern, not this
+			// provider's.
+			tokenCache, err := coalescing.NewCache(
+				provider.loadAccessToken,
+				&coalescing.CacheOptions{
+					LoadTimeout:  new(provider.mintTimeout()),
+					CacheNothing: true,
+				},
+			)
+			require.NoError(t, err)
+			provider.tokenCache = tokenCache
 
 			if testCase.getAccessTokenFn != nil {
 				provider.getAccessTokenFn = testCase.getAccessTokenFn
@@ -497,81 +484,51 @@ func TestAppCredentialProvider_getUsernameAndPassword(t *testing.T) {
 				fakePrivateKey,
 				fakeRepoURL,
 			)
-			testCase.assertions(t, provider.tokenCache, creds, err)
+			testCase.assertions(t, creds, err)
 		})
 	}
 }
 
-func TestAppCredentialProvider_getUsernameAndPassword_coalescing(
-	t *testing.T,
-) {
-	const (
-		fakeAppOrClientID  = "fake-id"
-		fakeInstallationID = int64(456)
-		fakePrivateKey     = "private-key"
-		fakeRepoURL        = "https://github.com/example/repo"
-		fakeAccessToken    = "test-token"
+func TestAppCredentialProvider_mintTimeout(t *testing.T) {
+	t.Parallel()
 
-		concurrency = 10
-	)
-
-	var mints atomic.Int32
-
-	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
-	provider.getAccessTokenFn = func(
-		string, int64, string, string,
-	) (*oauth2.Token, error) {
-		mints.Add(1)
-		// Hold the mint open long enough for the other goroutines to pile up
-		// behind it.
-		time.Sleep(50 * time.Millisecond)
-		return &oauth2.Token{
-			AccessToken: fakeAccessToken,
-			Expiry:      time.Now().Add(time.Hour),
-		}, nil
+	// A mint's bound has to cover every validation attempt this provider will
+	// make, waiting out the whole backoff schedule, plus the round-trips those
+	// attempts take.
+	testCases := []struct {
+		name     string
+		buffer   time.Duration
+		backoff  []time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "no waits, so one validation attempt",
+			buffer:   10 * time.Second,
+			expected: 10*time.Second + tokenValidationRequestTimeout,
+		},
+		{
+			name:    "one validation attempt more than there are waits",
+			buffer:  10 * time.Second,
+			backoff: []time.Duration{time.Second, 2 * time.Second, 4 * time.Second},
+			expected: 10*time.Second + 7*time.Second +
+				4*tokenValidationRequestTimeout,
+		},
 	}
-	provider.validateAccessTokenFn = func(
-		context.Context, string, string,
-	) (bool, error) {
-		return true, nil
-	}
-
-	creds := make([]*credentials.Credentials, concurrency)
-	errs := make([]error, concurrency)
-	var wg sync.WaitGroup
-	for i := range concurrency {
-		wg.Go(func() {
-			creds[i], errs[i] = provider.getUsernameAndPassword(
-				t.Context(),
-				fakeAppOrClientID,
-				fakeInstallationID,
-				fakePrivateKey,
-				fakeRepoURL,
-			)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &AppCredentialProvider{
+				validationBackoff: testCase.backoff,
+				mintTimeoutBuffer: testCase.buffer,
+			}
+			require.Equal(t, testCase.expected, provider.mintTimeout())
 		})
 	}
-	wg.Wait()
-
-	// However the goroutines were scheduled, exactly one token should have
-	// been minted. Callers that missed the in-flight mint entirely find the
-	// token already cached when their own flight begins.
-	require.Equal(t, int32(1), mints.Load())
-	for i := range concurrency {
-		require.NoError(t, errs[i])
-		require.NotNil(t, creds[i])
-		require.Equal(t, fakeAccessToken, creds[i].Password)
-	}
 }
 
-// This exercises the case where the context of the call that wins the
-// singleflight race is canceled mid-mint. Because the mint runs under an
-// orphaned context, the winner's cancellation must NOT cancel the shared mint.
-// The winner stops waiting and returns an "interrupted" error, but the single
-// mint runs to completion and the coalesced callers whose contexts are still
-// live receive the token from that SAME mint.
-func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
-	t *testing.T,
-) {
+func TestAppCredentialProvider_loadAccessToken_tokenNeverUsable(t *testing.T) {
+	t.Parallel()
+
 	const (
 		fakeAppOrClientID  = "fake-id"
 		fakeInstallationID = int64(456)
@@ -580,153 +537,42 @@ func TestAppCredentialProvider_getUsernameAndPassword_winnerCanceled(
 		fakeAccessToken    = "test-token"
 	)
 
-	var mints atomic.Int32
-	mintStarted := make(chan struct{})
-	release := make(chan struct{})
-
+	// Running out of time to show that a token works is reported as a failure to
+	// mint, rather than the token being handed over unvalidated. Exhausting the
+	// backoff schedule is not the same thing and does hand it over -- see
+	// waitForTokenUsable and its own test. How long the attempt may go on for is
+	// bounded by the cache this Loader function is given to, and belongs to that
+	// cache's own tests.
 	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
 	provider.getAccessTokenFn = func(
-		string, int64, string, string,
-	) (*oauth2.Token, error) {
-		if mints.Add(1) == 1 {
-			close(mintStarted)
-		}
-		return &oauth2.Token{
-			AccessToken: fakeAccessToken,
-			Expiry:      time.Now().Add(time.Hour),
-		}, nil
-	}
-	// Block validation until the provided context is canceled or the test
-	// releases it. This holds the winner's flight open for as long as the
-	// test needs it to remain in progress.
-	provider.validateAccessTokenFn = func(
-		ctx context.Context, _, _ string,
-	) (bool, error) {
-		select {
-		case <-ctx.Done():
-			return false, ctx.Err()
-		case <-release:
-			return true, nil
-		}
-	}
-
-	winnerCtx, cancel := context.WithCancel(t.Context())
-	winnerErr := make(chan error, 1)
-	go func() {
-		_, err := provider.getUsernameAndPassword(
-			winnerCtx,
-			fakeAppOrClientID,
-			fakeInstallationID,
-			fakePrivateKey,
-			fakeRepoURL,
-		)
-		winnerErr <- err
-	}()
-	// The winner is now mid-mint with its flight held open
-	<-mintStarted
-
-	// Several coalesced waiters, all with live contexts, all of which should
-	// recover from the winner's cancellation.
-	const numWaiters = 3
-	type result struct {
-		creds *credentials.Credentials
-		err   error
-	}
-	waiterRes := make(chan result, numWaiters)
-	for range numWaiters {
-		go func() {
-			creds, err := provider.getUsernameAndPassword(
-				t.Context(),
-				fakeAppOrClientID,
-				fakeInstallationID,
-				fakePrivateKey,
-				fakeRepoURL,
-			)
-			waiterRes <- result{creds: creds, err: err}
-		}()
-	}
-
-	// Give the waiters a moment to join the in-flight mint, then cancel the
-	// winner's context.
-	time.Sleep(100 * time.Millisecond)
-	cancel()
-
-	// The winner's own context was canceled, so it stops waiting and returns an
-	// interrupted error -- but it must NOT have canceled the shared mint.
-	winErr := <-winnerErr
-	require.ErrorIs(t, winErr, context.Canceled)
-	require.ErrorContains(t, winErr, "cache refresh will continue in the background")
-
-	// Allow the orphaned mint to validate.
-	close(release)
-
-	for range numWaiters {
-		res := <-waiterRes
-		require.NoError(t, res.err)
-		require.NotNil(t, res.creds)
-		require.Equal(t, fakeAccessToken, res.creds.Password)
-	}
-
-	// Exactly one mint: the winner's cancellation did not spawn a replacement,
-	// and the single orphaned mint served every coalesced waiter.
-	require.Equal(t, int32(1), mints.Load())
-
-	// That orphaned mint also cached the token for future callers.
-	cacheKey := provider.tokenCacheKey(
-		fakeAppOrClientID,
-		fakeInstallationID,
-		fakePrivateKey,
-		fakeRepoURL,
-	)
-	cached, found := provider.tokenCache.Get(cacheKey)
-	require.True(t, found)
-	require.Equal(t, fakeAccessToken, cached)
-}
-
-// This exercises the fail-safe that bounds the mint. The mint runs under an
-// orphaned context whose deadline is maxWait, so validation that never succeeds
-// (e.g. GitHub never confirming the token) must be cut off with a context
-// deadline error rather than hanging forever.
-func TestAppCredentialProvider_getUsernameAndPassword_timeout(t *testing.T) {
-	const (
-		fakeAppOrClientID  = "fake-id"
-		fakeInstallationID = int64(456)
-		fakePrivateKey     = "private-key"
-		fakeRepoURL        = "https://github.com/example/repo"
-		fakeAccessToken    = "test-token"
-	)
-
-	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
-	// Keep the orphaned context's deadline short so the test does not linger.
-	provider.validationBackoff = nil
-	provider.mintTimeoutBuffer = 50 * time.Millisecond
-	provider.getAccessTokenFn = func(
-		string, int64, string, string,
+		context.Context, string, int64, string, string,
 	) (*oauth2.Token, error) {
 		return &oauth2.Token{
 			AccessToken: fakeAccessToken,
 			Expiry:      time.Now().Add(time.Hour),
 		}, nil
 	}
-	// Validation never resolves on its own; it only returns once the mint's
-	// orphaned context hits its deadline.
 	provider.validateAccessTokenFn = func(
 		ctx context.Context, _, _ string,
 	) (bool, error) {
-		<-ctx.Done()
 		return false, ctx.Err()
 	}
 
-	creds, err := provider.getUsernameAndPassword(
-		t.Context(),
-		fakeAppOrClientID,
-		fakeInstallationID,
-		fakePrivateKey,
-		fakeRepoURL,
-	)
+	// A context already ended stands in for one whose deadline has passed.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	token, ttl, err := provider.loadAccessToken(ctx, appInput{
+		appOrClientID:     fakeAppOrClientID,
+		installationID:    fakeInstallationID,
+		encodedPrivateKey: fakePrivateKey,
+		repoURL:           fakeRepoURL,
+	})
+
 	require.ErrorContains(t, err, "error minting installation access token")
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Nil(t, creds)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, token)
+	require.Nil(t, ttl)
 }
 
 // A real (non-context) error from the mint is delivered to the caller rather
@@ -743,7 +589,7 @@ func TestAppCredentialProvider_getUsernameAndPassword_realError(t *testing.T) {
 
 	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
 	provider.getAccessTokenFn = func(
-		string, int64, string, string,
+		context.Context, string, int64, string, string,
 	) (*oauth2.Token, error) {
 		mints.Add(1)
 		return nil, errors.New("token error")
@@ -761,6 +607,7 @@ func TestAppCredentialProvider_getUsernameAndPassword_realError(t *testing.T) {
 		fakePrivateKey,
 		fakeRepoURL,
 	)
+	require.ErrorContains(t, err, "error minting installation access token")
 	require.ErrorContains(t, err, "token error")
 	require.Nil(t, creds)
 	// The error must not have triggered a retry.
@@ -1069,5 +916,67 @@ func TestAppCredentialProvider_extractBaseURL(t *testing.T) {
 			baseURL, err := p.extractBaseURL(testCase.repoURL)
 			testCase.assertions(t, baseURL, err)
 		})
+	}
+}
+
+func TestAppCredentialProvider_getUsernameAndPassword_perRepo(t *testing.T) {
+	t.Parallel()
+
+	// Coalescing, cancellation, and the mint's deadline all belong to the cache
+	// this provider delegates to, and are covered by that package's tests. What
+	// remains this provider's own responsibility is that the key it caches under
+	// and the input it mints from describe the same repository, since a token is
+	// scoped to one repository and no repository may be served another's.
+
+	const (
+		fakeAppOrClientID  = "fake-id"
+		fakeInstallationID = int64(456)
+		fakePrivateKey     = "private-key"
+		fakeRotatedKey     = "rotated-private-key"
+		fakeRepoA          = "https://github.com/example/repo-a"
+		fakeRepoB          = "https://github.com/example/repo-b"
+	)
+
+	provider := NewAppCredentialProvider().(*AppCredentialProvider) // nolint:forcetypeassert
+	provider.getAccessTokenFn = func(
+		_ context.Context, _ string, _ int64, privateKey string, repoURL string,
+	) (*oauth2.Token, error) {
+		// The token identifies the key it was minted with and the repository it
+		// was minted for.
+		return &oauth2.Token{
+			AccessToken: "token-for-" + privateKey + "@" + repoURL,
+			Expiry:      time.Now().Add(time.Hour),
+		}, nil
+	}
+	provider.validateAccessTokenFn = func(
+		context.Context, string, string,
+	) (bool, error) {
+		return true, nil
+	}
+
+	// Each dimension of the key varies in turn, and the first pair repeats at the
+	// end to confirm it is still served its own token.
+	for _, request := range []struct {
+		privateKey string
+		repoURL    string
+	}{
+		{fakePrivateKey, fakeRepoA},
+		{fakePrivateKey, fakeRepoB},
+		{fakeRotatedKey, fakeRepoA},
+		{fakePrivateKey, fakeRepoA},
+	} {
+		creds, err := provider.getUsernameAndPassword(
+			t.Context(),
+			fakeAppOrClientID,
+			fakeInstallationID,
+			request.privateKey,
+			request.repoURL,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(t, accessTokenUsername, creds.Username)
+		require.Equal(
+			t, "token-for-"+request.privateKey+"@"+request.repoURL, creds.Password,
+		)
 	}
 }


### PR DESCRIPTION
Providers that cache short-lived tokens did a plain check-then-act against their caches, so concurrent callers that missed the same key each performed a full token acquisition. A thundering herd is not possible because of the controller's bounded concurrency, however, on the occasion that two or more callers do concurrently experience a cache miss for the same key, they do race to perform duplicate work and cache their result. Acquiring a new token does not invalidate like tokens already issued, so the "last one wins" mechanics are not dangerous, but the duplicate work is genuinely wasteful.

The GitHub App credential provider was the only one with an existing answer to this problem. #6630 increased the relative cost of duplicate work performed by that particular credential provider, so that same PR introduced the pattern of concurrent callers that missed the same key coalescing on one execution of the process that acquires (and tests) a new token. This PR generalizes the solution introduced by #6630 and formalizes it into a reusable component shared by all the credential providers.

The coalescing load-through cache subtly raises the stakes on latent defects discovered during its introduction, so this commit corrects those as well: three token requests that nothing bounded, four responses dereferenced without a check (one at startup, where nothing recovers a panic), and a credential already past its expiry cached as though its lifetime were merely unknown — served, in ECR's case, for as long as ten hours.

Closes #6732
