### PR TITLE
feat(webhook): validate PromotionRequests at admission

### DIFF
--- a/charts/kargo/templates/kubernetes-webhooks-server/cluster-role.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/cluster-role.yaml
@@ -50,6 +50,7 @@ rules:
   - projectconfigs
   - promotiontasks
   - stages
+  - targets
   - warehouses
   verbs:
   - get

--- a/charts/kargo/templates/kubernetes-webhooks-server/webhooks.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/webhooks.yaml
@@ -210,6 +210,24 @@ webhooks:
     resources: ["promotions"]
     operations: ["CREATE", "UPDATE", "DELETE"]
   failurePolicy: Fail
+- name: promotionrequest.kargo.akuity.io
+  admissionReviewVersions: [ "v1" ]
+  sideEffects: None
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: kargo-webhooks-server
+      path: /validate-kargo-akuity-io-v1alpha1-promotionrequest
+    {{- if and (not .Values.webhooksServer.tls.selfSignedCert) .Values.webhooksServer.tls.caBundle }}
+    caBundle: {{ .Values.webhooksServer.tls.caBundle | b64enc }}
+    {{- end }}
+  rules:
+  - scope: Namespaced
+    apiGroups: ["kargo.akuity.io"]
+    apiVersions: ["v1alpha1"]
+    resources: ["promotionrequests"]
+    operations: ["CREATE", "UPDATE"]
+  failurePolicy: Fail
 - name: promotiontask.kargo.akuity.io
   admissionReviewVersions: [ "v1" ]
   sideEffects: None

--- a/cmd/controlplane/kubernetes_webhooks.go
+++ b/cmd/controlplane/kubernetes_webhooks.go
@@ -28,6 +28,7 @@ import (
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/project"
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/projectconfig"
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/promotion"
+	"github.com/akuity/kargo/pkg/webhook/kubernetes/promotionrequest"
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/promotiontask"
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/replicatedresource"
 	"github.com/akuity/kargo/pkg/webhook/kubernetes/stage"
@@ -185,6 +186,9 @@ func (o *kubernetesWebhooksServerOptions) run(ctx context.Context) error {
 	}
 	if err = promotion.SetupWebhookWithManager(ctx, webhookCfg, mgr); err != nil {
 		return fmt.Errorf("setup Promotion webhook: %w", err)
+	}
+	if err = promotionrequest.SetupWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("setup PromotionRequest webhook: %w", err)
 	}
 	if err = promotiontask.SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("setup PromotionTask webhook: %w", err)

