### PR TITLE
refactor(server): log requests and recover from panics with our own middleware

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -207,6 +207,19 @@ func (l *Logger) WithValues(keysAndValues ...any) *Logger {
 	}
 }
 
+// WithoutStackTraces returns a copy of a logger that does not attach a stack
+// trace to the records it writes. A stack trace describes the path to the
+// logging call, not the path to whatever went wrong, so it is worth having only
+// where an error is logged near where it arose. Callers that log errors on
+// behalf of code far below them should use this.
+func (l *Logger) WithoutStackTraces() *Logger {
+	return &Logger{
+		// Stack traces are attached at or above a level, so requiring a level
+		// above the highest one this package offers disables them.
+		logger: l.logger.WithOptions(zap.AddStacktrace(zapcore.FatalLevel)),
+	}
+}
+
 // Error logs a message at the error level.
 func (l *Logger) Error(err error, msg string, keysAndValues ...any) {
 	l.logger.Errorw(fmt.Sprintf("%s: %v", msg, err), keysAndValues...,

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -184,6 +184,20 @@ func TestLogger_WithValues(t *testing.T) {
 	require.Equal(t, []zapcore.Field{zap.Any("component", "test")}, entry.Context)
 }
 
+func TestLogger_WithoutStackTraces(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	// A logger built with AddStacktrace records one for an error; the same logger
+	// with stack traces removed does not.
+	logger := Wrap(zap.New(core, zap.AddStacktrace(zapcore.ErrorLevel)))
+
+	logger.Error(errors.New("something went wrong"), "an error occurred")
+	logger.WithoutStackTraces().Error(errors.New("something went wrong"), "an error occurred")
+
+	require.Len(t, logs.All(), 2)
+	require.NotEmpty(t, logs.All()[0].Stack)
+	require.Empty(t, logs.All()[1].Stack)
+}
+
 func TestLogger_Error(t *testing.T) {
 	core, logs := observer.New(zapcore.ErrorLevel)
 	// Wrap() has its own tests, so here we assume it works.

--- a/pkg/server/logging_middleware.go
+++ b/pkg/server/logging_middleware.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/akuity/kargo/pkg/logging"
+)
+
+// loggingMiddleware returns Gin middleware that records one line per request
+// using Kargo's own logger, so that LOG_LEVEL governs the request log as it
+// governs everything else.
+//
+// A server error is recorded at error level. A request that was refused is
+// recorded at info level, because a refusal is never routine and is the first
+// thing anyone looks for when a user reports being unable to do something.
+// Everything else is operational detail and recorded at debug level.
+//
+// This must be the outermost middleware, so that the status and any reported
+// error it records are the ones the client actually received.
+func loggingMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		c.Next()
+
+		status := c.Writer.Status()
+		// Without stack traces, because this middleware sits above every handler
+		// and every other middleware, so a trace from here describes only the path
+		// through Gin and reveals nothing about what went wrong.
+		logger := logging.LoggerFromContext(c.Request.Context()).
+			WithoutStackTraces().
+			WithValues(
+				"method", c.Request.Method,
+				"path", c.Request.URL.Path,
+				"status", status,
+				// Logged as a string because the encoder would otherwise render a
+				// duration as a bare number of seconds.
+				"duration", time.Since(start).String(),
+			)
+		reported := c.Errors.Last()
+
+		if status < http.StatusInternalServerError {
+			if reported != nil {
+				logger = logger.WithValues("error", reported.Err.Error())
+			}
+			if status == http.StatusUnauthorized || status == http.StatusForbidden {
+				logger.Info("refused request")
+				return
+			}
+			logger.Debug("handled request")
+			return
+		}
+		if reported == nil {
+			// Nothing was reported, which means a handler answered with a server
+			// error on its own rather than leaving that to the error-handling
+			// middleware.
+			logger.Error(errors.New("no error was reported"), "handled request")
+			return
+		}
+		logger.Error(reported.Err, "handled request")
+	}
+}

