### PR TITLE
fix(ui): Cannot view AnalysisRun result in UI when web provider returns text instead of JSON

### DIFF
--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -24,7 +24,8 @@ import {
   metricStatusLabel,
   metricSubstatus,
   printableCloudWatchQuery,
-  printableDatadogQuery
+  printableDatadogQuery,
+  transformMeasurements
 } from './transforms';
 import { AnalysisStatus, FunctionalStatus } from './types';
 
@@ -558,5 +559,35 @@ describe('analysis modal transforms', () => {
       chartValue: { latency: null, cpuUsage: null },
       tableValue: { latency: null, cpuUsage: null }
     });
+  });
+});
+
+describe('transformMeasurements()', () => {
+  test('plain-text measurement value (e.g. web provider returning "PASS") does not throw', () => {
+    expect(() =>
+      transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }])
+    ).not.toThrow();
+  });
+
+  test('plain-text measurement value has no tableValue', () => {
+    const result = transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }]);
+    expect(result.measurements[0].tableValue).toBeNull();
+  });
+
+  test('plain-text measurement value has no chart value', () => {
+    const result = transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }]);
+    expect(result.measurements[0].chartValue).toBeNull();
+  });
+
+  test('plain-text measurement value does not disable charting for the rest of the series', () => {
+    const result = transformMeasurements(
+      [],
+      [
+        { value: '1', phase: 'Successful' },
+        { value: 'PASS', phase: 'Successful' },
+        { value: '2', phase: 'Successful' }
+      ]
+    );
+    expect(result.chartable).toBe(true);
   });
 });

--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -24,7 +24,8 @@ import {
   metricStatusLabel,
   metricSubstatus,
   printableCloudWatchQuery,
-  printableDatadogQuery
+  printableDatadogQuery,
+  transformMeasurements
 } from './transforms';
 import { AnalysisStatus, FunctionalStatus } from './types';
 
@@ -558,5 +559,23 @@ describe('analysis modal transforms', () => {
       chartValue: { latency: null, cpuUsage: null },
       tableValue: { latency: null, cpuUsage: null }
     });
+  });
+});
+
+describe('transformMeasurements()', () => {
+  test('plain-text measurement value (e.g. web provider returning "PASS") does not throw', () => {
+    expect(() =>
+      transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }])
+    ).not.toThrow();
+  });
+
+  test('plain-text measurement value is surfaced as tableValue', () => {
+    const result = transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }]);
+    expect(result.measurements[0].tableValue).toBe('PASS');
+  });
+
+  test('plain-text measurement value is not chartable', () => {
+    const result = transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }]);
+    expect(result.chartable).toBe(false);
   });
 });

--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -564,9 +564,7 @@ describe('analysis modal transforms', () => {
 
 describe('transformMeasurements()', () => {
   test('plain-text measurement value (e.g. web provider returning "PASS") does not throw', () => {
-    expect(() =>
-      transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }])
-    ).not.toThrow();
+    expect(() => transformMeasurements([], [{ value: 'PASS', phase: 'Successful' }])).not.toThrow();
   });
 
   test('plain-text measurement value has no tableValue', () => {

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -783,7 +783,22 @@ const transformMeasurementValue = (
     };
   }
 
-  const parsedValue = JSON.parse(value);
+  let parsedValue;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    // this behavior matches rollouts with the following reasoning:
+    // - canChart == true - just one measurement with this set to false will prevent the chart from being displayed
+    // - chartValue == null - the chart will just show an absence of a point or a blip for this measurement
+    // - tableValue == null - while a healthcheck of "PASS" or "OK" might be worth seeing, allowing a string of
+    // onbounded length could make the table unusable (a stack trace, error message, a failed parsoning because 
+    // a long json string got truncated, etc.)
+    return {
+      canChart: true,
+      chartValue: null,
+      tableValue: null
+    };
+  }
 
   // single number measurement value
   if (isFiniteNumber(parsedValue)) {

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -783,7 +783,15 @@ const transformMeasurementValue = (
     };
   }
 
-  const parsedValue = JSON.parse(value);
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    return {
+      canChart: false,
+      tableValue: value
+    };
+  }
 
   // single number measurement value
   if (isFiniteNumber(parsedValue)) {

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -791,7 +791,7 @@ const transformMeasurementValue = (
     // - canChart == true - just one measurement with this set to false will prevent the chart from being displayed
     // - chartValue == null - the chart will just show an absence of a point or a blip for this measurement
     // - tableValue == null - while a healthcheck of "PASS" or "OK" might be worth seeing, allowing a string of
-    // onbounded length could make the table unusable (a stack trace, error message, a failed parsoning because 
+    // onbounded length could make the table unusable (a stack trace, error message, a failed parsoning because
     // a long json string got truncated, etc.)
     return {
       canChart: true,


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #4630

<!-- Describe what this PR does and why. -->

This PR represents the UI extension of https://github.com/argoproj/argo-rollouts/pull/4770 that addressed:
>Fixes a bug where the web metric provider always returned Successful for empty or non-JSON HTTP response bodies, without evaluating successCondition / failureCondition.

text was always supported but the `successCondition` was ignored and always returned as successful.

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [x] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
