### PR TITLE
fix(controller)!: use the latest available creation time for NewestBuild

### DIFF
--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -284,10 +284,21 @@ strategies are:
 - `NewestBuild`: This strategy selects the image with the most recent build
   time.
 
-  The build time is evaluated using the labels
-  `org.opencontainers.image.created` or `org.label-schema.build-date`. If
-  neither label is set, Kargo will fall back to using the `config.Created` time
-  of the image.
+  Build time is the latest date Kargo can find for an image: any
+  `org.opencontainers.image.created` or `org.label-schema.build-date` annotation
+  or label the image carries, and the creation time recorded in the image's own
+  config.
+
+  :::note
+
+  An image carrying no build time metadata of its own may report the build time
+  of the base image it was built from, or a fixed timestamp chosen by a build
+  tool to make image digests reproducible. Images reporting identical build
+  times cannot be ordered by this strategy, so stamping each build with
+  `org.opencontainers.image.created` is the most reliable way to make it behave
+  predictably.
+
+  :::
 
   :::warning
 

--- a/pkg/image/repository_client.go
+++ b/pkg/image/repository_client.go
@@ -357,12 +357,15 @@ func (r *repositoryClient) getImageFromV1ImageIndex(
 		)
 	}
 
-	// NB: Indices do not have their own creation date, but like all other objects
-	// in a registry, are immutable, therefore an index cannot have been created
-	// any earlier than the newest of the images it references. We'll find the
-	// latest creation time among all referenced images and use that as the
-	// creation time of the index.
-	var createdAt *time.Time
+	// NB: An index carries no creation date of its own the way an image config
+	// does. It may, however, claim one in its own annotations, and each of its
+	// references may claim one for the image that reference points to. Both are
+	// recorded when the index is authored, and are preferred in that order.
+	//
+	// Failing both, an index, like all other objects in a registry, is immutable,
+	// therefore it cannot have been created any earlier than the newest of the
+	// images it references. That is the closest remaining approximation.
+	var newestRefCreatedAt *time.Time
 	platforms := make([]platform, 0, len(idxManifest.Manifests))
 	for _, ref := range idxManifest.Manifests {
 		if ref.Platform == nil ||
@@ -382,19 +385,30 @@ func (r *repositoryClient) getImageFromV1ImageIndex(
 			// This really shouldn't happen.
 			return nil, fmt.Errorf("found no image with digest %s", ref.Digest)
 		}
-		if createdAt == nil || img.CreatedAt.After(*createdAt) {
-			createdAt = img.CreatedAt
+		refCreatedAt := creationTimeFromMetadata(ref.Annotations)
+		if refCreatedAt == nil {
+			refCreatedAt = img.CreatedAt
+		}
+		if newestRefCreatedAt == nil || refCreatedAt.After(*newestRefCreatedAt) {
+			newestRefCreatedAt = refCreatedAt
 		}
 		platforms = append(platforms, platform{
 			OS:          ref.Platform.OS,
 			Arch:        ref.Platform.Architecture,
 			Variant:     ref.Platform.Variant,
-			CreatedAt:   img.CreatedAt,
+			CreatedAt:   refCreatedAt,
 			Annotations: ref.Annotations,
 		})
 	}
 	if len(platforms) == 0 {
 		return nil, errors.New("empty V2 manifest list or OCI index is not supported")
+	}
+
+	// The index's own annotations are recorded when the index is authored, so
+	// they describe the index more reliably than anything it references.
+	createdAt := creationTimeFromMetadata(idxManifest.Annotations)
+	if createdAt == nil {
+		createdAt = newestRefCreatedAt
 	}
 
 	return &image{
@@ -430,33 +444,56 @@ func (r *repositoryClient) getImageFromV1Image(
 	return &image{
 		Digest: digest,
 		CreatedAt: getCreationTime(
-			[]map[string]string{
-				manifest.Annotations,
-				cfg.Config.Labels,
-			},
-			&cfg.Created.Time,
+			manifest.Annotations,
+			cfg.Config.Labels,
+			cfg.Created.Time,
 		),
 		Annotations: manifest.Annotations,
 	}, nil
 }
 
-func getCreationTime(sources []map[string]string, fallback *time.Time) *time.Time {
-	keys := []string{ociCreatedAnnotation, legacyBuildDateAnnotation}
+// getCreationTime determines an image's creation time from the metadata
+// available for it.
+//
+// Annotations are recorded in a manifest when that manifest is authored and are
+// never copied from a base image, so a creation time claimed by an annotation
+// is used as-is.
+//
+// Labels, by contrast, are copied from the base image unless a build explicitly
+// overwrites them, so a label may describe the base image rather than the image
+// carrying it. Every way a creation time can be understated -- a label
+// describing the base image, a timestamp carried over with a reused layer, a
+// fixed timestamp chosen to make builds reproducible -- makes it earlier than
+// the truth, and none makes it later. Whichever of the label and the config's
+// own creation time is later is therefore the nearer of the two to the truth.
+func getCreationTime(
+	annotations map[string]string,
+	labels map[string]string,
+	configCreatedAt time.Time,
+) *time.Time {
+	if createdAt := creationTimeFromMetadata(annotations); createdAt != nil {
+		return createdAt
+	}
+	createdAt := configCreatedAt
+	if labelCreatedAt := creationTimeFromMetadata(labels); labelCreatedAt != nil &&
+		labelCreatedAt.After(createdAt) {
+		createdAt = *labelCreatedAt
+	}
+	return &createdAt
+}
 
-	for _, source := range sources {
-		if source == nil {
-			continue
-		}
-		for _, key := range keys {
-			if createdStr, ok := source[key]; ok {
-				if created, err := time.Parse(time.RFC3339, createdStr); err == nil {
-					return &created
-				}
+// creationTimeFromMetadata returns the creation time claimed by the first
+// recognized key in the provided annotations or labels to have a parsable
+// value. It returns nil if there is none.
+func creationTimeFromMetadata(metadata map[string]string) *time.Time {
+	for _, key := range []string{ociCreatedAnnotation, legacyBuildDateAnnotation} {
+		if createdStr, ok := metadata[key]; ok {
+			if created, err := time.Parse(time.RFC3339, createdStr); err == nil {
+				return &created
 			}
 		}
 	}
-
-	return fallback
+	return nil
 }
 
 // rateLimitedRoundTripper is a rate limited implementation of

--- a/pkg/image/repository_client_test.go
+++ b/pkg/image/repository_client_test.go
@@ -531,6 +531,111 @@ func Test_repositoryClient_getImageFromV1ImageIndex(t *testing.T) {
 				require.Equal(t, "Test Vendor", img.Annotations["org.opencontainers.image.vendor"])
 			},
 		},
+		{
+			name: "creation time is taken from the index's own annotations",
+			idx: &mockImageIndex{
+				indexManifest: &v1.IndexManifest{
+					Manifests: []v1.Descriptor{{
+						Platform: &v1.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+					}},
+					Annotations: map[string]string{
+						ociCreatedAnnotation: "2023-03-01T00:00:00Z",
+					},
+				},
+			},
+			client: &repositoryClient{
+				getImageByDigestFn: func(context.Context, string) (*image, error) {
+					return &image{
+						Digest:    testDigest,
+						CreatedAt: ptr.To(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+					}, nil
+				},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime, err := time.Parse(time.RFC3339, "2023-03-01T00:00:00Z")
+				require.NoError(t, err)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+			},
+		},
+		{
+			name: "creation time is taken from a reference's annotations",
+			idx: &mockImageIndex{
+				indexManifest: &v1.IndexManifest{
+					Manifests: []v1.Descriptor{{
+						Platform: &v1.Platform{
+							OS:           "linux",
+							Architecture: "amd64",
+						},
+						Annotations: map[string]string{
+							ociCreatedAnnotation: "2023-02-01T00:00:00Z",
+						},
+					}},
+				},
+			},
+			client: &repositoryClient{
+				getImageByDigestFn: func(context.Context, string) (*image, error) {
+					return &image{
+						Digest:    testDigest,
+						CreatedAt: ptr.To(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+					}, nil
+				},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime, err := time.Parse(time.RFC3339, "2023-02-01T00:00:00Z")
+				require.NoError(t, err)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+				require.Len(t, img.Platforms, 1)
+				require.Equal(t, expectedTime, *img.Platforms[0].CreatedAt)
+			},
+		},
+		{
+			name: "creation time falls back to the newest referenced image",
+			idx: &mockImageIndex{
+				indexManifest: &v1.IndexManifest{
+					Manifests: []v1.Descriptor{
+						{
+							Digest: v1.Hash{Algorithm: "sha256", Hex: "aa"},
+							Platform: &v1.Platform{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+						},
+						{
+							Digest: v1.Hash{Algorithm: "sha256", Hex: "bb"},
+							Platform: &v1.Platform{
+								OS:           "linux",
+								Architecture: "arm64",
+							},
+						},
+					},
+				},
+			},
+			client: &repositoryClient{
+				getImageByDigestFn: func(_ context.Context, digest string) (*image, error) {
+					createdAt := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+					if digest == "sha256:bb" {
+						createdAt = time.Date(2023, 4, 1, 0, 0, 0, 0, time.UTC)
+					}
+					return &image{
+						Digest:    digest,
+						CreatedAt: &createdAt,
+					}, nil
+				},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime := time.Date(2023, 4, 1, 0, 0, 0, 0, time.UTC)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -781,6 +886,77 @@ func Test_repositoryClient_getImageFromV1Image(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, img)
 				expectedTime := time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+			},
+		},
+		{
+			// A label inherited from a base image describes the base image, which
+			// cannot have been created any later than the image built from it.
+			name: "config.Created is used when it is later than the OCI label",
+			img: &mockImage{
+				configFile: &v1.ConfigFile{
+					Created: v1.Time{Time: time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)},
+					Config: v1.Config{
+						Labels: map[string]string{
+							ociCreatedAnnotation: "2023-01-01T00:00:00Z",
+						},
+					},
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+				manifest: &v1.Manifest{},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime := time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+			},
+		},
+		{
+			// Some build tools write a fixed timestamp to the config so that
+			// identical inputs produce an identical digest.
+			name: "OCI label is used when it is later than config.Created",
+			img: &mockImage{
+				configFile: &v1.ConfigFile{
+					Created: v1.Time{},
+					Config: v1.Config{
+						Labels: map[string]string{
+							ociCreatedAnnotation: "2023-05-01T00:00:00Z",
+						},
+					},
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+				manifest: &v1.Manifest{},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime, err := time.Parse(time.RFC3339, "2023-05-01T00:00:00Z")
+				require.NoError(t, err)
+				require.Equal(t, expectedTime, *img.CreatedAt)
+			},
+		},
+		{
+			name: "annotation is used even when config.Created is later",
+			img: &mockImage{
+				configFile: &v1.ConfigFile{
+					Created:      v1.Time{Time: time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)},
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+				manifest: &v1.Manifest{
+					Annotations: map[string]string{
+						ociCreatedAnnotation: "2023-01-01T00:00:00Z",
+					},
+				},
+			},
+			assertions: func(t *testing.T, img *image, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, img)
+				expectedTime, err := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")
+				require.NoError(t, err)
 				require.Equal(t, expectedTime, *img.CreatedAt)
 			},
 		},


### PR DESCRIPTION
An image's creation time was taken from an `org.opencontainers.image.created` or `org.label-schema.build-date` label in preference to the creation time recorded in its config. Labels are copied from the base image unless a build overwrites them, so an image that sets no label of its own reports the build time of the image it was built from.

`ubuntu:26.04` -- and therefore `ubuntu:latest` -- carries such a label; `ubuntu:24.04` did not. Every image built from one of these between two republishes of the base reports an identical creation time. `NewestBuild` then sorts on a tie, falls back to reverse-lexical tag order, and truncates to `discoveryLimit`, so new images can go undiscovered rather than merely mis-ranked.

Separately, annotations on an index, and on an index's references to the images it contains, were read for display but never for creation time. Multi-arch builds annotated with `buildx --annotation index:...` got no benefit from them.

Creation time is now taken from the outermost metadata that claims one -- an index's annotations, then an index's reference to an image, then the image's own manifest -- and, failing all of those, from the later of the config's creation time and any claim in its labels. No object in a registry can be older than anything referencing it, and every way one of these timestamps goes wrong understates it: a label copied from a base image, a timestamp carried over with a reused layer, a fixed timestamp chosen to make digests reproducible. Taking the outermost claim, and otherwise the later of the two remaining, amounts to using the latest date available.

Verified against a local registry with images built to exhibit each shape: base image label inheritance, index-only annotations, a reproducible build with a fixed config timestamp, and all four metadata locations populated at once.

Note for upgrades: images that were previously mis-ranked, or truncated away by `discoveryLimit`, may become visible. On a `Warehouse` with auto-promotion enabled, that can trigger promotions for images that already existed. This is why this fix will not be back ported to v1.11.x and will, instead, ship with v1.12.0.

Refs: #4635, #4636, #5179

cc @34fathombelow
