### PR TITLE
fix(server): correct REST API error handling

### DIFF
--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -25,6 +25,7 @@ import (
 	libClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	libhttp "github.com/akuity/kargo/pkg/http"
 	"github.com/akuity/kargo/pkg/indexer"
 	"github.com/akuity/kargo/pkg/logging"
 	"github.com/akuity/kargo/pkg/server/config"
@@ -32,6 +33,21 @@ import (
 )
 
 const authHeaderKey = "Authorization"
+
+// errNoToken and errInvalidToken are the only authentication failures reported
+// to clients. Both carry a 401 and disclose nothing about which check rejected
+// the credential. Where the underlying reason is useful, sites wrap
+// errInvalidToken with it so that the detail reaches the logs while the
+// client's response remains opaque.
+//
+// Any other failure, such as an unreachable API server or a misconfigured
+// identity provider, is returned without a status code, which the
+// error-handling middleware reports as an internal error. A client must not be
+// able to mistake a broken control plane for a rejected token.
+var (
+	errNoToken      = libhttp.ErrorStr("no token provided", http.StatusUnauthorized)
+	errInvalidToken = libhttp.ErrorStr("invalid token", http.StatusUnauthorized)
+)
 
 // exemptPaths are REST paths that don't require authentication
 var exemptPaths = map[string]struct{}{
@@ -129,8 +145,10 @@ func (a *authMiddleware) Handler(c *gin.Context) {
 	newCtx, err := a.authenticate(ctx, path, rawToken)
 	if err != nil {
 		logger.Debug("authentication failed", "error", err.Error())
+		// Leave the status code and response body to the error-handling
+		// middleware, which honors the code carried by the error.
 		_ = c.Error(err)
-		c.AbortWithStatus(http.StatusUnauthorized)
+		c.Abort()
 		return
 	}
 
@@ -156,7 +174,7 @@ func (a *authMiddleware) authenticate(
 	}
 
 	if rawToken == "" {
-		return ctx, errors.New("no token provided")
+		return ctx, errNoToken
 	}
 
 	// Are we dealing with a JWT?
@@ -170,7 +188,7 @@ func (a *authMiddleware) authenticate(
 	// as to HOW we might be able to verify the token further.
 	untrustedClaims := jwt.RegisteredClaims{}
 	if _, _, err := a.parseUnverifiedJWTFn(rawToken, &untrustedClaims); err != nil {
-		return ctx, errors.New("invalid token")
+		return ctx, errInvalidToken
 	}
 	logger.Debug("found untrusted claims in token", "claims", untrustedClaims)
 
@@ -195,7 +213,7 @@ func (a *authMiddleware) authenticate(
 				},
 			), nil
 		}
-		return ctx, errors.New("invalid token")
+		return ctx, errInvalidToken
 	}
 
 	if a.cfg.OIDCConfig != nil &&
@@ -214,11 +232,20 @@ func (a *authMiddleware) authenticate(
 		)
 		sa, err := a.listServiceAccountsFn(ctx, c)
 		if err != nil {
-			return ctx, fmt.Errorf("list service accounts for user: %w", err)
+			// Stated explicitly because the underlying Kubernetes error carries a
+			// status code of its own, which the error-handling middleware would
+			// otherwise report to the client as if it described their request.
+			return ctx, libhttp.Error(
+				fmt.Errorf("list service accounts for user: %w", err),
+				http.StatusInternalServerError,
+			)
 		}
 		var username string
 		if un, ok := c[a.cfg.OIDCConfig.UsernameClaim]; ok {
 			if username, ok = un.(string); !ok {
+				// The token verified, so this is a mismatch between the identity
+				// provider and this server's configuration, not a bad credential.
+				// Left untyped so it is reported as an internal error.
 				return ctx, fmt.Errorf(
 					"claim %q must be a string; got %T",
 					a.cfg.OIDCConfig.UsernameClaim,
@@ -245,8 +272,7 @@ func (a *authMiddleware) authenticate(
 	// Test whether Kubernetes recognizes this token by making a request to /api
 	logger.Debug("could not verify token; checking if Kubernetes recognizes it")
 	if err := a.verifyKubernetesTokenFn(ctx, rawToken); err != nil {
-		logger.Debug("token not recognized by Kubernetes", "error", err)
-		return ctx, errors.New("invalid token")
+		return ctx, err
 	}
 	logger.Debug("token recognized by Kubernetes")
 
@@ -362,9 +388,15 @@ func (a *authMiddleware) verifyIDPIssuedToken(
 	}
 	token, err := a.oidcTokenVerifyFn(ctx, rawToken)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("%w: %w", errInvalidToken, err)
 	}
-	return a.oidcExtractClaimsFn(token)
+	c, err = a.oidcExtractClaimsFn(token)
+	if err != nil {
+		// The token verified, so failing to read its claims is our problem, not
+		// the client's. Left untyped so it is reported as an internal error.
+		return c, fmt.Errorf("extract claims from verified token: %w", err)
+	}
+	return c, nil
 }
 
 // verifyKargoIssuedToken attempts to verify that the provided raw token was
@@ -414,9 +446,18 @@ func (a *authMiddleware) verifyKubernetesToken(
 	}
 	defer resp.Body.Close()
 
+	// Only Kubernetes declining to recognize the token says anything about the
+	// token. Every other failure above is ours, and is left untyped so that it is
+	// reported as an internal error rather than as a rejected credential.
+	//
+	// TODO(krancour/fuskovic): This isn't perfect, but the strategy of verifying
+	// that Kubernetes recognized the token is already set to change in
+	// https://github.com/akuity/kargo/pull/6754 so we will not obsess over this
+	// for now.
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf(
-			"unexpected response from Kubernetes API server: %d",
+			"%w: unexpected response from Kubernetes API server: %d",
+			errInvalidToken,
 			resp.StatusCode,
 		)
 	}

--- a/pkg/server/auth_middleware_test.go
+++ b/pkg/server/auth_middleware_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
+	libhttp "github.com/akuity/kargo/pkg/http"
 	"github.com/akuity/kargo/pkg/server/config"
 	"github.com/akuity/kargo/pkg/server/dex"
 	libOIDC "github.com/akuity/kargo/pkg/server/oidc"
@@ -79,6 +80,8 @@ func TestWithExemptPaths(t *testing.T) {
 	)
 
 	router := gin.New()
+	srv := &server{}
+	router.Use(srv.handleError)
 	router.Use(middleware)
 	ok := func(c *gin.Context) { c.Status(http.StatusOK) }
 	router.GET(testExemptPath, ok)
@@ -474,7 +477,7 @@ func TestAuthenticate(t *testing.T) {
 					return nil, nil, nil
 				},
 				verifyKubernetesTokenFn: func(context.Context, string) error {
-					return errors.New("token not recognized")
+					return errInvalidToken
 				},
 			},
 			token: testToken,
@@ -482,6 +485,7 @@ func TestAuthenticate(t *testing.T) {
 			// This should result in an authentication error.
 			assertions: func(ctx context.Context, err error) {
 				require.Error(t, err)
+				requireErrorStatus(t, err, http.StatusUnauthorized)
 				require.Equal(t, "invalid token", err.Error())
 				_, ok := user.InfoFromContext(ctx)
 				require.False(t, ok)
@@ -716,6 +720,7 @@ func TestAuthMiddlewareHandler(t *testing.T) {
 		token          string
 		authMiddleware *authMiddleware
 		expectedStatus int
+		expectedBody   string
 		expectUserInfo bool
 	}{
 		{
@@ -732,6 +737,41 @@ func TestAuthMiddlewareHandler(t *testing.T) {
 			path:           "/v1beta1/projects",
 			authMiddleware: &authMiddleware{},
 			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   `{"error":"no token provided"}`,
+			expectUserInfo: false,
+		},
+		{
+			name: "token rejected",
+			path: "/v1beta1/projects",
+			authMiddleware: &authMiddleware{
+				parseUnverifiedJWTFn: func(string, jwt.Claims) (*jwt.Token, []string, error) {
+					return nil, nil, errors.New("not a JWT")
+				},
+			},
+			token:          "not-a-jwt",
+			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   `{"error":"invalid token"}`,
+			expectUserInfo: false,
+		},
+		{
+			// A failure to verify the token, as opposed to a failed verification,
+			// must not be reported to the client as a rejected credential.
+			name: "token verification fails",
+			path: "/v1beta1/projects",
+			authMiddleware: &authMiddleware{
+				parseUnverifiedJWTFn: func(_ string, claims jwt.Claims) (*jwt.Token, []string, error) {
+					rc, ok := claims.(*jwt.RegisteredClaims)
+					require.True(t, ok)
+					rc.Issuer = "unrecognized-issuer"
+					return nil, nil, nil
+				},
+				verifyKubernetesTokenFn: func(context.Context, string) error {
+					return errors.New("create transport: no credentials")
+				},
+			},
+			token:          "some-token",
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   `{"error":"internal server error"}`,
 			expectUserInfo: false,
 		},
 		{
@@ -762,6 +802,11 @@ func TestAuthMiddlewareHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			router := gin.New()
+			// The auth middleware delegates status codes and response bodies to
+			// the error-handling middleware, so both are needed to observe what
+			// a client actually receives.
+			srv := &server{}
+			router.Use(srv.handleError)
 			router.Use(tc.authMiddleware.Handler)
 			router.GET("/v1beta1/*path", func(c *gin.Context) {
 				_, hasUser := user.InfoFromContext(c.Request.Context())
@@ -778,14 +823,27 @@ func TestAuthMiddlewareHandler(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			require.Equal(t, tc.expectedStatus, w.Code)
+			if tc.expectedBody != "" {
+				require.JSONEq(t, tc.expectedBody, w.Body.String())
+			}
 		})
 	}
+}
+
+// requireErrorStatus asserts that err carries the expected HTTP status code for
+// the error-handling middleware to act on.
+func requireErrorStatus(t *testing.T, err error, code int) {
+	t.Helper()
+	var httpErr *libhttp.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, code, httpErr.Code())
 }
 
 func TestVerifyKubernetesToken(t *testing.T) {
 	const testToken = "test-bearer-token"
 	testCases := []struct {
 		name              string
+		noRestCfg         bool
 		mockK8sAPIHandler http.HandlerFunc
 		assertions        func(t *testing.T, err error)
 	}{
@@ -802,11 +860,24 @@ func TestVerifyKubernetesToken(t *testing.T) {
 			},
 		},
 		{
+			// The check could not be carried out, which says nothing about the
+			// token, so the error must carry no status code for the error-handling
+			// middleware to report to the client.
+			name:      "check cannot be performed",
+			noRestCfg: true,
+			assertions: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "REST config is not available")
+				var httpErr *libhttp.HTTPError
+				require.False(t, errors.As(err, &httpErr))
+			},
+		},
+		{
 			name: "Kubernetes API returns non-200",
 			mockK8sAPIHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
 			},
 			assertions: func(t *testing.T, err error) {
+				requireErrorStatus(t, err, http.StatusUnauthorized)
 				require.ErrorContains(
 					t, err, "unexpected response from Kubernetes API server",
 				)
@@ -815,10 +886,13 @@ func TestVerifyKubernetesToken(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			srv := httptest.NewServer(testCase.mockK8sAPIHandler)
-			t.Cleanup(srv.Close)
-			authenticator := &authMiddleware{
-				cfg: config.ServerConfig{RestConfig: &rest.Config{Host: srv.URL}},
+			authenticator := &authMiddleware{}
+			if !testCase.noRestCfg {
+				srv := httptest.NewServer(testCase.mockK8sAPIHandler)
+				t.Cleanup(srv.Close)
+				authenticator.cfg = config.ServerConfig{
+					RestConfig: &rest.Config{Host: srv.URL},
+				}
 			}
 			err := authenticator.verifyKubernetesToken(t.Context(), testToken)
 			testCase.assertions(t, err)

--- a/pkg/server/create_resource.go
+++ b/pkg/server/create_resource.go
@@ -35,10 +35,13 @@ type createResourceResult struct {
 	Error                   string         `json:"error,omitempty"`
 } // @name CreateResourceResult
 
-// resourceErrorResponse is the response body for resource API errors
-type resourceErrorResponse struct {
-	Error string `json:"error"`
-} // @name ResourceErrorResponse
+// resourceErrorResponse is the name errorResponse was first published under,
+// and the name the spec has to keep: renaming the schema would rename the
+// corresponding type in every generated client. This operation is the only one
+// that documents an error body, and it refers to this alias rather than to
+// errorResponse, which is what makes swag honor the name below.
+// nolint: unused
+type resourceErrorResponse = errorResponse // @name ResourceErrorResponse
 
 // @id CreateResource
 // @Summary Create resources

--- a/pkg/server/rest_router.go
+++ b/pkg/server/rest_router.go
@@ -317,12 +317,8 @@ func (s *server) handleError(c *gin.Context) {
 		var httpErr *libhttp.HTTPError
 		if ok := errors.As(err, &httpErr); ok {
 			if code := httpErr.Code(); code == http.StatusInternalServerError {
-				logging.LoggerFromContext(c.Request.Context()).
-					Error(err, "internal server error")
-				c.JSON(
-					http.StatusInternalServerError,
-					resourceErrorResponse{Error: "internal server error"},
-				)
+				s.respondInternalServerError(c, err)
+				return
 			}
 			c.JSON(httpErr.Code(), resourceErrorResponse{Error: httpErr.Error()})
 			return
@@ -332,9 +328,19 @@ func (s *server) handleError(c *gin.Context) {
 			c.JSON(int(statusErr.Status().Code), resourceErrorResponse{Error: err.Error()})
 			return
 		}
-		_ = c.Error(libhttp.Error(
-			errors.New("internal server error"),
-			http.StatusInternalServerError,
-		))
+		// An error of no recognized type is, by definition, one we did not
+		// anticipate. Report it as such rather than leaving the response empty.
+		s.respondInternalServerError(c, err)
 	}
+}
+
+// respondInternalServerError logs err and responds with a 500 whose body
+// discloses nothing about the underlying failure.
+func (s *server) respondInternalServerError(c *gin.Context, err error) {
+	logging.LoggerFromContext(c.Request.Context()).
+		Error(err, "internal server error")
+	c.JSON(
+		http.StatusInternalServerError,
+		resourceErrorResponse{Error: "internal server error"},
+	)
 }

--- a/pkg/server/rest_router.go
+++ b/pkg/server/rest_router.go
@@ -302,6 +302,11 @@ func (s *server) setupRESTRouter(ctx context.Context) *gin.Engine {
 	return router
 }
 
+// errorResponse is the body of every error response the REST API sends.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
 func (s *server) handleError(c *gin.Context) {
 	c.Next()
 	if len(c.Errors) > 0 {
@@ -310,7 +315,7 @@ func (s *server) handleError(c *gin.Context) {
 		// Check for MaxBytesError (body too large)
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			c.JSON(http.StatusRequestEntityTooLarge, resourceErrorResponse{Error: "request body too large"})
+			c.JSON(http.StatusRequestEntityTooLarge, errorResponse{Error: "request body too large"})
 			return
 		}
 
@@ -320,12 +325,12 @@ func (s *server) handleError(c *gin.Context) {
 				s.respondInternalServerError(c, err)
 				return
 			}
-			c.JSON(httpErr.Code(), resourceErrorResponse{Error: httpErr.Error()})
+			c.JSON(httpErr.Code(), errorResponse{Error: httpErr.Error()})
 			return
 		}
 		var statusErr *apierrors.StatusError
 		if ok := errors.As(err, &statusErr); ok {
-			c.JSON(int(statusErr.Status().Code), resourceErrorResponse{Error: err.Error()})
+			c.JSON(int(statusErr.Status().Code), errorResponse{Error: err.Error()})
 			return
 		}
 		// An error of no recognized type is, by definition, one we did not
@@ -341,6 +346,6 @@ func (s *server) respondInternalServerError(c *gin.Context, err error) {
 		Error(err, "internal server error")
 	c.JSON(
 		http.StatusInternalServerError,
-		resourceErrorResponse{Error: "internal server error"},
+		errorResponse{Error: "internal server error"},
 	)
 }

--- a/pkg/server/rest_router_test.go
+++ b/pkg/server/rest_router_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	libhttp "github.com/akuity/kargo/pkg/http"
+)
+
+func TestHandleError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testCases := []struct {
+		name           string
+		err            error
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "no error",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "",
+		},
+		{
+			name:           "request body too large",
+			err:            &http.MaxBytesError{Limit: 1024},
+			expectedStatus: http.StatusRequestEntityTooLarge,
+			expectedBody:   `{"error":"request body too large"}`,
+		},
+		{
+			name:           "error carrying a client-facing status code",
+			err:            libhttp.ErrorStr("invalid token", http.StatusUnauthorized),
+			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   `{"error":"invalid token"}`,
+		},
+		{
+			// The body must contain nothing but the obfuscated message. Writing
+			// the underlying message as well would disclose internal detail.
+			name: "error carrying a 500",
+			err: libhttp.Error(
+				errors.New("create TokenReview: forbidden"),
+				http.StatusInternalServerError,
+			),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   `{"error":"internal server error"}`,
+		},
+		{
+			name: "Kubernetes status error",
+			err: apierrors.NewNotFound(
+				schema.GroupResource{Group: "kargo.akuity.io", Resource: "stages"},
+				"fake-stage",
+			),
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   `{"error":"stages.kargo.akuity.io \"fake-stage\" not found"}`,
+		},
+		{
+			// An unrecognized error must not be mistaken for success.
+			name:           "error of no recognized type",
+			err:            fmt.Errorf("error signing ID token: %w", errors.New("no key")),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   `{"error":"internal server error"}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &server{}
+			router := gin.New()
+			router.Use(s.handleError)
+			router.GET("/", func(c *gin.Context) {
+				if testCase.err != nil {
+					_ = c.Error(testCase.err)
+					return
+				}
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			require.Equal(t, testCase.expectedStatus, w.Code)
+			require.Equal(t, testCase.expectedBody, w.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
Three distinct but related changes to the REST API's error handling, one per commit.

1. **`handleError` now writes exactly one response for every error reported to it.** It previously wrote none in one case and two in another.

    1. When an error matched none of its known types, it re-reported the error instead of answering it. Nothing ever reads that: `handleError` inspects `c.Errors` on its way back out of the middleware chain, so it is the last code to look, and appending to that slice afterward has no effect. Gin then wrote its default 200 and ended the request. A handler reporting an untyped error answered as though it had succeeded.

    1. An error carrying a 500 was answered twice, the second write disclosing the underlying message the first had deliberately obfuscated.

1. **The authentication middleware no longer reports server failures as rejected credentials.** It aborted with a 401 for every error, so an unreachable Kubernetes API server, an identity provider that could not be reached at startup, and a username claim of the wrong type all reached the client as a bad credential. The dashboard signs a user out on any 401, so a control plane problem presented as "your credentials are bad" and logged everyone out, with the real cause visible only at debug level.

    It now returns errors carrying a status code and lets `handleError` answer. A 401 is opt-in and reserved for failures attributable to the credential; anything else is reported as an internal error and logged at error level. Clients also get a body on these responses now, where a 401 previously had none.

1. **The error envelope type is named for what it is.** `handleError` returns it for every error from every endpoint, not only for the resource endpoints it was named after. Its published schema name is preserved, so `swagger.json` and every generated client are byte-for-byte unchanged.
