### PR TITLE
fix(github): Fixes regression where bypass rules are respected for GitHub

### DIFF
--- a/pkg/gitprovider/github/github.go
+++ b/pkg/gitprovider/github/github.go
@@ -52,12 +52,28 @@ const (
 	mergeableStateUnknown = "unknown"
 )
 
-// mergeBaseModifiedMsg is the substring GitHub includes in the message of a 405
-// merge error when the base branch moved between the mergeability check and the
-// merge call. This is the one transient 405 (it clears on retry); all other 405s
-// from the merge endpoint are permanent. Full message: "Base branch was
-// modified. Review and try the merge again."
-const mergeBaseModifiedMsg = "Base branch was modified"
+// Substrings GitHub includes in the message of a 405 from the merge endpoint.
+// GitHub uses that one status code for every reason a merge cannot be
+// performed, so the message is the only way to tell a condition that may clear
+// on its own from one that never will.
+const (
+	// mergeBaseModifiedMsg appears when the base branch moved between the
+	// mergeability check and the merge call. Full message: "Base branch was
+	// modified. Review and try the merge again."
+	mergeBaseModifiedMsg = "Base branch was modified"
+	// mergeNotMergeableMsg is GitHub's generic rejection when the PR's state does
+	// not permit a merge -- most often an unsatisfied branch protection rule.
+	// Full message: "Pull Request is not mergeable"
+	mergeNotMergeableMsg = "Pull Request is not mergeable"
+	// mergeNotAllowedMsg marks a merge method the repository will not accept.
+	// GitHub words this several ways -- "Squash merges are not allowed on this
+	// repository", "Merge commits are not allowed on this repository.", "Rebase
+	// merges are not allowed", and, where a ruleset restricts the methods
+	// permitted for a branch, wording that names the selected method -- so match
+	// only the phrase they share. No transient rejection contains it as far as we
+	// can tell.
+	mergeNotAllowedMsg = "not allowed"
+)
 
 var registration = gitprovider.Registration{
 	Predicate: func(repoURL string) bool {
@@ -219,7 +235,8 @@ func (p *provider) CreatePullRequest(
 	if opts == nil {
 		opts = &gitprovider.CreatePullRequestOpts{}
 	}
-	ghPR, _, err := p.client.CreatePullRequest(ctx,
+	ghPR, _, err := p.client.CreatePullRequest(
+		ctx,
 		p.owner,
 		p.repo,
 		&github.NewPullRequest{
@@ -238,7 +255,8 @@ func (p *provider) CreatePullRequest(
 	}
 	pr := convertGithubPR(*ghPR)
 	if len(opts.Labels) > 0 {
-		_, _, err = p.client.AddLabelsToIssue(ctx,
+		_, _, err = p.client.AddLabelsToIssue(
+			ctx,
 			p.owner,
 			p.repo,
 			int(pr.Number),
@@ -347,15 +365,34 @@ func (p *provider) MergePullRequest(
 	// such as pending checks, a base branch that has moved forward, or
 	// mergeability that GitHub is still computing -- all of which a caller should
 	// retry rather than fail on.
+	//
+	// policyBlocked records that the merge is blocked by repository policy, which
+	// changes how a rejection from the merge call itself is interpreted below.
+	var policyBlocked bool
 	switch ghPR.GetMergeableState() {
 	case mergeableStateClean, mergeableStateUnstable, mergeableStateHasHooks:
 		// Mergeable now; fall through to the merge attempt below.
 	case mergeableStateDirty:
 		// A genuine merge conflict will not clear without human intervention.
 		return nil, false, fmt.Errorf("pull request %d has conflicts and cannot be merged", id)
-	case mergeableStateBlocked, mergeableStateBehind, mergeableStateDraft, mergeableStateUnknown:
-		// Not ready to merge yet, but the condition may clear; signal "not ready"
-		// so the caller can retry on a subsequent reconciliation.
+	case mergeableStateBlocked, mergeableStateBehind:
+		// The merge is blocked by branch protection or a repository ruleset: an
+		// unsatisfied required review or status check, or a base branch that has
+		// moved forward under a strict check requirement.
+		//
+		// mergeable_state describes the rules configured on the repository, not
+		// the permissions of the caller, so it cannot tell us whether these rules
+		// actually apply to the token in hand. A ruleset may name that identity as
+		// a bypass actor, in which case GitHub will merge the PR despite the
+		// blocked state. Attempt the merge and let GitHub adjudicate; if it
+		// declines, the error handling below treats that as "not ready" rather
+		// than as a failure.
+		policyBlocked = true
+	case mergeableStateDraft, mergeableStateUnknown:
+		// A draft cannot be merged by anyone, and unknown means GitHub has not
+		// finished computing mergeability. Neither warrants a merge attempt, but
+		// both may clear; signal "not ready" so the caller can retry on a
+		// subsequent reconciliation.
 		return nil, false, nil
 	default:
 		// mergeable_state is unset or unrecognized; fall back to the Mergeable
@@ -376,26 +413,17 @@ func (p *provider) MergePullRequest(
 	)
 	if err != nil {
 		// GitHub returns 405 ("Method Not Allowed") whenever the merge cannot be
-		// performed, which spans both transient and permanent conditions. The one
-		// transient case is "Base branch was modified": the base tip moved between
-		// the mergeability check above and this merge call (a TOCTOU race that
-		// fires when concurrent merges land on the same base). It is the only 405
-		// we retry -- report "not ready" so the caller tries again on the next
-		// reconciliation.
-		//
-		// Other 405s are permanent and must not be retried, or the step would loop
-		// forever under wait=true. The most common is a configured merge method
-		// that is disabled on the repo (e.g. mergeMethod: squash with squash
-		// merges turned off): the gate sees the PR as mergeable, so every retry
-		// would re-attempt and re-fail. We fall through and surface GitHub's
-		// message (carried by the wrapped error) so the misconfiguration is
-		// visible instead of silently looping.
+		// performed, which spans both transient and permanent conditions. Only the
+		// transient ones may be reported as "not ready" for the caller to retry;
+		// reporting a permanent one that way would loop forever under wait=true.
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && ghErr.Response != nil &&
 			ghErr.Response.StatusCode == http.StatusMethodNotAllowed &&
-			strings.Contains(ghErr.Message, mergeBaseModifiedMsg) {
+			isTransientMerge405(ghErr.Message, policyBlocked) {
 			return nil, false, nil
 		}
+		// Permanent, or at least not recognizably transient. Surface GitHub's
+		// message (carried by the wrapped error) so the cause is visible.
 		return nil, false, fmt.Errorf("error merging pull request %d: %w", id, err)
 	}
 	if mergeResult == nil {
@@ -417,6 +445,43 @@ func (p *provider) MergePullRequest(
 	pr := convertGithubPR(*updatedPR)
 
 	return &pr, true, nil
+}
+
+// isTransientMerge405 reports whether the message of a 405 from GitHub's merge endpoint describes a
+// condition that may clear on its own, meaning the merge is worth re-attempting. policyBlocked
+// indicates the pull request was blocked by repository policy when its mergeability was checked,
+// which widens what counts as transient.
+func isTransientMerge405(msg string, policyBlocked bool) bool {
+	switch {
+	case strings.Contains(msg, mergeNotAllowedMsg):
+		// The requested merge method is not permitted, whether disabled for the repository (e.g.
+		// mergeMethod: squash with squash merges turned off) or restricted for the branch by a
+		// ruleset. This is a misconfiguration that no amount of waiting will resolve, and it is
+		// permanent even for a PR that policy blocks -- check it first.
+		return false
+	case strings.Contains(msg, mergeBaseModifiedMsg):
+		// The base tip moved between the mergeability check and the merge call: a
+		// TOCTOU race that fires when concurrent merges land on the same base.
+		return true
+	case strings.Contains(msg, mergeNotMergeableMsg):
+		// GitHub's generic rejection: its own view of the pull request does not permit the merge,
+		// contradicting the mergeable_state it reported moments earlier. This is deliberately not
+		// gated on policyBlocked, which is derived from that same read. This case is what handles a
+		// stale one, so gating it would mean trusting the value the rejection just discredited.
+		// Report not-ready and let a fresher read decide.
+		//
+		// The retry cannot spin forever, because the caller should re-read the PR before trying
+		// again. Once GitHub finishes recomputing, a conflict surfaces as mergeable_state dirty and
+		// fails terminally, while an unsatisfied rule surfaces as blocked and takes the
+		// policyBlocked path.
+		return true
+	default:
+		// Anything else is transient only if the PR was already blocked by policy when we checked.
+		// In that case the rejection tells us the caller is not authorized to bypass the rules, and
+		// the merge becomes possible once the rules are satisfied -- a review lands, a required
+		// check passes. Absent that context, treat the 405 as permanent rather than retry blindly.
+		return policyBlocked
+	}
 }
 
 // GetCommitURL implements gitprovider.Interface.

--- a/pkg/gitprovider/github/github_test.go
+++ b/pkg/gitprovider/github/github_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/akuity/kargo/pkg/gitprovider"
 )
 
-const testRepoOwner = "akuity"
-const testRepoName = "kargo"
+const (
+	testRepoOwner = "akuity"
+	testRepoName  = "kargo"
+)
 
 func TestRegistrationPredicate(t *testing.T) {
 	testCases := []struct {
@@ -506,7 +508,7 @@ func TestMergePullRequest(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:     "mergeable_state behind is not ready",
+			name:     "mergeable_state draft is not ready",
 			prNumber: 203,
 			setupMock: func(m *mockGithubClient) {
 				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(203)).
@@ -514,13 +516,135 @@ func TestMergePullRequest(t *testing.T) {
 						Number:         github.Ptr(203),
 						State:          github.Ptr("open"),
 						Merged:         github.Ptr(false),
+						Draft:          github.Ptr(true),
 						Mergeable:      github.Ptr(true),
-						MergeableState: github.Ptr("behind"),
+						MergeableState: github.Ptr("draft"),
 						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
 						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/203"),
 					}, &github.Response{}, nil)
 			},
 			expectError: false,
+		},
+		{
+			// mergeable_state describes the repository's rules, not the caller's
+			// permissions. A caller authorized to bypass them merges a blocked PR,
+			// so the merge must be attempted rather than pre-empted.
+			name:     "mergeable_state blocked merges for a bypass-authorized caller",
+			prNumber: 205,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(205)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(205),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("blocked"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/205"),
+					}, &github.Response{}, nil).Once()
+
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(205), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(&github.PullRequestMergeResult{
+						SHA:    github.Ptr("merge_sha"),
+						Merged: github.Ptr(true),
+					}, &github.Response{}, nil)
+
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(205)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(205),
+						State:          github.Ptr("closed"),
+						Merged:         github.Ptr(true),
+						MergeCommitSHA: github.Ptr("merge_sha"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/205"),
+						MergedAt:       &github.Timestamp{Time: time.Now()},
+					}, &github.Response{}, nil).Once()
+			},
+			expectedMerged: true,
+		},
+		{
+			// The caller is not authorized to bypass the rules. The block may still
+			// clear on its own (a review lands, a check passes), so this is
+			// not-ready rather than an error.
+			name:     "mergeable_state blocked rejected by GitHub is not ready",
+			prNumber: 206,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(206)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(206),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("blocked"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/206"),
+					}, &github.Response{}, nil).Once()
+
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(206), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						// Real message observed from GitHub when a required status
+						// check has not yet reported.
+						Message: `Required status check "ci" is expected.`,
+					})
+			},
+			expectedMerged: false,
+		},
+		{
+			// A disabled merge method is permanent even for a blocked PR, so it must
+			// not be mistaken for the rejection above.
+			name:      "mergeable_state blocked with disabled merge method is terminal",
+			prNumber:  207,
+			mergeOpts: &gitprovider.MergePullRequestOpts{MergeMethod: "squash"},
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(207)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(207),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("blocked"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/207"),
+					}, &github.Response{}, nil).Once()
+
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(207), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						Message:  "Squash merges are not allowed on this repository.",
+					})
+			},
+			expectError:   true,
+			errorContains: "Squash merges are not allowed",
+		},
+		{
+			// A branch that is behind its base is blocked by a strict required
+			// check, which a bypass-authorized caller may also override.
+			name:     "mergeable_state behind attempts the merge",
+			prNumber: 208,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(208)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(208),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("behind"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/208"),
+					}, &github.Response{}, nil).Once()
+
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(208), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						Message:  "Base branch was modified. Review and try the merge again.",
+					})
+			},
+			expectedMerged: false,
 		},
 		{
 			name:     "mergeable_state dirty fails with conflict",
@@ -619,6 +743,33 @@ func TestMergePullRequest(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "Squash merges are not allowed",
+		},
+		{
+			name:     "merge call returns 405 not mergeable is not ready",
+			prNumber: 407,
+			setupMock: func(m *mockGithubClient) {
+				m.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(407)).
+					Return(&github.PullRequest{
+						Number:         github.Ptr(407),
+						State:          github.Ptr("open"),
+						Merged:         github.Ptr(false),
+						Mergeable:      github.Ptr(true),
+						MergeableState: github.Ptr("clean"),
+						Head:           &github.PullRequestBranch{SHA: github.Ptr("head_sha")},
+						HTMLURL:        github.Ptr("https://github.com/akuity/kargo/pull/407"),
+					}, &github.Response{}, nil).Once()
+
+				// GitHub's own view of the PR was stale or has since changed. Its
+				// generic rejection is recomputed as checks report and reviews land,
+				// so the provider treats it as not-ready rather than as an error.
+				m.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(407), "",
+					mock.AnythingOfType("*github.PullRequestOptions")).
+					Return(nil, nil, &github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+						Message:  "Pull Request is not mergeable",
+					})
+			},
+			expectedMerged: false,
 		},
 		{
 			name:     "nil merge result",
@@ -813,6 +964,130 @@ func TestMergePullRequest(t *testing.T) {
 			}
 
 			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// TestMergePullRequestNotMergeableThenDirty is a sanity check that isTransientMerge405
+// handles merge conflict PRs properly. A conflict can reach the merge call
+// behind a mergeable_state that GitHub has not finished recomputing, and the first attempt reports
+// not-ready, but the caller re-reads the PR on the next attempt. So the conflict then fails
+// terminally instead of being retried indefinitely.
+func TestMergePullRequestNotMergeableThenDirty(t *testing.T) {
+	mockClient := &mockGithubClient{}
+	p := provider{
+		owner:  testRepoOwner,
+		repo:   testRepoName,
+		client: mockClient,
+	}
+
+	// First attempt: GitHub still reports the state it computed before the
+	// conflicting change landed, so the gate proceeds to the merge call, which
+	// GitHub rejects.
+	mockClient.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(500)).
+		Return(&github.PullRequest{
+			Number:         new(500),
+			State:          new("open"),
+			Merged:         new(false),
+			Mergeable:      new(true),
+			MergeableState: new("clean"),
+			Head:           &github.PullRequestBranch{SHA: new("head_sha")},
+			HTMLURL:        new("https://github.com/akuity/kargo/pull/500"),
+		}, &github.Response{}, nil).Once()
+	mockClient.On("MergePullRequest", mock.Anything, testRepoOwner, testRepoName, int(500), "",
+		mock.AnythingOfType("*github.PullRequestOptions")).
+		Return(nil, nil, &github.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+			Message:  "Pull Request is not mergeable",
+		}).Once()
+
+	pr, merged, err := p.MergePullRequest(t.Context(), 500, nil)
+	require.NoError(t, err)
+	require.False(t, merged)
+	require.Nil(t, pr)
+
+	// Second attempt: GitHub has finished recomputing and reports the conflict.
+	mockClient.On("GetPullRequests", mock.Anything, testRepoOwner, testRepoName, int(500)).
+		Return(&github.PullRequest{
+			Number:         new(500),
+			State:          new("open"),
+			Merged:         new(false),
+			Mergeable:      new(false),
+			MergeableState: new("dirty"),
+			Head:           &github.PullRequestBranch{SHA: new("head_sha")},
+			HTMLURL:        new("https://github.com/akuity/kargo/pull/500"),
+		}, &github.Response{}, nil).Once()
+
+	pr, merged, err = p.MergePullRequest(t.Context(), 500, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "has conflicts and cannot be merged")
+	require.False(t, merged)
+	require.Nil(t, pr)
+
+	// The conflict must be caught by the gate, without a second merge attempt.
+	mockClient.AssertExpectations(t)
+	mockClient.AssertNumberOfCalls(t, "MergePullRequest", 1)
+}
+
+func TestIsTransientMerge405(t *testing.T) {
+	tests := []struct {
+		name          string
+		msg           string
+		policyBlocked bool
+		expected      bool
+	}{
+		{
+			name:     "base branch modified",
+			msg:      "Base branch was modified. Review and try the merge again.",
+			expected: true,
+		},
+		{
+			name:     "not mergeable",
+			msg:      "Pull Request is not mergeable",
+			expected: true,
+		},
+		{
+			name:          "disabled squash merges",
+			msg:           "Squash merges are not allowed on this repository",
+			policyBlocked: true,
+			expected:      false,
+		},
+		{
+			name:          "disabled merge commits",
+			msg:           "Merge commits are not allowed on this repository.",
+			policyBlocked: true,
+			expected:      false,
+		},
+		{
+			name:          "disabled rebase merges",
+			msg:           "Rebase merges are not allowed",
+			policyBlocked: true,
+			expected:      false,
+		},
+		{
+			// A ruleset restricting the merge methods permitted for the branch
+			// words this differently from the repository-level settings above.
+			name:          "merge method restricted by a ruleset",
+			msg:           "The selected merge method (squash) is not allowed",
+			policyBlocked: true,
+			expected:      false,
+		},
+		{
+			name:          "unsatisfied branch protection rule",
+			msg:           `Required status check "ci" is expected.`,
+			policyBlocked: true,
+			expected:      true,
+		},
+		{
+			name:     "unrecognized message without a policy block",
+			msg:      `Required status check "ci" is expected.`,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, isTransientMerge405(tt.msg, tt.policyBlocked))
 		})
 	}
 }

