### PR TITLE
refactor(controller): drop the PromotionRequest reconciler's injectable seam

### DIFF
--- a/cmd/controlplane/controller.go
+++ b/cmd/controlplane/controller.go
@@ -477,7 +477,6 @@ func (o *controllerOptions) setupReconcilers(
 		ctx,
 		kargoMgr,
 		promotionrequests.ReconcilerConfigFromEnv(),
-		promotionrequests.DefaultReconcile,
 	); err != nil {
 		return fmt.Errorf("error setting up PromotionRequests reconciler: %w", err)
 	}

--- a/pkg/controller/promotionrequests/promotionrequests.go
+++ b/pkg/controller/promotionrequests/promotionrequests.go
@@ -60,13 +60,11 @@ func ReconcilerConfigFromEnv() ReconcilerConfig {
 }
 
 // SetupReconcilerWithManager initializes the PromotionRequest reconciler and
-// registers it with the provided Manager. The behavior that fans a
-// PromotionRequest out into Promotions is supplied by reconcileFn.
+// registers it with the provided Manager.
 func SetupReconcilerWithManager(
 	ctx context.Context,
 	mgr manager.Manager,
 	cfg ReconcilerConfig,
-	reconcileFn ReconcileFn,
 ) error {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&kargoapi.PromotionRequest{}).
