### PR TITLE
fix(ui): Plain text crashes verification window

### DIFF
--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -24,7 +24,8 @@ import {
   metricStatusLabel,
   metricSubstatus,
   printableCloudWatchQuery,
-  printableDatadogQuery
+  printableDatadogQuery,
+  transformMeasurements
 } from './transforms';
 import { AnalysisStatus, FunctionalStatus } from './types';
 
@@ -557,6 +558,17 @@ describe('analysis modal transforms', () => {
       canChart: false,
       chartValue: { latency: null, cpuUsage: null },
       tableValue: { latency: null, cpuUsage: null }
+    });
+  });
+
+  test('transformMeasurements() with a non-JSON string measurement value', () => {
+    // a provider may return a plain string (e.g. "kargo") that is not valid JSON;
+    // this should not throw -- the value is placed in the table as-is
+    expect(transformMeasurements([], [{ value: 'kargo' }])).toEqual({
+      chartable: false,
+      min: 0,
+      max: null,
+      measurements: [{ value: 'kargo', chartValue: null, tableValue: 'kargo' }]
     });
   });
 });

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -783,7 +783,17 @@ const transformMeasurementValue = (
     };
   }
 
-  const parsedValue = JSON.parse(value);
+  let parsedValue;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    // value is a plain string (not JSON) -- not chartable
+    return {
+      canChart: false,
+      chartValue: null,
+      tableValue: value
+    };
+  }
 
   // single number measurement value
   if (isFiniteNumber(parsedValue)) {


### PR DESCRIPTION
When you have a check which is basic text Kargo is trying to parse it as JSON, but for plain text that fails, meaning that then you can't view the result. This fails safely back to just returning the basic value.

<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #4630


## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure


This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**
