### PR TITLE
feat: populate the Argo CD context annotation from promotion step output

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -149,6 +149,21 @@ refresh groups of `Application`s with heterogeneous configurations.
 | `apps[].sources[].helm.images[].key` | `string` | Y | The key to update within the target `ApplicationSource`'s `helm.parameters` map. See Helm documentation on the [format and limitations](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set) of the notation used in this field. |
 | `apps[].sources[].helm.images[].value` | `string` | Y | Specifies the new value for the key. Typically, a value from [`chartFrom()`](../40-expressions.md#chartfrom) is used here. |
 
+## Output
+
+| Name | Type | Description |
+|------|------|-------------|
+| `apps` | `[]object` | The Argo CD `Application` resources the step resolved and updated. Kargo uses this to link the target `Stage` to those `Application`s in the UI. |
+| `apps[].name` | `string` | The name of the Argo CD `Application`. |
+| `apps[].namespace` | `string` | The namespace of the Argo CD `Application`. |
+
+:::note
+
+When `apps` are selected by label selector, this output is the concrete list of
+`Application`s the selector matched.
+
+:::
+
 ## Health Checks
 
 The `argocd-update` step is unique among all other built-in promotion steps in

--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-wait.md
@@ -81,6 +81,25 @@ during the wait.
 | `apps[].selector.matchExpressions[].values` | `[]string` | N | An array of string values. Required when `operator` is `In` or `NotIn`. Must be empty when `operator` is `Exists` or `DoesNotExist`. |
 | `apps[].waitFor` | `[]string` | N | Conditions to wait for. Valid values: `health`, `sync`, `operation`, `suspended`, `degraded`. Defaults to `[health, sync, operation]` when omitted. |
 
+## Output
+
+| Name | Type | Description |
+|------|------|-------------|
+| `apps` | `[]object` | The Argo CD `Application` resources the step resolved and waited for. Kargo uses this to link the target `Stage` to those `Application`s in the UI. |
+| `apps[].name` | `string` | The name of the Argo CD `Application`. |
+| `apps[].namespace` | `string` | The namespace of the Argo CD `Application`. |
+
+:::note
+
+Unlike [`argocd-update`](argocd-update.md), this step registers no health checks
+for the target `Stage`; it assesses `Application` health only while the
+`Promotion` is running. This output is therefore how a `Stage` promoted with
+`argocd-wait` alone — for instance, when syncs are triggered by Argo CD
+auto-sync rather than by Kargo — is still linked to its `Application`s in the
+UI.
+
+:::
+
 ## Examples
 
 ### Common Usage

--- a/pkg/api/argocd_context.go
+++ b/pkg/api/argocd_context.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"fmt"
+	"slices"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// ArgoCDAppsOutputKey is the key under which Argo CD-aware promotion steps
+// report the Argo CD Applications they resolved as step output. The value is a
+// list of ArgoCDAppRef in the JSON-native form produced by
+// ArgoCDAppRefsToOutput.
+const ArgoCDAppsOutputKey = "apps"
+
+const (
+	argoCDAppNameKey      = "name"
+	argoCDAppNamespaceKey = "namespace"
+)
+
+// argoCDStepKinds are the kinds of promotion steps that report the Argo CD
+// Applications they resolved under ArgoCDAppsOutputKey.
+var argoCDStepKinds = []string{"argocd-update", "argocd-wait"}
+
+// ArgoCDAppRef identifies a single Argo CD Application associated with a Stage.
+// A list of these is JSON-encoded into the AnnotationKeyArgoCDContext
+// annotation, from which the UI builds deep links into Argo CD.
+type ArgoCDAppRef struct {
+	// Name is the name of the Argo CD Application.
+	Name string `json:"name"`
+	// Namespace is the namespace of the Argo CD Application.
+	Namespace string `json:"namespace"`
+}
+
+// ArgoCDAppRefsToOutput converts refs into the representation an Argo CD-aware
+// step must report them as.
+//
+// Step output is shared state, and shared state is deep-copied between steps
+// with runtime.DeepCopyJSON, which panics on any value that is not one of the
+// types JSON decodes to. A []ArgoCDAppRef would therefore take the Promotion
+// controller down on the next step, so refs are flattened to the maps they
+// would have been decoded into.
+func ArgoCDAppRefsToOutput(refs []ArgoCDAppRef) []any {
+	out := make([]any, len(refs))
+	for i, ref := range refs {
+		out[i] = map[string]any{
+			argoCDAppNameKey:      ref.Name,
+			argoCDAppNamespaceKey: ref.Namespace,
+		}
+	}
+	return out
+}
+
+// argoCDAppRefsFromStepOutputs extracts ArgoCDAppRefs from the outputs of any
+// Argo CD-aware steps among the ones provided. state is the aggregated state of
+// a Promotion, keyed by step alias.
+//
+// The steps are expected to have been inflated -- i.e. every step has an alias
+// assigned and any steps belonging to a PromotionTask have been expanded --
+// which is the case for the steps of any Promotion admitted by the Promotion
+// webhook.
+//
+// Malformed or absent output is not an error. Any step whose output does not
+// have the expected shape simply contributes nothing.
+func argoCDAppRefsFromStepOutputs(
+	steps []kargoapi.PromotionStep,
+	state map[string]any,
+) []ArgoCDAppRef {
+	var refs []ArgoCDAppRef
+	for _, step := range steps {
+		if !slices.Contains(argoCDStepKinds, step.Uses) || step.As == "" {
+			continue
+		}
+		stepOutput, ok := state[step.As].(map[string]any)
+		if !ok {
+			continue
+		}
+		refs = append(refs, argoCDAppRefsFromRawApps(stepOutput[ArgoCDAppsOutputKey])...)
+	}
+	return refs
+}
+
+// argoCDAppRefsFromHealthChecks extracts ArgoCDAppRefs from the configuration of
+// the provided health check steps.
+//
+// Argo CD-aware steps report the Applications they resolved as step output, but
+// only as of a recent version of Kargo. Health check configuration remains the
+// sole source of Argo CD context for any Promotion whose argocd-update step
+// executed before the upgrade to such a version.
+//
+// Malformed or absent configuration is not an error. Any health check whose
+// configuration does not have the expected shape simply contributes nothing.
+func argoCDAppRefsFromHealthChecks(
+	healthChecks []kargoapi.HealthCheckStep,
+) []ArgoCDAppRef {
+	var refs []ArgoCDAppRef
+	for _, healthCheck := range healthChecks {
+		refs = append(
+			refs,
+			argoCDAppRefsFromRawApps(healthCheck.GetConfig()[ArgoCDAppsOutputKey])...,
+		)
+	}
+	return refs
+}
+
+// argoCDAppRefsFromRawApps converts the unstructured representation of a list
+// of Argo CD Applications into ArgoCDAppRefs. Anything that does not have the
+// expected shape is skipped.
+func argoCDAppRefsFromRawApps(rawApps any) []ArgoCDAppRef {
+	appList, ok := rawApps.([]any)
+	if !ok {
+		return nil
+	}
+	refs := make([]ArgoCDAppRef, 0, len(appList))
+	for _, rawApp := range appList {
+		app, ok := rawApp.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := app[argoCDAppNameKey].(string)
+		namespace, _ := app[argoCDAppNamespaceKey].(string)
+		refs = append(refs, ArgoCDAppRef{Name: name, Namespace: namespace})
+	}
+	return refs
+}
+
+// dedupeArgoCDAppRefs returns the provided ArgoCDAppRefs with duplicates and
+// refs lacking a name removed, preserving the order of first occurrence.
+//
+// Deduplication matters because a single Argo CD Application is commonly
+// reported by more than one contributor -- e.g. by both an argocd-update step's
+// output and the health check that same step registered, or by an argocd-update
+// step and a subsequent argocd-wait step targeting the same Application.
+func dedupeArgoCDAppRefs(refs []ArgoCDAppRef) []ArgoCDAppRef {
+	deduped := make([]ArgoCDAppRef, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if ref.Name == "" {
+			// A ref without a name is not actionable, and would break the UI's
+			// parsing of the annotation for the Stage as a whole.
+			continue
+		}
+		key := fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, ref)
+	}
+	return deduped
+}

