### PR TITLE
refactor(server): authorize by identity rather than by replaying the token

### DIFF
--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -210,10 +210,7 @@ func (a *authMiddleware) authenticate(
 			logger.Debug("admin token verified as issued by Kargo API server")
 			return user.ContextWithInfo(
 				ctx,
-				user.Info{
-					IsAdmin:     true,
-					BearerToken: rawToken,
-				},
+				user.Info{IsAdmin: true},
 			), nil
 		}
 		return ctx, errInvalidToken
@@ -261,7 +258,6 @@ func (a *authMiddleware) authenticate(
 			user.Info{
 				Claims:                     c,
 				ServiceAccountsByNamespace: sa,
-				BearerToken:                rawToken,
 				UsernameClaim:              a.cfg.OIDCConfig.UsernameClaim,
 				Username:                   username,
 			},
@@ -282,10 +278,7 @@ func (a *authMiddleware) authenticate(
 
 	return user.ContextWithInfo(
 		ctx,
-		user.Info{
-			BearerToken:        rawToken,
-			KubernetesUserInfo: k8sUserInfo,
-		},
+		user.Info{KubernetesUserInfo: k8sUserInfo},
 	), nil
 }
 

--- a/pkg/server/auth_middleware_test.go
+++ b/pkg/server/auth_middleware_test.go
@@ -360,7 +360,6 @@ func TestAuthenticate(t *testing.T) {
 				require.True(t, u.IsAdmin)
 				require.Empty(t, u.Claims["sub"])
 				require.Empty(t, u.Claims["groups"])
-				require.Equal(t, testToken, u.BearerToken)
 			},
 		},
 		"failure verifying IDP-issued token": {
@@ -444,7 +443,6 @@ func TestAuthenticate(t *testing.T) {
 				require.Equal(t, "ironman", u.Claims["sub"])
 				require.Equal(t, "tony@starkindustries.com", u.Claims["email"])
 				require.Equal(t, []string{"avengers", "shield"}, u.Claims["groups"])
-				require.Equal(t, testToken, u.BearerToken)
 			},
 		},
 		"unrecognized JWT recognized by Kubernetes": {
@@ -469,7 +467,6 @@ func TestAuthenticate(t *testing.T) {
 				require.NoError(t, err)
 				u, ok := user.InfoFromContext(ctx)
 				require.True(t, ok)
-				require.Equal(t, testToken, u.BearerToken)
 				require.NotNil(t, u.KubernetesUserInfo)
 				require.Equal(t, "system:serviceaccount:kargo-demo:ci-bot", u.KubernetesUserInfo.Username)
 			},

--- a/pkg/server/get_analysisrun_logs.go
+++ b/pkg/server/get_analysisrun_logs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/akuity/kargo/pkg/expressions"
 	libhttp "github.com/akuity/kargo/pkg/http"
 	"github.com/akuity/kargo/pkg/logging"
-	"github.com/akuity/kargo/pkg/server/user"
 )
 
 // getJobMetric confirms the existence of a JobMetric with the provided name or,