--- a/pkg/gitprovider/github/pr_integration_test.go
+++ b/pkg/gitprovider/github/pr_integration_test.go
@@ -133,11 +133,15 @@ func TestMergeGate(t *testing.T) {
 		t.Logf("PR #%d: GitHub reports mergeable_state=%q", prNumber, state)
 		require.Equal(t, "blocked", state, "expected GitHub to block the merge")
 
+		// The gate attempts the merge anyway, since mergeable_state cannot say
+		// whether this token is authorized to bypass the rule. This assumes
+		// TEST_GITHUB_TOKEN is *not* a bypass actor for the protection above; if it
+		// were, GitHub would merge the PR here.
 		mergedPR, merged, mergeErr := prov.MergePullRequest(t.Context(), prNumber, nil)
 		require.NoError(t, mergeErr)
 		require.False(t, merged)
 		require.Nil(t, mergedPR)
-		t.Logf("gate returned not-ready (no merge, no error), so the caller retries")
+		t.Logf("GitHub declined the merge; gate returned not-ready, so the caller retries")
 	})
 }
 

--- a/pkg/gitprovider/testing/README.md
+++ b/pkg/gitprovider/testing/README.md
@@ -30,10 +30,11 @@ with the `repo` scope works (`gh auth token` if it has that scope).
 `dirty` subtests need only the three GitHub variables above. The `blocked`
 subtest is **opt-in** and additionally requires:
 
