### PR TITLE
fix(ui): add missing promotion steps to wizard registry

### DIFF
--- a/ui/src/features/promotion-directives/registry/use-discover-registries.test.ts
+++ b/ui/src/features/promotion-directives/registry/use-discover-registries.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+import { useDiscoverPromotionDirectivesRegistries } from './use-discover-registries';
+
+const SCHEMA_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../gen/directives'
+);
+
+// steps are <step>-config.json; common.json and argocd-common.json are shared defs
+const schemaStepNames = () =>
+  fs
+    .readdirSync(SCHEMA_DIR)
+    .filter((file) => file.endsWith('-config.json'))
+    .map((file) => file.replace(/-config\.json$/, ''))
+    .sort();
+
+const registeredIdentifiers = () =>
+  useDiscoverPromotionDirectivesRegistries()
+    .runners.map((runner) => runner.identifier)
+    .sort();
+
+// Every generated step schema must appear in the wizard registry exactly once.
+test('every promotion step schema has a registry entry', () => {
+  const stepNames = schemaStepNames();
+
+  // catch a wrong SCHEMA_DIR instead of comparing two empty lists
+  expect(stepNames.length).toBeGreaterThan(0);
+
+  expect(registeredIdentifiers()).toEqual(stepNames);
+});
+
+test('registry does not register the same step twice', () => {
+  const identifiers = registeredIdentifiers();
+
+  expect(identifiers).toEqual([...new Set(identifiers)]);
+});

--- a/ui/src/features/promotion-directives/registry/use-discover-registries.ts
+++ b/ui/src/features/promotion-directives/registry/use-discover-registries.ts
@@ -2,6 +2,8 @@ import { JSONSchema7 } from 'json-schema';
 
 // IMPORTANT(Marvin9): this must be replaced with proper discovery mechanism
 import argocdUpdateConfig from '@ui/gen/directives/argocd-update-config.json';
+import argocdWaitConfig from '@ui/gen/directives/argocd-wait-config.json';
+import composeOutputConfig from '@ui/gen/directives/compose-output-config.json';
 import copyConfig from '@ui/gen/directives/copy-config.json';
 import deleteConfig from '@ui/gen/directives/delete-config.json';
 import failConfig from '@ui/gen/directives/fail-config.json';
@@ -9,18 +11,28 @@ import fileWriteConfig from '@ui/gen/directives/file-write-config.json';
 import gitOverwriteConfig from '@ui/gen/directives/git-clear-config.json';
 import gitCloneConfig from '@ui/gen/directives/git-clone-config.json';
 import gitCommitConfig from '@ui/gen/directives/git-commit-config.json';
+import gitMergePRConfig from '@ui/gen/directives/git-merge-pr-config.json';
 import gitOpenPR from '@ui/gen/directives/git-open-pr-config.json';
 import gitPushConfig from '@ui/gen/directives/git-push-config.json';
+import gitTagConfig from '@ui/gen/directives/git-tag-config.json';
 import gitWaitForPR from '@ui/gen/directives/git-wait-for-pr-config.json';
+import githubPushConfig from '@ui/gen/directives/github-push-config.json';
 import helmTemplateConfig from '@ui/gen/directives/helm-template-config.json';
 import helmUpdateChartConfig from '@ui/gen/directives/helm-update-chart-config.json';
 import httpConfig from '@ui/gen/directives/http-config.json';
+import httpDownloadConfig from '@ui/gen/directives/http-download-config.json';
 import jsonParseConfig from '@ui/gen/directives/json-parse-config.json';
 import jsonUpdateConfig from '@ui/gen/directives/json-update-config.json';
 import kustomizeBuildConfig from '@ui/gen/directives/kustomize-build-config.json';
 import kustomizeSetImageConfig from '@ui/gen/directives/kustomize-set-image-config.json';
+import ociDownloadConfig from '@ui/gen/directives/oci-download-config.json';
+import ociPushConfig from '@ui/gen/directives/oci-push-config.json';
+import setFreightAliasConfig from '@ui/gen/directives/set-freight-alias-config.json';
+import setMetadataConfig from '@ui/gen/directives/set-metadata-config.json';
+import tarConfig from '@ui/gen/directives/tar-config.json';
 import tomlParseConfig from '@ui/gen/directives/toml-parse-config.json';
 import tomlUpdateConfig from '@ui/gen/directives/toml-update-config.json';
