### PR TITLE
fix(ui): unblock the token renewal page's own requests

### DIFF
--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -49,7 +49,10 @@ var (
 	errInvalidToken = libhttp.ErrorStr("invalid token", http.StatusUnauthorized)
 )
 
-// exemptPaths are REST paths that don't require authentication
+// exemptPaths are REST paths that don't require authentication. The UI's fetch
+// wrapper keeps its own copy of the entries the UI calls (authExemptPaths in
+// ui/src/lib/api/custom-fetch.ts); a path added here that the UI calls should
+// be added there as well.
 var exemptPaths = map[string]struct{}{
 	"/v1beta1/system/public-server-config": {},
 	"/v1beta1/login":                       {},

--- a/ui/src/lib/api/custom-fetch.test.ts
+++ b/ui/src/lib/api/custom-fetch.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { authTokenKey, refreshTokenKey } from '../../config/auth';
+
+import { customFetch } from './custom-fetch';
+
+// The tests run in Vitest's default node environment, which has neither
+// localStorage nor window.
+const fakeLocalStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => void store.set(key, String(value)),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    }
+  };
+};
+
+// Builds an unsigned JWT whose exp is `offsetSeconds` from now. customFetch
+// only parses the payload, so a real signature is unnecessary.
+const jwt = (offsetSeconds: number) => {
+  const payload = { exp: Math.floor(Date.now() / 1000) + offsetSeconds };
+  return `header.${btoa(JSON.stringify(payload))}.signature`;
+};
+
+describe('customFetch', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let replaceMock: ReturnType<typeof vi.fn>;
+
+  const stubWindow = (pathname: string) => {
+    replaceMock = vi.fn();
+    vi.stubGlobal('window', {
+      __KARGO_BASE_PATH__: '',
+      location: { pathname, replace: replaceMock }
+    });
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', fakeLocalStorage());
+    fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    stubWindow('/');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('navigates to the renewal page when the token has expired and a refresh token exists', async () => {
+    localStorage.setItem(authTokenKey, jwt(-60));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+
+    await expect(customFetch('/v1beta1/projects')).rejects.toMatchObject({ status: 401 });
+    expect(replaceMock).toHaveBeenCalledWith('/token-renew?redirectTo=/');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not block requests to exempt endpoints on an expired token', async () => {
+    localStorage.setItem(authTokenKey, jwt(-60));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+
+    await customFetch('/v1beta1/system/public-server-config');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('ignores the query string when matching exempt endpoints', async () => {
+    localStorage.setItem(authTokenKey, jwt(-60));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+
+    await customFetch('/v1beta1/system/public-server-config?ts=1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('does not end the session on a 401 from an exempt endpoint', async () => {
+    localStorage.setItem(authTokenKey, jwt(-60));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+    fetchMock.mockResolvedValue(
+      new Response('{"error":"invalid token"}', {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    await expect(customFetch('/v1beta1/login')).rejects.toMatchObject({ status: 401 });
+    expect(localStorage.getItem(authTokenKey)).not.toBeNull();
+    expect(localStorage.getItem(refreshTokenKey)).toBe('refresh-1');
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('ends the session on a 401 received elsewhere', async () => {
+    localStorage.setItem(authTokenKey, jwt(3600));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+    fetchMock.mockResolvedValue(
+      new Response('{"error":"invalid token"}', {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    await expect(customFetch('/v1beta1/projects')).rejects.toMatchObject({ status: 401 });
+    expect(localStorage.getItem(authTokenKey)).toBeNull();
+    expect(replaceMock).toHaveBeenCalledWith('/login?redirectTo=/');
+  });
+});

--- a/ui/src/lib/api/custom-fetch.test.ts
+++ b/ui/src/lib/api/custom-fetch.test.ts
@@ -35,7 +35,7 @@ describe('customFetch', () => {
     replaceMock = vi.fn();
     vi.stubGlobal('window', {
       __KARGO_BASE_PATH__: '',
-      location: { pathname, replace: replaceMock }
+      location: { origin: 'http://localhost:3333', pathname, replace: replaceMock }
     });
   };
 
@@ -70,14 +70,32 @@ describe('customFetch', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  test('ignores the query string when matching exempt endpoints', async () => {
+  test.for([
+    ['a query string', '/v1beta1/system/public-server-config?ts=1'],
+    ['a fragment', '/v1beta1/system/public-server-config#section'],
+    ['a fragment ahead of a query string', '/v1beta1/system/public-server-config#a?ts=1'],
+    ['a trailing slash', '/v1beta1/system/public-server-config/'],
+    ['upper case', '/V1BETA1/SYSTEM/PUBLIC-SERVER-CONFIG'],
+    ['a trailing slash and a query string', '/v1beta1/system/public-server-config/?ts=1'],
+    ['dot segments', '/v1beta1/projects/../system/./public-server-config']
+  ])('matches an exempt endpoint written with %s', async ([, url]) => {
     localStorage.setItem(authTokenKey, jwt(-60));
     localStorage.setItem(refreshTokenKey, 'refresh-1');
 
-    await customFetch('/v1beta1/system/public-server-config?ts=1');
+    await customFetch(url);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('does not treat a non-exempt endpoint as exempt because of a shared prefix', async () => {
+    localStorage.setItem(authTokenKey, jwt(-60));
+    localStorage.setItem(refreshTokenKey, 'refresh-1');
+
+    await expect(customFetch('/v1beta1/login/extra')).rejects.toMatchObject({ status: 401 });
+    expect(replaceMock).toHaveBeenCalledWith('/token-renew?redirectTo=/');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test('does not end the session on a 401 from an exempt endpoint', async () => {

--- a/ui/src/lib/api/custom-fetch.ts
+++ b/ui/src/lib/api/custom-fetch.ts
@@ -36,6 +36,13 @@ const renewToken = () => {
   );
 };
 
+// The endpoints the UI calls that require no authentication. Their requests
+// must not be blocked by the token expiry check, or the renewal and login
+// pages could never fetch the public config they depend on. Every entry here
+// must be on the server's exempt list (exemptPaths in
+// pkg/server/auth_middleware.go).
+const authExemptPaths = new Set(['/v1beta1/system/public-server-config', '/v1beta1/login']);
+
 /**
  * Custom fetch function used by all generated API hooks.
  *
@@ -50,7 +57,8 @@ export const customFetch = async <T>(url: string, options?: RequestInit): Promis
   const baseUrl = getBaseUrl();
   const fullUrl = `${baseUrl}${url}`;
 
-  const token = localStorage.getItem(authTokenKey);
+  const requiresAuth = !authExemptPaths.has(url.split('?')[0]);
+  const token = requiresAuth ? localStorage.getItem(authTokenKey) : null;
   const refreshToken = localStorage.getItem(refreshTokenKey);
 
   if (token) {
@@ -103,7 +111,7 @@ export const customFetch = async <T>(url: string, options?: RequestInit): Promis
     headers
   });
 
-  if (response.status === 401) {
+  if (requiresAuth && response.status === 401) {
     logout();
   }
 

--- a/ui/src/lib/api/custom-fetch.ts
+++ b/ui/src/lib/api/custom-fetch.ts
@@ -36,12 +36,31 @@ const renewToken = () => {
   );
 };
 
+// Reduces a request URL to just its lowercased path, so that neither a query
+// string, a fragment, a dot segment, nor casing can silently defeat an
+// exemption. Resolving against the current origin is what the browser does
+// with these paths anyway, so the result is the path the server receives.
+const normalizePath = (url: string): string => {
+  try {
+    return new URL(url, window.location.origin).pathname.toLowerCase();
+  } catch {
+    // Unparseable, so it cannot match a known path. Returning the input
+    // unchanged fails closed: the caller treats it as requiring auth.
+    return url;
+  }
+};
+
 // The endpoints the UI calls that require no authentication. Their requests
 // must not be blocked by the token expiry check, or the renewal and login
 // pages could never fetch the public config they depend on. Every entry here
 // must be on the server's exempt list (exemptPaths in
-// pkg/server/auth_middleware.go).
-const authExemptPaths = new Set(['/v1beta1/system/public-server-config', '/v1beta1/login']);
+// pkg/server/auth_middleware.go). Each is registered both bare and with a
+// trailing slash, the two forms a caller could reasonably write. Entries are
+// written pre-normalized because normalizePath reads window, which is not
+// available when this module is first evaluated.
+const authExemptPaths = new Set(
+  ['/v1beta1/system/public-server-config', '/v1beta1/login'].flatMap((path) => [path, `${path}/`])
+);
 
 /**
  * Custom fetch function used by all generated API hooks.
@@ -57,7 +76,7 @@ export const customFetch = async <T>(url: string, options?: RequestInit): Promis
   const baseUrl = getBaseUrl();
   const fullUrl = `${baseUrl}${url}`;
 
-  const requiresAuth = !authExemptPaths.has(url.split('?')[0]);
+  const requiresAuth = !authExemptPaths.has(normalizePath(url));
   const token = requiresAuth ? localStorage.getItem(authTokenKey) : null;
   const refreshToken = localStorage.getItem(refreshTokenKey);
 


### PR DESCRIPTION
## Description

Closes #6746

With OIDC enabled, the UI could not renew a session: at ID token expiry it bounced through /token-renew and landed logged out on /login, without ever sending the refresh token grant.

The renewal page needs the public server config before it can run the grant. Until v1.10 it fetched that config over the unauthenticated ConnectRPC transport, so the fetch was never subject to any token checks. The v1.11 REST migration regenerated that call onto customFetch, whose pre-flight sees the expired token, starts another navigation to /token-renew, and throws before sending. The renewal page's first request is blocked by the very check that sent the user there, so renewal cannot complete no matter how often it is retried. The config query then errors, and TokenRenew responds by logging out, which also discards the refresh token. Direct visits to /login with an expired token stored trip the same check through that page's own config fetch.

customFetch now skips the token handling for endpoints that require no authentication, keeping a client-side copy of the entries the UI calls from the server's exempt list (exemptPaths in pkg/server/auth_middleware.go): the public server config and admin login. Exempt requests are sent without a token, and a 401 on them no longer ends the session.

Verified against a Dex install issuing 2m ID tokens: renewal completes at expiry (POST /token returns 200 and the session continues, matching v1.10.9 behavior on the same cluster), /login with an expired token stored no longer bounces, and admin login and its expiry logout are unaffected.

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**