### PR TITLE
fix(ui): tolerate non-JSON AnalysisRun measurement values

### DIFF
--- a/ui/src/features/common/analysis-modal/transforms.test.ts
+++ b/ui/src/features/common/analysis-modal/transforms.test.ts
@@ -24,7 +24,8 @@ import {
   metricStatusLabel,
   metricSubstatus,
   printableCloudWatchQuery,
-  printableDatadogQuery
+  printableDatadogQuery,
+  transformMeasurements
 } from './transforms';
 import { AnalysisStatus, FunctionalStatus } from './types';
 
@@ -557,6 +558,45 @@ describe('analysis modal transforms', () => {
       canChart: false,
       chartValue: { latency: null, cpuUsage: null },
       tableValue: { latency: null, cpuUsage: null }
+    });
+  });
+
+  // Regression: a provider that returns plain text (the web provider passes a
+  // text/plain body through unchanged) used to throw a SyntaxError out of
+  // JSON.parse and take the whole analysis modal down with it.
+  test('transformMeasurements() with a plain text measurement value', () => {
+    expect(transformMeasurements([], [{ value: 'PASS' }])).toEqual({
+      chartable: false,
+      min: 0,
+      max: null,
+      measurements: [{ value: 'PASS', chartValue: null, tableValue: 'PASS' }]
+    });
+  });
+  test('transformMeasurements() with a malformed JSON measurement value', () => {
+    expect(transformMeasurements([], [{ value: '{"cpuUsage":' }])).toEqual({
+      chartable: false,
+      min: 0,
+      max: null,
+      measurements: [{ value: '{"cpuUsage":', chartValue: null, tableValue: '{"cpuUsage":' }]
+    });
+  });
+  test('transformMeasurements() still parses a valid JSON measurement value', () => {
+    expect(transformMeasurements([], [{ value: '500' }])).toEqual({
+      chartable: true,
+      min: 0,
+      max: 500,
+      measurements: [{ value: '500', chartValue: 500, tableValue: 500 }]
+    });
+  });
+  test('transformMeasurements() with both parseable and unparseable values', () => {
+    expect(transformMeasurements([], [{ value: '500' }, { value: 'PASS' }])).toEqual({
+      chartable: false,
+      min: 0,
+      max: 500,
+      measurements: [
+        { value: '500', chartValue: 500, tableValue: 500 },
+        { value: 'PASS', chartValue: null, tableValue: 'PASS' }
+      ]
     });
   });
 });

--- a/ui/src/features/common/analysis-modal/transforms.ts
+++ b/ui/src/features/common/analysis-modal/transforms.ts
@@ -783,7 +783,19 @@ const transformMeasurementValue = (
     };
   }
 
-  const parsedValue = JSON.parse(value);
+  let parsedValue;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    // Providers are not obliged to return JSON. The web provider, for one,
+    // passes a plain text response through untouched. Such a value cannot be
+    // charted, but it is still worth surfacing in the table as-is.
+    return {
+      canChart: false,
+      chartValue: null,
+      tableValue: value
+    };
+  }
 
   // single number measurement value
   if (isFiniteNumber(parsedValue)) {


### PR DESCRIPTION
## Description

Closes #4630

Argo Rollouts' `web` provider passes a plain text response body through unchanged, so an AnalysisRun measurement value is not guaranteed to be JSON. `transformMeasurementValue` called `JSON.parse` without a guard, so clicking an AnalysisRun under a Stage's Verifications tab failed with `SyntaxError: Unexpected token 'P', "PASS" is not valid JSON` and the analysis modal did not render at all.

An unparseable value is now treated as a non-chartable table value, surfacing the raw string rather than discarding it. This is consistent with how the function already handles unsupported formats a few lines below (`// unsupported formats are stringified and put into table`).

Verified the added tests fail without the fix, reproducing the reporter's exact `SyntaxError`, and pass with it. Full UI suite passes (190 tests); `lint-ui` and `typecheck-ui` are clean.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)