--- a/pkg/webhook/kubernetes/promotionrequest/webhook.go
+++ b/pkg/webhook/kubernetes/promotionrequest/webhook.go
@@ -1,0 +1,262 @@
+package promotionrequest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
+	libWebhook "github.com/akuity/kargo/pkg/webhook/kubernetes"
+)
+
+var promotionRequestGroupKind = schema.GroupKind{
+	Group: kargoapi.GroupVersion.Group,
+	Kind:  "PromotionRequest",
+}
+
+type webhook struct {
+	client client.Client
+}
+
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	w := &webhook{
+		client: mgr.GetClient(),
+	}
+	return ctrl.NewWebhookManagedBy(mgr, &kargoapi.PromotionRequest{}).
+		WithValidator(w).
+		Complete()
+}
+
+func (w *webhook) ValidateCreate(
+	ctx context.Context,
+	promotionRequest *kargoapi.PromotionRequest,
+) (admission.Warnings, error) {
+	var errs field.ErrorList
+	if err := libWebhook.ValidateProject(ctx, w.client, promotionRequest); err != nil {
+		var statusErr *apierrors.StatusError
+		if ok := errors.As(err, &statusErr); ok {
+			return nil, statusErr
+		}
+		var fieldErr *field.Error
+		if ok := errors.As(err, &fieldErr); !ok {
+			return nil, apierrors.NewInternalError(err)
+		}
+		errs = append(errs, fieldErr)
+	}
+
+	specErrs, internalErr := w.validateSpec(
+		ctx,
+		field.NewPath("spec"),
+		promotionRequest,
+	)
+	if internalErr != nil {
+		return nil, apierrors.NewInternalError(internalErr)
+	}
+	if errs = append(errs, specErrs...); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(
+			promotionRequestGroupKind,
+			promotionRequest.Name,
+			errs,
+		)
+	}
+	return nil, nil
+}
+
+func (w *webhook) ValidateUpdate(
+	ctx context.Context,
+	_ *kargoapi.PromotionRequest,
+	promotionRequest *kargoapi.PromotionRequest,
+) (admission.Warnings, error) {
+	// spec.stage and spec.freight cannot have changed -- the schema's transition
+	// rules reject that before this runs -- but spec.targets can, so the same
+	// checks apply to an update as to a create.
+	errs, internalErr := w.validateSpec(
+		ctx,
+		field.NewPath("spec"),
+		promotionRequest,
+	)
+	if internalErr != nil {
+		return nil, apierrors.NewInternalError(internalErr)
+	}
+	if len(errs) > 0 {
+		return nil, apierrors.NewInvalid(
+			promotionRequestGroupKind,
+			promotionRequest.Name,
+			errs,
+		)
+	}
+	return nil, nil
+}
+
+func (w *webhook) ValidateDelete(
+	context.Context,
+	*kargoapi.PromotionRequest,
+) (admission.Warnings, error) {
+	// No-op
+	return nil, nil
+}
+
+// validateSpec returns a list of field errors describing everything wrong with
+// the PromotionRequest's spec, or a non-nil error if a check could not be
+// carried out at all. The two are distinct: the former rejects the object, the
+// latter fails the admission request.
+func (w *webhook) validateSpec(
+	ctx context.Context,
+	f *field.Path,
+	promotionRequest *kargoapi.PromotionRequest,
+) (field.ErrorList, error) {
+	var errs field.ErrorList
+
+	errs = append(errs, validateTargetsUnique(
+		f.Child("targets"),
+		promotionRequest.Spec.Targets,
+	)...)
+
+	stageErrs, err := w.validateStage(ctx, f.Child("stage"), promotionRequest)
+	if err != nil {
+		return nil, err
+	}
+	errs = append(errs, stageErrs...)
+
+	targetErrs, err := w.validateTargetsExist(
+		ctx,
+		f.Child("targets"),
+		promotionRequest,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return append(errs, targetErrs...), nil
+}
+
+// validateTargetsUnique enforces the uniqueness of Target names.
+//
+// The schema cannot do this: spec.targets is an atomic list rather than a
+// list-map precisely to avoid the per-item ownership tracking a list-map
+// records in managedFields, which roughly doubles the storage cost of every
+// entry. A CEL rule is no better, since expressing uniqueness costs O(n^2)
+// over the very lists that motivated the atomic list in the first place.
+func validateTargetsUnique(
+	f *field.Path,
+	targets []kargoapi.PromotionRequestTarget,
+) field.ErrorList {
+	var errs field.ErrorList
+	seen := make(map[string]struct{}, len(targets))
+	for i, target := range targets {
+		if _, duplicate := seen[target.Name]; duplicate {
+			errs = append(errs, field.Duplicate(f.Index(i).Child("name"), target.Name))
+			continue
+		}
+		seen[target.Name] = struct{}{}
+	}
+	return errs
+}
+
+// validateStage confirms that the named Stage exists and governs Targets. A
+// PromotionRequest promotes Freight to a Stage's Targets, so a classic Stage --
+// one that promotes to itself -- has nothing for a PromotionRequest to do.
+func (w *webhook) validateStage(
+	ctx context.Context,
+	f *field.Path,
+	promotionRequest *kargoapi.PromotionRequest,
+) (field.ErrorList, error) {
+	stage, err := api.GetStage(
+		ctx,
+		w.client,
+		types.NamespacedName{
+			Namespace: promotionRequest.Namespace,
+			Name:      promotionRequest.Spec.Stage,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error getting Stage %q in namespace %q: %w",
+			promotionRequest.Spec.Stage, promotionRequest.Namespace, err,
+		)
+	}
+	if stage == nil {
+		return field.ErrorList{
+			field.Invalid(
+				f,
+				promotionRequest.Spec.Stage,
+				fmt.Sprintf(
+					"Stage %q not found in namespace %q",
+					promotionRequest.Spec.Stage, promotionRequest.Namespace,
+				),
+			),
+		}, nil
+	}
+	if stage.Spec.Targets == nil {
+		return field.ErrorList{
+			field.Invalid(
+				f,
+				promotionRequest.Spec.Stage,
+				fmt.Sprintf(
+					"Stage %q does not select Targets; it is promoted to with a "+
+						"Promotion rather than a PromotionRequest",
+					promotionRequest.Spec.Stage,
+				),
+			),
+		}, nil
+	}
+	return nil, nil
+}
+
+// validateTargetsExist confirms that every named Target exists in the
+// PromotionRequest's own Project.
+//
+// It deliberately does not check that each Target still matches the Stage's
+// selectors. spec.targets is a snapshot of what the Stage governed when the
+// request was created, and a Target's labels changing afterwards must not
+// retroactively invalidate a request that is already in flight.
+func (w *webhook) validateTargetsExist(
+	ctx context.Context,
+	f *field.Path,
+	promotionRequest *kargoapi.PromotionRequest,
+) (field.ErrorList, error) {
+	if len(promotionRequest.Spec.Targets) == 0 {
+		return nil, nil
+	}
+
+	// One List beats one Get per Target: a fleet PromotionRequest may name
+	// thousands, and this runs on every admission.
+	list := kargoapi.TargetList{}
+	if err := w.client.List(
+		ctx,
+		&list,
+		client.InNamespace(promotionRequest.Namespace),
+	); err != nil {
+		return nil, fmt.Errorf(
+			"error listing Targets in namespace %q: %w",
+			promotionRequest.Namespace, err,
+		)
+	}
+	existing := make(map[string]struct{}, len(list.Items))
+	for _, target := range list.Items {
+		existing[target.Name] = struct{}{}
+	}
+
+	var errs field.ErrorList
+	for i, target := range promotionRequest.Spec.Targets {
+		if _, ok := existing[target.Name]; !ok {
+			errs = append(errs, field.Invalid(
+				f.Index(i).Child("name"),
+				target.Name,
+				fmt.Sprintf(
+					"Target %q not found in namespace %q",
+					target.Name, promotionRequest.Namespace,
+				),
+			))
+		}
+	}
+	return errs, nil
+}

--- a/pkg/webhook/kubernetes/promotionrequest/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotionrequest/webhook_test.go
@@ -1,16 +1,20 @@
 package promotionrequest
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -312,6 +316,104 @@ func Test_webhook_ValidateDelete(t *testing.T) {
 	warnings, err := w.ValidateDelete(t.Context(), promotionRequest())
 	assert.Empty(t, warnings)
 	assert.NoError(t, err)
+}
+
+// Test_webhook_failsClosed covers the paths where a lookup the webhook depends
+// on fails. A transient API error must fail the admission request rather than
+// silently admit a PromotionRequest nothing has actually checked.
+func Test_webhook_failsClosed(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	// Fresh objects per client: the builder takes ownership of what it is given
+	// and stamps a resourceVersion onto it, so subtests that run in parallel
+	// cannot share fixtures.
+	newWebhook := func(funcs interceptor.Funcs) *webhook {
+		return &webhook{
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(append(
+					projectObjects(),
+					targetAwareStage(),
+					target("us-east"),
+				)...).
+				WithInterceptorFuncs(funcs).
+				Build(),
+		}
+	}
+
+	t.Run("Stage lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(interceptor.Funcs{
+			Get: func(
+				ctx context.Context,
+				c client.WithWatch,
+				key client.ObjectKey,
+				obj client.Object,
+				opts ...client.GetOption,
+			) error {
+				if _, ok := obj.(*kargoapi.Stage); ok {
+					return errors.New("something went wrong")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+
+		_, err := w.ValidateCreate(t.Context(), promotionRequest("us-east"))
+		require.True(t, apierrors.IsInternalError(err), "got %T: %v", err, err)
+		assert.ErrorContains(t, err, "something went wrong")
+	})
+
+	t.Run("Target lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(interceptor.Funcs{
+			List: func(
+				ctx context.Context,
+				c client.WithWatch,
+				list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				if _, ok := list.(*kargoapi.TargetList); ok {
+					return errors.New("something went wrong")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		})
+
+		_, err := w.ValidateCreate(t.Context(), promotionRequest("us-east"))
+		require.True(t, apierrors.IsInternalError(err), "got %T: %v", err, err)
+		assert.ErrorContains(t, err, "something went wrong")
+	})
+
+	t.Run("Target lookup fails on update", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(interceptor.Funcs{
+			List: func(
+				ctx context.Context,
+				c client.WithWatch,
+				list client.ObjectList,
+				opts ...client.ListOption,
+			) error {
+				if _, ok := list.(*kargoapi.TargetList); ok {
+					return errors.New("something went wrong")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		})
+
+		_, err := w.ValidateUpdate(
+			t.Context(),
+			promotionRequest("us-east"),
+			promotionRequest("us-east", "us-west"),
+		)
+		require.True(t, apierrors.IsInternalError(err), "got %T: %v", err, err)
+	})
 }
 
 func Test_validateTargetsUnique(t *testing.T) {

--- a/pkg/webhook/kubernetes/promotionrequest/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotionrequest/webhook_test.go
@@ -1,0 +1,373 @@
+package promotionrequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+const testProject = "fake-project"
+
+func projectObjects() []client.Object {
+	return []client.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testProject,
+				Labels: map[string]string{
+					kargoapi.LabelKeyProject: kargoapi.LabelValueTrue,
+				},
+			},
+		},
+		&kargoapi.Project{ObjectMeta: metav1.ObjectMeta{Name: testProject}},
+	}
+}
+
+func targetAwareStage() *kargoapi.Stage {
+	return &kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testProject, Name: "fake-stage"},
+		Spec: kargoapi.StageSpec{
+			Targets: &kargoapi.StageTargets{
+				Selectors: []metav1.LabelSelector{{
+					MatchLabels: map[string]string{"region": "us"},
+				}},
+			},
+		},
+	}
+}
+
+func target(name string) *kargoapi.Target {
+	return &kargoapi.Target{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testProject, Name: name},
+	}
+}
+
+func promotionRequest(targets ...string) *kargoapi.PromotionRequest {
+	specTargets := make([]kargoapi.PromotionRequestTarget, len(targets))
+	for i, name := range targets {
+		specTargets[i] = kargoapi.PromotionRequestTarget{Name: name}
+	}
+	return &kargoapi.PromotionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testProject,
+			Name:      "fake-stage.01jexample.abcdef1",
+		},
+		Spec: kargoapi.PromotionRequestSpec{
+			Stage:   "fake-stage",
+			Freight: "fake-freight",
+			Targets: specTargets,
+		},
+	}
+}
+
+func Test_webhook_ValidateCreate(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	tests := []struct {
+		name             string
+		objects          []client.Object
+		promotionRequest *kargoapi.PromotionRequest
+		assertions       func(*testing.T, admission.Warnings, error)
+	}{
+		{
+			name: "project does not exist",
+			objects: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testProject}},
+			},
+			promotionRequest: promotionRequest(),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, `namespace "fake-project" is not a project`)
+			},
+		},
+		{
+			name:    "Stage does not exist",
+			objects: append(projectObjects(), target("us-east")),
+			// No Stage, so the request names one that cannot govern anything.
+			promotionRequest: promotionRequest("us-east"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, `Stage "fake-stage" not found`)
+			},
+		},
+		{
+			name: "Stage is not target-aware",
+			objects: append(
+				projectObjects(),
+				&kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "fake-stage",
+					},
+				},
+				target("us-east"),
+			),
+			promotionRequest: promotionRequest("us-east"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, "does not select Targets")
+			},
+		},
+		{
+			// The guarantee spec.targets' doc comment promises, which the schema
+			// deliberately does not enforce.
+			name: "duplicate Target names",
+			objects: append(
+				projectObjects(),
+				targetAwareStage(),
+				target("us-east"),
+			),
+			promotionRequest: promotionRequest("us-east", "us-east"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, "Duplicate value")
+				assert.ErrorContains(t, err, "us-east")
+			},
+		},
+		{
+			name: "Target does not exist",
+			objects: append(
+				projectObjects(),
+				targetAwareStage(),
+				target("us-east"),
+			),
+			promotionRequest: promotionRequest("us-east", "nonexistent"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, `Target "nonexistent" not found`)
+			},
+		},
+		{
+			name: "Target in another Project does not count",
+			objects: append(
+				projectObjects(),
+				targetAwareStage(),
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "other-project",
+						Name:      "us-east",
+					},
+				},
+			),
+			promotionRequest: promotionRequest("us-east"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.ErrorContains(t, err, `Target "us-east" not found`)
+			},
+		},
+		{
+			name: "valid",
+			objects: append(
+				projectObjects(),
+				targetAwareStage(),
+				target("us-east"),
+				target("us-west"),
+			),
+			promotionRequest: promotionRequest("us-east", "us-west"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			// A Stage may govern no Targets at the moment the request is
+			// created. That is recorded, not rejected.
+			name:             "empty Targets list is valid",
+			objects:          append(projectObjects(), targetAwareStage()),
+			promotionRequest: promotionRequest(),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			// spec.targets is a snapshot of what the Stage governed at creation.
+			// A Target whose labels have since stopped matching must not
+			// retroactively invalidate a request already in flight.
+			name: "Target no longer matching the Stage's selectors is still valid",
+			objects: append(
+				projectObjects(),
+				targetAwareStage(),
+				&kargoapi.Target{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testProject,
+						Name:      "us-east",
+						Labels:    map[string]string{"region": "eu"},
+					},
+				},
+			),
+			promotionRequest: promotionRequest("us-east"),
+			assertions: func(t *testing.T, warnings admission.Warnings, err error) {
+				assert.Empty(t, warnings)
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := &webhook{
+				client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(testCase.objects...).
+					Build(),
+			}
+			warnings, err := w.ValidateCreate(t.Context(), testCase.promotionRequest)
+			testCase.assertions(t, warnings, err)
+		})
+	}
+}
+
+func Test_webhook_ValidateUpdate(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	newWebhook := func(objects ...client.Object) *webhook {
+		return &webhook{
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build(),
+		}
+	}
+
+	t.Run("adding a Target in flight is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(append(
+			projectObjects(),
+			targetAwareStage(),
+			target("us-east"),
+			target("us-west"),
+		)...)
+
+		warnings, err := w.ValidateUpdate(
+			t.Context(),
+			promotionRequest("us-east"),
+			promotionRequest("us-east", "us-west"),
+		)
+		assert.Empty(t, warnings)
+		assert.NoError(t, err)
+	})
+
+	t.Run("adding a duplicate Target is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(append(
+			projectObjects(),
+			targetAwareStage(),
+			target("us-east"),
+		)...)
+
+		warnings, err := w.ValidateUpdate(
+			t.Context(),
+			promotionRequest("us-east"),
+			promotionRequest("us-east", "us-east"),
+		)
+		assert.Empty(t, warnings)
+		assert.ErrorContains(t, err, "Duplicate value")
+	})
+
+	t.Run("adding a nonexistent Target is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWebhook(append(
+			projectObjects(),
+			targetAwareStage(),
+			target("us-east"),
+		)...)
+
+		warnings, err := w.ValidateUpdate(
+			t.Context(),
+			promotionRequest("us-east"),
+			promotionRequest("us-east", "nonexistent"),
+		)
+		assert.Empty(t, warnings)
+		assert.ErrorContains(t, err, `Target "nonexistent" not found`)
+	})
+}
+
+func Test_webhook_ValidateDelete(t *testing.T) {
+	t.Parallel()
+
+	w := &webhook{}
+	warnings, err := w.ValidateDelete(t.Context(), promotionRequest())
+	assert.Empty(t, warnings)
+	assert.NoError(t, err)
+}
+
+func Test_validateTargetsUnique(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		targets    []string
+		assertions func(*testing.T, field.ErrorList)
+	}{
+		{
+			name:    "empty",
+			targets: nil,
+			assertions: func(t *testing.T, errs field.ErrorList) {
+				assert.Empty(t, errs)
+			},
+		},
+		{
+			name:    "all unique",
+			targets: []string{"us-east", "us-west", "eu-west"},
+			assertions: func(t *testing.T, errs field.ErrorList) {
+				assert.Empty(t, errs)
+			},
+		},
+		{
+			name:    "one duplicate reports once, at the later index",
+			targets: []string{"us-east", "us-west", "us-east"},
+			assertions: func(t *testing.T, errs field.ErrorList) {
+				require.Len(t, errs, 1)
+				assert.Equal(t, field.ErrorTypeDuplicate, errs[0].Type)
+				assert.Equal(t, "targets[2].name", errs[0].Field)
+			},
+		},
+		{
+			name:    "a name repeated three times reports twice",
+			targets: []string{"us-east", "us-east", "us-east"},
+			assertions: func(t *testing.T, errs field.ErrorList) {
+				require.Len(t, errs, 2)
+				assert.Equal(t, "targets[1].name", errs[0].Field)
+				assert.Equal(t, "targets[2].name", errs[1].Field)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			targets := make([]kargoapi.PromotionRequestTarget, len(testCase.targets))
+			for i, name := range testCase.targets {
+				targets[i] = kargoapi.PromotionRequestTarget{Name: name}
+			}
+			testCase.assertions(
+				t,
+				validateTargetsUnique(field.NewPath("targets"), targets),
+			)
+		})
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on #6829, which nests the Stage's Target selector under `spec.targets`. Review only the top two commits.

## Description

Adds a validating webhook for `PromotionRequest`, covering three things the schema cannot express.

### Target names must be unique

`spec.targets`' doc comment already promises this:

> Target names MUST be unique; this is enforced by the validating webhook rather than by the schema…

but nothing enforced it until now. The field is an atomic list rather than a list-map precisely to avoid the per-item ownership tracking a list-map records in `managedFields`, which roughly doubles the storage cost of every entry — a real cost on a fleet request naming thousands of Targets. A CEL rule is no better: expressing uniqueness costs `O(n²)` over exactly the lists the atomic list exists to keep affordable. One pass in the webhook costs `O(n)`.

### The Stage must exist and must select Targets

A PromotionRequest promotes Freight to a Stage's Targets. A classic Stage — one that promotes to itself — has nothing for a PromotionRequest to do, so a request naming one would be reconciled forever without effect.

### Every named Target must exist in the Project

Done with a single `List` rather than a `Get` per Target, since this runs on every admission and a fleet request may name thousands.

**Deliberately absent:** any check that a Target still *matches* the Stage's selectors. `spec.targets` is a snapshot of what the Stage governed when the request was created, so a Target relabelled afterwards must not retroactively invalidate a request already in flight. There's a test for that.

## Notes for reviewers

- **Validation runs on update as well as create.** `spec.targets` is mutable — the governing Stage may add Targets to an in-flight request — so an addition gets the same scrutiny as the original list. `spec.stage` and `spec.freight` can't change; the schema's transition rules reject that before the webhook runs.
- **The webhooks server needed a new grant.** It now reads Targets, which weren't in its ClusterRole.
- **`stage.Spec.TargetSelectors == nil` is inlined** rather than using `api.IsTargetAware`, which lives on #6805. Worth converging on the helper once both have landed.
- **Not in this PR:** the defaulting webhook. Resolving the Stage's selectors into `spec.targets` at admission, and resolving promote-by-origin for target-aware Stages (currently a 400), are tracked separately — @thomastaylor312 asked for the latter as a follow-up on #6805.

## Validation

- `make lint-go`, `make test-chart`, `go test -race ./pkg/webhook/...`
- Rendered the chart and confirmed the webhook registration and the `targets` grant both appear
- Tests cover: project missing, Stage missing, Stage not target-aware, duplicate names, Target missing, Target in another Project, empty Targets list, a relabelled Target still validating, and update-path additions

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

