### PR TITLE
refactor(credentials): register providers only where credentials are resolved

### DIFF
--- a/charts/kargo/templates/controller/configmap.yaml
+++ b/charts/kargo/templates/controller/configmap.yaml
@@ -17,6 +17,15 @@ data:
   {{- end }}
   LOG_LEVEL: {{ quote .Values.controller.logLevel }}
   LOG_FORMAT: {{ quote .Values.controller.logFormat }}
+  {{- /*
+  The controller is the only component that resolves credentials. Since all
+  credential providers automatically register themselves at startup through
+  bare imports and all control plane components are part of the same binary,
+  the only way to prevent providers from self-registering where they are not
+  needed is to rely on an environment variable that is only set on the
+  controller.
+  */}}
+  CREDENTIAL_PROVIDERS_ENABLED: "true"
   KARGO_NAMESPACE: {{ include "kargo.dataNamespace" . }}
   SYSTEM_RESOURCES_NAMESPACE: {{ quote .Values.global.systemResources.namespace }}
   {{- if or (not .Values.controller.shardName) .Values.controller.isDefault }}

--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	stdruntime "runtime"
 	"sync"
@@ -124,6 +125,22 @@ func (o *controllerOptions) complete() {
 }
 
 func (o *controllerOptions) run(ctx context.Context) error {
+	// The controller is the only component that resolves credentials. Since all
+	// credential providers automatically register themselves at startup through
+	// bare imports and all control plane components are part of the same binary,
+	// the only way to prevent providers from self-registering where they are not
+	// needed is to rely on an environment variable that is only set on the
+	// controller.
+	//
+	// If we see here that the env var is not set, we will know that the
+	// credential providers have already NOT registered themselves. We need them
+	// to, so we're loud about it.
+	if !credentials.ProvidersEnabled() {
+		return errors.New(
+			"credential providers are not enabled; set CREDENTIAL_PROVIDERS_ENABLED=true",
+		)
+	}
+
 	kargoMgr, localClusterClient, stagesReconcilerCfg, err := o.setupKargoManager(
 		ctx,
 		stages.ReconcilerConfigFromEnv(),

--- a/pkg/credentials/acr/workload_identity.go
+++ b/pkg/credentials/acr/workload_identity.go
@@ -44,6 +44,9 @@ const (
 var acrURLRegex = regexp.MustCompile(`^([a-zA-Z0-9-]+)\.azurecr\.io/`)
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if provider := NewWorkloadIdentityProvider(context.Background()); provider != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/basic/basic.go
+++ b/pkg/credentials/basic/basic.go
@@ -12,6 +12,9 @@ const (
 )
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	provider := &CredentialProvider{}
 	credentials.DefaultProviderRegistry.MustRegister(
 		credentials.ProviderRegistration{

--- a/pkg/credentials/ecr/access_key.go
+++ b/pkg/credentials/ecr/access_key.go
@@ -24,6 +24,9 @@ const (
 )
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if provider := NewAccessKeyProvider(); provider != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/ecr/managed_identity.go
+++ b/pkg/credentials/ecr/managed_identity.go
@@ -43,6 +43,9 @@ const (
 )
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if provider := NewManagedIdentityProvider(context.Background()); provider != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/gar/service_account_key.go
+++ b/pkg/credentials/gar/service_account_key.go
@@ -22,6 +22,9 @@ const (
 )
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if provider := NewServiceAccountKeyProvider(); provider != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/gar/workload_identity_federation.go
+++ b/pkg/credentials/gar/workload_identity_federation.go
@@ -35,6 +35,9 @@ const (
 )
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if p := NewWorkloadIdentityFederationProvider(context.Background()); p != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/github/app.go
+++ b/pkg/credentials/github/app.go
@@ -44,6 +44,9 @@ const (
 var base64Regex = regexp.MustCompile(`^[a-zA-Z0-9+/]*={0,2}$`)
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	if provider := NewAppCredentialProvider(); provider != nil {
 		credentials.DefaultProviderRegistry.MustRegister(
 			credentials.ProviderRegistration{

--- a/pkg/credentials/registration.go
+++ b/pkg/credentials/registration.go
@@ -1,0 +1,21 @@
+package credentials
+
+import (
+	"github.com/akuity/kargo/pkg/os"
+	"github.com/akuity/kargo/pkg/types"
+)
+
+// ProvidersEnabled indicates whether credential providers should add themselves
+// to DefaultProviderRegistry. Every provider's init() consults this before
+// doing anything else.
+//
+// Kargo's components share a single binary, so a provider's init() runs no
+// matter which component was invoked, and deciding whether a provider applies
+// is not free: it reads configuration and, in one case, reaches for a cloud
+// provider's metadata server. Only components that resolve credentials have any
+// use for that, so the rest opt out by leaving this unset. An environment
+// variable is the only mechanism available, as init() runs before a component
+// has had any chance to say what it is.
+func ProvidersEnabled() bool {
+	return types.MustParseBool(os.GetEnv("CREDENTIAL_PROVIDERS_ENABLED", "false"))
+}

--- a/pkg/credentials/ssh/ssh.go
+++ b/pkg/credentials/ssh/ssh.go
@@ -10,6 +10,9 @@ import (
 const sshPrivateKey = "sshPrivateKey"
 
 func init() {
+	if !credentials.ProvidersEnabled() {
+		return
+	}
 	provider := &CredentialProvider{}
 	credentials.DefaultProviderRegistry.MustRegister(
 		credentials.ProviderRegistration{


### PR DESCRIPTION
Credential providers register themselves from `init()`, and deciding whether one applies is not free: each reads configuration, and GCP's reaches for the metadata server, which off GCP means a DNS lookup and a failed request. All control plane components share one binary, so that work ran in every one of them, whether or not it would ever resolve a credential. The API server's startup logs advertised as much, reporting three providers it has no use for.

Providers now register only when `CREDENTIAL_PROVIDERS_ENABLED` is set, which the chart sets on the controller alone. An environment variable is the only mechanism available, since `init()` runs before a component has had any chance to say what it is.

The controller refuses to start without it. Providers that never register would otherwise leave it resolving nothing beyond credentials stored directly in `Secret`s, and doing so silently.