--- a/pkg/api/argocd_context_test.go
+++ b/pkg/api/argocd_context_test.go
@@ -1,0 +1,463 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// The inputs to both extractors are untyped values decoded from a Promotion's
+// status, which is to say they are whatever happens to be there. Every case
+// below asserts on the extracted result, but the more important assertion is
+// implicit: a type assertion that does not hold must yield nothing rather than
+// panic, because a panic here takes down the Stage controller.
+
+func TestArgoCDAppRefsToOutput(t *testing.T) {
+	t.Parallel()
+
+	refs := []ArgoCDAppRef{
+		{Name: "app-a", Namespace: "argocd"},
+		{Name: "app-b"},
+	}
+	output := ArgoCDAppRefsToOutput(refs)
+
+	require.Equal(
+		t,
+		[]any{
+			map[string]any{"name": "app-a", "namespace": "argocd"},
+			map[string]any{"name": "app-b", "namespace": ""},
+		},
+		output,
+	)
+
+	// Step output becomes shared state, which is deep-copied between steps
+	// with runtime.DeepCopyJSON. That panics on any value that is not one of
+	// the types JSON decodes to, so the output must contain none.
+	state := map[string]any{"step": map[string]any{ArgoCDAppsOutputKey: output}}
+	require.NotPanics(t, func() { runtime.DeepCopyJSON(state) })
+
+	// What a step reports must be what the annotation reads back out, both
+	// before the state is serialized and after it round-trips through JSON.
+	require.Equal(
+		t,
+		refs,
+		argoCDAppRefsFromStepOutputs(
+			[]kargoapi.PromotionStep{{Uses: "argocd-wait", As: "step"}},
+			state,
+		),
+	)
+
+	stateJSON, err := json.Marshal(state)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(stateJSON, &decoded))
+	require.Equal(
+		t,
+		refs,
+		argoCDAppRefsFromStepOutputs(
+			[]kargoapi.PromotionStep{{Uses: "argocd-wait", As: "step"}},
+			decoded,
+		),
+	)
+}
+
+func Test_argoCDAppRefsFromStepOutputs(t *testing.T) {
+	t.Parallel()
+
+	const waitStep = "argocd-wait"
+
+	testCases := []struct {
+		name     string
+		steps    []kargoapi.PromotionStep
+		state    map[string]any
+		expected []ArgoCDAppRef
+	}{
+		{
+			name: "nil steps and nil state",
+		},
+		{
+			name:  "state is nil",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+		},
+		{
+			name:  "state has no entry for the step",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{"other": map[string]any{}},
+		},
+		{
+			name:  "step has no alias",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep}},
+			state: map[string]any{
+				"": map[string]any{
+					ArgoCDAppsOutputKey: []any{map[string]any{"name": "app"}},
+				},
+			},
+		},
+		{
+			// Any step may produce an "apps" output. Only Argo CD-aware steps
+			// are permitted to contribute to the Argo CD context.
+			name:  "step is not Argo CD-aware",
+			steps: []kargoapi.PromotionStep{{Uses: "compose-output", As: "compose"}},
+			state: map[string]any{
+				"compose": map[string]any{
+					ArgoCDAppsOutputKey: []any{map[string]any{"name": "app"}},
+				},
+			},
+		},
+		{
+			name:  "step output is not an object",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{"wait": "not-an-object"},
+		},
+		{
+			name:  "step output is nil",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{"wait": nil},
+		},
+		{
+			name:  "step output is a list",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{"wait": []any{"a", "b"}},
+		},
+		{
+			name:  "step output has no apps key",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{"healthStatus": map[string]any{}},
+			},
+		},
+		{
+			name:  "apps is not a list",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{ArgoCDAppsOutputKey: "not-a-list"},
+			},
+		},
+		{
+			name:  "apps is nil",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{ArgoCDAppsOutputKey: nil},
+			},
+		},
+		{
+			name:  "apps is an object",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: map[string]any{"name": "app"},
+				},
+			},
+		},
+		{
+			name:  "apps is an empty list",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{ArgoCDAppsOutputKey: []any{}},
+			},
+		},
+		{
+			name:  "apps entries are not objects",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{nil, "app", 42, true, []any{"nested"}},
+				},
+			},
+		},
+		{
+			// State is normally decoded from JSON, so it holds only JSON types.
+			// Should a caller ever pass state that has not been round-tripped
+			// through JSON, the Go types the steps actually emit must not be
+			// mistaken for something extractable, nor cause a panic.
+			name:  "apps is a list of concrete Go structs",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+				},
+			},
+		},
+		{
+			name:  "app fields are not strings",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{
+						map[string]any{"name": 42, "namespace": true},
+						map[string]any{"name": nil, "namespace": []any{}},
+					},
+				},
+			},
+			// Unusable fields decode to their zero value rather than being
+			// dropped here. Refs without a name are dropped by
+			// dedupeArgoCDAppRefs.
+			expected: []ArgoCDAppRef{{}, {}},
+		},
+		{
+			name:  "app object is empty",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{ArgoCDAppsOutputKey: []any{map[string]any{}}},
+			},
+			expected: []ArgoCDAppRef{{}},
+		},
+		{
+			name:  "app has extra fields",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{map[string]any{
+						"name":      "app",
+						"namespace": "argocd",
+						"extra":     map[string]any{"deeply": []any{"nested"}},
+					}},
+				},
+			},
+			expected: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+		},
+		{
+			name:  "usable entries survive alongside unusable ones",
+			steps: []kargoapi.PromotionStep{{Uses: waitStep, As: "wait"}},
+			state: map[string]any{
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{
+						"junk",
+						map[string]any{"name": "app", "namespace": "argocd"},
+						nil,
+					},
+				},
+			},
+			expected: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+		},
+		{
+			name: "a broken step does not prevent extraction from others",
+			steps: []kargoapi.PromotionStep{
+				{Uses: "argocd-update", As: "update"},
+				{Uses: waitStep, As: "wait"},
+			},
+			state: map[string]any{
+				"update": "not-an-object",
+				"wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{
+						map[string]any{"name": "app", "namespace": "argocd"},
+					},
+				},
+			},
+			expected: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+		},
+		{
+			name: "apps from multiple steps, in step order",
+			steps: []kargoapi.PromotionStep{
+				{Uses: "argocd-update", As: "update"},
+				{Uses: waitStep, As: "task-1::wait"},
+			},
+			state: map[string]any{
+				"update": map[string]any{
+					ArgoCDAppsOutputKey: []any{
+						map[string]any{"name": "app-a", "namespace": "argocd"},
+					},
+				},
+				"task-1::wait": map[string]any{
+					ArgoCDAppsOutputKey: []any{
+						map[string]any{"name": "app-b", "namespace": "other"},
+					},
+				},
+			},
+			expected: []ArgoCDAppRef{
+				{Name: "app-a", Namespace: "argocd"},
+				{Name: "app-b", Namespace: "other"},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t,
+				testCase.expected,
+				argoCDAppRefsFromStepOutputs(testCase.steps, testCase.state),
+			)
+		})
+	}
+}
+
+func Test_argoCDAppRefsFromHealthChecks(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		healthChecks []kargoapi.HealthCheckStep
+		expected     []ArgoCDAppRef
+	}{
+		{
+			name: "nil health checks",
+		},
+		{
+			name:         "nil config",
+			healthChecks: []kargoapi.HealthCheckStep{{Uses: "argocd-update"}},
+		},
+		{
+			name: "empty raw config",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{},
+			}},
+		},
+		{
+			name: "unparsable raw config",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps": [`)},
+			}},
+		},
+		{
+			name: "config is not an object",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`["apps"]`)},
+			}},
+		},
+		{
+			name: "config has no apps key",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"other":"value"}`)},
+			}},
+		},
+		{
+			name: "apps is not a list",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps":"not-a-list"}`)},
+			}},
+		},
+		{
+			name: "apps entries are not objects",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps":[null,"app",42,true,[]]}`)},
+			}},
+		},
+		{
+			name: "app fields are not strings",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps":[{"name":42,"namespace":null}]}`)},
+			}},
+			expected: []ArgoCDAppRef{{}},
+		},
+		{
+			// The shape an argocd-update step's health check criteria have
+			// always had. Extra fields are ignored.
+			name: "argocd-update health check criteria",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses: "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(
+					`{"apps":[{"name":"app","namespace":"argocd","desiredRevisions":["abc123"]}]}`,
+				)},
+			}},
+			expected: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+		},
+		{
+			// Namespace is omitempty in the health check criteria, so criteria
+			// recorded before this field was consistently populated may lack
+			// it. The ref must still be usable.
+			name: "argocd-update health check criteria without a namespace",
+			healthChecks: []kargoapi.HealthCheckStep{{
+				Uses:   "argocd-update",
+				Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps":[{"name":"app"}]}`)},
+			}},
+			expected: []ArgoCDAppRef{{Name: "app"}},
+		},
+		{
+			name: "a broken health check does not prevent extraction from others",
+			healthChecks: []kargoapi.HealthCheckStep{
+				{
+					Uses:   "argocd-update",
+					Config: &apiextensionsv1.JSON{Raw: []byte(`{"apps":{}}`)},
+				},
+				{
+					Uses: "argocd-update",
+					Config: &apiextensionsv1.JSON{Raw: []byte(
+						`{"apps":[{"name":"app","namespace":"argocd"}]}`,
+					)},
+				},
+			},
+			expected: []ArgoCDAppRef{{Name: "app", Namespace: "argocd"}},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t,
+				testCase.expected,
+				argoCDAppRefsFromHealthChecks(testCase.healthChecks),
+			)
+		})
+	}
+}
+
+func Test_dedupeArgoCDAppRefs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		refs     []ArgoCDAppRef
+		expected []ArgoCDAppRef
+	}{
+		{
+			name:     "nil refs",
+			expected: []ArgoCDAppRef{},
+		},
+		{
+			// A ref whose name could not be extracted would break the UI's
+			// parsing of the annotation for the Stage as a whole.
+			name:     "refs without a name are dropped",
+			refs:     []ArgoCDAppRef{{}, {Namespace: "argocd"}},
+			expected: []ArgoCDAppRef{},
+		},
+		{
+			name:     "a ref without a namespace is kept",
+			refs:     []ArgoCDAppRef{{Name: "app"}},
+			expected: []ArgoCDAppRef{{Name: "app"}},
+		},
+		{
+			name: "duplicates are dropped, order of first occurrence is kept",
+			refs: []ArgoCDAppRef{
+				{Name: "app-b", Namespace: "argocd"},
+				{Name: "app-a", Namespace: "argocd"},
+				{Name: "app-b", Namespace: "argocd"},
+			},
+			expected: []ArgoCDAppRef{
+				{Name: "app-b", Namespace: "argocd"},
+				{Name: "app-a", Namespace: "argocd"},
+			},
+		},
+		{
+			name: "same name in different namespaces are distinct",
+			refs: []ArgoCDAppRef{
+				{Name: "app", Namespace: "argocd"},
+				{Name: "app", Namespace: "other"},
+				{Name: "app"},
+			},
+			expected: []ArgoCDAppRef{
+				{Name: "app", Namespace: "argocd"},
+				{Name: "app", Namespace: "other"},
+				{Name: "app"},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, testCase.expected, dedupeArgoCDAppRefs(testCase.refs))
+		})
+	}
+}

