### PR TITLE
feat: create PromotionRequests for target-aware Stages

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -142,11 +142,13 @@ func AddMigrationAnnotationValue(obj client.Object, migrationType string) {
 
 // SetCreateActorAnnotation stamps promo with AnnotationKeyCreateActor set to
 // actor. It initializes the annotations map if necessary.
-func SetCreateActorAnnotation(promo *kargoapi.Promotion, actor string) {
-	if promo.Annotations == nil {
-		promo.Annotations = make(map[string]string)
+func SetCreateActorAnnotation(obj client.Object, actor string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
 	}
-	promo.Annotations[kargoapi.AnnotationKeyCreateActor] = actor
+	annotations[kargoapi.AnnotationKeyCreateActor] = actor
+	obj.SetAnnotations(annotations)
 }
 
 // CreateActorAnnotationValue extracts the v1alpha1.AnnotationKeyCreateActor

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -28,10 +28,11 @@ const (
 	// embedded in a generated Promotion name.
 	promotionShortHashLength = 7
 
-	// maxStageNamePrefixForPromotionName is the maximum length of the Stage
-	// name used as the prefix of a generated Promotion name before it would
-	// exceed the Kubernetes resource name limit of 253.
-	maxStageNamePrefixForPromotionName = 253 -
+	// maxPrefixForPromotionName is the maximum length of the descriptive prefix
+	// of a generated Promotion name -- the Stage name, or the Stage and Target
+	// names together -- before the name would exceed the Kubernetes resource
+	// name limit of 253.
+	maxPrefixForPromotionName = 253 -
 		len(promotionNameSeparator) - ulid.EncodedSize -
 		len(promotionNameSeparator) - promotionShortHashLength
 )
@@ -89,7 +90,15 @@ func NewMinimalPromotionForOrigin(
 // in this format -- the embedded ULID makes lex order match creation order.
 // Callers that need a Promotion name should always use this function.
 func GeneratePromotionName(stageName, freight string) string {
-	if stageName == "" || freight == "" {
+	return generatePromotionStyleName(stageName, freight)
+}
+
+// generatePromotionStyleName generates a name of the form
+// <prefix>.<ulid>.<short-hash> for a resource that promotes a piece of Freight.
+// The embedded ULID makes lex order match creation order, which sorting logic
+// elsewhere in Kargo relies on.
+func generatePromotionStyleName(prefix, freight string) string {
+	if prefix == "" || freight == "" {
 		return ""
 	}
 
@@ -98,12 +107,16 @@ func GeneratePromotionName(stageName, freight string) string {
 		shortHash = shortHash[0:promotionShortHashLength]
 	}
 
-	shortStageName := stageName
-	if len(stageName) > maxStageNamePrefixForPromotionName {
-		shortStageName = shortStageName[0:maxStageNamePrefixForPromotionName]
+	if len(prefix) > maxPrefixForPromotionName {
+		// Truncation can land on a separator or hyphen, neither of which a
+		// Kubernetes resource name may end with.
+		prefix = strings.TrimRight(
+			prefix[0:maxPrefixForPromotionName],
+			promotionNameSeparator+"-",
+		)
 	}
 
-	parts := []string{shortStageName, ulid.Make().String(), shortHash}
+	parts := []string{prefix, ulid.Make().String(), shortHash}
 	return strings.ToLower(strings.Join(parts, promotionNameSeparator))
 }
 

--- a/pkg/api/promotion_request.go
+++ b/pkg/api/promotion_request.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// GeneratePromotionRequestName generates a name for a PromotionRequest by
+// combining the Stage name, a ULID, and a short hash of the Freight, in the
+// same format used for Promotion names. Callers that need a PromotionRequest
+// name should always use this function.
+func GeneratePromotionRequestName(stageName, freight string) string {
+	return generatePromotionStyleName(stageName, freight)
+}
+
+// GenerateChildPromotionName generates a name for a Promotion created by a
+// PromotionRequest to promote Freight to one of its Targets.
+//
+// The name has the format of:
+//
+//	<stage-name>.<target-name>.<ulid>.<short-hash>
+//
+// Naming a child after its Target makes the fan-out legible at a glance and
+// greppable by Target. The ULID and Freight hash are retained so that repeated
+// promotions to the same Target do not collide, and so that lex order continues
+// to match creation order as it does for every other Promotion.
+func GenerateChildPromotionName(stageName, targetName, freight string) string {
+	if stageName == "" || targetName == "" {
+		return ""
+	}
+	return generatePromotionStyleName(
+		stageName+promotionNameSeparator+targetName,
+		freight,
+	)
+}
+
+// NewPromotionRequest constructs a PromotionRequest expressing the intent to
+// promote the given Freight to the Targets the Stage governs.
+//
+// The Stage's target selectors are resolved to concrete Targets here, once, and
+// the result recorded in spec.targets. That list is never recomputed: a
+// PromotionRequest is a snapshot of what the Stage governed at this moment, so
+// its threshold and terminal state are computed against a fixed set rather than
+// a selector that could match differently later. A Target that appears after
+// this point is picked up by a subsequent PromotionRequest, not by re-resolving
+// this one.
+//
+// The Stage is set as the controlling owner, so its PromotionRequests are
+// garbage-collected with it.
+//
+// The Stage MUST be target-aware. Callers should gate on IsTargetAware.
+func NewPromotionRequest(
+	ctx context.Context,
+	c client.Client,
+	stage *kargoapi.Stage,
+	freightName string,
+) (*kargoapi.PromotionRequest, error) {
+	targets, err := ListTargetsForStage(ctx, c, stage)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error resolving Targets governed by Stage %q in namespace %q: %w",
+			stage.Name, stage.Namespace, err,
+		)
+	}
+
+	// Never nil: spec.targets is a required field, so a nil slice would
+	// serialize as null and be rejected. An empty list is meaningful -- it
+	// records that the Stage governed no Targets at this moment.
+	specTargets := make([]kargoapi.PromotionRequestTarget, len(targets))
+	for i, target := range targets {
+		specTargets[i] = kargoapi.PromotionRequestTarget{Name: target.Name}
+	}
+
+	labels := map[string]string{kargoapi.LabelKeyStage: stage.Name}
+	// The PromotionRequest reconciler filters by shard, so a PromotionRequest
+	// must carry the shard of the Stage that it promotes on behalf of. Without
+	// this, only the default controller would ever reconcile it.
+	if stage.Spec.Shard != "" {
+		labels[kargoapi.LabelKeyShard] = stage.Spec.Shard
+	}
+
+	return &kargoapi.PromotionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: stage.Namespace,
+			Name:      GeneratePromotionRequestName(stage.Name, freightName),
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(
+					stage,
+					kargoapi.GroupVersion.WithKind("Stage"),
+				),
+			},
+		},
+		Spec: kargoapi.PromotionRequestSpec{
+			Stage:   stage.Name,
+			Freight: freightName,
+			Targets: specTargets,
+		},
+	}, nil
+}