+import untarConfig from '@ui/gen/directives/untar-config.json';
 import yamlMergeConfig from '@ui/gen/directives/yaml-merge-config.json';
 import yamlParseConfig from '@ui/gen/directives/yaml-parse-config.json';
 import yamlUpdateConfig from '@ui/gen/directives/yaml-update-config.json';
@@ -38,8 +50,16 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
         config: argocdUpdateConfig as JSONSchema7
       },
       {
+        identifier: 'argocd-wait',
+        config: argocdWaitConfig as JSONSchema7
+      },
+      {
         identifier: 'copy',
         config: copyConfig as JSONSchema7
+      },
+      {
+        identifier: 'compose-output',
+        config: composeOutputConfig as JSONSchema7
       },
       {
         identifier: 'delete',
@@ -67,8 +87,20 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
         config: gitOpenPR as unknown as JSONSchema7
       },
       {
+        identifier: 'git-merge-pr',
+        config: gitMergePRConfig as JSONSchema7
+      },
+      {
         identifier: 'git-wait-for-pr',
         config: gitWaitForPR as unknown as JSONSchema7
+      },
+      {
+        identifier: 'git-tag',
+        config: gitTagConfig as JSONSchema7
+      },
+      {
+        identifier: 'github-push',
+        config: githubPushConfig as JSONSchema7
       },
       {
         identifier: 'yaml-merge',
@@ -99,10 +131,6 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
         config: tomlUpdateConfig as unknown as JSONSchema7
       },
       {
-        identifier: 'git-push',
-        config: gitPushConfig as unknown as JSONSchema7
-      },
-      {
         identifier: 'git-clear',
         config: gitOverwriteConfig as JSONSchema7
       },
@@ -125,6 +153,34 @@ export const useDiscoverPromotionDirectivesRegistries = (): PromotionDirectivesR
       {
         identifier: 'http',
         config: httpConfig as JSONSchema7
+      },
+      {
+        identifier: 'http-download',
+        config: httpDownloadConfig as JSONSchema7
+      },
+      {
+        identifier: 'oci-download',
+        config: ociDownloadConfig as JSONSchema7
+      },
+      {
+        identifier: 'oci-push',
+        config: ociPushConfig as JSONSchema7
+      },
+      {
+        identifier: 'tar',
+        config: tarConfig as JSONSchema7
+      },
+      {
+        identifier: 'untar',
+        config: untarConfig as JSONSchema7
+      },
+      {
+        identifier: 'set-freight-alias',
+        config: setFreightAliasConfig as JSONSchema7
+      },
+      {
+        identifier: 'set-metadata',
+        config: setMetadataConfig as JSONSchema7
       },
       {
         identifier: 'fail',


### PR DESCRIPTION
## Description

Closes #6770

The registry backing the stage creation wizard is hand-maintained, so steps added to the backend don't appear in the UI until they're mapped in `use-discover-registries.ts`. Twelve had drifted out of sync: `argocd-wait`, `compose-output`, `git-merge-pr`, `git-tag`, `github-push`, `http-download`, `oci-download`, `oci-push`, `set-freight-alias`, `set-metadata`, `tar`, `untar`.

Beyond the missing picker entries, this also broke opening any Stage whose promotion template used one of them — `usePromotionWizardStepsState` throws `could not discover runner <step>` when a step has no registry entry.

Their schemas were already generated into `ui/src/gen/directives`, so no codegen was needed. Also removes a duplicate `git-push` entry that rendered the step twice.

Adds a test asserting the registry stays in sync with the generated schemas and that no step is registered twice, so it can't drift again unnoticed.

<img width="1506" height="894" alt="Screenshot 2026-08-13 at 8 58 30 PM" src="https://github.com/user-attachments/assets/9ea1b06d-d3ce-4204-9bfd-ae002b704cff" />

Stage creation wizard with this change applied — all 35 built-in steps now listed, `git-push` no longer duplicated.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [x] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**