-- `TEST_GITHUB_REQUIRE_STATUS_CHECK=true`, and
-- the repo's `main` branch protected with a **required status check the PR will
-  never satisfy**. With an unsatisfied required check, GitHub reports the PR's
-  `mergeable_state` as `blocked` — the same not-ready gate branch as `behind`:
+- `TEST_GITHUB_REQUIRE_STATUS_CHECK=true`, and the repo's `main` branch protected with a **required
+  status check the PR will never satisfy**. With an unsatisfied required check, GitHub reports the
+  PR's `mergeable_state` as `blocked` — the same gate branch as `behind`, where the merge is
+  attempted and GitHub decides. `enforce_admins` below matters: the subtest expects GitHub to
+  decline, so `TEST_GITHUB_TOKEN` must not be authorized to bypass the protection.
 
   ```bash
   gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'


### PR DESCRIPTION
## Description

The change in #6490 made it so that we didn't even attempt to merge when it showed that merging was blocked. Before, we would still attempt to merge and let GitHub block the merge if the user wasn't authorized. This restores that behavior for PRs in the blocked and behind states.

This is the default behavior requested in #6623, so this has the knock on effect of closing that issue as well

## Checklist

### Quality

I manually validated this against a live repo to ensure that merges would still be blocked appropriately

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [X] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.
