### PR TITLE
feat(cli): remember the SSO callback port across logins

### DIFF
--- a/pkg/cli/cmd/login/login.go
+++ b/pkg/cli/cmd/login/login.go
@@ -83,6 +83,14 @@ kargo login https://kargo.example.com --kubeconfig
 # Log in using the local kubeconfig and ignore cert warnings
 kargo login https://kargo.example.com --kubeconfig --insecure-skip-tls-verify
 `),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// A login method must be specified unless we're falling back on a stored
+			// one, which only happens when no server address is specified.
+			if len(args) == 1 || cmdOpts.Config.AuthMethod == "" {
+				cmd.MarkFlagsOneRequired("admin", "kubeconfig", "sso")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdOpts.complete(args)
 
@@ -118,40 +126,35 @@ func (o *loginOptions) addFlags(cmd *cobra.Command) {
 		"Port to use for the callback URL; 0 selects any available, unprivileged port. "+
 			"Only used when --sso is specified.")
 
-	// If we do not have a saved configuration, we require the user to specify a
-	// login method. If we do have a saved configuration, we allow the user to
-	// omit the login method and use the last used method.
-	if o.Config.AuthMethod == "" {
-		cmd.MarkFlagsOneRequired("admin", "kubeconfig", "sso")
-	}
-
 	cmd.MarkFlagsMutuallyExclusive("admin", "kubeconfig", "sso")
 }
 
 // complete sets the options from the command arguments.
 func (o *loginOptions) complete(args []string) {
-	// Use the API address in config as a default address
-	o.ServerAddress = o.Config.APIAddress
 	if len(args) == 1 {
 		o.ServerAddress = normalizeURL(args[0])
 	}
-
-	// If no port was specified, reuse any port stored in the configuration,
-	// provided we're logging in to the same server it was stored for.
-	if o.CallbackPort == 0 && o.ServerAddress == o.Config.APIAddress {
-		o.CallbackPort = o.Config.CallbackPort
-	}
-
-	// If no auth method flag was explicitly set, use the stored method
-	if !o.UseAdmin && !o.UseKubeconfig && !o.UseSSO && o.Config.AuthMethod != "" {
-		switch o.Config.AuthMethod {
-		case authMethodAdmin:
-			o.UseAdmin = true
-		case authMethodKubeconfig:
-			o.UseKubeconfig = true
-		case authMethodSSO:
-			o.UseSSO = true
+	// If a server address was not specified, but one is stored in the
+	// configuration, inherit it from the configuration. Only if doing so, also
+	// inherit other login options from the configuration.
+	if o.ServerAddress == "" && o.Config.APIAddress != "" {
+		o.ServerAddress = o.Config.APIAddress
+		if !o.UseAdmin && !o.UseKubeconfig && !o.UseSSO && o.Config.AuthMethod != "" {
+			switch o.Config.AuthMethod {
+			case authMethodAdmin:
+				o.UseAdmin = true
+			case authMethodKubeconfig:
+				o.UseKubeconfig = true
+			case authMethodSSO:
+				o.UseSSO = true
+			}
 		}
+		if o.CallbackPort == 0 {
+			o.CallbackPort = o.Config.CallbackPort
+		}
+		// Note: We deliberately do NOT inherit o.InsecureTLS from the stored config
+		// because we want to force the user to re-assess that choice each time they
+		// log in.
 	}
 }
 

--- a/pkg/cli/cmd/login/login.go
+++ b/pkg/cli/cmd/login/login.go
@@ -136,6 +136,12 @@ func (o *loginOptions) complete(args []string) {
 		o.ServerAddress = normalizeURL(args[0])
 	}
 
+	// If no port was specified, reuse any port stored in the configuration,
+	// provided we're logging in to the same server it was stored for.
+	if o.CallbackPort == 0 && o.ServerAddress == o.Config.APIAddress {
+		o.CallbackPort = o.Config.CallbackPort
+	}
+
 	// If no auth method flag was explicitly set, use the stored method
 	if !o.UseAdmin && !o.UseKubeconfig && !o.UseSSO && o.Config.AuthMethod != "" {
 		switch o.Config.AuthMethod {
@@ -214,6 +220,7 @@ func (o *loginOptions) run(ctx context.Context) error {
 	o.Config.BearerToken = bearerToken
 	o.Config.RefreshToken = refreshToken
 	o.Config.InsecureSkipTLSVerify = o.InsecureTLS
+	o.Config.CallbackPort = o.CallbackPort
 
 	if err = libConfig.SaveCLIConfig(o.Config); err != nil {
 		return fmt.Errorf("error persisting configuration: %w", err)

--- a/pkg/cli/cmd/login/login_test.go
+++ b/pkg/cli/cmd/login/login_test.go
@@ -25,7 +25,7 @@ func Test_loginOptions_complete(t *testing.T) {
 		assert func(*testing.T, *loginOptions)
 	}{
 		{
-			name: "no stored config and no port specified",
+			name: "server specified with no stored config",
 			args: []string{"kargo.example.com"},
 			assert: func(t *testing.T, o *loginOptions) {
 				require.Equal(t, "https://kargo.example.com", o.ServerAddress)
@@ -33,7 +33,7 @@ func Test_loginOptions_complete(t *testing.T) {
 			},
 		},
 		{
-			name: "stored server address, auth method, and port are reused",
+			name: "stored options are inherited when no server is specified",
 			config: libConfig.CLIConfig{
 				APIAddress:   "https://kargo.example.com",
 				AuthMethod:   authMethodSSO,
@@ -42,17 +42,6 @@ func Test_loginOptions_complete(t *testing.T) {
 			assert: func(t *testing.T, o *loginOptions) {
 				require.Equal(t, "https://kargo.example.com", o.ServerAddress)
 				require.True(t, o.UseSSO)
-				require.Equal(t, 8085, o.CallbackPort)
-			},
-		},
-		{
-			name: "stored port is reused when the same server is specified",
-			config: libConfig.CLIConfig{
-				APIAddress:   "https://kargo.example.com",
-				CallbackPort: 8085,
-			},
-			args: []string{"https://kargo.example.com"},
-			assert: func(t *testing.T, o *loginOptions) {
 				require.Equal(t, 8085, o.CallbackPort)
 			},
 		},
@@ -68,13 +57,31 @@ func Test_loginOptions_complete(t *testing.T) {
 			},
 		},
 		{
-			name: "stored port is not reused for a different server",
+			name: "stored options are not inherited when a server is specified",
 			config: libConfig.CLIConfig{
 				APIAddress:   "https://kargo.example.com",
+				AuthMethod:   authMethodSSO,
 				CallbackPort: 8085,
 			},
-			args: []string{"https://kargo.other.com"},
+			args: []string{"https://kargo.example.org"},
 			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, "https://kargo.example.org", o.ServerAddress)
+				require.False(t, o.UseSSO)
+				require.Zero(t, o.CallbackPort)
+			},
+		},
+		{
+			name: "stored options are not inherited even when the specified " +
+				"server matches the stored one",
+			config: libConfig.CLIConfig{
+				APIAddress:   "https://kargo.example.com",
+				AuthMethod:   authMethodSSO,
+				CallbackPort: 8085,
+			},
+			args: []string{"https://kargo.example.com"},
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, "https://kargo.example.com", o.ServerAddress)
+				require.False(t, o.UseSSO)
 				require.Zero(t, o.CallbackPort)
 			},
 		},

--- a/pkg/cli/cmd/login/login_test.go
+++ b/pkg/cli/cmd/login/login_test.go
@@ -12,7 +12,85 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	libConfig "github.com/akuity/kargo/pkg/cli/config"
 )
+
+func Test_loginOptions_complete(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config libConfig.CLIConfig
+		args   []string
+		port   int
+		assert func(*testing.T, *loginOptions)
+	}{
+		{
+			name: "no stored config and no port specified",
+			args: []string{"kargo.example.com"},
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, "https://kargo.example.com", o.ServerAddress)
+				require.Zero(t, o.CallbackPort)
+			},
+		},
+		{
+			name: "stored server address, auth method, and port are reused",
+			config: libConfig.CLIConfig{
+				APIAddress:   "https://kargo.example.com",
+				AuthMethod:   authMethodSSO,
+				CallbackPort: 8085,
+			},
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, "https://kargo.example.com", o.ServerAddress)
+				require.True(t, o.UseSSO)
+				require.Equal(t, 8085, o.CallbackPort)
+			},
+		},
+		{
+			name: "stored port is reused when the same server is specified",
+			config: libConfig.CLIConfig{
+				APIAddress:   "https://kargo.example.com",
+				CallbackPort: 8085,
+			},
+			args: []string{"https://kargo.example.com"},
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, 8085, o.CallbackPort)
+			},
+		},
+		{
+			name: "specified port overrides stored port",
+			config: libConfig.CLIConfig{
+				APIAddress:   "https://kargo.example.com",
+				CallbackPort: 8085,
+			},
+			port: 9090,
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Equal(t, 9090, o.CallbackPort)
+			},
+		},
+		{
+			name: "stored port is not reused for a different server",
+			config: libConfig.CLIConfig{
+				APIAddress:   "https://kargo.example.com",
+				CallbackPort: 8085,
+			},
+			args: []string{"https://kargo.other.com"},
+			assert: func(t *testing.T, o *loginOptions) {
+				require.Zero(t, o.CallbackPort)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			o := &loginOptions{
+				Config:       testCase.config,
+				CallbackPort: testCase.port,
+			}
+			o.complete(testCase.args)
+			testCase.assert(t, o)
+		})
+	}
+}
 
 func TestReceiveAuthCode(t *testing.T) {
 	const (

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -69,6 +69,11 @@ type CLIConfig struct {
 	// re-authenticates. When true, refresh tokens will not be used, thereby
 	// forcing users to periodically re-assess this choice.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+	// CallbackPort is the port to use for the callback URL during SSO login.
+	// This is only set when the user explicitly specified a port during login
+	// and is reused by subsequent SSO logins to the same server unless
+	// overridden.
+	CallbackPort int `json:"callbackPort,omitempty"`
 	// Project is the default Project for the command.
 	Project string `json:"project,omitempty"`
 }
@@ -159,6 +164,7 @@ func MaskedConfig(config CLIConfig) CLIConfig {
 		BearerToken:           dataMask,
 		RefreshToken:          dataMask,
 		InsecureSkipTLSVerify: config.InsecureSkipTLSVerify,
+		CallbackPort:          config.CallbackPort,
 		Project:               config.Project,
 	}
 }

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -118,6 +118,7 @@ func TestMaskedConfig(t *testing.T) {
 		BearerToken:           "secret",
 		RefreshToken:          "secret",
 		InsecureSkipTLSVerify: true,
+		CallbackPort:          8085,
 		Project:               "project",
 	}
 	maskedConfig := MaskedConfig(testConfig)
@@ -126,6 +127,7 @@ func TestMaskedConfig(t *testing.T) {
 	require.Equal(t, dataMask, maskedConfig.BearerToken)
 	require.Equal(t, dataMask, maskedConfig.RefreshToken)
 	require.Equal(t, true, maskedConfig.InsecureSkipTLSVerify)
+	require.Equal(t, 8085, maskedConfig.CallbackPort)
 	require.Equal(t, "project", maskedConfig.Project)
 }
 


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #6800

When `--port` is specified during SSO login, persist it in the CLI configuration (as an optional `callbackPort` field) and reuse it on subsequent logins to the same server, the same way the server address and auth method are already remembered.

- `kargo login <server> --sso --port 8085` saves the port alongside the auth method and server address; a later bare `kargo login` reuses all three.
- Specifying `--port` again overrides and saves the new value.
- When no port was ever specified, nothing is stored and the CLI keeps selecting a random unprivileged port (current behavior, unchanged).
- The stored port is scoped to the server address it was saved for; logging in to a different server does not reuse it.

This helps with OIDC identity providers that require redirect URIs to be registered exactly, including the port (e.g. Azure AD / Entra ID, Okta), where users previously had to re-specify `--port` on every interactive re-login.

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