@@ -75,10 +73,7 @@ func SetupReconcilerWithManager(
 		WithEventFilter(cfg.shardPredicate()).
 		WithOptions(controller.CommonOptions(cfg.MaxConcurrentReconciles)).
 		Named(cfg.Name()).
-		Complete(&reconciler{
-			client:      mgr.GetClient(),
-			reconcileFn: reconcileFn,
-		}); err != nil {
+		Complete(&reconciler{client: mgr.GetClient()}); err != nil {
 		return fmt.Errorf("error building PromotionRequest reconciler: %w", err)
 	}
 
@@ -91,17 +86,16 @@ func SetupReconcilerWithManager(
 	return nil
 }
 
-// ReconcileFn reconciles a PromotionRequest after it has been loaded.
-type ReconcileFn func(
-	ctx context.Context,
-	kubeClient client.Client,
-	promotionRequest *kargoapi.PromotionRequest,
-) (ctrl.Result, error)
-
-// reconciler delegates PromotionRequest reconciliation to its configured function.
+// reconciler reports on every PromotionRequest it observes that fanning Freight
+// out to Targets is a Kargo Enterprise-only feature, so that a user whose Stage
+// has stopped promoting can find out why from the object it produced.
+//
+// There is deliberately no hook to swap this behavior out. A reconciler that
+// fans a PromotionRequest out into Promotions must also watch the child
+// Promotions that drive it forward, and a watch is not something a swappable
+// Reconcile body can contribute; such a reconciler is its own controller.
 type reconciler struct {
-	client      client.Client
-	reconcileFn ReconcileFn
+	client client.Client
 }
 
 func (r *reconciler) Reconcile(
@@ -113,19 +107,7 @@ func (r *reconciler) Reconcile(
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	return r.reconcileFn(ctx, r.client, promotionRequest)
-}
-
-// DefaultReconcile is the ReconcileFn used when no fan-out implementation has
-// been supplied. It reports on the PromotionRequest itself that fanning Freight
-// out to Targets is a Kargo Enterprise-only feature, so that a user whose Stage
-// has stopped promoting can find out why from the object it produced.
-func DefaultReconcile(
-	ctx context.Context,
-	kubeClient client.Client,
-	promotionRequest *kargoapi.PromotionRequest,
-) (ctrl.Result, error) {
-	if err := kubeclient.PatchStatus(ctx, kubeClient, promotionRequest, func(status *kargoapi.PromotionRequestStatus) {
+	if err := kubeclient.PatchStatus(ctx, r.client, promotionRequest, func(status *kargoapi.PromotionRequestStatus) {
 		status.ObservedGeneration = promotionRequest.Generation
 		status.Phase = kargoapi.PromotionRequestPhaseErrored
 		if status.FinishedAt == nil {

--- a/pkg/controller/promotionrequests/promotionrequests_test.go
+++ b/pkg/controller/promotionrequests/promotionrequests_test.go
@@ -1,7 +1,6 @@
 package promotionrequests
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -131,10 +130,7 @@ func TestReconcile(t *testing.T) {
 			WithObjects(promotionRequest).
 			WithStatusSubresource(&kargoapi.PromotionRequest{}).
 			Build()
-		r := &reconciler{
-			client:      c,
-			reconcileFn: DefaultReconcile,
-		}
+		r := &reconciler{client: c}
 		req := ctrl.Request{NamespacedName: client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
@@ -166,45 +162,9 @@ func TestReconcile(t *testing.T) {
 		require.Equal(t, firstStatus, &actual.Status)
 	})
 
-	t.Run("delegates to configured reconcile function", func(t *testing.T) {
-		promotionRequest := &kargoapi.PromotionRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      name,
-			},
-		}
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(promotionRequest).
-			Build()
-		r := &reconciler{
-			client: c,
-			reconcileFn: func(
-				_ context.Context,
-				kubeClient client.Client,
-				actual *kargoapi.PromotionRequest,
-			) (ctrl.Result, error) {
-				require.Same(t, c, kubeClient)
-				require.Equal(t, promotionRequest.Name, actual.Name)
-				return ctrl.Result{Requeue: true}, nil
-			},
-		}
-
-		result, err := r.Reconcile(t.Context(), ctrl.Request{
-			NamespacedName: client.ObjectKey{
-				Namespace: namespace,
-				Name:      name,
-			},
-		})
-
-		require.NoError(t, err)
-		require.Equal(t, ctrl.Result{Requeue: true}, result)
-	})
-
 	t.Run("PromotionRequest not found", func(t *testing.T) {
 		r := &reconciler{
-			client:      fake.NewClientBuilder().WithScheme(scheme).Build(),
-			reconcileFn: DefaultReconcile,
+			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
 		}
 
 		result, err := r.Reconcile(t.Context(), ctrl.Request{


### PR DESCRIPTION
`SetupReconcilerWithManager` took a `ReconcileFn` so the reconciler's behavior could be swapped out later:

```go
type ReconcileFn func(ctx, kubeClient, promotionRequest) (ctrl.Result, error)

func SetupReconcilerWithManager(ctx, mgr, cfg, reconcileFn ReconcileFn) error
```

Only one function was ever passed. And working through what a reconciler that actually fans a `PromotionRequest` out into `Promotion`s would need, the seam does not fit it.

### Why a function is the wrong extension point here

A fan-out reconciler must watch the child `Promotion`s it creates. A `PromotionRequest`'s spec barely changes after creation — `spec.stage` and `spec.freight` are immutable and only `spec.targets` may grow — so nearly every reconcile after the first is triggered by a child changing phase. That watch is an `Owns(&kargoapi.Promotion{})` on the controller builder, and this package builds the controller with `For` alone. **A swappable `Reconcile` body cannot contribute a watch.**

Two smaller ones point the same way:

- **An uncached reader.** The seam hands over `mgr.GetClient()`. Listing owned `Promotion`s through the informer cache immediately after creating them reads as "this Target has no Promotion yet" and creates a duplicate, so fan-out needs `mgr.GetAPIReader()`.
- **Fan-out concurrency.** A request naming thousands of Targets should not hand the promotion engine the entire fleet in one pass. That is a knob about the fan-out, and it does not belong in this package.

Each would have to be smuggled in by closure, or added here on behalf of a caller this package does not have. At that point the caller is not supplying a function, it is supplying a controller through a keyhole.

### What changes

The reconciler becomes concrete: it records its status on the `PromotionRequest` and nothing else. Fan-out, when it is implemented, is its own controller with its own watches — a smaller commitment than an extension point that only appears to fit, and it leaves nothing here to be misread as an integration contract.

- `ReconcileFn` and the exported `DefaultReconcile` are gone; the body moves into `reconciler.Reconcile`.
- `SetupReconcilerWithManager` loses its fourth parameter.
- Net −57 lines.

No behavior change: `DefaultReconcile` was the only `ReconcileFn` ever passed, and its logic is unchanged — same phase, same condition, same idempotence (a second reconcile produces an empty merge patch and no write). The test asserting that is unchanged; only the subtest exercising the delegation itself is removed.
