### PR TITLE
feat(ui): show how long each promotion step took

### DIFF
--- a/ui/src/features/stage/promotion-step-duration.tsx
+++ b/ui/src/features/stage/promotion-step-duration.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+import { StepExecutionMetadata } from '@ui/gen/api/v2/models';
+
+import { formatStepDuration, stepDurationMs } from './utils/step-duration';
+
+// A running step re-renders on this interval so its elapsed time counts up,
+// which is what distinguishes a step that is stuck from one that is merely slow.
+const TICK_INTERVAL_MS = 1000;
+
+export const StepDuration = ({ meta }: { meta?: StepExecutionMetadata }) => {
+  const running = !!meta?.startedAt && !meta?.finishedAt;
+
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!running) {
+      return;
+    }
+    const interval = setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [running]);
+
+  const elapsed = stepDurationMs(meta, now);
+
+  if (elapsed === null) {
+    return null;
+  }
+
+  return (
+    <span
+      className='text-xs text-gray-500 ml-auto tabular-nums'
+      title={
+        meta?.finishedAt
+          ? `Started ${meta.startedAt}, finished ${meta.finishedAt}`
+          : `Started ${meta?.startedAt}`
+      }
+    >
+      {formatStepDuration(elapsed)}
+    </span>
+  );
+};

--- a/ui/src/features/stage/promotion-step-duration.tsx
+++ b/ui/src/features/stage/promotion-step-duration.tsx
@@ -1,27 +1,23 @@
 import { useEffect, useState } from 'react';
 
-import { StepExecutionMetadata } from '@ui/gen/api/v2/models';
+import {
+  getPromotionDirectiveStepStatus,
+  PromotionDirectiveStepStatus
+} from '@ui/features/common/promotion-directive-step-status/utils';
+import { Promotion, StepExecutionMetadata } from '@ui/gen/api/v2/models';
+import { parseDate } from '@ui/utils/dates';
 
-import { formatStepDuration, stepDurationMs } from './utils/step-duration';
+import { elapsedStepDurationMs, formatStepDuration } from './utils/step-duration';
 
-// A running step re-renders on this interval so its elapsed time counts up,
-// which is what distinguishes a step that is stuck from one that is merely slow.
 const TICK_INTERVAL_MS = 1000;
 
