### PR TITLE
fix: dropped origins when aborting queued promotions

### DIFF
--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -758,6 +758,15 @@ func (r *RegularStageReconciler) syncPromotions(
 			if promo.Status.Freight != nil {
 				ref.Freight = promo.Status.Freight.DeepCopy()
 			}
+			// A Promotion that was aborted before it ever reached Running never
+			// had the chance to build a FreightCollection. Recording it as-is
+			// would make the Stage forget Freight origins the previous
+			// lastPromotion had already collected, permanently breaking any
+			// subsequent Promotion's ability to inherit them.
+			if promo.Status.StartedAt == nil && ref.Status.FreightCollection == nil &&
+				newStatus.LastPromotion != nil && newStatus.LastPromotion.Status != nil {
+				ref.Status.FreightCollection = newStatus.LastPromotion.Status.FreightCollection
+			}
 			newStatus.LastPromotion = &ref
 			if promo.Status.Phase == kargoapi.PromotionPhaseSucceeded {
 				// If the Promotion was successful, then we should add the Freight

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -2086,6 +2086,88 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for https://github.com/akuity/kargo/issues/6810.
+			// Aborting a Promotion before it ever reaches Running leaves its
+			// status.freightCollection nil (it never ran promote()). Folding
+			// that Promotion into status.lastPromotion must not clobber the
+			// multi-origin collection the Stage already had.
+			name:                 "aborted promotion that never started preserves inherited freight collection",
+			autoPromotionEnabled: true,
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+				Spec: kargoapi.StageSpec{
+					RequestedFreight: []kargoapi.FreightRequest{
+						{Origin: kargoapi.FreightOrigin{Kind: kargoapi.FreightOriginKindWarehouse, Name: "git-origin"}},
+						{Origin: kargoapi.FreightOrigin{Kind: kargoapi.FreightOriginKindWarehouse, Name: "image-origin"}},
+					},
+				},
+				Status: kargoapi.StageStatus{
+					CurrentPromotion: &kargoapi.PromotionReference{
+						Name: "promotion-2",
+					},
+					LastPromotion: &kargoapi.PromotionReference{
+						Name: "promotion-1",
+						Status: &kargoapi.PromotionStatus{
+							Phase: kargoapi.PromotionPhaseSucceeded,
+							FreightCollection: &kargoapi.FreightCollection{
+								ID: "two-origin-collection",
+								Freight: map[string]kargoapi.FreightReference{
+									"Warehouse/git-origin": {
+										Name: "git-freight",
+										Origin: kargoapi.FreightOrigin{
+											Kind: kargoapi.FreightOriginKindWarehouse,
+											Name: "git-origin",
+										},
+									},
+									"Warehouse/image-origin": {
+										Name: "image-freight",
+										Origin: kargoapi.FreightOrigin{
+											Kind: kargoapi.FreightOriginKindWarehouse,
+											Name: "image-origin",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "promotion-2",
+						Namespace:         "fake-project",
+						CreationTimestamp: metav1.Time{Time: now},
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage: "test-stage",
+					},
+					Status: kargoapi.PromotionStatus{
+						// Aborted before StartedAt was ever set, i.e. it never
+						// reached promote() and never got a FreightCollection.
+						Phase:      kargoapi.PromotionPhaseAborted,
+						FinishedAt: &metav1.Time{Time: now},
+					},
+				},
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.False(t, hasPendingPromotions)
+
+				require.NotNil(t, status.LastPromotion)
+				assert.Equal(t, "promotion-2", status.LastPromotion.Name)
+				assert.Equal(t, kargoapi.PromotionPhaseAborted, status.LastPromotion.Status.Phase)
+
+				require.NotNil(t, status.LastPromotion.Status.FreightCollection)
+				require.Len(t, status.LastPromotion.Status.FreightCollection.Freight, 2)
+				assert.Contains(t, status.LastPromotion.Status.FreightCollection.Freight, "Warehouse/git-origin")
+				assert.Contains(t, status.LastPromotion.Status.FreightCollection.Freight, "Warehouse/image-origin")
+			},
+		},
+		{
 			name:                 "handles promotion phase transition",
 			autoPromotionEnabled: true,
 			stage: &kargoapi.Stage{


### PR DESCRIPTION
Closes: https://github.com/akuity/kargo/issues/6810

Scripts and resources used for end-to-end testing can be found [here](https://github.com/akuity/kargo/issues/6810#issuecomment-5315787792).

### Before

<img width="820" height="190" alt="issue-6810-before" src="https://github.com/user-attachments/assets/fefb34a0-a9f9-467d-874e-ee423a3e5dba" />

### After

<img width="1147" height="658" alt="issue-6810-after" src="https://github.com/user-attachments/assets/cf35018f-e8b8-451a-a133-9e8905fbd9c4" />