--- a/pkg/server/logging_middleware_test.go
+++ b/pkg/server/logging_middleware_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	libhttp "github.com/akuity/kargo/pkg/http"
+	"github.com/akuity/kargo/pkg/logging"
+)
+
+func TestLoggingMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testCases := []struct {
+		name string
+		// level is the level the logger is configured with, so that what a given
+		// LOG_LEVEL suppresses is observable.
+		level          zapcore.Level
+		handler        gin.HandlerFunc
+		expectedStatus int
+		assertions     func(t *testing.T, entries []observer.LoggedEntry)
+	}{
+		{
+			name:           "successful request is recorded at debug level",
+			level:          zapcore.DebugLevel,
+			handler:        func(c *gin.Context) { c.Status(http.StatusOK) },
+			expectedStatus: http.StatusOK,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				require.Len(t, entries, 1)
+				require.Equal(t, zapcore.DebugLevel, entries[0].Level)
+				require.Equal(t, "handled request", entries[0].Message)
+				fields := entries[0].ContextMap()
+				require.Equal(t, http.MethodGet, fields["method"])
+				require.Equal(t, "/", fields["path"])
+				require.EqualValues(t, http.StatusOK, fields["status"])
+				require.Contains(t, fields, "duration")
+			},
+		},
+		{
+			// Which is the whole point: gin's own logger writes regardless of the
+			// configured level.
+			name:           "successful request is suppressed at error level",
+			level:          zapcore.ErrorLevel,
+			handler:        func(c *gin.Context) { c.Status(http.StatusOK) },
+			expectedStatus: http.StatusOK,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				require.Empty(t, entries)
+			},
+		},
+		{
+			name:  "refused request is recorded at info level, with its reason",
+			level: zapcore.InfoLevel,
+			handler: func(c *gin.Context) {
+				_ = c.Error(libhttp.ErrorStr("invalid token", http.StatusUnauthorized))
+			},
+			expectedStatus: http.StatusUnauthorized,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				require.Len(t, entries, 1)
+				require.Equal(t, zapcore.InfoLevel, entries[0].Level)
+				require.Equal(t, "refused request", entries[0].Message)
+				fields := entries[0].ContextMap()
+				require.EqualValues(t, http.StatusUnauthorized, fields["status"])
+				require.Equal(t, "invalid token", fields["error"])
+			},
+		},
+		{
+			name:  "forbidden request is recorded at info level",
+			level: zapcore.InfoLevel,
+			handler: func(c *gin.Context) {
+				_ = c.Error(libhttp.ErrorStr("not permitted", http.StatusForbidden))
+			},
+			expectedStatus: http.StatusForbidden,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				require.Len(t, entries, 1)
+				require.Equal(t, zapcore.InfoLevel, entries[0].Level)
+				require.EqualValues(t, http.StatusForbidden, entries[0].ContextMap()["status"])
+			},
+		},
+		{
+			name:  "request for something absent is recorded at debug level",
+			level: zapcore.InfoLevel,
+			handler: func(c *gin.Context) {
+				_ = c.Error(libhttp.ErrorStr("not found", http.StatusNotFound))
+			},
+			expectedStatus: http.StatusNotFound,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				require.Empty(t, entries)
+			},
+		},
+		{
+			// A server error is worth recording even when nothing else is.
+			name:  "failed request is recorded at error level",
+			level: zapcore.ErrorLevel,
+			handler: func(c *gin.Context) {
+				_ = c.Error(errors.New("something we did not anticipate"))
+			},
+			expectedStatus: http.StatusInternalServerError,
+			assertions: func(t *testing.T, entries []observer.LoggedEntry) {
+				// Exactly one record: the error-handling middleware responds, but
+				// leaves the recording of what happened to this middleware.
+				require.Len(t, entries, 1)
+				last := entries[0]
+				require.Equal(t, zapcore.ErrorLevel, last.Level)
+				// Logger.Error folds the error into the message.
+				require.Equal(
+					t,
+					"handled request: something we did not anticipate",
+					last.Message,
+				)
+				fields := last.ContextMap()
+				require.EqualValues(t, http.StatusInternalServerError, fields["status"])
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			core, recorded := observer.New(testCase.level)
+			logger := logging.Wrap(zap.New(core))
+
+			s := &server{}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Request = c.Request.WithContext(
+					logging.ContextWithLogger(c.Request.Context(), logger),
+				)
+				c.Next()
+			})
+			router.Use(loggingMiddleware())
+			router.Use(s.handleError)
+			router.GET("/", testCase.handler)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			require.Equal(t, testCase.expectedStatus, w.Code)
+			testCase.assertions(t, recorded.All())
+		})
+	}
+}