-export const StepDuration = ({ meta }: { meta?: StepExecutionMetadata }) => {
-  const running = !!meta?.startedAt && !meta?.finishedAt;
-
-  const [now, setNow] = useState(() => Date.now());
+const RunningStepDuration = ({ meta }: { meta?: StepExecutionMetadata }) => {
+  const [elapsed, setElapsed] = useState(() => elapsedStepDurationMs(meta));
 
   useEffect(() => {
-    if (!running) {
-      return;
-    }
-    const interval = setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS);
+    const interval = setInterval(() => setElapsed(elapsedStepDurationMs(meta)), TICK_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [running]);
-
-  const elapsed = stepDurationMs(meta, now);
+  }, [meta]);
 
   if (elapsed === null) {
     return null;
@@ -29,14 +25,46 @@ export const StepDuration = ({ meta }: { meta?: StepExecutionMetadata }) => {
 
   return (
     <span
-      className='text-xs text-gray-500 ml-auto tabular-nums'
-      title={
-        meta?.finishedAt
-          ? `Started ${meta.startedAt}, finished ${meta.finishedAt}`
-          : `Started ${meta?.startedAt}`
-      }
+      className={'text-xs text-gray-500 ml-auto tabular-nums'}
+      title={`Started ${meta?.startedAt}`}
     >
       {formatStepDuration(elapsed)}
+    </span>
+  );
+};
+
+export const StepDuration = ({
+  promotion,
+  stepIndex
+}: {
+  promotion?: Promotion;
+  stepIndex: number;
+}) => {
+  const meta = promotion?.status?.stepExecutionMetadata?.[stepIndex];
+
+  if (
+    getPromotionDirectiveStepStatus(stepIndex, promotion?.status) ===
+    PromotionDirectiveStepStatus.RUNNING
+  ) {
+    return <RunningStepDuration meta={meta} />;
+  }
+
+  const startedAt = parseDate(meta?.startedAt);
+  // A Promotion aborted or errored mid-step can leave that step's finishedAt
+  // unstamped. The Promotion's own finishedAt is when the step really stopped.
+  const finishedAtRaw = meta?.finishedAt || promotion?.status?.finishedAt;
+  const finishedAt = parseDate(finishedAtRaw);
+
+  if (!startedAt || !finishedAt) {
+    return null;
+  }
+
+  return (
+    <span
+      className={'text-xs text-gray-500 ml-auto tabular-nums'}
+      title={`Started ${meta?.startedAt}\nFinished ${finishedAtRaw}`}
+    >
+      {formatStepDuration(finishedAt.getTime() - startedAt.getTime())}
     </span>
   );
 };

--- a/ui/src/features/stage/promotion-step.tsx
+++ b/ui/src/features/stage/promotion-step.tsx
@@ -17,7 +17,7 @@ import YamlEditor from '@ui/features/common/code-editor/yaml-editor-lazy';
 import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
 import { usePromotionDirectivesRegistryContext } from '@ui/features/promotion-directives/registry/context/use-registry-context';
 import { Runner } from '@ui/features/promotion-directives/registry/types';
-import { Promotion, PromotionStep, StepExecutionMetadata } from '@ui/gen/api/v2/models';
+import { Promotion, PromotionStep } from '@ui/gen/api/v2/models';
 import uiPlugins from '@ui/plugins';
 import { UiPluginHoles } from '@ui/plugins/atoms/ui-plugin-hole/ui-plugin-holes';
 
@@ -29,13 +29,13 @@ export const Step = ({
   result,
   output,
   promotion,
-  stepMetadata
+  stepIndex
 }: {
   step: PromotionStep;
   result: PromotionDirectiveStepStatus;
   output?: object;
   promotion?: Promotion;
-  stepMetadata?: StepExecutionMetadata;
+  stepIndex: number;
 }) => {
   const [showDetails, setShowDetails] = useState(false);
 
@@ -152,7 +152,7 @@ export const Step = ({
               )}
             </UiPluginHoles.DeepLinks.PromotionStep>
           )}
-          <StepDuration meta={stepMetadata} />
+          <StepDuration promotion={promotion} stepIndex={stepIndex} />
         </Flex>
       </Flex>
     ),

--- a/ui/src/features/stage/promotion-step.tsx
+++ b/ui/src/features/stage/promotion-step.tsx
@@ -17,22 +17,25 @@ import YamlEditor from '@ui/features/common/code-editor/yaml-editor-lazy';
 import { PromotionDirectiveStepStatus } from '@ui/features/common/promotion-directive-step-status/utils';
 import { usePromotionDirectivesRegistryContext } from '@ui/features/promotion-directives/registry/context/use-registry-context';
 import { Runner } from '@ui/features/promotion-directives/registry/types';
-import { Promotion, PromotionStep } from '@ui/gen/api/v2/models';
+import { Promotion, PromotionStep, StepExecutionMetadata } from '@ui/gen/api/v2/models';
 import uiPlugins from '@ui/plugins';
 import { UiPluginHoles } from '@ui/plugins/atoms/ui-plugin-hole/ui-plugin-holes';
 
+import { StepDuration } from './promotion-step-duration';
 import { objectToYAML } from './utils/promotion';
 
 export const Step = ({
   step,
   result,
   output,
-  promotion
+  promotion,
+  stepMetadata
 }: {
   step: PromotionStep;
   result: PromotionDirectiveStepStatus;
   output?: object;
   promotion?: Promotion;
+  stepMetadata?: StepExecutionMetadata;
 }) => {
   const [showDetails, setShowDetails] = useState(false);
 
@@ -149,6 +152,7 @@ export const Step = ({
               )}
             </UiPluginHoles.DeepLinks.PromotionStep>
           )}
