### PR TITLE
fix(ui): handle non-JSON AnalysisRun measurement values

### DIFF
--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -24,7 +24,8 @@ import {
   metricStatusLabel,
   metricSubstatus,
   printableCloudWatchQuery,
-  printableDatadogQuery
+  printableDatadogQuery,
+  transformMeasurements
 } from './transforms';
 import { AnalysisStatus, FunctionalStatus } from './types';
 
@@ -557,6 +558,21 @@ describe('analysis modal transforms', () => {
       canChart: false,
       chartValue: { latency: null, cpuUsage: null },
       tableValue: { latency: null, cpuUsage: null }
+    });
+  });
+
+  test('transformMeasurements() with a plain, non-JSON string measurement value', () => {
+    expect(transformMeasurements([], [{ value: 'kargo' }])).toEqual({
+      chartable: false,
+      min: 0,
+      max: null,
+      measurements: [
+        {
+          value: 'kargo',
+          chartValue: undefined,
+          tableValue: 'kargo'
+        }
+      ]
     });
   });
 });

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -783,7 +783,17 @@ const transformMeasurementValue = (
     };
   }
 
-  const parsedValue = JSON.parse(value);
+  let parsedValue;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    // providers such as web can return a plain, non-JSON string (e.g. "ok") --
+    // display it as-is rather than failing to render the measurement
+    return {
+      canChart: false,
+      tableValue: value
+    };
+  }
 
   // single number measurement value
   if (isFiniteNumber(parsedValue)) {


### PR DESCRIPTION
## Summary
- `transformMeasurementValue()` in the analysis modal called `JSON.parse()` on every metric measurement value unconditionally. Providers such as `web` can return a plain-text response (not JSON), which throws inside the `useMemo()` that builds the AnalysisRun chart/table data and leaves the panel unable to open (a brief "flash" with no further UI, per the console error in the issue).
- Catch the parse failure and fall back to displaying the raw string in the table, non-chartable — consistent with how other unsupported value shapes are already handled in this function.
- Added a unit test covering a plain, non-JSON string measurement value.

Fixes #6785

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (targeted eslint run on changed files)
- [x] `pnpm test` (`vitest run`) — 187/187 passing, including new test case