### PR TITLE
fix: yaml-merge silently dropping YAML aliases and null-valued keys  

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/yaml-merge.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/yaml-merge.md
@@ -23,8 +23,12 @@ Merging is performed as follows:
   key, the sequence from the second document replaces the first (no merging).
 - **Keys present only in one document:** Keys that exist in only one document
   are included as-is in the result.
-- **Null values:** If a key is set to `null` in the second document, it removes
-  or overrides the value from the first document.
+- **Null values:** If a key is set to `null` in the second document, the
+  result has that key set to `null` as well -- it is not removed. `null` is
+  treated like any other scalar value.
+- **Anchors, aliases, and merge keys:** YAML anchors (`&name`), aliases
+  (`*name`), and the `<<` merge key are preserved as-is. They are never
+  resolved or expanded by this step.
 
 :::
 

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/yaml-merge.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/yaml-merge.md
@@ -24,7 +24,7 @@ Merging is performed as follows:
 - **Keys present only in one document:** Keys that exist in only one document
   are included as-is in the result.
 - **Null values:** If a key is set to `null` in the second document, the
-  result has that key set to `null` as well -- it is not removed. `null` is
+  result has that key set to `null` as well. It is not removed. `null` is
   treated like any other scalar value.
 - **Anchors, aliases, and merge keys:** YAML anchors (`&name`), aliases
   (`*name`), and the `<<` merge key are preserved as-is. They are never

--- a/pkg/yaml/merge.go
+++ b/pkg/yaml/merge.go
@@ -1,56 +1,114 @@
 package yaml
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path"
 
-	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
-	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 // MergeFiles merges the specified list of YAML files into an output file at
 // the specified path. All specified input files must exist. If a file already
 // exists at the specified path for the output, it will be overwritten.
+//
+// Files are merged in order: the first file is the base and each subsequent
+// file is layered over it. Mappings are merged recursively; sequences and
+// scalars (including explicit nulls) from a later file fully replace the
+// corresponding value from an earlier file; and keys present in only one
+// file are carried through unchanged. Anchors, aliases, and merge keys are
+// never resolved or expanded -- they are copied through as-is.
 func MergeFiles(inputPaths []string, outputPath string) error {
 	if outputPath == "" {
 		return fmt.Errorf("output path must not be empty")
 	}
 
-	var mergeTarget *kyaml.RNode
+	var merged *yaml.Node
 	for _, inputPath := range inputPaths {
-		patchNode, err := kyaml.ReadFile(inputPath)
+		fileBytes, err := os.ReadFile(inputPath)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				continue
-			}
 			return fmt.Errorf("error reading input file %s: %w", inputPath, err)
 		}