+          <StepDuration meta={stepMetadata} />
         </Flex>
       </Flex>
     ),

--- a/ui/src/features/stage/promotion-steps.tsx
+++ b/ui/src/features/stage/promotion-steps.tsx
@@ -71,7 +71,7 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
         result,
         output: outputsByStepAlias[step.as || ''],
         promotion: props.promotion,
-        stepMetadata: props.promotion?.status?.stepExecutionMetadata?.[i]
+        stepIndex: i
       }),
       key
     };

--- a/ui/src/features/stage/promotion-steps.tsx
+++ b/ui/src/features/stage/promotion-steps.tsx
@@ -70,7 +70,8 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
         step,
         result,
         output: outputsByStepAlias[step.as || ''],
-        promotion: props.promotion
+        promotion: props.promotion,
+        stepMetadata: props.promotion?.status?.stepExecutionMetadata?.[i]
       }),
       key
     };

--- a/ui/src/features/stage/utils/step-duration.test.ts
+++ b/ui/src/features/stage/utils/step-duration.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatStepDuration, stepDurationMs } from './step-duration';
+
+const START = '2026-08-13T00:00:00Z';
+const startMs = new Date(START).getTime();
+
+describe('stepDurationMs()', () => {
+  test('returns null when the step has no metadata', () => {
+    expect(stepDurationMs(undefined)).toBeNull();
+  });
+  test('returns null when the step has not started', () => {
+    expect(stepDurationMs({ status: 'Running' })).toBeNull();
+  });
+  test('returns null for an unparseable startedAt', () => {
+    expect(stepDurationMs({ startedAt: 'not a date' })).toBeNull();
+  });
+  test('measures a finished step from startedAt to finishedAt', () => {
+    expect(stepDurationMs({ startedAt: START, finishedAt: '2026-08-13T00:00:05Z' })).toBe(5000);
+  });
+  test('ignores `now` for a finished step', () => {
+    expect(
+      stepDurationMs({ startedAt: START, finishedAt: '2026-08-13T00:00:05Z' }, startMs + 900000)
+    ).toBe(5000);
+  });
+  test('measures a running step from startedAt to now', () => {
+    expect(stepDurationMs({ startedAt: START }, startMs + 12000)).toBe(12000);
+  });
+  test('treats an unparseable finishedAt as still running', () => {
+    expect(stepDurationMs({ startedAt: START, finishedAt: '' }, startMs + 3000)).toBe(3000);
+  });
+  // Clock skew between control plane and browser must not render as "-3s".
+  test('returns null when now precedes startedAt', () => {
+    expect(stepDurationMs({ startedAt: START }, startMs - 3000)).toBeNull();
+  });
+});
+
+describe('formatStepDuration()', () => {
+  // API timestamps carry second precision, so a sub-second step computes to
+  // exactly 0; "0ms" would imply precision the data does not have.
+  test('a zero duration renders as less than a second', () => {
+    expect(formatStepDuration(0)).toBe('<1s');
+  });
+  test('other sub-second durations render in milliseconds', () => {
+    expect(formatStepDuration(1)).toBe('1ms');
+    expect(formatStepDuration(999)).toBe('999ms');
+  });
+  test('sub-minute durations render in seconds', () => {
+    expect(formatStepDuration(1000)).toBe('1s');
+    expect(formatStepDuration(1999)).toBe('1s');
+    expect(formatStepDuration(59000)).toBe('59s');
+  });
+  test('sub-hour durations render in minutes and seconds', () => {
+    expect(formatStepDuration(60000)).toBe('1m');
+    expect(formatStepDuration(65000)).toBe('1m 5s');
+    expect(formatStepDuration(3599000)).toBe('59m 59s');
+  });
+  test('longer durations render in hours and minutes', () => {
+    expect(formatStepDuration(3600000)).toBe('1h');
+    expect(formatStepDuration(3660000)).toBe('1h 1m');
+    expect(formatStepDuration(48 * 3600000)).toBe('48h');
+  });
+});