--- a/pkg/api/stage.go
+++ b/pkg/api/stage.go
@@ -224,10 +224,14 @@ func RefreshStage(
 // necessary for the frontend to display ArgoCD information for the Stage.
 //
 // The annotation value is a JSON-encoded list of ArgoCD apps that are
-// associated with the Stage, constructed from the HealthCheckSteps from
-// the latest Promotion.
+// associated with the Stage, constructed from the given Promotion. Two sources
+// contribute: the Applications that Argo CD-aware steps reported as step
+// output, and the Applications named by the health check criteria those steps
+// registered. The latter is what Promotions from before Argo CD-aware steps
+// began reporting step output rely on.
 //
-// If no ArgoCD apps are found, the annotation is removed.
+// If the Promotion is nil, or no ArgoCD apps are found, the annotation is
+// removed.
 //
 // This deliberately takes the Stage's identity rather than a caller's working
 // Stage object. This is to avoid the patchAnnotation() call in this method
@@ -236,28 +240,20 @@ func RefreshStage(
 func AnnotateStageWithArgoCDContext(
 	ctx context.Context,
 	c client.Client,
-	healthChecks []kargoapi.HealthCheckStep,
+	promo *kargoapi.Promotion,
 	stage types.NamespacedName,
 ) error {
-	var argoCDApps []map[string]any
-	for _, healthCheck := range healthChecks {
-		healthCheckConfig := healthCheck.GetConfig()
-
-		appsList, ok := healthCheckConfig["apps"].([]any)
-		if !ok {
-			continue
-		}
-
-		for _, rawApp := range appsList {
-			appConfig, ok := rawApp.(map[string]any)
-			if !ok {
-				continue
-			}
-			argoCDApps = append(argoCDApps, map[string]any{
-				"name":      appConfig["name"],
-				"namespace": appConfig["namespace"],
-			})
-		}
+	var argoCDApps []ArgoCDAppRef
+	if promo != nil {
+		argoCDApps = append(
+			argoCDApps,
+			argoCDAppRefsFromStepOutputs(promo.Spec.Steps, promo.Status.GetState())...,
+		)
+		argoCDApps = append(
+			argoCDApps,
+			argoCDAppRefsFromHealthChecks(promo.Status.HealthChecks)...,
+		)
+		argoCDApps = dedupeArgoCDAppRefs(argoCDApps)
 	}
 
 	target := &kargoapi.Stage{

--- a/pkg/api/stage_test.go
+++ b/pkg/api/stage_test.go
@@ -836,7 +836,7 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 		err := AnnotateStageWithArgoCDContext(
 			t.Context(),
 			c,
-			[]kargoapi.HealthCheckStep{},
+			&kargoapi.Promotion{},
 			types.NamespacedName{
 				Namespace: "fake-namespace",
 				Name:      "fake-stage",
@@ -845,74 +845,175 @@ func TestAnnotateStageWithArgoCDContext(t *testing.T) {
 		require.ErrorContains(t, err, "not found")
 	})
 
-	t.Run("success", func(t *testing.T) {
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			&kargoapi.Stage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-stage",
-					Namespace: "fake-namespace",
+	testCases := []struct {
+		name     string
+		promo    *kargoapi.Promotion
+		expected string
+	}{
+		{
+			// Argo CD-aware steps did not always report the Applications they
+			// resolved as step output. Health check criteria remain the only
+			// source of Argo CD context for such Promotions.
+			name: "health check criteria only",
+			promo: &kargoapi.Promotion{
+				Status: kargoapi.PromotionStatus{
+					HealthChecks: []kargoapi.HealthCheckStep{{
+						Uses: "argocd-update",
+						Config: &apiextensionsv1.JSON{
+							Raw: []byte(`{"apps":[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]}`),
+						},
+					}},
 				},
 			},
-		).Build()
-
-		err := AnnotateStageWithArgoCDContext(
-			t.Context(),
-			c,
-			[]kargoapi.HealthCheckStep{
-				{
-					Uses: "argocd-update",
-					Config: &apiextensionsv1.JSON{
-						Raw: []byte(`{"apps": [{"name": "fake-argo-app", "namespace": "fake-argo-namespace"}]}`),
+			expected: `[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]`,
+		},
+		{
+			name: "step output only",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{{Uses: "argocd-wait", As: "wait"}},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{
+						Raw: []byte(
+							`{"wait":{"apps":[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]}}`,
+						),
 					},
 				},
 			},
-			types.NamespacedName{
-				Namespace: "fake-namespace",
-				Name:      "fake-stage",
-			},
-		)
-		require.NoError(t, err)
-
-		stage, err := GetStage(t.Context(), c, types.NamespacedName{
-			Namespace: "fake-namespace",
-			Name:      "fake-stage",
-		})
-		require.NoError(t, err)
-		require.Equal(t,
-			`[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]`,
-			stage.Annotations[kargoapi.AnnotationKeyArgoCDContext])
-	})
-
-	t.Run("no ArgoCD apps", func(t *testing.T) {
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			&kargoapi.Stage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-stage",
-					Namespace: "fake-namespace",
-					Annotations: map[string]string{
-						kargoapi.AnnotationKeyArgoCDContext: "fake-annotation",
+			expected: `[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]`,
+		},
+		{
+			name: "step output from a task step",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{{Uses: "argocd-wait", As: "task-1::wait"}},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{
+						Raw: []byte(
+							`{"task-1::wait":{"apps":[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]}}`,
+						),
 					},
 				},
 			},
-		).Build()
+			expected: `[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]`,
+		},
+		{
+			// An argocd-update step reports the same Applications through both
+			// its output and the health check criteria it registers, and a
+			// subsequent argocd-wait step commonly targets those same
+			// Applications.
+			name: "duplicate apps across sources are deduped",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{
+						{Uses: "argocd-update", As: "update"},
+						{Uses: "argocd-wait", As: "wait"},
+					},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{
+						Raw: []byte(`{
+							"update":{"apps":[
+								{"name":"fake-argo-app","namespace":"fake-argo-namespace"},
+								{"name":"other-argo-app","namespace":"fake-argo-namespace"}
+							]},
+							"wait":{"apps":[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]}
+						}`),
+					},
+					HealthChecks: []kargoapi.HealthCheckStep{{
+						Uses: "argocd-update",
+						Config: &apiextensionsv1.JSON{
+							Raw: []byte(`{"apps":[{"name":"fake-argo-app","namespace":"fake-argo-namespace"}]}`),
+						},
+					}},
+				},
+			},
+			expected: `[{"name":"fake-argo-app","namespace":"fake-argo-namespace"},` +
+				`{"name":"other-argo-app","namespace":"fake-argo-namespace"}]`,
+		},
+		{
+			name: "output of non-Argo CD steps is ignored",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{{Uses: "compose-output", As: "compose"}},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{
+						Raw: []byte(`{"compose":{"apps":[{"name":"not-an-argo-app"}]}}`),
+					},
+				},
+			},
+		},
+		{
+			name: "malformed output contributes nothing",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{
+						{Uses: "argocd-wait", As: "wait"},
+						{Uses: "argocd-wait", As: "other-wait"},
+					},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{
+						Raw: []byte(`{"wait":{"apps":"not-a-list"},"other-wait":{"apps":[42,{}]}}`),
+					},
+				},
+			},
+		},
+		{
+			name: "unparsable state",
+			promo: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Steps: []kargoapi.PromotionStep{{Uses: "argocd-wait", As: "wait"}},
+				},
+				Status: kargoapi.PromotionStatus{
+					State: &apiextensionsv1.JSON{Raw: []byte(`{"wait":`)},
+				},
+			},
+		},
+		{
+			name:  "no ArgoCD apps",
+			promo: &kargoapi.Promotion{},
+		},
+		{
+			name: "nil Promotion",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-stage",
+						Namespace: "fake-namespace",
+						Annotations: map[string]string{
+							kargoapi.AnnotationKeyArgoCDContext: "fake-annotation",
+						},
+					},
+				},
+			).Build()
 