@@ -238,7 +237,6 @@ func (s *server) getStageFromAnalysisRun(
 // are themselves, used in evaluation of a URL template. The request is
 // returned. If it is not successfully constructed, an error is returned.
 func (s *server) buildRequest(
-	ctx context.Context,
 	stage *kargoapi.Stage,
 	run *rolloutsapi.AnalysisRun,
 	jobMetricName, jobNamespace, jobName, containerName string,
@@ -276,8 +274,6 @@ func (s *server) buildRequest(
 	}
 	if s.cfg.AnalysisRunLogToken != "" {
 		env["token"] = s.cfg.AnalysisRunLogToken
-	} else if userInfo, ok := user.InfoFromContext(ctx); ok {
-		env["token"] = userInfo.BearerToken
 	}
 	for key, valTemplate := range s.cfg.AnalysisRunLogHTTPHeaders {
 		valTemplateAny, err := expressions.EvaluateTemplate(valTemplate, env)
@@ -445,7 +441,6 @@ func (s *server) getAnalysisRunLogs(c *gin.Context) {
 	}
 
 	httpReq, err := s.buildRequest(
-		ctx,
 		stage,
 		analysisRun,
 		jobMetricName,

--- a/pkg/server/get_analysisrun_logs_test.go
+++ b/pkg/server/get_analysisrun_logs_test.go
@@ -638,7 +638,6 @@ func TestServer_buildRequest(t *testing.T) {
 				},
 			}
 			req, err := s.buildRequest(
-				t.Context(),
 				&kargoapi.Stage{
 					ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
 				},

--- a/pkg/server/kubernetes/client.go
+++ b/pkg/server/kubernetes/client.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
+	authnv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -911,9 +911,9 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 				for serviceAccountToCheck := range serviceAccountsToCheck {
 					err := reviewSubjectAccess(
 						ctx,
-						internalClient.Scheme(),
+						internalClient,
 						ra,
-						withServiceAccount(serviceAccountToCheck),
+						serviceAccountSubject(serviceAccountToCheck),
 					)
 					if err == nil {
 						return internalClient, nil
@@ -926,13 +926,17 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 			return nil, newForbiddenError(ra)
 		}
 
-		// If we get to here, we're dealing with a user who "authenticated" by just
-		// passing their bearer token for the Kubernetes API server.
+		if userInfo.KubernetesUserInfo == nil {
+			return nil, errors.New("not allowed")
+		}
+
+		// If we get to here, we're dealing with a user whose token was recognized
+		// by the Kubernetes API server, which told us who they are.
 		if err := reviewSubjectAccess(
 			ctx,
-			internalClient.Scheme(),
+			internalClient,
 			ra,
-			withBearerToken(userInfo.BearerToken),
+			kubernetesUserSubject(*userInfo.KubernetesUserInfo),
 		); err != nil {
 			return nil, fmt.Errorf("review subject access: %w", err)
 		}
@@ -940,93 +944,59 @@ func getAuthorizedClient(globalServiceAccountNamespaces []string) func(
 	}
 }
 
-type subjectOption func(*userClientOptions)
-
-func withBearerToken(bearerToken string) subjectOption {
-	return func(opts *userClientOptions) {
-		opts.bearerToken = bearerToken
-	}
+// reviewSubject is the identity whose access is reviewed by
+// reviewSubjectAccess.
+type reviewSubject struct {
+	username string
+	uid      string
+	groups   []string
+	extra    map[string]authv1.ExtraValue
 }
 
-func withServiceAccount(name types.NamespacedName) subjectOption {
-	return func(opts *userClientOptions) {
-		opts.subject = &userClientSubject{
-			username: fmt.Sprintf("system:serviceaccount:%s:%s", name.Namespace, name.Name),
+// kubernetesUserSubject is the user the Kubernetes API server resolved a bearer
+// token to. Groups, UID and extras are all carried across, because omitting them
+// would ask a different question: whether the user is permitted on the strength
+// of their username alone.
+func kubernetesUserSubject(u authnv1.UserInfo) reviewSubject {
+	subject := reviewSubject{
+		username: u.Username,
+		uid:      u.UID,
+		groups:   u.Groups,
+	}
+	if len(u.Extra) > 0 {
+		subject.extra = make(map[string]authv1.ExtraValue, len(u.Extra))
+		for k, v := range u.Extra {
+			subject.extra[k] = authv1.ExtraValue(v)
 		}
 	}
+	return subject
 }
 
-type userClientSubject struct {
-	username string
+func serviceAccountSubject(name types.NamespacedName) reviewSubject {
+	return reviewSubject{
+		username: fmt.Sprintf("system:serviceaccount:%s:%s", name.Namespace, name.Name),
+	}
 }
 
-type userClientOptions struct {
-	bearerToken string
-	subject     *userClientSubject
-}
-
-// reviewSubjectAccess submits a (Self)SubjectAccessReview to determine
-// whether the subject that configured with subjectOption is allowed to
-// do the desired operation.
+// reviewSubjectAccess submits a SubjectAccessReview to determine whether the
+// provided subject is allowed to do the desired operation.
 func reviewSubjectAccess(
 	ctx context.Context,
-	scheme *runtime.Scheme,
+	cl libClient.Client,
 	ra authv1.ResourceAttributes,
-	opts ...subjectOption,
+	subject reviewSubject,
 ) error {
-	cfg, err := GetRestConfig(ctx, os.Getenv("KUBECONFIG"))
-	if err != nil {
-		return fmt.Errorf("get REST config: %w", err)
-	}
-
-	var opt userClientOptions
-	for _, apply := range opts {
-		apply(&opt)
-	}
-
-	if opt.bearerToken != "" {
-		cfg.BearerToken = opt.bearerToken
-		// These MUST be blanked out because they all seem to take precedence over the
-		// cfg.BearerToken field.
-		// TODO: Are there more things to blank out here?
-		cfg.BearerTokenFile = ""
-		cfg.CertData = nil
-		cfg.CertFile = ""
-	}
-
-	userClient, err := libClient.New(
-		cfg,
-		libClient.Options{
-			Scheme: scheme,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("create user-specific Kubernetes client: %w", err)
-	}
-
-	if opt.subject != nil {
-		review := &authv1.SubjectAccessReview{
-			Spec: authv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &ra,
-				User:               opt.subject.username,
-			},
-		}
-		if err := userClient.Create(ctx, review); err != nil {
-			return fmt.Errorf("submit SubjectAccessReview: %w", err)
-		}
-		if review.Status.Allowed {
-			return nil
-		}
-		return newForbiddenError(ra)
-	}
-
-	review := &authv1.SelfSubjectAccessReview{
-		Spec: authv1.SelfSubjectAccessReviewSpec{
+	review := &authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &ra,
+			User:               subject.username,
+			UID:                subject.uid,
+			Groups:             subject.groups,
+			Extra:              subject.extra,
 		},
 	}
-	if err := userClient.Create(ctx, review); err != nil {
-		return fmt.Errorf("submit SelfSubjectAccessReview: %w", err)
+	if err := cl.Create(ctx, review); err != nil {
+		return fmt.Errorf("submit SubjectAccessReview: %w", err)
 	}
 	if review.Status.Allowed {
 		return nil

--- a/pkg/server/kubernetes/client_test.go
+++ b/pkg/server/kubernetes/client_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	authnv1 "k8s.io/api/authentication/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/client-go/rest"
 	libClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/akuity/kargo/pkg/server/user"
 )
@@ -400,10 +403,50 @@ func TestAllClientOperations(t *testing.T) {
 
 func TestGetAuthorizedClient(t *testing.T) {
 	testInternalClient := fake.NewClientBuilder().Build()
+
+	testKubernetesUser := authnv1.UserInfo{
+		Username: "system:serviceaccount:kargo-demo:ci-bot",
+		UID:      "abc-123",
+		Groups:   []string{"system:serviceaccounts", "system:authenticated"},
+		Extra:    map[string]authnv1.ExtraValue{"authentication.kubernetes.io/pod-name": {"fake-pod"}},
+	}
+
+	// reviewingClient returns a client that asserts the SubjectAccessReview it is
+	// asked to create describes testKubernetesUser, and answers with allowed.
+	reviewingClient := func(t *testing.T, allowed bool) libClient.WithWatch {
+		scheme := runtime.NewScheme()
+		require.NoError(t, authv1.AddToScheme(scheme))
+		return fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(
+			interceptor.Funcs{
+				Create: func(
+					_ context.Context,
+					_ libClient.WithWatch,
+					obj libClient.Object,
+					_ ...libClient.CreateOption,
+				) error {
+					review, ok := obj.(*authv1.SubjectAccessReview)
+					require.True(t, ok)
+					require.Equal(t, testKubernetesUser.Username, review.Spec.User)
+					require.Equal(t, testKubernetesUser.UID, review.Spec.UID)
+					require.Equal(t, testKubernetesUser.Groups, review.Spec.Groups)
+					require.Equal(
+						t,
+						authv1.ExtraValue{"fake-pod"},
+						review.Spec.Extra["authentication.kubernetes.io/pod-name"],
+					)
+					review.Status.Allowed = allowed
+					return nil
+				},
+			},
+		).Build()
+	}
+
 	testCases := []struct {
-		name     string
-		userInfo *user.Info
-		assert   func(*testing.T, libClient.Client, error)
+		name string
+		// internalClient, when nil, defaults to testInternalClient.
+		internalClient libClient.WithWatch
+		userInfo       *user.Info
+		assert         func(*testing.T, libClient.Client, error)
 	}{
 		{
 			name: "no context-bound user.Info",
@@ -431,21 +474,55 @@ func TestGetAuthorizedClient(t *testing.T) {
 				require.True(t, apierrors.IsForbidden(err))
 			},
 		},
+		{
+			// A token Kubernetes recognized, whose identity Kubernetes also
+			// authorizes.
+			name:           "Kubernetes-verified user, permitted",
+			internalClient: reviewingClient(t, true),
+			userInfo:       &user.Info{KubernetesUserInfo: &testKubernetesUser},
+			assert: func(t *testing.T, client libClient.Client, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, client)
+			},
+		},
+		{
+			name:           "Kubernetes-verified user, not permitted",
+			internalClient: reviewingClient(t, false),
+			userInfo:       &user.Info{KubernetesUserInfo: &testKubernetesUser},
+			assert: func(t *testing.T, _ libClient.Client, err error) {
+				require.True(t, apierrors.IsForbidden(err))
+			},
+		},
+		{
+			// Neither an admin, nor mapped to any ServiceAccount, nor bearing an
+			// identity from Kubernetes. There is no subject to authorize.
+			name:     "user with no identity at all",
+			userInfo: &user.Info{},
+			assert: func(t *testing.T, _ libClient.Client, err error) {
+				require.Error(t, err)
+				require.Equal(t, "not allowed", err.Error())
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			ctx := t.Context()
 			if testCase.userInfo != nil {
-				ctx := user.ContextWithInfo(t.Context(), *testCase.userInfo)
-				client, err := getAuthorizedClient(nil)(
-					ctx,
-					testInternalClient,
-					"", // Verb doesn't matter for these tests
-					schema.GroupVersionResource{},
-					"",                    // Subresource doesn't matter for these tests
-					libClient.ObjectKey{}, // Object key doesn't matter for these tests
-				)
-				testCase.assert(t, client, err)
+				ctx = user.ContextWithInfo(ctx, *testCase.userInfo)
 			}
+			internalClient := testCase.internalClient
+			if internalClient == nil {
+				internalClient = testInternalClient
+			}
+			client, err := getAuthorizedClient(nil)(
+				ctx,
+				internalClient,
+				"", // Verb doesn't matter for these tests
+				schema.GroupVersionResource{},
+				"",                    // Subresource doesn't matter for these tests
+				libClient.ObjectKey{}, // Object key doesn't matter for these tests
+			)
+			testCase.assert(t, client, err)
 		})
 	}
 }

--- a/pkg/server/user/user.go
+++ b/pkg/server/user/user.go
@@ -22,17 +22,6 @@ type Info struct {
 	// non-admin user whose credentials have
 	// been successfully verified by the server's authentication middleware.
 	Claims map[string]any
-	// BearerToken is the raw bearer token presented in the Authorization header
-	// of any request requiring authentication.
-	//
-	// #nosec G117 -- This struct is an internal, context-bound representation of
-	// a user. This field, if set, contains the token the user presented to
-	// authenticate themselves, which we subsequently determined to be a valid
-	// token for the Kargo control plane's underlying Kubernetes cluster. This
-	// token is ultimately used for no purpose other than self-service subject
-	// access review (SSAR) calls to the Kubernetes API server. Importantly, it is
-	// never transmitted to anywhere else.
-	BearerToken string
 	// ServiceAccountsByNamespace is the mapping of namespace names to sets of
 	// ServiceAccounts that a user has been mapped to.
 	ServiceAccountsByNamespace map[string]map[types.NamespacedName]struct{}


### PR DESCRIPTION
Follow-up to #6754, which taught the authentication middleware to submit a `TokenReview` and keep the identity Kubernetes resolved a bearer token to. With that identity on hand, the token itself has no remaining job.

Authorization for these users was a `SelfSubjectAccessReview` submitted *as them*, which is the only reason the API server retained their bearer token at all. A `SubjectAccessReview` naming the identity answers the same question, so `user.Info` no longer carries a credential. The identity is described in full — groups, UID and extras — because a `SubjectAccessReview` specifying a user without groups asks whether that user is permitted on the strength of their username alone, and group bindings are the ordinary way a cluster's identity provider grants access.

Calling this a security improvement would be generous. A credential no longer sits in a context-bound struct for the life of a request, which is one fewer place it exists, but Go is memory-safe and the token was never transmitted anywhere except back to the API server that issued the review. Take it as tidiness with a mild security flavor.

The simplification is the more tangible part. Nothing needs a per-request Kubernetes client anymore, so `reviewSubjectAccess` submits the review with the API server's own client — which retires the `rest.Config` construction, the credential-blanking with its "are there more things to blank out here?" TODO, the `SelfSubjectAccessReview` branch, and the options plumbing that existed only to choose between a token and a subject. That also makes this authorization path unit-testable for the first time, since it no longer reads a kubeconfig from the environment.

Removing the field takes one feature with it: when no token `Secret` was configured, `${{ token }}` in an AnalysisRun log request header resolved to the bearer token the user presented to Kargo. That credential cannot be validated by an arbitrary HTTP log service, which is the only kind this feature retrieves from — logs are aggregated outside the cluster precisely because the control plane cannot serve them. The behavior was never documented and never useful.

Verified end to end against a live cluster with API tokens, including that permissions are still enforced exactly as before: granted verbs succeed, ungranted verbs and other projects are refused.
