### PR TITLE
docs: add Kargo CLI usage guide

### DIFF
--- a/docs/docs/40-operator-guide/10-basic-installation.md
+++ b/docs/docs/40-operator-guide/10-basic-installation.md
@@ -18,7 +18,7 @@ for steps, and
 for guidance on configuring Kargo to address common operational concerns.
 
 If you're a developer looking for instructions for installing the Kargo CLI, see
-[Installing the CLI](../50-user-guide/05-installing-the-cli/index.md).
+[Installing the CLI](../50-user-guide/05-cli/10-installation.md).
 
 :::
 

--- a/docs/docs/50-user-guide/05-cli/10-installation.md
+++ b/docs/docs/50-user-guide/05-cli/10-installation.md
@@ -18,37 +18,11 @@ the Operator Guide.
 
 To install:
 
-<Tabs groupId="os">
-<TabItem value="macos" label="macOS" default>
+1. Download the CLI binary.
 
-```shell
-brew install kargo
-```
-
-</TabItem>
-<TabItem value="linux-wsl" label="Linux or WSL">
-
-```shell
-arch=$(uname -m)
-[ "$arch" = "x86_64" ] && arch=amd64
-curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
-chmod +x kargo
-```
-
-</TabItem>
-<TabItem value="windows" label="Windows PowerShell">
-
-```shell
-Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
-```
-
-</TabItem>
-</Tabs>
-
-To download the CLI binary manually instead:
-
-1. Select the <Hlt>CLI</Hlt> tab from the left navbar of the UI. There, you can
-   select the appropriate binary for your operating system and CPU architecture.
+   The easiest method of downloading the binary is by selecting the
+   <Hlt>CLI</Hlt> tab from the left navbar of the UI. There, you can select
+   the appropriate binary for your operating system and CPU architecture.
 
    CLI downloads offered at this location will automatically match the version
    of your Kargo API server for optimum compatibility.
@@ -59,6 +33,35 @@ To download the CLI binary manually instead:
 
    ![CLI Tab in Kargo UI](../05-installing-the-cli/img/cli-installation.png)
 
-1. Complete the manual installation by moving the binary to a location in your
-   file system that is included in the value of your `PATH` environment
-   variable.
+   If you prefer, use one of the following commands to install the CLI:
+
+   <Tabs groupId="os">
+   <TabItem value="macos" label="macOS" default>
+
+   ```shell
+   brew install kargo
+   ```
+
+   </TabItem>
+   <TabItem value="linux-wsl" label="Linux or WSL">
+
+   ```shell
+   arch=$(uname -m)
+   [ "$arch" = "x86_64" ] && arch=amd64
+   curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
+   chmod +x kargo
+   ```
+
+   </TabItem>
+   <TabItem value="windows" label="Windows PowerShell">
+
+   ```shell
+   Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+   ```
+
+   </TabItem>
+   </Tabs>
+
+1. If you downloaded the binary manually, complete the installation by moving
+   it to a location in your file system that is included in the value of your
+   `PATH` environment variable.

--- a/docs/docs/50-user-guide/05-cli/10-installation.md
+++ b/docs/docs/50-user-guide/05-cli/10-installation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Installing the CLI
+sidebar_label: Installation
 ---
 
 # Installing the Kargo CLI
@@ -31,7 +31,7 @@ To install:
     (e.g. `kargo-darwin-arm64`), so be sure to rename it to simply `kargo` (or
     `kargo.exe` for Windows).
 
-    ![CLI Tab in Kargo UI](./img/cli-installation.png)
+    ![CLI Tab in Kargo UI](../05-installing-the-cli/img/cli-installation.png)
 
     If you prefer, the following commands will download the latest version of
     the CLI for your specific OS and CPU architecture and will also rename the

--- a/docs/docs/50-user-guide/05-cli/10-installation.md
+++ b/docs/docs/50-user-guide/05-cli/10-installation.md
@@ -16,7 +16,13 @@ the Operator Guide.
 
 :::
 