--- a/pkg/server/recovery_middleware.go
+++ b/pkg/server/recovery_middleware.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"syscall"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/akuity/kargo/pkg/logging"
+)
+
+// recoveryMiddleware returns Gin middleware that recovers from a panic in any
+// handler downstream of it and reports it as an error rather than answering the
+// request itself. The error-handling middleware then responds as it does to any
+// other unanticipated error.
+//
+// This exists in preference to gin.Recovery(), which answers a panic with
+// c.AbortWithStatus and therefore sends a 500 with an empty body, leaving a
+// client nothing to parse and bypassing the error-handling middleware
+// altogether. Reporting the panic instead keeps every error response the same
+// shape and keeps response writing in one place.
+//
+// This must be registered inside the error-handling middleware, so that the
+// error it reports is still there to be found when that middleware inspects the
+// request on its way back out.
+func recoveryMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			// A client that has gone away is not worth a stack trace, and there is
+			// nothing left to respond to. gin.Recovery() singles out these same
+			// three conditions for the same reason.
+			if err, ok := rec.(error); ok &&
+				(errors.Is(err, syscall.EPIPE) ||
+					errors.Is(err, syscall.ECONNRESET) ||
+					errors.Is(err, http.ErrAbortHandler)) {
+				logging.LoggerFromContext(c.Request.Context()).Debug(
+					"client closed the connection",
+					"error", err.Error(),
+				)
+				c.Abort()
+				return
+			}
+			// The stack accompanies the error rather than being logged separately,
+			// so that a panic produces one record containing everything known about
+			// it.
+			_ = c.Error(fmt.Errorf("recovered from panic: %v\n%s", rec, debug.Stack()))
+			c.Abort()
+		}()
+
+		c.Next()
+	}
+}

--- a/pkg/server/recovery_middleware_test.go
+++ b/pkg/server/recovery_middleware_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoveryMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testCases := []struct {
+		name           string
+		handler        gin.HandlerFunc
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "no panic",
+			handler:        func(c *gin.Context) { c.Status(http.StatusOK) },
+			expectedStatus: http.StatusOK,
+			expectedBody:   "",
+		},
+		{
+			// The panic must reach the error-handling middleware, which answers it
+			// with the same body every other error gets, disclosing nothing.
+			name:           "panic",
+			handler:        func(*gin.Context) { panic("kaboom") },
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   `{"error":"internal server error"}`,
+		},
+		{
+			name:           "panic with an error value",
+			handler:        func(*gin.Context) { panic(errors.New("kaboom")) },
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   `{"error":"internal server error"}`,
+		},
+		{
+			// There is no client left to answer, so nothing is written. Gin's
+			// recorder reports the status it was initialized with.
+			name:           "client went away",
+			handler:        func(*gin.Context) { panic(syscall.EPIPE) },
+			expectedStatus: http.StatusOK,
+			expectedBody:   "",
+		},
+		{
+			name:           "handler aborted",
+			handler:        func(*gin.Context) { panic(http.ErrAbortHandler) },
+			expectedStatus: http.StatusOK,
+			expectedBody:   "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &server{}
+			router := gin.New()
+			router.Use(s.handleError)
+			router.Use(recoveryMiddleware())
+			router.GET("/", testCase.handler)
+
+			w := httptest.NewRecorder()
+			// A panic escaping the middleware would fail the test by crashing it.
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			require.Equal(t, testCase.expectedStatus, w.Code)
+			require.Equal(t, testCase.expectedBody, w.Body.String())
+		})
+	}
+}

--- a/pkg/server/rest_router.go
+++ b/pkg/server/rest_router.go
@@ -9,7 +9,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	libhttp "github.com/akuity/kargo/pkg/http"
-	"github.com/akuity/kargo/pkg/logging"
 )
 
 // nolint: lll
