### PR TITLE
fix(sso): redirect to previously expected page instead of home page

### DIFF
--- a/ui/src/pages/login/login.tsx
+++ b/ui/src/pages/login/login.tsx
@@ -26,7 +26,9 @@ export const Login = () => {
     return <Navigate to={paths.home} replace />;
   }
 
-  if (isLoggedIn) {
+  const isOIDCCallback = params.has('code') && params.has('state');
+
+  if (isLoggedIn && !isOIDCCallback) {
     return <Navigate to={safeRedirectTo ? generatePath(safeRedirectTo) : paths.home} replace />;
   }
 


### PR DESCRIPTION
Rare case but here is how to reproduce

Configure expiry settings in dex config (Only to reproduce)

```yaml
# charts/kargo/templates/dex-server/secret.yaml

    expiry:
      idTokens: 60s
```

1. Log in. Open Tab A on /settings/cluster-config, Tab B on /system-secrets. [Both pages take in example are arbitrary but are pages where auth protected API call occurs]
2. kubectl -n kargo rollout restart deploy/kargo-dex-server
3. Wait out idTokens (~2 min). Both tabs drop to their own login screens 
4. Log in on Tab A → correct page.
5. Click SSO on Tab B → home.

The solution is that when Step-5 is reached, there is token already in localStorage, so `<Login />` component gets `isLoggedIn` as `true` because it only checks `token`'s existence (this is intentional), and thus redirects to Home page rather than expected page