-To install:
+To install on macOS, use [Homebrew](https://brew.sh/):
+
+```shell
+brew install kargo
+```
+
+For other platforms, or if you prefer a manual installation:
 
 1. Download the CLI binary.
 
@@ -57,6 +63,6 @@ To install:
     </TabItem>
     </Tabs>
 
-1. Regardless of your chosen download method, complete the installation by
-   moving the binary to a location in your file system that is included in the
-   value of your `PATH` environment variable.
+1. Complete a manual installation by moving the binary to a location in your
+   file system that is included in the value of your `PATH` environment
+   variable.

--- a/docs/docs/50-user-guide/05-cli/10-installation.md
+++ b/docs/docs/50-user-guide/05-cli/10-installation.md
@@ -16,53 +16,49 @@ the Operator Guide.
 
 :::
 
-To install on macOS, use [Homebrew](https://brew.sh/):
+To install:
+
+<Tabs groupId="os">
+<TabItem value="macos" label="macOS" default>
 
 ```shell
 brew install kargo
 ```
 
-For other platforms, or if you prefer a manual installation:
+</TabItem>
+<TabItem value="linux-wsl" label="Linux or WSL">
 
-1. Download the CLI binary.
+```shell
+arch=$(uname -m)
+[ "$arch" = "x86_64" ] && arch=amd64
+curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
+chmod +x kargo
+```
 
-    The easiest method of downloading the binary is by selecting the
-    <Hlt>CLI</Hlt> tab from the left navbar of the UI. There, you can select
-    the appropriate binary for your operating system and CPU architecture.
+</TabItem>
+<TabItem value="windows" label="Windows PowerShell">
 
-    CLI downloads offered at this location will automatically match the version
-    of your Kargo API server for optimum compatibility.
+```shell
+Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
+```
 
-    Your downloaded binary will be suffixed with your OS and CPU architecture
-    (e.g. `kargo-darwin-arm64`), so be sure to rename it to simply `kargo` (or
-    `kargo.exe` for Windows).
+</TabItem>
+</Tabs>
 
-    ![CLI Tab in Kargo UI](../05-installing-the-cli/img/cli-installation.png)
+To download the CLI binary manually instead:
 
-    If you prefer, the following commands will download the latest version of
-    the CLI for your specific OS and CPU architecture and will also rename the
-    binary to `kargo` (or `kargo.exe` on Windows.)
+1. Select the <Hlt>CLI</Hlt> tab from the left navbar of the UI. There, you can
+   select the appropriate binary for your operating system and CPU architecture.
 
-    <Tabs groupId="os">
-    <TabItem value="mac-linux-wsl" label="Mac, Linux, or WSL" default>
+   CLI downloads offered at this location will automatically match the version
+   of your Kargo API server for optimum compatibility.
 
-    ```shell
-    arch=$(uname -m)
-    [ "$arch" = "x86_64" ] && arch=amd64
-    curl -L -o kargo https://github.com/akuity/kargo/releases/latest/download/kargo-"$(uname -s | tr '[:upper:]' '[:lower:]')-${arch}"
-    chmod +x kargo
-    ```
+   Your downloaded binary will be suffixed with your OS and CPU architecture
+   (e.g. `kargo-darwin-arm64`), so be sure to rename it to simply `kargo` (or
+   `kargo.exe` for Windows).
 
-    </TabItem>
-    <TabItem value="windows" label="Windows Powershell">
+   ![CLI Tab in Kargo UI](../05-installing-the-cli/img/cli-installation.png)
 
-    ```shell
-    Invoke-WebRequest -URI https://github.com/akuity/kargo/releases/latest/download/kargo-windows-amd64.exe -OutFile kargo.exe
-    ```
-
-    </TabItem>
-    </Tabs>
-
-1. Complete a manual installation by moving the binary to a location in your
+1. Complete the manual installation by moving the binary to a location in your
    file system that is included in the value of your `PATH` environment
    variable.

--- a/docs/docs/50-user-guide/05-cli/20-usage.md
+++ b/docs/docs/50-user-guide/05-cli/20-usage.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Using the CLI
+sidebar_label: Usage
 description: Learn how to use the Kargo command line interface
 ---
 
@@ -8,7 +8,7 @@ description: Learn how to use the Kargo command line interface
 The Kargo command line interface (CLI) lets you manage Kargo resources and
 promote Freight from a terminal.
 
-Before using the CLI, [install it](./index.md) and
+Before using the CLI, [install it](./10-installation.md) and
 [log in](../20-how-to-guides/10-logging-in/index.md).
 
 ## Getting help
@@ -28,7 +28,7 @@ Many commands operate on a `Project`. Specify one for an individual command
 with the `--project` option:
 
 ```shell
-kargo get stages --project=my-project
+kargo get stages --project my-project
 ```
 
 To avoid repeating the option, set a default project:
@@ -51,16 +51,16 @@ Use `kargo get` to list resources or retrieve a resource by name:
 kargo get projects
 
 # List Stages in a Project
-kargo get stages --project=my-project
+kargo get stages --project my-project
 
 # Get a Stage by name
-kargo get stages --project=my-project test
+kargo get stages --project my-project test
 
 # List Freight produced by a Warehouse
-kargo get freight --project=my-project --warehouse=my-warehouse
+kargo get freight --project my-project --warehouse my-warehouse
 
 # List Promotions for a Stage
-kargo get promotions --project=my-project --stage=test
+kargo get promotions --project my-project --stage test
 ```
 
 Run `kargo get --help` to see every resource type that can be retrieved.
@@ -72,10 +72,10 @@ select the current auto-promotion candidate from a Warehouse:
 
 ```shell
 # Promote Freight by name
-kargo promote --project=my-project --freight=abc123 --stage=test
+kargo promote --project my-project --freight abc123 --stage test
 
 # Promote Freight selected from a Warehouse
-kargo promote --project=my-project --warehouse=my-warehouse --stage=test
+kargo promote --project my-project --warehouse my-warehouse --stage test
 ```
 
 The `--warehouse` option accepts a Warehouse name, not an origin in
@@ -87,14 +87,14 @@ including selecting Freight by alias and promoting to downstream Stages.
 Use `kargo refresh` to make Kargo reconcile a resource immediately:
 
 ```shell
-kargo refresh warehouse --project=my-project my-warehouse
-kargo refresh stage --project=my-project test
+kargo refresh warehouse --project my-project my-warehouse
+kargo refresh stage --project my-project test
 ```
 
 To (re)run verification for a Stage's current Freight, use:
 
 ```shell
-kargo verify stage --project=my-project test
+kargo verify stage --project my-project test
 ```
 
 ## Apply resource definitions

--- a/docs/docs/50-user-guide/05-cli/_category_.json
+++ b/docs/docs/50-user-guide/05-cli/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "CLI",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/50-user-guide/05-installing-the-cli/10-using-the-cli.md
+++ b/docs/docs/50-user-guide/05-installing-the-cli/10-using-the-cli.md
@@ -8,8 +8,8 @@ description: Learn how to use the Kargo command line interface
 The Kargo command line interface (CLI) lets you manage Kargo resources and
 promote Freight from a terminal.
 
-Before using the CLI, [install it](./05-installing-the-cli/index.md) and
-[log in](./20-how-to-guides/10-logging-in/index.md).
+Before using the CLI, [install it](./index.md) and
+[log in](../20-how-to-guides/10-logging-in/index.md).
 
 ## Getting help
 

--- a/docs/docs/50-user-guide/07-using-the-cli.md
+++ b/docs/docs/50-user-guide/07-using-the-cli.md
@@ -1,0 +1,122 @@
+---
+sidebar_label: Using the CLI
+description: Learn how to use the Kargo command line interface
+---
+
+# Using the Kargo CLI
+
+The Kargo command line interface (CLI) lets you manage Kargo resources and
+promote Freight from a terminal.
+
+Before using the CLI, [install it](./05-installing-the-cli/index.md) and
+[log in](./20-how-to-guides/10-logging-in/index.md).
+
+## Getting help
+
+Run `kargo --help` to list all available commands. To learn about a command,
+its arguments, and its options, append `--help` to that command:
+
+```shell
+kargo promote --help
+```
+
+The CLI includes examples in the help output for many commands.
+
+## Selecting a project
+
+Many commands operate on a `Project`. Specify one for an individual command
+with the `--project` option:
+
+```shell
+kargo get stages --project=my-project
+```
+
+To avoid repeating the option, set a default project:
+
+```shell
+kargo config set-project my-project
+```
+
+View the default project with `kargo config get-project`. Use
+`kargo config set-project ""` to clear it.
+
+## Common workflows
+
+### Inspect Kargo resources
+
+Use `kargo get` to list resources or retrieve a resource by name:
+
+```shell
+# List Projects
+kargo get projects
+
+# List Stages in a Project
+kargo get stages --project=my-project
+
+# Get a Stage by name
+kargo get stages --project=my-project test
+
+# List Freight produced by a Warehouse
+kargo get freight --project=my-project --warehouse=my-warehouse
+
+# List Promotions for a Stage
+kargo get promotions --project=my-project --stage=test
+```
+
+Run `kargo get --help` to see every resource type that can be retrieved.
+
+### Promote Freight
+
+Use `kargo promote` to promote a specific piece of Freight, or to have Kargo
+select the current auto-promotion candidate from a Warehouse:
+
+```shell
+# Promote Freight by name
+kargo promote --project=my-project --freight=abc123 --stage=test
+
+# Promote Freight selected from a Warehouse
+kargo promote --project=my-project --warehouse=my-warehouse --stage=test
+```
+
+The `--warehouse` option accepts a Warehouse name, not an origin in
+`Warehouse/name` form. See `kargo promote --help` for all promotion options,
+including selecting Freight by alias and promoting to downstream Stages.
+
+### Refresh or verify resources
+
+Use `kargo refresh` to make Kargo reconcile a resource immediately:
+
+```shell
+kargo refresh warehouse --project=my-project my-warehouse
+kargo refresh stage --project=my-project test
+```
+
+To (re)run verification for a Stage's current Freight, use:
+
+```shell
+kargo verify stage --project=my-project test
+```
+
+## Apply resource definitions
+
+Use `kargo apply` to create or update resources from YAML:
+
+```shell
+kargo apply -f stage.yaml
+```
+
+Use `kargo create`, `kargo update`, and `kargo delete` when you prefer to
+manage individual resources from the command line. Run each command with
+`--help` to see supported resource types and examples.
+
+## Shell completion
+
+The CLI can generate completion scripts for Bash, Fish, PowerShell, and Zsh.
+For example, to enable Zsh completion in the current shell:
+
+```shell
+source <(kargo completion zsh)
+```
+
+Run `kargo completion --help` and `kargo completion <shell> --help` for
+installation instructions for your shell.

--- a/docs/docs/50-user-guide/20-how-to-guides/10-logging-in/index.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/10-logging-in/index.md
@@ -5,7 +5,7 @@ description: Learn how to log in to Kargo
 # Logging In
 
 Whether you wish to interact with Kargo through its web-based UI or through
-its [CLI](../../05-installing-the-cli/index.md), you will need to log in first.
+its [CLI](../../05-cli/10-installation.md), you will need to log in first.
 
 1. Obtain the address of your Kargo API server.
 

--- a/docs/docs/80-release-notes/88-v1.11.0.md
+++ b/docs/docs/80-release-notes/88-v1.11.0.md
@@ -93,7 +93,7 @@ With the CLI, the current auto-promotion candidate can be resolved automatically
 by just specifying a Warehouse instead of specific Freight:
 
 ```shell
-kargo promote --project=my-project --warehouse=my-warehouse --stage=test
+kargo promote --project my-project --warehouse my-warehouse --stage test
 ```
 
 ## ⚡ Performance & Responsiveness {#performance-responsiveness}

--- a/docs/docs/80-release-notes/88-v1.11.0.md
+++ b/docs/docs/80-release-notes/88-v1.11.0.md
@@ -93,7 +93,7 @@ With the CLI, the current auto-promotion candidate can be resolved automatically
 by just specifying a Warehouse instead of specific Freight:
 
 ```shell
-kargo promote --project my-project --stage test --origin Warehouse/my-warehouse
+kargo promote --project=my-project --warehouse=my-warehouse --stage=test
 ```
 
 ## ⚡ Performance & Responsiveness {#performance-responsiveness}


### PR DESCRIPTION
## Summary
- add a User Guide page covering essential Kargo CLI workflows and shell completion
- correct the v1.11.0 release-notes promotion command to use `--warehouse`

## Test plan
- [x] Build the docs site with `pnpm build`
- [x] Verify documented CLI commands against the latest built CLI

Made with [Cursor](https://cursor.com)