-		if mergeTarget == nil {
-			mergeTarget = patchNode
-			continue
+		var doc yaml.Node
+		if err = yaml.Unmarshal(fileBytes, &doc); err != nil {
+			return fmt.Errorf("error reading input file %s: %w", inputPath, err)
 		}
-		if mergeTarget, err = merge2.Merge(
-			patchNode, mergeTarget, kyaml.MergeOptions{},
-		); err != nil {
-			return fmt.Errorf("error merging in file %s: %w", inputPath, err)
+		if len(doc.Content) == 0 {
+			continue // Empty file
 		}
+		merged = mergeNodes(merged, doc.Content[0])
 	}
 
 	if err := os.MkdirAll(path.Dir(outputPath), 0o700); err != nil {
 		return fmt.Errorf("error writing merged YAML to %s: %w", outputPath, err)
 	}
-	if mergeTarget == nil {
+	if merged == nil {
 		if err := os.WriteFile(outputPath, []byte{}, 0600); err != nil {
 			return fmt.Errorf("error writing empty file to %s: %w", outputPath, err)
 		}
 		return nil
 	}
-	if err := kyaml.WriteFile(mergeTarget, outputPath); err != nil {
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(merged); err != nil {
+		return fmt.Errorf("error marshaling merged YAML: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("error marshaling merged YAML: %w", err)
+	}
+	if err := os.WriteFile(outputPath, buf.Bytes(), 0600); err != nil {
 		return fmt.Errorf("error writing merged YAML to %s: %w", outputPath, err)
 	}
 
 	return nil
+}
+
+// mergeNodes merges src over dst and returns the result. When both nodes are
+// mappings, they are merged recursively, key by key. In every other case
+// (including a kind mismatch, e.g. a sequence overriding a mapping) src is
+// returned as-is: scalars and sequences fully replace the value from dst,
+// and node kinds this function doesn't specifically interpret -- notably
+// yaml.AliasNode, which backs both aliases and the `<<` merge key -- are
+// preserved rather than silently dropped.
+func mergeNodes(dst, src *yaml.Node) *yaml.Node {
+	if dst == nil || dst.Kind != yaml.MappingNode || src.Kind != yaml.MappingNode {
+		return src
+	}
+
+	merged := &yaml.Node{
+		Kind:        yaml.MappingNode,
+		Style:       dst.Style,
+		Tag:         dst.Tag,
+		HeadComment: dst.HeadComment,
+		LineComment: dst.LineComment,
+		FootComment: dst.FootComment,
+	}
+
+	srcValueByKey := make(map[string]*yaml.Node, len(src.Content)/2)
+	for i := 0; i < len(src.Content); i += 2 {
+		srcValueByKey[src.Content[i].Value] = src.Content[i+1]
+	}
+
+	mergedKeys := make(map[string]bool, len(dst.Content)/2)
+	for i := 0; i < len(dst.Content); i += 2 {
+		key, value := dst.Content[i], dst.Content[i+1]
+		mergedKeys[key.Value] = true
+		if srcValue, ok := srcValueByKey[key.Value]; ok {
+			value = mergeNodes(value, srcValue)
+		}
+		merged.Content = append(merged.Content, key, value)
+	}
+
+	for i := 0; i < len(src.Content); i += 2 {
+		key := src.Content[i]
+		if mergedKeys[key.Value] {
+			continue
+		}
+		merged.Content = append(merged.Content, key, src.Content[i+1])
+	}
+
+	return merged
 }

--- a/pkg/yaml/merge.go
+++ b/pkg/yaml/merge.go
@@ -18,7 +18,7 @@ import (
 // scalars (including explicit nulls) from a later file fully replace the
 // corresponding value from an earlier file; and keys present in only one
 // file are carried through unchanged. Anchors, aliases, and merge keys are
-// never resolved or expanded -- they are copied through as-is.
+// never resolved or expanded. They are copied through as-is.
 func MergeFiles(inputPaths []string, outputPath string) error {
 	if outputPath == "" {
 		return fmt.Errorf("output path must not be empty")
@@ -70,8 +70,8 @@ func MergeFiles(inputPaths []string, outputPath string) error {
 // mappings, they are merged recursively, key by key. In every other case
 // (including a kind mismatch, e.g. a sequence overriding a mapping) src is
 // returned as-is: scalars and sequences fully replace the value from dst,
-// and node kinds this function doesn't specifically interpret -- notably
-// yaml.AliasNode, which backs both aliases and the `<<` merge key -- are
+// and any node kind this function doesn't specifically interpret (notably
+// yaml.AliasNode, which backs both aliases and the `<<` merge key) is
 // preserved rather than silently dropped.
 func mergeNodes(dst, src *yaml.Node) *yaml.Node {
 	if dst == nil || dst.Kind != yaml.MappingNode || src.Kind != yaml.MappingNode {

--- a/pkg/yaml/merge_test.go
+++ b/pkg/yaml/merge_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 func TestMergeFiles(t *testing.T) {
@@ -104,6 +105,81 @@ vehicles:
 - Millennium Falcon`,
 					string(fileBytes),
 				)
+			},
+		},
+		{
+			// This reproduces the exact scenario from
+			// https://github.com/akuity/kargo/issues/6740: aliases, the `<<`
+			// merge key, and explicit nulls must all survive a merge.
+			name: "aliases, merge keys, and explicit nulls are preserved",
+			fsFiles: map[string]string{
+				"overlay.yaml": `someFlag: false`,
+				"values.yaml": `
+db:
+  name: &db-name mydb
+pgbouncer:
+  readinessDbName: *db-name
+  nodeSelector:
+defaults: &defaults
+  image: my-image
+other:
+  <<: *defaults`,
+			},
+			inputPaths: []string{
+				"overlay.yaml",
+				"values.yaml",
+			},
+			outputPath: "merged.yaml",
+			assertions: func(t *testing.T, outputPath string, err error) {
+				require.NoError(t, err)
+				fileBytes, err := os.ReadFile(outputPath)
+				require.NoError(t, err)
+
+				var merged map[string]any
+				require.NoError(t, yaml.Unmarshal(fileBytes, &merged))
+
+				require.Equal(t, false, merged["someFlag"])
+
+				pgbouncer, ok := merged["pgbouncer"].(map[string]any)
+				require.True(t, ok, "pgbouncer should be a map, got %#v", merged["pgbouncer"])
+				require.Equal(
+					t, "mydb", pgbouncer["readinessDbName"],
+					"aliased value should have been preserved",
+				)
+				nodeSelector, exists := pgbouncer["nodeSelector"]
+				require.True(t, exists, "explicit null key should not be dropped")
+				require.Nil(t, nodeSelector)
+
+				other, ok := merged["other"].(map[string]any)
+				require.True(t, ok, "other should be a map, got %#v", merged["other"])
+				require.Equal(
+					t, "my-image", other["image"],
+					"merge key (<<) value should have been preserved",
+				)
+			},
+		},
+		{
+			name: "explicit null overrides a prior non-null value without deleting the key",
+			fsFiles: map[string]string{
+				"base.yaml":     `foo: bar`,
+				"override.yaml": `foo:`,
+			},
+			inputPaths: []string{
+				"base.yaml",
+				"override.yaml",
+			},
+			outputPath: "merged.yaml",
+			assertions: func(t *testing.T, outputPath string, err error) {
+				require.NoError(t, err)
+				fileBytes, err := os.ReadFile(outputPath)
+				require.NoError(t, err)
+
+				var merged map[string]any
+				require.NoError(t, yaml.Unmarshal(fileBytes, &merged))
+
+				foo, exists := merged["foo"]
+				require.True(t, exists, "explicit null override should not delete the key")
+				require.Nil(t, foo)
 			},
 		},
 	}


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/6740