--- a/pkg/api/promotion_request_test.go
+++ b/pkg/api/promotion_request_test.go
@@ -1,0 +1,362 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func TestGeneratePromotionRequestName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		stageName  string
+		freight    string
+		assertions func(*testing.T, string)
+	}{
+		{
+			name:      "empty Stage name",
+			stageName: "",
+			freight:   "fake-freight",
+			assertions: func(t *testing.T, name string) {
+				require.Empty(t, name)
+			},
+		},
+		{
+			name:      "empty Freight",
+			stageName: "fake-stage",
+			freight:   "",
+			assertions: func(t *testing.T, name string) {
+				require.Empty(t, name)
+			},
+		},
+		{
+			name:      "Stage name and short Freight hash",
+			stageName: "fake-stage",
+			freight:   "abcdef1234567890",
+			assertions: func(t *testing.T, name string) {
+				parts := strings.Split(name, ".")
+				require.Len(t, parts, 3)
+				require.Equal(t, "fake-stage", parts[0])
+				require.Equal(t, "abcdef1", parts[2])
+			},
+		},
+		{
+			name:      "over-long Stage name is truncated",
+			stageName: strings.Repeat("a", 300),
+			freight:   "abcdef1234567890",
+			assertions: func(t *testing.T, name string) {
+				require.LessOrEqual(t, len(name), 253)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testCase.assertions(t, GeneratePromotionRequestName(testCase.stageName, testCase.freight))
+		})
+	}
+}
+
+func TestGenerateChildPromotionName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		stageName  string
+		targetName string
+		freight    string
+		assertions func(*testing.T, string)
+	}{
+		{
+			name:       "empty Target name",
+			stageName:  "fake-stage",
+			targetName: "",
+			freight:    "fake-freight",
+			assertions: func(t *testing.T, name string) {
+				require.Empty(t, name)
+			},
+		},
+		{
+			name:       "empty Stage name",
+			stageName:  "",
+			targetName: "fake-target",
+			freight:    "fake-freight",
+			assertions: func(t *testing.T, name string) {
+				require.Empty(t, name)
+			},
+		},
+		{
+			name:       "Stage and Target name",
+			stageName:  "prod",
+			targetName: "us-east",
+			freight:    "abcdef1234567890",
+			assertions: func(t *testing.T, name string) {
+				parts := strings.Split(name, ".")
+				require.Len(t, parts, 4)
+				require.Equal(t, "prod", parts[0])
+				require.Equal(t, "us-east", parts[1])
+				require.Equal(t, "abcdef1", parts[3])
+			},
+		},
+		{
+			name:       "repeated calls do not collide",
+			stageName:  "prod",
+			targetName: "us-east",
+			freight:    "abcdef1234567890",
+			assertions: func(t *testing.T, name string) {
+				other := GenerateChildPromotionName("prod", "us-east", "abcdef1234567890")
+				require.NotEqual(t, name, other)
+			},
+		},
+		{
+			name:       "over-long names are truncated to a valid resource name",
+			stageName:  strings.Repeat("a", 200),
+			targetName: strings.Repeat("b", 200),
+			freight:    "abcdef1234567890",
+			assertions: func(t *testing.T, name string) {
+				require.LessOrEqual(t, len(name), 253)
+				// Truncation must not leave a separator or hyphen adjacent to
+				// the ULID, which would make the name invalid.
+				require.NotContains(t, name, "..")
+				require.NotContains(t, name, "-.")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testCase.assertions(t, GenerateChildPromotionName(
+				testCase.stageName,
+				testCase.targetName,
+				testCase.freight,
+			))
+		})
+	}
+}
+
+func TestNewPromotionRequest(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project = "fake-project"
+		stage   = "fake-stage"
+		freight = "abcdef1234567890"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	testStage := &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: project,
+			Name:      stage,
+			UID:       "fake-uid",
+		},
+		Spec: kargoapi.StageSpec{
+			Shard: "my-shard",
+			Targets: &kargoapi.StageTargets{
+				Selectors: []metav1.LabelSelector{{
+					MatchLabels: map[string]string{"region": "us"},
+				}},
+			},
+		},
+	}
+
+	newTarget := func(name string, labels map[string]string) *kargoapi.Target {
+		return &kargoapi.Target{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: project,
+				Name:      name,
+				Labels:    labels,
+			},
+		}
+	}
+
+	// Deep-copy: the builder takes ownership of the objects it is given, and
+	// these fixtures are shared across parallel subtests.
+	newClient := func(targets ...*kargoapi.Target) client.Client {
+		builder := fake.NewClientBuilder().WithScheme(scheme)
+		for _, target := range targets {
+			builder = builder.WithObjects(target.DeepCopy())
+		}
+		return builder.Build()
+	}
+
+	usEast := newTarget("us-east", map[string]string{"region": "us"})
+	usWest := newTarget("us-west", map[string]string{"region": "us"})
+	euWest := newTarget("eu-west", map[string]string{"region": "eu"})
+
+	t.Run("resolves selectors to Targets and records Stage and Freight", func(t *testing.T) {
+		t.Parallel()
+
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(usWest, usEast, euWest), testStage, freight,
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, project, promoReq.Namespace)
+		require.Equal(t, stage, promoReq.Spec.Stage)
+		require.Equal(t, freight, promoReq.Spec.Freight)
+		require.True(t, strings.HasPrefix(promoReq.Name, stage+"."))
+		// Only Targets matching the selector, sorted by name so that repeated
+		// calls agree.
+		require.Equal(
+			t,
+			[]kargoapi.PromotionRequestTarget{
+				{Name: "us-east"},
+				{Name: "us-west"},
+			},
+			promoReq.Spec.Targets,
+		)
+	})
+
+	t.Run("the resolved list is a snapshot, not a live query", func(t *testing.T) {
+		t.Parallel()
+
+		c := newClient(usEast)
+		promoReq, err := NewPromotionRequest(t.Context(), c, testStage, freight)
+		require.NoError(t, err)
+		require.Len(t, promoReq.Spec.Targets, 1)
+
+		// A Target appearing after the PromotionRequest was built does not
+		// belong to it. It is picked up by a subsequent PromotionRequest, not
+		// by re-resolving this one.
+		require.NoError(t, c.Create(t.Context(), usWest.DeepCopy()))
+		require.Equal(
+			t,
+			[]kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+			promoReq.Spec.Targets,
+		)
+	})
+
+	t.Run("selectors describe a union of Targets", func(t *testing.T) {
+		t.Parallel()
+
+		union := testStage.DeepCopy()
+		union.Spec.Targets = &kargoapi.StageTargets{
+			Selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"region": "us"}},
+				{MatchLabels: map[string]string{"region": "eu"}},
+			},
+		}
+		inUS := newTarget("us-east", map[string]string{"region": "us"})
+		inEU := newTarget("eu-west", map[string]string{"region": "eu"})
+
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(inUS, inEU), union, freight,
+		)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]kargoapi.PromotionRequestTarget{
+				{Name: "eu-west"},
+				{Name: "us-east"},
+			},
+			promoReq.Spec.Targets,
+		)
+	})
+
+	t.Run("a Target matching two selectors appears once", func(t *testing.T) {
+		t.Parallel()
+
+		multiSelector := testStage.DeepCopy()
+		multiSelector.Spec.Targets = &kargoapi.StageTargets{
+			Selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"region": "us"}},
+				{MatchLabels: map[string]string{"tier": "prod"}},
+			},
+		}
+		both := newTarget("us-east", map[string]string{"region": "us", "tier": "prod"})
+
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(both), multiSelector, freight,
+		)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+			promoReq.Spec.Targets,
+		)
+	})
+
+	t.Run("the Stage is the controlling owner", func(t *testing.T) {
+		t.Parallel()
+
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(usEast), testStage, freight,
+		)
+		require.NoError(t, err)
+
+		require.Len(t, promoReq.OwnerReferences, 1)
+		ownerRef := promoReq.OwnerReferences[0]
+		require.Equal(t, stage, ownerRef.Name)
+		require.Equal(t, "Stage", ownerRef.Kind)
+		require.Equal(t, kargoapi.GroupVersion.String(), ownerRef.APIVersion)
+		require.NotNil(t, ownerRef.Controller)
+		require.True(t, *ownerRef.Controller)
+	})
+
+	t.Run("identifying labels", func(t *testing.T) {
+		t.Parallel()
+
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(usEast), testStage, freight,
+		)
+		require.NoError(t, err)
+		require.Equal(t, stage, promoReq.Labels[kargoapi.LabelKeyStage])
+		// Without the shard label, only the default controller would ever
+		// reconcile this PromotionRequest.
+		require.Equal(t, "my-shard", promoReq.Labels[kargoapi.LabelKeyShard])
+	})
+
+	t.Run("an unsharded Stage yields no shard label", func(t *testing.T) {
+		t.Parallel()
+
+		unsharded := testStage.DeepCopy()
+		unsharded.Spec.Shard = ""
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(usEast), unsharded, freight,
+		)
+		require.NoError(t, err)
+		require.NotContains(t, promoReq.Labels, kargoapi.LabelKeyShard)
+	})
+
+	t.Run("selectors matching nothing yield an empty list, not nil", func(t *testing.T) {
+		t.Parallel()
+
+		// spec.targets is required and has no omitempty, so a nil slice would
+		// serialize as null and be rejected by the API server. An empty list
+		// records that the Stage governed no Targets at this moment.
+		promoReq, err := NewPromotionRequest(
+			t.Context(), newClient(euWest), testStage, freight,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, promoReq.Spec.Targets)
+		require.Empty(t, promoReq.Spec.Targets)
+	})
+
+	t.Run("invalid selector", func(t *testing.T) {
+		t.Parallel()
+
+		bad := testStage.DeepCopy()
+		bad.Spec.Targets = &kargoapi.StageTargets{
+			Selectors: []metav1.LabelSelector{{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "region",
+					Operator: "NotAnOperator",
+				}},
+			}},
+		}
+		_, err := NewPromotionRequest(t.Context(), newClient(), bad, freight)
+		require.ErrorContains(t, err, "error resolving Targets governed by Stage")
+	})
+}

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -102,7 +102,7 @@ func TestGeneratePromotionName(t *testing.T) {
 				require.Len(t, result, 253) // Kubernetes resource name limit
 				require.Equal(
 					t,
-					maxStageNamePrefixForPromotionName,
+					maxPrefixForPromotionName,
 					len(result[:strings.Index(result, ".")]),
 				)
 			},