-		err := AnnotateStageWithArgoCDContext(
-			t.Context(),
-			c,
-			[]kargoapi.HealthCheckStep{},
-			types.NamespacedName{
+			stageKey := types.NamespacedName{
 				Namespace: "fake-namespace",
 				Name:      "fake-stage",
-			},
-		)
-		require.NoError(t, err)
+			}
+			require.NoError(t, AnnotateStageWithArgoCDContext(
+				t.Context(), c, testCase.promo, stageKey,
+			))
 
-		stage, err := GetStage(t.Context(), c, types.NamespacedName{
-			Namespace: "fake-namespace",
-			Name:      "fake-stage",
+			stage, err := GetStage(t.Context(), c, stageKey)
+			require.NoError(t, err)
+			if testCase.expected == "" {
+				require.NotContains(t, stage.Annotations, kargoapi.AnnotationKeyArgoCDContext)
+				return
+			}
+			require.Equal(
+				t,
+				testCase.expected,
+				stage.Annotations[kargoapi.AnnotationKeyArgoCDContext],
+			)
 		})
-		require.NoError(t, err)
-
-		require.NotContains(t, stage.Annotations, kargoapi.AnnotationKeyArgoCDContext)
-	})
+	}
 }

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -789,12 +789,12 @@ func (r *RegularStageReconciler) syncPromotions(
 				// ArgoCD Applications. This is used to provide deep links to the
 				// ArgoCD UI for the Stage in the Kargo UI.
 				//
-				// NB: If the health checks do not include ArgoCD Applications,
+				// NB: If the Promotion did not involve any ArgoCD Applications,
 				// then the annotation will be removed.
 				if err := api.AnnotateStageWithArgoCDContext(
 					ctx,
 					r.client,
-					promo.Status.HealthChecks,
+					promo,
 					client.ObjectKeyFromObject(stage),
 				); err != nil {
 					// Let the error be logged, but do not return it as it is not

--- a/pkg/promotion/runner/builtin/argocd_updater.go
+++ b/pkg/promotion/runner/builtin/argocd_updater.go
@@ -166,6 +166,9 @@ func (a *argocdUpdater) run(
 
 	updateResults := make([]argocd.OperationPhase, 0, len(stepCfg.Apps))
 	var appHealthChecks []checkers.ArgoCDAppHealthCheck
+	// Applications resolved by this step, reported as output so the Stage
+	// controller can annotate the Stage with Argo CD context.
+	var resolvedApps []api.ArgoCDAppRef
 	for i := range stepCfg.Apps {
 		update := &stepCfg.Apps[i]
 
@@ -205,6 +208,10 @@ func (a *argocdUpdater) run(
 				Namespace:        app.Namespace,
 				DesiredRevisions: desiredRevisions,
 			})
+			resolvedApps = append(resolvedApps, api.ArgoCDAppRef{
+				Name:      app.Name,
+				Namespace: app.Namespace,
+			})
 
 			// Process the application and get its phase.
 			phase, err := a.processApplication(ctx, stepCtx, update, app)
@@ -239,6 +246,9 @@ func (a *argocdUpdater) run(
 
 	return promotion.StepResult{
 		Status: aggregatedStatus,
+		Output: map[string]any{
+			api.ArgoCDAppsOutputKey: api.ArgoCDAppRefsToOutput(resolvedApps),
+		},
 		HealthCheck: &health.Criteria{
 			Kind: stepKindArgoCDUpdate,
 			Input: health.Input{

--- a/pkg/promotion/runner/builtin/argocd_updater_test.go
+++ b/pkg/promotion/runner/builtin/argocd_updater_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/kubeclient"
 	"github.com/akuity/kargo/pkg/promotion"
@@ -950,6 +951,16 @@ func Test_argoCDUpdater_run(t *testing.T) {
 				apps, ok := res.HealthCheck.Input["apps"]
 				assert.True(t, ok)
 				assert.Len(t, apps, 3)
+				// The same apps are reported as step output.
+				assert.Equal(
+					t,
+					api.ArgoCDAppRefsToOutput([]api.ArgoCDAppRef{
+						{Name: "app1", Namespace: "argocd"},
+						{Name: "app2", Namespace: "argocd"},
+						{Name: "app3", Namespace: "argocd"},
+					}),
+					res.Output[api.ArgoCDAppsOutputKey],
+				)
 			},
 		},
 		{
@@ -1279,6 +1290,7 @@ func Test_argoCDUpdater_run(t *testing.T) {
 				&promotion.StepContext{},
 				testCase.stepCfg,
 			)
+			requireJSONNativeOutput(t, res)
 			testCase.assertions(t, res, err)
 		})
 	}

--- a/pkg/promotion/runner/builtin/argocd_waiter.go
+++ b/pkg/promotion/runner/builtin/argocd_waiter.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
 	libargocd "github.com/akuity/kargo/pkg/argocd"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/logging"
@@ -132,6 +133,12 @@ func (w *argocdWaiter) run(
 		newHealthStatuses[k] = v
 	}
 
+	// Applications resolved by this step, reported as output so the Stage
+	// controller can annotate the Stage with Argo CD context. This is the only
+	// place the Applications this step resolved are reported; the step
+	// deliberately registers no health check criteria.
+	var resolvedApps []api.ArgoCDAppRef
+
 	allReady := true
 	for i := range stepCfg.Apps {
 		appSpec := &stepCfg.Apps[i]
@@ -162,6 +169,11 @@ func (w *argocdWaiter) run(
 				"app", app.Name, "namespace", app.Namespace,
 			)
 
+			resolvedApps = append(resolvedApps, api.ArgoCDAppRef{
+				Name:      app.Name,
+				Namespace: app.Namespace,
+			})
+
 			ready, healthStatus, err :=
 				w.checkAppReadinessFn(ctx, app, waitFor, prevHealthStatuses[appKey])
 			if healthStatus != "" {
@@ -170,9 +182,7 @@ func (w *argocdWaiter) run(
 			if err != nil {
 				return promotion.StepResult{
 					Status: kargoapi.PromotionStepStatusErrored,
-					Output: map[string]any{
-						healthStatusKey: newHealthStatuses,
-					},
+					Output: waitStepOutput(resolvedApps, newHealthStatuses),
 				}, err
 			}
 			if !ready {
@@ -188,19 +198,27 @@ func (w *argocdWaiter) run(
 		logger.Info("all applications are ready", "status", "Succeeded")
 		return promotion.StepResult{
 			Status: kargoapi.PromotionStepStatusSucceeded,
-			Output: map[string]any{
-				healthStatusKey: newHealthStatuses,
-			},
+			Output: waitStepOutput(resolvedApps, newHealthStatuses),
 		}, nil
 	}
 
 	logger.Info("waiting for applications to become ready")
 	return promotion.StepResult{
 		Status: kargoapi.PromotionStepStatusRunning,
-		Output: map[string]any{
-			healthStatusKey: newHealthStatuses,
-		},
+		Output: waitStepOutput(resolvedApps, newHealthStatuses),
 	}, nil
+}
+
+// waitStepOutput assembles the output of an argocd-wait step from the Argo CD
+// Applications it has resolved and their last observed health statuses.
+func waitStepOutput(
+	apps []api.ArgoCDAppRef,
+	healthStatuses map[string]any,
+) map[string]any {
+	return map[string]any{
+		api.ArgoCDAppsOutputKey: api.ArgoCDAppRefsToOutput(apps),
+		healthStatusKey:         healthStatuses,
+	}
 }
 
 // checkAppReadiness checks whether a single Argo CD Application meets the

--- a/pkg/promotion/runner/builtin/argocd_waiter_test.go
+++ b/pkg/promotion/runner/builtin/argocd_waiter_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/promotion"
 	"github.com/akuity/kargo/pkg/x/promotion/runner/builtin"
@@ -173,8 +174,10 @@ func Test_argocdWaiter_run(t *testing.T) {
 		{
 			name: "checkAppReadiness terminal error stops loop",
 			runner: &argocdWaiter{
-				argocdClient:      fake.NewFakeClient(),
-				getApplicationsFn: appsFn(&argocd.Application{}),
+				argocdClient: fake.NewFakeClient(),
+				getApplicationsFn: appsFn(&argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "argocd"},
+				}),
 				checkAppReadinessFn: func(
 					context.Context, *argocd.Application,
 					[]builtin.WaitFor, string,
@@ -192,6 +195,14 @@ func Test_argocdWaiter_run(t *testing.T) {
 				assert.Equal(t, kargoapi.PromotionStepStatusErrored, res.Status)
 				require.True(t, promotion.IsTerminal(err))
 				require.ErrorContains(t, err, "bad condition")
+				// Applications resolved before bailing are still reported.
+				assert.Equal(
+					t,
+					api.ArgoCDAppRefsToOutput(
+						[]api.ArgoCDAppRef{{Name: "my-app", Namespace: "argocd"}},
+					),
+					res.Output[api.ArgoCDAppsOutputKey],
+				)
 			},
 		},
 		{
@@ -245,13 +256,23 @@ func Test_argocdWaiter_run(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, kargoapi.PromotionStepStatusRunning, res.Status)
 				assert.Nil(t, res.RetryAfter)
+				assert.Equal(
+					t,
+					api.ArgoCDAppRefsToOutput([]api.ArgoCDAppRef{
+						{Name: "app-a", Namespace: "argocd"},
+						{Name: "app-b", Namespace: "argocd"},
+					}),
+					res.Output[api.ArgoCDAppsOutputKey],
+				)
 			},
 		},
 		{
 			name: "all apps ready returns Succeeded",
 			runner: &argocdWaiter{
-				argocdClient:      fake.NewFakeClient(),
-				getApplicationsFn: appsFn(&argocd.Application{}),
+				argocdClient: fake.NewFakeClient(),
+				getApplicationsFn: appsFn(&argocd.Application{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "argocd"},
+				}),
 				checkAppReadinessFn: func(
 					context.Context, *argocd.Application,
 					[]builtin.WaitFor, string,
@@ -266,6 +287,13 @@ func Test_argocdWaiter_run(t *testing.T) {
 			assertions: func(t *testing.T, res promotion.StepResult, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, kargoapi.PromotionStepStatusSucceeded, res.Status)
+				assert.Equal(
+					t,
+					api.ArgoCDAppRefsToOutput(
+						[]api.ArgoCDAppRef{{Name: "my-app", Namespace: "argocd"}},
+					),
+					res.Output[api.ArgoCDAppsOutputKey],
+				)
 			},
 		},
 		{
@@ -305,9 +333,21 @@ func Test_argocdWaiter_run(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			res, err := tc.runner.run(context.Background(), tc.stepCtx, tc.stepCfg)
+			requireJSONNativeOutput(t, res)
 			tc.assertions(t, res, err)
 		})
 	}
+}
+
+// requireJSONNativeOutput asserts that a step's output can serve as shared
+// state. The engine deep-copies shared state with runtime.DeepCopyJSON before
+// every subsequent step, which panics on any value that is not one of the
+// types JSON decodes to -- taking the Promotion controller down with it.
+func requireJSONNativeOutput(t *testing.T, res promotion.StepResult) {
+	t.Helper()
+	require.NotPanics(t, func() {
+		runtime.DeepCopyJSON(map[string]any{"output": res.Output})
+	})
 }
 
 func Test_argocdWaiter_checkAppReadiness(t *testing.T) {


### PR DESCRIPTION
## Summary

The `kargo.akuity.io/argocd-context` annotation, which the UI uses to build deep links into Argo CD from the Stage view, was derived solely from the health check criteria registered by `argocd-update`. `argocd-wait` resolves Argo CD `Application`s but registers no health check, so Stages promoted with it got no deep links — and a Stage that switched from `argocd-update` to `argocd-wait` lost the links it already had, because the annotation is removed when nothing contributes apps.

Both steps now report the `Application`s they resolved as step output, and the annotation is built from that.

### How it works

`ArgoCDAppRef` is the single shape every contributor is reduced to. Two transformers feed it, and the results are merged and deduplicated:

- **Step output** — `argocd-update` and `argocd-wait` both report the `Application`s they resolved under an `apps` output key. Refs are built from the resolved `Application` objects rather than from step config, so the namespace is always concrete even when apps were selected by label selector.
- **Health check criteria** — the existing behavior, retained for backward compatibility (see below).

Deduplication is by `namespace/name`. It matters because in the normal case a single `Application` is reported by up to three contributors: an `argocd-update` step's output, the health check that same step registers, and a subsequent `argocd-wait` step targeting the same app.

`argocd-wait` still registers no `health.Criteria`. It assesses health only while the `Promotion` runs, and Stage health semantics are unchanged.

### Backward compatibility

Steps are not re-executed across reconciliations, so a `Promotion` whose `argocd-update` step completed before an upgrade to this version finishes after it with health checks but no `apps` output. Dropping the health-check transformer would silently lose that Stage's links until its next promotion, so it is kept. It can be removed a release or two later.

### Note on decoding

Everything read out of step output and health check criteria is untyped. Extraction is written so that a type assertion that does not hold contributes nothing rather than panicking, which would take down the Stage controller. This is covered by 38 test cases that break the decode chain at every link.

The reverse direction is equally hazardous and cost us a live crash during manual testing (see below): step output becomes shared state, which the engine deep-copies with `runtime.DeepCopyJSON` before every subsequent step. That panics on anything outside `bool/int64/float64/string/[]any/map[string]any/nil`. `ArgoCDAppRefsToOutput()` flattens refs to the maps they would have been decoded into, and both runners' `run` tests now assert that every case's output can serve as shared state.

## Test plan

### Automated

```bash
make lint-go        # 0 issues
make test-unit
```

New unit coverage:

- `pkg/api/argocd_context_test.go` — both transformers against malformed, absent, and wrongly-typed input; non-Argo-CD steps emitting their own `apps` key are excluded; dedupe ordering and nameless-ref dropping; output survives `DeepCopyJSON` and round-trips back through the extractor unchanged.
- `pkg/api/stage_test.go` — table-driven: health-checks-only (the backward-compat path), step-output-only, a `task-1::wait` alias, cross-source dedupe, unparsable `status.state`, nil `Promotion`.
- Both runners — output assertions, plus a `requireJSONNativeOutput` guard in each `run` test loop.

### Manual test matrix

Run against a Tilt dev environment with three Stages in one Project, each promoting independently: one using `argocd-update`, one using `argocd-wait` (against an auto-synced `Application`, so Kargo never triggers the sync), and one using both against the same `Application`.

| Stage | Before | After |
|---|---|---|
| `argocd-update` only | annotation present | identical |
| `argocd-wait` only | **no annotation** | annotation present, deep links work |
| both, same app | present (health check) | present, exactly one entry |

The matrix caught a crash the unit tests did not: emitting `[]ArgoCDAppRef` directly panicked the Promotion controller with `cannot deep copy []api.ArgoCDAppRef` as soon as a second step ran. Only the two-step Stage reproduced it — a step's own output is never deep-copied during its own iteration, and state is reseeded from JSON-decoded `status.state` at the start of every reconciliation, so the struct never survives a reconciliation boundary. Fixed, and guarded by the test described above.

The backward-compatibility leg was exercised separately by starting a promotion on `main`, letting the `argocd-update` step complete, then swapping in the branch binary: the annotation is still produced, from health checks alone.

## Follow-ups

Not addressed here, both pre-existing:

- The "step output must be JSON-native" invariant is unwritten and unenforced. Nothing in `StepResult` or the runner interface signals it, and no shared guard exists. Every other built-in step hand-rolls `map[string]any` and happens to be safe — but `DeepCopyJSON` rejects plain `int`, so a step emitting one would panic identically. The `requireJSONNativeOutput` helper added here is trivially promotable into a shared test util.
- `health.Input.DeepCopy()` and `promotion.Context.DeepCopy()` have no non-test callers today, but both would panic the same way if called mid-execution: `argocd-update` puts `[]checkers.ArgoCDAppHealthCheck` structs into `health.Input`, and `Context.DeepCopy()` calls `State.DeepCopy()`.

Closes #6762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