@@ -54,12 +53,44 @@ import (
 // @name Authorization
 // @description Bearer token authentication. Obtain token via OIDC/PKCE flow with your identity provider.
 func (s *server) setupRESTRouter(ctx context.Context) *gin.Engine {
-	router := gin.Default()
+	// Unconditionally set Gin to "release mode" (as opposed to the default of
+	// "debug mode"). This suppresses Gin-related log noise that we don't want,
+	// even at development time.
+	//
+	// Note: The mode is package-level state, so the following statements reaches
+	// beyond this function. This is tolerable because the engine built below is
+	// the only one the server ever builds. Were we ever to build more, we would,
+	// in all likelihood, want them all to be in release mode as well.
+	gin.SetMode(gin.ReleaseMode)
 
-	// Error handling middleware
+	router := gin.New()
+
+	// Middleware nests, with each layer registered here wrapping the ones
+	// registered after it. Each of the layers below does its work on the way back
+	// out, so the order determines what each one is able to see:
+	//
+	//	logging            ─┐ request
+	//	  error handling    │
+	//	    panic recovery  │
+	//	      authn         │
+	//	        handler    ─┤
+	//	      authn         │
+	//	    panic recovery  │
+	//	  error handling    │
+	//	logging            ─┘ response
+	//
+	// Logging is outermost so that it records the status the client actually
+	// received, which is not settled until everything within has finished
+	// writing. Error handling comes next because it is the only thing that writes
+	// an error response. Panic recovery goes inside it, so that a recovered panic
+	// is reported as an error and answered on the way out like any other; were it
+	// outside, a panic would bypass error handling entirely and recovery would
+	// have to write its own response. Authentication is innermost of the four so
+	// that its rejections are answered by the error handling middleware, and so
+	// that a panic within it is recovered too.
+	router.Use(loggingMiddleware())
 	router.Use(s.handleError)
-
-	// Authentication middleware (only if auth is configured)
+	router.Use(recoveryMiddleware())
 	if s.cfg.AdminConfig != nil || s.cfg.OIDCConfig != nil {
 		router.Use(NewAuthMiddleware(ctx, s.cfg, s.client.InternalClient()))
 	}
@@ -322,7 +353,7 @@ func (s *server) handleError(c *gin.Context) {
 		var httpErr *libhttp.HTTPError
 		if ok := errors.As(err, &httpErr); ok {
 			if code := httpErr.Code(); code == http.StatusInternalServerError {
-				s.respondInternalServerError(c, err)
+				s.respondInternalServerError(c)
 				return
 			}
 			c.JSON(httpErr.Code(), errorResponse{Error: httpErr.Error()})
@@ -335,15 +366,15 @@ func (s *server) handleError(c *gin.Context) {
 		}
 		// An error of no recognized type is, by definition, one we did not
 		// anticipate. Report it as such rather than leaving the response empty.
-		s.respondInternalServerError(c, err)
+		s.respondInternalServerError(c)
 	}
 }
 
-// respondInternalServerError logs err and responds with a 500 whose body
-// discloses nothing about the underlying failure.
-func (s *server) respondInternalServerError(c *gin.Context, err error) {
-	logging.LoggerFromContext(c.Request.Context()).
-		Error(err, "internal server error")
+// respondInternalServerError responds with a 500 whose body discloses nothing
+// about the underlying failure. The error itself is recorded by the request
+// logging middleware, which knows what was requested as well as what went
+// wrong.
+func (s *server) respondInternalServerError(c *gin.Context) {
 	c.JSON(
 		http.StatusInternalServerError,
 		errorResponse{Error: "internal server error"},


### PR DESCRIPTION
`gin.Default()` installs Gin's logger, which writes a line per request to stdout in its own format and ignores `LOG_LEVEL` entirely. Requests are now recorded through Kargo's logger, with `method`, `path`, `status` and `duration` as fields.

Levels are chosen so that a stock installation, which runs at `INFO`, sees what matters and nothing else. A refused request — a `401` or a `403` — is recorded at `info`, because a refusal is never routine and is the first thing anyone looks for when a user cannot do something. Server errors are recorded at `error`. Everything else, including a request for something absent, is `debug`: the dashboard asks for resources that may not exist yet and treats their absence as an answer.

Errors are logged without a stack trace, via a new `Logger.WithoutStackTraces`. A trace describes the path to the logging call, so it is worth having only where an error is logged near where it arose, which a middleware sitting above every handler never is.

Dropping Gin's logger means dropping `gin.Default()`, which takes Gin's panic recovery with it. Rather than reinstate `gin.Recovery()`, which answers a panic by aborting with an empty-bodied `500`, recovery now reports the panic and its stack as an error and lets the error-handling middleware answer it. A panic therefore gets the same response body as any other unanticipated error. That also leaves the error-handling middleware as the only thing writing an error response, so it no longer logs one itself.

Gin is finally put in release mode, which stops it writing a line per registered route, and a warning about the mode, at startup. Nothing else Gin gates on the mode is reachable from here.