--- a/pkg/api/stage.go
+++ b/pkg/api/stage.go
@@ -73,6 +73,16 @@ func ListStagesByWarehouses(
 	return stages, nil
 }
 
+// IsTargetAware returns true if the Stage governs Targets, i.e. promotes
+// Freight to destinations described by Target resources rather than to itself.
+//
+// The presence of the targets block is what decides this, not what its
+// selectors happen to match. A Stage whose selectors currently match nothing is
+// still target-aware; it simply governs no Targets at the moment.
+func IsTargetAware(stage *kargoapi.Stage) bool {
+	return stage != nil && stage.Spec.Targets != nil
+}
+
 // StageMatchesAnyWarehouse returns true if the Stage requests Freight that
 // originated from at least one of the specified warehouses, either directly
 // or through upstream stages.

--- a/pkg/api/target.go
+++ b/pkg/api/target.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+// ListTargetsForStage returns the Targets in the Stage's own Project that the
+// Stage governs, i.e. those matching any of its target selectors. Results are
+// sorted by name so that repeated calls agree on ordering.
+//
+// A classic Stage -- one with no targets block -- governs no Targets, and this
+// returns an empty slice for it. An empty selector within the list selects
+// every Target in the Project.
+func ListTargetsForStage(
+	ctx context.Context,
+	c client.Client,
+	stage *kargoapi.Stage,
+) ([]kargoapi.Target, error) {
+	if !IsTargetAware(stage) {
+		return nil, nil
+	}
+
+	// A Target matching more than one selector must still be governed once.
+	seen := make(map[string]struct{})
+	var targets []kargoapi.Target
+
+	for i := range stage.Spec.Targets.Selectors {
+		selector, err := metav1.LabelSelectorAsSelector(
+			&stage.Spec.Targets.Selectors[i],
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing target selector %d: %w", i, err)
+		}
+
+		list := kargoapi.TargetList{}
+		if err = c.List(
+			ctx,
+			&list,
+			client.InNamespace(stage.Namespace),
+			client.MatchingLabelsSelector{Selector: selector},
+		); err != nil {
+			return nil, fmt.Errorf(
+				"error listing Targets in namespace %q: %w",
+				stage.Namespace, err,
+			)
+		}
+
+		for _, target := range list.Items {
+			if _, ok := seen[target.Name]; ok {
+				continue
+			}
+			seen[target.Name] = struct{}{}
+			targets = append(targets, target)
+		}
+	}
+
+	slices.SortFunc(targets, func(lhs, rhs kargoapi.Target) int {
+		return strings.Compare(lhs.Name, rhs.Name)
+	})
+	return targets, nil
+}

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -1966,7 +1966,7 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 		}
 
 		if api.IsTargetAware(stage) {
-			if err = r.autoPromoteToTargets(ctx, stage, &candidate, origin); err != nil {
+			if err = r.createAutoPromotionRequest(ctx, stage, &candidate, origin); err != nil {
 				return newStatus, err
 			}
 			continue
@@ -2067,10 +2067,10 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 	return newStatus, nil
 }
 
-// autoPromoteToTargets creates a PromotionRequest expressing the intent to
-// promote the candidate Freight to every Target that the target-aware Stage
-// governs. Resolving the Stage's target selectors to Targets is the
-// PromotionRequest reconciler's job, not this controller's.
+// createAutoPromotionRequest creates a PromotionRequest expressing the intent
+// to promote the candidate Freight to the Targets that the target-aware Stage
+// governs. Those Targets are resolved once, as the request is built, and
+// recorded on it; the request does not promote anything itself.
 //
 // The guard against duplicate work here is deliberately stricter than the one
 // autoPromoteFreight applies to Promotions: a PromotionRequest is created only when
@@ -2079,7 +2079,11 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 // "succeeded, but the outcome is not yet recorded in status" to reason about --
 // and absent a guard that holds unconditionally, every reconcile would create
 // another PromotionRequest.
-func (r *RegularStageReconciler) autoPromoteToTargets(
+//
+// The guard is confined to auto-promotion. Promoting the same Freight to the
+// same Stage again deliberately -- rolling back to it, say -- goes through the
+// API server, which creates a PromotionRequest unconditionally.
+func (r *RegularStageReconciler) createAutoPromotionRequest(
 	ctx context.Context,
 	stage *kargoapi.Stage,
 	candidate *kargoapi.Freight,

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -154,6 +154,19 @@ func (r *RegularStageReconciler) SetupWithManager(
 		)
 	}
 
+	// This index is used to determine if a PromotionRequest already exists for a
+	// Stage and Freight combination.
+	if err := sharedIndexer.IndexField(
+		ctx,
+		&kargoapi.PromotionRequest{},
+		indexer.PromotionRequestsByStageAndFreightField,
+		indexer.PromotionRequestsByStageAndFreight,
+	); err != nil {
+		return fmt.Errorf(
+			"error setting up index for PromotionRequests by Stage and Freight: %w", err,
+		)
+	}
+
 	// This index is used to find Freight that are directly available from a
 	// Warehouse and can be automatically promoted to a Stage.
 	if err := sharedIndexer.IndexField(
@@ -1952,6 +1965,13 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 			continue
 		}
 
+		if api.IsTargetAware(stage) {
+			if err = r.autoPromoteToTargets(ctx, stage, &candidate, origin); err != nil {
+				return newStatus, err
+			}
+			continue
+		}
+
 		// Do not create duplicate work: stand down while any Promotion for
 		// this candidate is either still in flight or succeeded with an
 		// outcome not yet recorded in Stage status.
@@ -2045,6 +2065,100 @@ func (r *RegularStageReconciler) autoPromoteFreight(
 	}
 
 	return newStatus, nil
+}
+
+// autoPromoteToTargets creates a PromotionRequest expressing the intent to
+// promote the candidate Freight to every Target that the target-aware Stage
+// governs. Resolving the Stage's target selectors to Targets is the
+// PromotionRequest reconciler's job, not this controller's.
+//
+// The guard against duplicate work here is deliberately stricter than the one
+// autoPromoteFreight applies to Promotions: a PromotionRequest is created only when
+// no PromotionRequest for this Stage and Freight exists at all, in any phase. Stage
+// status does not yet track PromotionRequests, so there is no equivalent of
+// "succeeded, but the outcome is not yet recorded in status" to reason about --
+// and absent a guard that holds unconditionally, every reconcile would create
+// another PromotionRequest.
+func (r *RegularStageReconciler) autoPromoteToTargets(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+	candidate *kargoapi.Freight,
+	origin string,
+) error {
+	logger := logging.LoggerFromContext(ctx).WithValues(
+		"origin", origin,
+		"freight", candidate.Name,
+	)
+
+	exists, err := r.promotionRequestExistsForStageFreight(ctx, stage, candidate.Name)
+	if err != nil {
+		return fmt.Errorf(
+			"error listing existing PromotionRequests for Freight %q in namespace %q: %w",
+			candidate.Name, stage.Namespace, err,
+		)
+	}
+	if exists {
+		logger.Debug("a PromotionRequest already exists for Stage and Freight")
+		return nil
+	}
+
+	promotionRequest, err := api.NewPromotionRequest(ctx, r.client, stage, candidate.Name)
+	if err != nil {
+		return fmt.Errorf(
+			"error building PromotionRequest for Freight %q in namespace %q: %w",
+			candidate.Name, stage.Namespace, err,
+		)
+	}
+
+	if err = r.client.Create(ctx, promotionRequest); err != nil {
+		// Tolerate an admission denial exactly as the Promotion path does:
+		// nothing is persisted, so a later reconcile re-attempts once the
+		// denying policy no longer applies.
+		if apierrors.IsForbidden(err) {
+			logger.Debug(
+				"auto-promotion was denied by an admission webhook",
+				"error", err.Error(),
+			)
+			return nil
+		}
+		return fmt.Errorf(
+			"error creating PromotionRequest for Freight %q in namespace %q: %w",
+			candidate.Name, stage.Namespace, err,
+		)
+	}
+
+	// No event is recorded. Kargo's promotion events carry a Promotion, and a
+	// PromotionRequest has none of its own; the events belong to the child
+	// Promotions that its reconciler creates.
+	logger.Debug(
+		"created PromotionRequest resource",
+		"promotionRequest", promotionRequest.Name,
+	)
+	return nil
+}
+
+// promotionRequestExistsForStageFreight reports whether any PromotionRequest exists for
+// the given Stage and Freight, in any phase.
+func (r *RegularStageReconciler) promotionRequestExistsForStageFreight(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+	freightName string,
+) (bool, error) {
+	promotionRequests := &kargoapi.PromotionRequestList{}
+	if err := r.client.List(
+		ctx,
+		promotionRequests,
+		client.InNamespace(stage.Namespace),
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector(
+				indexer.PromotionRequestsByStageAndFreightField,
+				indexer.StageAndFreightKey(stage.Name, freightName),
+			),
+		},
+	); err != nil {
+		return false, err
+	}
+	return len(promotionRequests.Items) > 0, nil
 }
 
 // stageAwaitingFreightForOrigin reports whether this reconcile pass has already

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -6272,6 +6272,170 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 			},
 		},
 		{
+			name:                 "target-aware Stage gets a PromotionRequest, not a Promotion",
+			autoPromotionEnabled: true,
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: "test-warehouse",
+						},
+						Sources: kargoapi.FreightSources{Direct: true},
+					}},
+					Targets: &kargoapi.StageTargets{
+						Selectors: []metav1.LabelSelector{{
+							MatchLabels: map[string]string{"region": "us"},
+						}},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "fake-project",
+						Name:              "test-freight-1",
+						CreationTimestamp: metav1.Time{Time: now},
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "us-east",
+						Labels:    map[string]string{"region": "us"},
+					},
+				},
+				// Present in the Project but not matched by the Stage's
+				// selector, so it must not appear in the resolved list.
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "eu-west",
+						Labels:    map[string]string{"region": "eu"},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				recorder *fakeevent.EventRecorder,
+				c client.Client,
+				_ kargoapi.StageStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+
+				promoList := &kargoapi.PromotionList{}
+				require.NoError(t, c.List(t.Context(), promoList, client.InNamespace("fake-project")))
+				assert.Empty(t, promoList.Items)
+
+				reqList := &kargoapi.PromotionRequestList{}
+				require.NoError(t, c.List(t.Context(), reqList, client.InNamespace("fake-project")))
+				require.Len(t, reqList.Items, 1)
+				assert.Equal(t, "test-stage", reqList.Items[0].Spec.Stage)
+				assert.Equal(t, "test-freight-1", reqList.Items[0].Spec.Freight)
+				// The Stage's selectors are resolved to Targets at creation:
+				// only the Target matching the selector is included.
+				assert.Equal(
+					t,
+					[]kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+					reqList.Items[0].Spec.Targets,
+				)
+				// The Stage owns the PromotionRequest.
+				require.Len(t, reqList.Items[0].OwnerReferences, 1)
+				assert.Equal(t, "test-stage", reqList.Items[0].OwnerReferences[0].Name)
+
+				// A PromotionRequest has no Promotion to carry an event.
+				assert.Empty(t, recorder.Events)
+			},
+		},
+		{
+			name:                 "target-aware Stage skips promotion if a PromotionRequest already exists",
+			autoPromotionEnabled: true,
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: "test-warehouse",
+						},
+						Sources: kargoapi.FreightSources{Direct: true},
+					}},
+					Targets: &kargoapi.StageTargets{
+						Selectors: []metav1.LabelSelector{{}},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Warehouse{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-warehouse",
+					},
+				},
+				&kargoapi.Freight{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "fake-project",
+						Name:              "test-freight-1",
+						CreationTimestamp: metav1.Time{Time: now},
+					},
+					Origin: kargoapi.FreightOrigin{
+						Kind: kargoapi.FreightOriginKindWarehouse,
+						Name: "test-warehouse",
+					},
+				},
+				// Already terminal. Unlike the Promotion path, a target-aware
+				// Stage stands down on any existing PromotionRequest regardless of
+				// phase, so that a Stage whose PromotionRequests never reach a
+				// recorded outcome cannot create one on every reconcile.
+				&kargoapi.PromotionRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "test-stage.existing",
+					},
+					Spec: kargoapi.PromotionRequestSpec{
+						Stage:   "test-stage",
+						Freight: "test-freight-1",
+						Targets: []kargoapi.PromotionRequestTarget{},
+					},
+					Status: kargoapi.PromotionRequestStatus{
+						Phase: kargoapi.PromotionRequestPhaseErrored,
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				_ *fakeevent.EventRecorder,
+				c client.Client,
+				_ kargoapi.StageStatus,
+				err error,
+			) {
+				require.NoError(t, err)
+
+				setList := &kargoapi.PromotionRequestList{}
+				require.NoError(t, c.List(t.Context(), setList, client.InNamespace("fake-project")))
+				require.Len(t, setList.Items, 1)
+				assert.Equal(t, "test-stage.existing", setList.Items[0].Name)
+			},
+		},
+		{
 			name:                 "sorts by discoveredAt when set",
 			autoPromotionEnabled: true,
 			stage: &kargoapi.Stage{
@@ -8223,6 +8387,11 @@ func TestRegularStageReconciler_autoPromoteFreight(t *testing.T) {
 					&kargoapi.Freight{},
 					indexer.FreightApprovedForStagesField,
 					indexer.FreightApprovedForStages,
+				).
+				WithIndex(
+					&kargoapi.PromotionRequest{},
+					indexer.PromotionRequestsByStageAndFreightField,
+					indexer.PromotionRequestsByStageAndFreight,
 				)
 
 			c := builder.Build()

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -33,6 +33,8 @@ const (
 	PromotionsByStageField           = "stage"
 	PromotionsByTerminalField        = "terminal"
 
+	PromotionRequestsByStageAndFreightField = "stageAndFreight"
+
 	RunningPromotionsByArgoCDApplicationsField = "applications"
 	RunningPromotionsByArgoCDSelectorsField    = "argoCDSelectors"
 	RunningPromotionsByPullRequestURLField     = "pullRequestURL"
@@ -427,6 +429,19 @@ func PromotionsByStageAndFreight(obj client.Object) []string {
 
 	return []string{
 		StageAndFreightKey(promo.Spec.Stage, promo.Spec.Freight),
+	}
+}
+
+// PromotionRequestsByStageAndFreight is a client.IndexerFunc that indexes
+// PromotionRequests by the Stage and Freight they promote.
+func PromotionRequestsByStageAndFreight(obj client.Object) []string {
+	promotionRequest, ok := obj.(*kargoapi.PromotionRequest)
+	if !ok {
+		return nil
+	}
+
+	return []string{
+		StageAndFreightKey(promotionRequest.Spec.Stage, promotionRequest.Spec.Freight),
 	}
 }
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -911,6 +911,23 @@ func TestPromotionsByStageAndFreight(t *testing.T) {
 	require.Equal(t, []string{"fake-stage:fake-freight"}, res)
 }
 
+func TestPromotionRequestsByStageAndFreight(t *testing.T) {
+	t.Run("PromotionRequest", func(t *testing.T) {
+		promotionRequest := &kargoapi.PromotionRequest{
+			Spec: kargoapi.PromotionRequestSpec{
+				Stage:   "fake-stage",
+				Freight: "fake-freight",
+			},
+		}
+		res := PromotionRequestsByStageAndFreight(promotionRequest)
+		require.Equal(t, []string{"fake-stage:fake-freight"}, res)
+	})
+
+	t.Run("not a PromotionRequest", func(t *testing.T) {
+		require.Nil(t, PromotionRequestsByStageAndFreight(&kargoapi.Promotion{}))
+	})
+}
+
 func TestFreightByWarehouse(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/pkg/server/promote_downstream.go
+++ b/pkg/server/promote_downstream.go
@@ -55,7 +55,8 @@ type promoteDownstreamRequest struct {
 // @id PromoteDownstream
 // @Summary Promote downstream
 // @Description Creates a Promotion resource for each of a Stage's immediately
-// @Description downstream Stages.
+// @Description downstream Stages. Downstream Stages that select Targets yield a
+// @Description PromotionRequest each, returned separately under "promotionRequests".
 // @Tags Core, Project-Level
 // @Security BearerAuth
 // @Accept json
@@ -185,11 +186,39 @@ func (s *server) promoteDownstream(c *gin.Context) {
 
 	promoteErrs := make([]error, 0, len(downstreams))
 	createdPromos := make([]*kargoapi.Promotion, 0, len(downstreams))
+	createdPromoReqs := make([]*kargoapi.PromotionRequest, 0, len(downstreams))
 
 	for _, downstream := range downstreams {
 		// Skip "control flow" stages with no promotion steps
 		if downstream.Spec.PromotionTemplate != nil &&
 			len(downstream.Spec.PromotionTemplate.Spec.Steps) == 0 {
+			continue
+		}
+
+		// A downstream Stage that selects Targets fans Freight out to them via
+		// a PromotionRequest rather than promoting to itself with a Promotion.
+		if api.IsTargetAware(&downstream) {
+			// Both the Target lookup and the create go through the internal
+			// client. PromotionRequests are system-owned, and the promote-verb
+			// check above IS the authorization decision for this downstream
+			// Stage; which Targets it governs is a detail of carrying it out.
+			newPromoReq, err := api.NewPromotionRequest(
+				ctx, s.client.InternalClient(), &downstream, freight.Name,
+			)
+			if err != nil {
+				promoteErrs = append(promoteErrs, err)
+				continue
+			}
+			if actor != "" {
+				api.SetCreateActorAnnotation(newPromoReq, actor)
+			}
+			if err = s.client.InternalClient().Create(ctx, newPromoReq); err != nil {
+				promoteErrs = append(promoteErrs, err)
+				continue
+			}
+			// No event is recorded: Kargo's promotion events carry a Promotion,
+			// and a PromotionRequest has none of its own.
+			createdPromoReqs = append(createdPromoReqs, newPromoReq)
 			continue
 		}
 
@@ -210,6 +239,9 @@ func (s *server) promoteDownstream(c *gin.Context) {
 	}
 
 	response := gin.H{"promotions": createdPromos}
+	if len(createdPromoReqs) > 0 {
+		response["promotionRequests"] = createdPromoReqs
+	}
 	if len(promoteErrs) > 0 {
 		response["errors"] = errors.Join(promoteErrs...).Error()
 		c.JSON(http.StatusMultiStatus, response)

--- a/pkg/server/promote_downstream_test.go
+++ b/pkg/server/promote_downstream_test.go
@@ -93,6 +93,22 @@ func Test_server_promoteDownstream(t *testing.T) {
 		},
 	}
 
+	// Same name as testDownstreamStage, so that it is found downstream of the
+	// Stage under test, but governing Targets rather than promoting to itself.
+	testTargetAwareDownstreamStage := testDownstreamStage.DeepCopy()
+	testTargetAwareDownstreamStage.Spec.Targets = &kargoapi.StageTargets{
+		Selectors: []metav1.LabelSelector{{
+			MatchLabels: map[string]string{"region": "us"},
+		}},
+	}
+	testDownstreamTarget := &kargoapi.Target{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "us-east",
+			Namespace: testProject.Name,
+			Labels:    map[string]string{"region": "us"},
+		},
+	}
+
 	testRESTEndpoint(
 		t, &config.ServerConfig{},
 		http.MethodPost, "/v1beta1/projects/"+testProject.Name+"/stages/"+testStage.Name+"/promotions/downstream",
@@ -199,6 +215,57 @@ func Test_server_promoteDownstream(t *testing.T) {
 					require.Len(t, promos.Items, 1)
 					require.Equal(t, testDownstreamStage.Name, promos.Items[0].Spec.Stage)
 					require.Equal(t, testFreight.Name, promos.Items[0].Spec.Freight)
+				},
+			},
+			{
+				name: "target-aware downstream Stage yields a PromotionRequest",
+				clientBuilder: fake.NewClientBuilder().WithObjects(
+					testProject,
+					testStage,
+					testTargetAwareDownstreamStage,
+					testFreight,
+					testDownstreamTarget,
+				),
+				serverSetup: func(_ *testing.T, s *server) {
+					s.authorizeFn = func(
+						context.Context,
+						string,
+						schema.GroupVersionResource,
+						string,
+						client.ObjectKey,
+					) error {
+						return nil
+					}
+				},
+				body: mustJSONBody(promoteDownstreamRequest{
+					Freight: testFreight.Name,
+				}),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+					require.Contains(t, w.Body.String(), "promotionRequests")
+
+					promos := &kargoapi.PromotionList{}
+					require.NoError(t, c.List(t.Context(), promos, client.InNamespace(testProject.Name)))
+					require.Empty(t, promos.Items)
+
+					reqs := &kargoapi.PromotionRequestList{}
+					require.NoError(t, c.List(t.Context(), reqs, client.InNamespace(testProject.Name)))
+					require.Len(t, reqs.Items, 1)
+					require.Equal(t, testTargetAwareDownstreamStage.Name, reqs.Items[0].Spec.Stage)
+					require.Equal(t, testFreight.Name, reqs.Items[0].Spec.Freight)
+					// The downstream Stage's selectors are resolved to Targets
+					// at creation.
+					require.Equal(
+						t,
+						[]kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+						reqs.Items[0].Spec.Targets,
+					)
+					require.Len(t, reqs.Items[0].OwnerReferences, 1)
+					require.Equal(
+						t,
+						testTargetAwareDownstreamStage.Name,
+						reqs.Items[0].OwnerReferences[0].Name,
+					)
 				},
 			},
 		},

--- a/pkg/server/promote_to_stage.go
+++ b/pkg/server/promote_to_stage.go
@@ -64,7 +64,9 @@ type promoteToStageRequest struct {
 // @Param project path string true "Project name"
 // @Param stage path string true "Stage name"
 // @Param body body promoteToStageRequest true "Promote request"
-// @Success 201 {object} kargoapi.Promotion "Promotion resource (github.com/akuity/kargo/api/v1alpha1.Promotion)"
+// @Description A Stage that selects Targets yields a PromotionRequest, which fans
+// @Description the Freight out to each of them, in place of a single Promotion.
+// @Success 201 {object} kargoapi.Promotion "Promotion resource, or a PromotionRequest for a Stage that selects Targets"
 // @Router /v1beta1/projects/{project}/stages/{stage}/promotions [post]
 func (s *server) promoteToStage(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -125,6 +127,21 @@ func (s *server) promoteToStage(c *gin.Context) {
 	}
 
 	if req.Origin != "" {
+		if api.IsTargetAware(stage) {
+			// Promotion by origin relies on the Promotion defaulting webhook to
+			// resolve the origin to a candidate Freight at admission time.
+			// PromotionRequests have no such webhook, so there is nothing to resolve
+			// the origin. Refuse rather than silently create a Promotion that
+			// bypasses the Stage's Targets.
+			_ = c.Error(libhttp.ErrorStr(
+				fmt.Sprintf(
+					"promotion by origin is not supported for Stage %q, which selects Targets",
+					stageName,
+				),
+				http.StatusBadRequest,
+			))
+			return
+		}
 		// Let admission resolve the origin to the auto-promotion candidate
 		// Freight. That keeps "promote by origin" race-free for REST clients.
 		origin, parseErr := kargoapi.ParseFreightOrigin(req.Origin)
@@ -202,6 +219,35 @@ func (s *server) promoteToStage(c *gin.Context) {
 			fmt.Sprintf("Freight %q is not available to Stage %q", freight.Name, stageName),
 			http.StatusBadRequest,
 		))
+		return
+	}
+
+	// A Stage that selects Targets fans Freight out to them via a PromotionRequest
+	// rather than promoting to itself with a single Promotion.
+	if api.IsTargetAware(stage) {
+		// Both the Target lookup and the create go through the internal client.
+		// PromotionRequests are system-owned, and the promote-verb check above
+		// IS the authorization decision for this request; which Targets the
+		// Stage governs is a detail of carrying it out. Resolving as the user
+		// would also break the kargo-promoter role, which holds the promote
+		// verb but no permission to list Targets.
+		promotionRequest, prErr := api.NewPromotionRequest(
+			ctx, s.client.InternalClient(), stage, freight.Name,
+		)
+		if prErr != nil {
+			_ = c.Error(prErr)
+			return
+		}
+		if u, ok := user.InfoFromContext(ctx); ok {
+			api.SetCreateActorAnnotation(promotionRequest, api.FormatEventUserActor(u))
+		}
+		if err = s.client.InternalClient().Create(ctx, promotionRequest); err != nil {
+			_ = c.Error(err)
+			return
+		}
+		// No event is recorded: Kargo's promotion events carry a Promotion, and
+		// a PromotionRequest has none of its own.
+		c.JSON(http.StatusCreated, promotionRequest)
 		return
 	}
 

--- a/pkg/server/promote_to_stage_test.go
+++ b/pkg/server/promote_to_stage_test.go
@@ -168,6 +168,50 @@ func Test_server_promoteToStage(t *testing.T) {
 				},
 			},
 			{
+				// Taylor's question on #6805: re-promoting the same Freight --
+				// rolling back to it, say -- must still produce a request. The
+				// stand-down guard exists only in the Stage controller's
+				// auto-promotion loop; this path creates unconditionally.
+				name: "re-promoting the same Freight yields a second PromotionRequest",
+				clientBuilder: fake.NewClientBuilder().WithObjects(
+					testProject,
+					testTargetAwareStage,
+					testFreight,
+					testTarget,
+					&kargoapi.PromotionRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testProject.Name,
+							Name:      testStage.Name + ".existing.01jexam",
+							Labels: map[string]string{
+								kargoapi.LabelKeyStage: testStage.Name,
+							},
+						},
+						Spec: kargoapi.PromotionRequestSpec{
+							Stage:   testStage.Name,
+							Freight: testFreight.Name,
+							Targets: []kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+						},
+						Status: kargoapi.PromotionRequestStatus{
+							Phase: kargoapi.PromotionRequestPhaseSucceeded,
+						},
+					},
+				),
+				serverSetup: authorizeAllStagesPromote,
+				body: mustJSONBody(promoteToStageRequest{
+					Freight: testFreight.Name,
+				}),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+
+					reqs := &kargoapi.PromotionRequestList{}
+					require.NoError(t, c.List(t.Context(), reqs, client.InNamespace(testProject.Name)))
+					require.Len(t, reqs.Items, 2)
+					// Distinct objects: names embed a ULID, so a repeat
+					// promotion of the same Stage and Freight cannot collide.
+					require.NotEqual(t, reqs.Items[0].Name, reqs.Items[1].Name)
+				},
+			},
+			{
 				name: "Promotion by origin is refused for a target-aware Stage",
 				clientBuilder: fake.NewClientBuilder().WithObjects(
 					testProject,

--- a/pkg/server/promote_to_stage_test.go
+++ b/pkg/server/promote_to_stage_test.go
@@ -103,10 +103,96 @@ func Test_server_promoteToStage(t *testing.T) {
 		},
 	}
 
+	// Same name as testStage, so that it can stand in for it at the endpoint
+	// under test, but governing Targets rather than promoting to itself.
+	testTargetAwareStage := testStage.DeepCopy()
+	testTargetAwareStage.Spec.Targets = &kargoapi.StageTargets{
+		Selectors: []metav1.LabelSelector{{
+			MatchLabels: map[string]string{"region": "us"},
+		}},
+	}
+	testTarget := &kargoapi.Target{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "us-east",
+			Namespace: testProject.Name,
+			Labels:    map[string]string{"region": "us"},
+		},
+	}
+	// Present in the Project but not matched by the Stage's selector, so it
+	// must not appear in the resolved list.
+	testUnselectedTarget := &kargoapi.Target{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eu-west",
+			Namespace: testProject.Name,
+			Labels:    map[string]string{"region": "eu"},
+		},
+	}
+
 	testRESTEndpoint(
 		t, &config.ServerConfig{},
 		http.MethodPost, "/v1beta1/projects/"+testProject.Name+"/stages/"+testStage.Name+"/promotions",
 		[]restTestCase{
+			{
+				name: "Target-aware Stage yields a PromotionRequest",
+				clientBuilder: fake.NewClientBuilder().WithObjects(
+					testProject,
+					testTargetAwareStage,
+					testFreight,
+					testTarget,
+					testUnselectedTarget,
+				),
+				serverSetup: authorizeAllStagesPromote,
+				body: mustJSONBody(promoteToStageRequest{
+					Freight: testFreight.Name,
+				}),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					require.Equal(t, http.StatusCreated, w.Code)
+
+					promos := &kargoapi.PromotionList{}
+					require.NoError(t, c.List(t.Context(), promos, client.InNamespace(testProject.Name)))
+					require.Empty(t, promos.Items)
+
+					reqs := &kargoapi.PromotionRequestList{}
+					require.NoError(t, c.List(t.Context(), reqs, client.InNamespace(testProject.Name)))
+					require.Len(t, reqs.Items, 1)
+					require.Equal(t, testStage.Name, reqs.Items[0].Spec.Stage)
+					require.Equal(t, testFreight.Name, reqs.Items[0].Spec.Freight)
+					// The Stage's selectors are resolved to Targets at creation.
+					require.Equal(
+						t,
+						[]kargoapi.PromotionRequestTarget{{Name: "us-east"}},
+						reqs.Items[0].Spec.Targets,
+					)
+					require.Len(t, reqs.Items[0].OwnerReferences, 1)
+					require.Equal(t, testStage.Name, reqs.Items[0].OwnerReferences[0].Name)
+				},
+			},
+			{
+				name: "Promotion by origin is refused for a target-aware Stage",
+				clientBuilder: fake.NewClientBuilder().WithObjects(
+					testProject,
+					testTargetAwareStage,
+					testFreight,
+				),
+				serverSetup: authorizeAllStagesPromote,
+				body: mustJSONBody(promoteToStageRequest{
+					Origin: testFreight.Origin.String(),
+				}),
+				assertions: func(t *testing.T, w *httptest.ResponseRecorder, c client.Client) {
+					// Nothing resolves an origin for a PromotionRequest, so this
+					// must fail loudly rather than fall back to a Promotion
+					// that would bypass the Stage's Targets.
+					require.Equal(t, http.StatusBadRequest, w.Code)
+
+					promos := &kargoapi.PromotionList{}
+					require.NoError(t, c.List(t.Context(), promos, client.InNamespace(testProject.Name)))
+					require.Empty(t, promos.Items)
+
+					reqs := &kargoapi.PromotionRequestList{}
+					require.NoError(t, c.List(t.Context(), reqs, client.InNamespace(testProject.Name)))
+					require.Empty(t, reqs.Items)
+				},
+			},
 			{
 				name:          "Project not found",
 				clientBuilder: fake.NewClientBuilder(),

--- a/pkg/x/client/generated/api/openapi.yaml
+++ b/pkg/x/client/generated/api/openapi.yaml
@@ -1875,6 +1875,8 @@ paths:
       description: |-
         Create a Promotion resource to transition a specified Stage into
         the state represented by the specified Freight.
+        A Stage that selects Targets yields a PromotionRequest, which fans
+        the Freight out to each of them, in place of a single Promotion.
       operationId: PromoteToStage
       parameters:
       - description: Project name
@@ -1902,7 +1904,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Promotion"
-          description: Promotion resource (github.com/akuity/kargo/api/v1alpha1.Promotion)
+          description: "Promotion resource, or a PromotionRequest for a Stage that\
+            \ selects Targets"
       security:
       - BearerAuth: []
       summary: Promote to Stage
@@ -1913,7 +1916,8 @@ paths:
     post:
       description: |-
         Creates a Promotion resource for each of a Stage's immediately
-        downstream Stages.
+        downstream Stages. Downstream Stages that select Targets yield a
+        PromotionRequest each, returned separately under "promotionRequests".
       operationId: PromoteDownstream
       parameters:
       - description: Project name

--- a/pkg/x/client/generated/api_core.go
+++ b/pkg/x/client/generated/api_core.go
@@ -4837,7 +4837,8 @@ func (r ApiPromoteDownstreamRequest) Execute() (*any, *http.Response, error) {
 PromoteDownstream Promote downstream
 
 Creates a Promotion resource for each of a Stage's immediately
-downstream Stages.
+downstream Stages. Downstream Stages that select Targets yield a
+PromotionRequest each, returned separately under "promotionRequests".
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param project Project name
@@ -4972,6 +4973,8 @@ PromoteToStage Promote to Stage
 
 Create a Promotion resource to transition a specified Stage into
 the state represented by the specified Freight.
+A Stage that selects Targets yields a PromotionRequest, which fans
+the Freight out to each of them, in place of a single Promotion.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param project Project name

--- a/swagger.json
+++ b/swagger.json
@@ -2554,7 +2554,7 @@
     },
     "/v1beta1/projects/{project}/stages/{stage}/promotions": {
       "post": {
-        "description": "Create a Promotion resource to transition a specified Stage into\nthe state represented by the specified Freight.",
+        "description": "Create a Promotion resource to transition a specified Stage into\nthe state represented by the specified Freight.\nA Stage that selects Targets yields a PromotionRequest, which fans\nthe Freight out to each of them, in place of a single Promotion.",
         "consumes": [
           "application/json"
         ],
@@ -2594,7 +2594,7 @@
         ],
         "responses": {
           "201": {
-            "description": "Promotion resource (github.com/akuity/kargo/api/v1alpha1.Promotion)",
+            "description": "Promotion resource, or a PromotionRequest for a Stage that selects Targets",
             "schema": {
               "$ref": "#/definitions/Promotion"
             }
@@ -2609,7 +2609,7 @@
     },
     "/v1beta1/projects/{project}/stages/{stage}/promotions/downstream": {
       "post": {
-        "description": "Creates a Promotion resource for each of a Stage's immediately\ndownstream Stages.",
+        "description": "Creates a Promotion resource for each of a Stage's immediately\ndownstream Stages. Downstream Stages that select Targets yield a\nPromotionRequest each, returned separately under \"promotionRequests\".",
         "consumes": [
           "application/json"
         ],

--- a/ui/src/gen/api/v2/core/core.ts
+++ b/ui/src/gen/api/v2/core/core.ts
@@ -3694,6 +3694,8 @@ export function useGetStageLinks<
 /**
  * Create a Promotion resource to transition a specified Stage into
 the state represented by the specified Freight.
+A Stage that selects Targets yields a PromotionRequest, which fans
+the Freight out to each of them, in place of a single Promotion.
  * @summary Promote to Stage
  */
 export type promoteToStageResponse201 = {
@@ -3790,7 +3792,8 @@ export const usePromoteToStage = <TError = ErrorType<unknown>, TContext = unknow
 };
 /**
  * Creates a Promotion resource for each of a Stage's immediately
-downstream Stages.
+downstream Stages. Downstream Stages that select Targets yield a
+PromotionRequest each, returned separately under "promotionRequests".
  * @summary Promote downstream
  */
 export type promoteDownstreamResponse201 = {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #6829, which nests the Stage's Target selector under `spec.targets`. Review only the top three commits.

## Description

Connects `PromotionRequest` to every place that creates a Promotion. A Stage that selects Targets promotes Freight to them rather than to itself, so the Stage controller's auto-promotion loop, `promote-to-stage`, and `promote-downstream` now create a PromotionRequest instead of a Promotion when the Stage is target-aware.

- `api.NewPromotionRequest(ctx, c, stage, freight)` resolves the Stage's target selector to concrete Targets once and records them in `spec.targets`, sets the Stage as controlling owner, and stamps stage + shard labels. The list is a snapshot and is never recomputed, so a request's threshold is computed against a fixed set.
- The server endpoints create PromotionRequests through the **internal client**: users hold no PromotionRequest permissions by design, and the endpoints' existing `promote`-verb check on the Stage is the authorization decision. Both call sites document the justification per the internal-client policy and are covered by tests.
- Auto-promotion stands down whenever any PromotionRequest for the (Stage, Freight) exists, in any phase — Stage status doesn't track requests yet, so a stricter guard than the Promotion path's is the only one that can't loop. Backed by a new `PromotionRequestsByStageAndFreight` index.
- Promotion by origin is refused (400) for target-aware Stages: nothing resolves an origin for a PromotionRequest, and falling back to a Promotion would silently bypass the Stage's Targets.
- `GenerateChildPromotionName` establishes the `<stage>.<target>.<ulid>.<hash>` naming contract for the child Promotions the reconciler will create.
- `promote-downstream` returns created requests under a separate `promotionRequests` key; `promote-to-stage` returns the PromotionRequest as its 201 body.

Deliberately **not** in this PR:

- Keeping `spec.targetSelectors` in sync with the Stage's own as they change (follow-up; until then a request reflects the Stage's selectors as of creation).
- Reflecting PromotionRequest aggregation data in Stage status.
- The fan-out reconciler itself.

## Validation

- `make lint-go`
- `go test -race ./pkg/api/... ./pkg/indexer/... ./pkg/server/... ./pkg/controller/stages/...`
- `make test-chart`