--- a/ui/src/features/stage/utils/step-duration.test.ts
+++ b/ui/src/features/stage/utils/step-duration.test.ts
@@ -1,37 +1,41 @@
 import { describe, expect, test } from 'vitest';
 
-import { formatStepDuration, stepDurationMs } from './step-duration';
+import { elapsedStepDurationMs, formatStepDuration } from './step-duration';
 
 const START = '2026-08-13T00:00:00Z';
 const startMs = new Date(START).getTime();
 
-describe('stepDurationMs()', () => {
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('elapsedStepDurationMs()', () => {
   test('returns null when the step has no metadata', () => {
-    expect(stepDurationMs(undefined)).toBeNull();
+    expect(elapsedStepDurationMs(undefined)).toBeNull();
   });
   test('returns null when the step has not started', () => {
-    expect(stepDurationMs({ status: 'Running' })).toBeNull();
+    expect(elapsedStepDurationMs({ status: 'Running' })).toBeNull();
   });
   test('returns null for an unparseable startedAt', () => {
-    expect(stepDurationMs({ startedAt: 'not a date' })).toBeNull();
+    expect(elapsedStepDurationMs({ startedAt: 'not a date' })).toBeNull();
   });
-  test('measures a finished step from startedAt to finishedAt', () => {
-    expect(stepDurationMs({ startedAt: START, finishedAt: '2026-08-13T00:00:05Z' })).toBe(5000);
+  test('measures from startedAt to now', () => {
+    expect(elapsedStepDurationMs({ startedAt: START }, startMs + 12 * SECOND)).toBe(12 * SECOND);
   });
-  test('ignores `now` for a finished step', () => {
+  // The caller only mounts the ticking component for a step with no finishedAt,
+  // but the function ignores it either way rather than quietly disagreeing.
+  test('ignores finishedAt', () => {
     expect(
-      stepDurationMs({ startedAt: START, finishedAt: '2026-08-13T00:00:05Z' }, startMs + 900000)
-    ).toBe(5000);
-  });
-  test('measures a running step from startedAt to now', () => {
-    expect(stepDurationMs({ startedAt: START }, startMs + 12000)).toBe(12000);
-  });
-  test('treats an unparseable finishedAt as still running', () => {
-    expect(stepDurationMs({ startedAt: START, finishedAt: '' }, startMs + 3000)).toBe(3000);
+      elapsedStepDurationMs(
+        { startedAt: START, finishedAt: '2026-08-13T00:00:05Z' },
+        startMs + 3 * SECOND
+      )
+    ).toBe(3 * SECOND);
   });
   // Clock skew between control plane and browser must not render as "-3s".
   test('returns null when now precedes startedAt', () => {
-    expect(stepDurationMs({ startedAt: START }, startMs - 3000)).toBeNull();
+    expect(elapsedStepDurationMs({ startedAt: START }, startMs - 3 * SECOND)).toBeNull();
   });
 });
 
@@ -41,23 +45,47 @@ describe('formatStepDuration()', () => {
   test('a zero duration renders as less than a second', () => {
     expect(formatStepDuration(0)).toBe('<1s');
   });
+  // Sub-second values bypass date-fns entirely -- intervalToDuration truncates
+  // them to an empty Duration, which formatDuration renders as ''.
   test('other sub-second durations render in milliseconds', () => {
     expect(formatStepDuration(1)).toBe('1ms');
     expect(formatStepDuration(999)).toBe('999ms');
   });
   test('sub-minute durations render in seconds', () => {
-    expect(formatStepDuration(1000)).toBe('1s');
+    expect(formatStepDuration(SECOND)).toBe('1s');
     expect(formatStepDuration(1999)).toBe('1s');
-    expect(formatStepDuration(59000)).toBe('59s');
+    expect(formatStepDuration(59 * SECOND)).toBe('59s');
   });
   test('sub-hour durations render in minutes and seconds', () => {
-    expect(formatStepDuration(60000)).toBe('1m');
-    expect(formatStepDuration(65000)).toBe('1m 5s');
-    expect(formatStepDuration(3599000)).toBe('59m 59s');
+    expect(formatStepDuration(MINUTE)).toBe('1m');
+    expect(formatStepDuration(MINUTE + 5 * SECOND)).toBe('1m 5s');
+    expect(formatStepDuration(HOUR - SECOND)).toBe('59m 59s');
   });
-  test('longer durations render in hours and minutes', () => {
-    expect(formatStepDuration(3600000)).toBe('1h');
-    expect(formatStepDuration(3660000)).toBe('1h 1m');
-    expect(formatStepDuration(48 * 3600000)).toBe('48h');
+  test('hour-scale durations render in hours and minutes', () => {
+    expect(formatStepDuration(HOUR)).toBe('1h');
+    expect(formatStepDuration(HOUR + MINUTE)).toBe('1h 1m');
+    expect(formatStepDuration(HOUR + 40 * MINUTE)).toBe('1h 40m');
+  });
+  // Above an hour, seconds are noise rather than precision.
+  test('drops seconds from durations of an hour or more', () => {
+    expect(formatStepDuration(HOUR + 30 * SECOND)).toBe('1h');
+    expect(formatStepDuration(DAY + HOUR + MINUTE + SECOND)).toBe('1d 1h 1m');
+  });
+  // date-fns normalizes whole days out of the hours field, so a two-day step
+  // reads "2d" rather than "48h".
+  test('day-scale durations render in days', () => {
+    expect(formatStepDuration(DAY)).toBe('1d');
+    expect(formatStepDuration(2 * DAY)).toBe('2d');
+    expect(formatStepDuration(DAY + HOUR)).toBe('1d 1h');
+  });
+  // intervalToDuration rolls 40 days up into {months: 1, days: 9}. The coarse
+  // units must all be formatted or the largest component vanishes.
+  test('does not drop the largest unit of a very long duration', () => {
+    expect(formatStepDuration(40 * DAY)).toBe('1mo 9d');
+  });
+  // Zero-valued units are omitted rather than padded, so nothing renders "0m".
+  test('omits zero-valued units', () => {
+    expect(formatStepDuration(2 * MINUTE)).toBe('2m');
+    expect(formatStepDuration(2 * HOUR)).toBe('2h');
   });
 });

--- a/ui/src/features/stage/utils/step-duration.ts
+++ b/ui/src/features/stage/utils/step-duration.ts
@@ -1,0 +1,65 @@
+import { StepExecutionMetadata } from '@ui/gen/api/v2/models';
+import { parseDate } from '@ui/utils/dates';
+
+/**
+ * stepDurationMs returns how long a promotion step has been executing, in
+ * milliseconds.
+ *
+ * A step that has finished is measured from startedAt to finishedAt. A step
+ * that is still running is measured from startedAt to `now`, so callers that
+ * re-render on a timer show a live elapsed time. Returns null when the step has
+ * not started yet, or when the timestamps are missing or unparseable.
+ */
+export const stepDurationMs = (
+  meta?: StepExecutionMetadata,
+  now: number = Date.now()
+): number | null => {
+  const startedAt = parseDate(meta?.startedAt);
+  if (!startedAt) {
+    return null;
+  }
+
+  const finishedAt = parseDate(meta?.finishedAt);
+  const end = finishedAt ? finishedAt.getTime() : now;
+
+  const elapsed = end - startedAt.getTime();
+  // Clock skew between the control plane and the browser can put `now` behind
+  // startedAt. Showing "-3s" would be worse than showing nothing.
+  return elapsed < 0 ? null : elapsed;
+};
+
+/**
+ * formatStepDuration renders a duration in milliseconds compactly.
+ *
+ * Step durations span many orders of magnitude -- a yaml-update finishes in
+ * milliseconds while a git-wait-for-pr may run for hours -- so the unit adapts
+ * rather than using a single fixed granularity.
+ */
+export const formatStepDuration = (ms: number): string => {
+  // API timestamps are RFC 3339 with second precision, so any step faster than
+  // a second computes to exactly 0. Rendering that as "0ms" would imply a
+  // precision the data does not have. Sub-second values other than 0 are still
+  // formatted exactly, in case finer-grained timestamps arrive later.
+  if (ms === 0) {
+    return '<1s';
+  }
+
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) {
+    return seconds > 0 ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+};

--- a/ui/src/features/stage/utils/step-duration.ts
+++ b/ui/src/features/stage/utils/step-duration.ts
@@ -1,16 +1,37 @@
+import { FormatDistanceToken, formatDuration, intervalToDuration } from 'date-fns';
+
 import { StepExecutionMetadata } from '@ui/gen/api/v2/models';
 import { parseDate } from '@ui/utils/dates';
 
+const oneSecondMs = 1000;
+const oneHourMs = 60 * 60 * oneSecondMs;
+
+// formatDuration delegates each unit to locale.formatDistance(token, count),
+// which is the supported hook for non-English output. Reusing it for compact
+// units keeps date-fns in charge of picking and normalizing units while
+// rendering "1h 40m" instead of en-US's "1 hour 40 minutes".
+const compactUnits: Partial<Record<FormatDistanceToken, string>> = {
+  xSeconds: 's',
+  xMinutes: 'm',
+  xHours: 'h',
+  xDays: 'd',
+  xMonths: 'mo',
+  xYears: 'y'
+};
+
+const compactLocale = {
+  formatDistance: (token: FormatDistanceToken, count: number) =>
+    `${count}${compactUnits[token] ?? ''}`
+};
+
 /**
- * stepDurationMs returns how long a promotion step has been executing, in
- * milliseconds.
+ * elapsedStepDurationMs returns how long a still-running promotion step has
+ * been executing, in milliseconds, measured from startedAt to `now`.
  *
- * A step that has finished is measured from startedAt to finishedAt. A step
- * that is still running is measured from startedAt to `now`, so callers that
- * re-render on a timer show a live elapsed time. Returns null when the step has
- * not started yet, or when the timestamps are missing or unparseable.
+ * Callers pass a `now` that advances on a timer so the elapsed time counts up.
+ * Returns null when the step has not started yet or startedAt is unparseable.
  */
-export const stepDurationMs = (
+export const elapsedStepDurationMs = (
   meta?: StepExecutionMetadata,
   now: number = Date.now()
 ): number | null => {
@@ -19,10 +40,7 @@ export const stepDurationMs = (
     return null;
   }
 
-  const finishedAt = parseDate(meta?.finishedAt);
-  const end = finishedAt ? finishedAt.getTime() : now;
-
-  const elapsed = end - startedAt.getTime();
+  const elapsed = now - startedAt.getTime();
   // Clock skew between the control plane and the browser can put `now` behind
   // startedAt. Showing "-3s" would be worse than showing nothing.
   return elapsed < 0 ? null : elapsed;
@@ -36,30 +54,23 @@ export const stepDurationMs = (
  * rather than using a single fixed granularity.
  */
 export const formatStepDuration = (ms: number): string => {
-  // API timestamps are RFC 3339 with second precision, so any step faster than
-  // a second computes to exactly 0. Rendering that as "0ms" would imply a
-  // precision the data does not have. Sub-second values other than 0 are still
-  // formatted exactly, in case finer-grained timestamps arrive later.
-  if (ms === 0) {
-    return '<1s';
+  // intervalToDuration truncates to whole seconds, so a sub-second value would
+  // arrive at formatDuration as an empty Duration and render as ''. API
+  // timestamps are RFC 3339 with second precision, so exactly 0 is the common
+  // case, and "0ms" would imply a precision the data does not have. Other
+  // sub-second values are still formatted exactly, in case finer-grained
+  // timestamps arrive later.
+  if (ms < oneSecondMs) {
+    return ms === 0 ? '<1s' : `${ms}ms`;
   }
 
-  if (ms < 1000) {
-    return `${ms}ms`;
-  }
-
-  const totalSeconds = Math.floor(ms / 1000);
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`;
-  }
-
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (totalMinutes < 60) {
-    return seconds > 0 ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`;
-  }
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  return formatDuration(intervalToDuration({ start: 0, end: ms }), {
+    locale: compactLocale,
+    // Seconds are meaningful precision below an hour and noise above it. Every
+    // coarser unit is listed so a long duration never silently loses its
+    // largest component -- intervalToDuration rolls 40 days up into
+    // {months: 1, days: 9}, which a shorter list would render as just "9d".
+    format:
+      ms < oneHourMs ? ['minutes', 'seconds'] : ['years', 'months', 'days', 'hours', 'minutes']
+  });
 };


### PR DESCRIPTION
## Description

Closes #6806

The promotion view shows a duration for the promotion as a whole, but individual steps show only their status. When a promotion is slow there is no way to tell *which* step accounted for it without inspecting the `Promotion` resource by hand.

This renders an elapsed time against each step:

- **Finished step** — measured from `startedAt` to `finishedAt`.
- **Running step** — counts up from `startedAt` on a one second tick, which is what distinguishes a step that is stuck from one that is merely slow.
- **Not yet started** — renders nothing.

The data was already present in `status.stepExecutionMetadata` and already exposed on the generated `StepExecutionMetadata` model, so there is **no API, CRD or codegen change** — this is purely presentational.

### Completed promotion

`git-clone` took 2s; the two sub-second steps read `<1s`.

![completed promotion with per-step durations](https://raw.githubusercontent.com/utkarshcmu/kargo/screenshots-6806/3-after-succeeded.png)

### Running promotion — before / after

Before, a running promotion showed no timing at all (note the promotion-level `duration` row is absent entirely until the promotion is terminal):

![before](https://raw.githubusercontent.com/utkarshcmu/kargo/screenshots-6806/1-before-running.png)

After, the running step reports how long it has been waiting:

![after](https://raw.githubusercontent.com/utkarshcmu/kargo/screenshots-6806/2-after-running.png)

### Live counter

The elapsed time on a running step ticks, then settles on its final value when the step reaches a terminal state:

![live counter ticking then finishing](https://raw.githubusercontent.com/utkarshcmu/kargo/screenshots-6806/4-live-counter.gif)

## Notes for reviewers

**`<1s` rather than `0ms`.** API timestamps are RFC 3339 with second precision, so every sub-second step computes to exactly `0`. Rendering that as `0ms` would imply a precision the data does not have, so a zero duration renders as `<1s`. Non-zero sub-second values are still formatted exactly, in case finer-grained timestamps arrive later.

**Clock skew.** If the browser clock is behind the control plane, a running step's elapsed time would go negative; `stepDurationMs` returns `null` in that case so nothing is rendered rather than showing `-3s`.

**Timer scope.** The one second interval is owned by a small `StepDuration` component and only runs while a step is actually running, so finished steps do not hold a timer.

**Out of scope.** While testing this I noticed the promotion drawer does not refetch while it is open, so a step reaching a terminal state is only reflected after the view is reopened (the elapsed time itself ticks client-side regardless). That is pre-existing behaviour and untouched here — happy to open a separate issue for it.

Tested against a real promotion in a local kind cluster, including a step left running for 20+ minutes.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
