### PR TITLE
fix(api): order Promotions by the ULID in their name, not the whole name

### DIFF
--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -224,14 +224,68 @@ func ComparePromotionByPhaseAndCreationTime(a, b kargoapi.Promotion) int {
 		// Non-terminal Promotions are ordered in ascending order based on the
 		// ULID in the Promotion name. This ensures that the Promotion which
 		// was (or will be) enqueued first is at the top.
-		return strings.Compare(a.Name, b.Name)
+		return comparePromotionNamesByULID(a.Name, b.Name)
 	default:
 		// Terminal Promotions are ordered in descending order based on the
 		// ULID in the Promotion name. This ensures that the most recent
 		// Promotion is at the top, limiting the number of Promotions which
 		// have to be further inspected to collect the "new" Promotions.
-		return strings.Compare(b.Name, a.Name)
+		return comparePromotionNamesByULID(b.Name, a.Name)
 	}
+}
+
+// comparePromotionNamesByULID orders two generated Promotion names by the ULID
+// they embed, rather than by comparing the names whole.
+//
+// Comparing whole names is only equivalent to comparing ULIDs while everything
+// to the left of the ULID is identical, which stopped being true once a
+// Promotion could be named after the Target it promotes to. Two Promotions of
+// the same Stage then differ at the Target segment, the comparison resolves
+// there, and it never reaches the ULID at all -- so an older Promotion to
+// "us-west" would sort after a newer one to "us-east", and a Stage would start
+// promoting to the second while the first was still outstanding.
+//
+// Both generated name formats put the ULID in the second-to-last
+// dot-separated segment:
+//
+//	<stage>.<ulid>.<short-hash>
+//	<stage>.<target>.<ulid>.<short-hash>
+//
+// Indexing from the end is what makes that reliable: a Kubernetes name may
+// contain dots, so a Stage or Target named "foo.bar" adds segments on the left,
+// while the short hash never contains one.
+//
+// Names that do not carry a parseable ULID -- a Promotion created before Kargo
+// generated names, or one named by hand -- fall back to comparing whole names,
+// preserving the previous behavior rather than declaring them equal and leaving
+// the sort unstable.
+func comparePromotionNamesByULID(a, b string) int {
+	aULID, aOK := promotionNameULID(a)
+	bULID, bOK := promotionNameULID(b)
+	if !aOK || !bOK {
+		return strings.Compare(a, b)
+	}
+	return strings.Compare(aULID, bULID)
+}
+
+// promotionNameULID returns the ULID embedded in a generated Promotion name,
+// and whether one was found. The returned value keeps the case it appears in:
+// generated names are lowercased, and lowercasing a ULID preserves ordering,
+// since Crockford base32 digits sort before its letters in ASCII either way.
+func promotionNameULID(name string) (string, bool) {
+	parts := strings.Split(name, promotionNameSeparator)
+	// A generated name has at least a prefix, a ULID, and a hash.
+	if len(parts) < 3 {
+		return "", false
+	}
+	candidate := parts[len(parts)-2]
+	if len(candidate) != ulid.EncodedSize {
+		return "", false
+	}
+	if _, err := ulid.ParseStrict(candidate); err != nil {
+		return "", false
+	}
+	return candidate, true
 }
 
 // ComparePromotionPhase compares two Promotion phases. It returns a negative

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -256,16 +256,42 @@ func ComparePromotionByPhaseAndCreationTime(a, b kargoapi.Promotion) int {
 // while the short hash never contains one.
 //
 // Names that do not carry a parseable ULID -- a Promotion created before Kargo
-// generated names, or one named by hand -- fall back to comparing whole names,
-// preserving the previous behavior rather than declaring them equal and leaving
-// the sort unstable.
+// generated names, or one named by hand -- are compared whole, preserving the
+// previous behavior rather than declaring them equal and leaving the sort
+// unstable.
+//
+// A ULID and an arbitrary string are not on the same comparison axis, so a pair
+// where only one name carries a ULID is decided by which one does, not by
+// comparing the names. Choosing the axis per pair is what would break
+// transitivity, and slices.SortFunc gives no guarantees about the order it
+// produces for a comparator that is not a strict weak ordering. Consider:
+//
+//	a = "b.7zzzzzzzzzzzzzzzzzzzzzzzzz.abc1234"
+//	b = "m"
+//	c = "z.00000000000000000000000000.abc1234"
+//
+// A per-pair axis compares a and b, and b and c, as whole names, giving a < b
+// and b < c, but compares a and c as ULIDs, giving a > c. No order satisfies
+// all three, so a single hand-named Promotion alongside generated ones would be
+// enough to make the Stage's choice of current Promotion arbitrary.
 func comparePromotionNamesByULID(a, b string) int {
 	aULID, aOK := promotionNameULID(a)
 	bULID, bOK := promotionNameULID(b)
-	if !aOK || !bOK {
+	switch {
+	case aOK && bOK:
+		return strings.Compare(aULID, bULID)
+	case aOK != bOK:
+		// Bucket by whether a ULID is present. Names without one sort first,
+		// which -- because the caller inverts the arguments for terminal
+		// Promotions -- puts them ahead of generated names among non-terminal
+		// Promotions and behind them among terminal ones.
+		if aOK {
+			return 1
+		}
+		return -1
+	default:
 		return strings.Compare(a, b)
 	}
-	return strings.Compare(aULID, bULID)
 }
 
 // promotionNameULID returns the ULID embedded in a generated Promotion name,

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1261,4 +1262,137 @@ func Test_promotionTaskVarsToStepVars(t *testing.T) {
 			tt.assertions(t, result, err)
 		})
 	}
+}
+
+// An older PromotionRequest must drain before a newer one starts. Both name
+// their children after the Target being promoted to, so every child of the same
+// Stage shares the "<stage>." prefix and then diverges at the Target segment.
+// Comparing names whole resolves there and never reaches the ULID, which
+// interleaves the two requests: the Stage promotes to the newer request's
+// first Target while the older request still has Targets outstanding.
+func TestComparePromotionByPhaseAndCreationTime_doesNotInterleaveRequests(t *testing.T) {
+	t.Parallel()
+
+	const (
+		stage    = "tier-2"
+		freightA = "aaaa111122223333"
+		freightB = "bbbb444455556666"
+	)
+
+	// Request A is created first, so all four of its ULIDs precede all of B's.
+	// Targets are visited in spec order within each request.
+	older := []kargoapi.Promotion{
+		{ObjectMeta: metav1.ObjectMeta{Name: GenerateChildPromotionName(stage, "us-west", freightA)}},
+		{ObjectMeta: metav1.ObjectMeta{Name: GenerateChildPromotionName(stage, "us-east", freightA)}},
+	}
+	newer := []kargoapi.Promotion{
+		{ObjectMeta: metav1.ObjectMeta{Name: GenerateChildPromotionName(stage, "us-west", freightB)}},
+		{ObjectMeta: metav1.ObjectMeta{Name: GenerateChildPromotionName(stage, "us-east", freightB)}},
+	}
+
+	olderNames := map[string]struct{}{}
+	for _, promo := range older {
+		olderNames[promo.Name] = struct{}{}
+	}
+
+	// All non-terminal, so ordering is decided entirely by name.
+	promos := append(append([]kargoapi.Promotion{}, newer...), older...)
+	slices.SortFunc(promos, ComparePromotionByPhaseAndCreationTime)
+
+	// Every child of the older request must sort ahead of every child of the
+	// newer one. Asserting only on promos[0] would pass even while interleaved.
+	var seenNewer bool
+	for _, promo := range promos {
+		_, isOlder := olderNames[promo.Name]
+		if !isOlder {
+			seenNewer = true
+			continue
+		}
+		require.False(
+			t, seenNewer,
+			"%q belongs to the older request but sorts after a child of the newer one; "+
+				"the Stage would start the newer request before the older one finished",
+			promo.Name,
+		)
+	}
+
+	require.Contains(t, olderNames, promos[0].Name)
+}
+
+func Test_promotionNameULID(t *testing.T) {
+	t.Parallel()
+
+	id := ulid.Make().String()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+		found    bool
+	}{
+		{
+			name:     "classic generated name",
+			input:    strings.ToLower("tier-2." + id + ".abc1234"),
+			expected: strings.ToLower(id),
+			found:    true,
+		},
+		{
+			name:     "Target-aware generated name",
+			input:    strings.ToLower("tier-2.us-east." + id + ".abc1234"),
+			expected: strings.ToLower(id),
+			found:    true,
+		},
+		{
+			// A dotted Stage or Target name shifts the prefix, which is why the
+			// ULID is located from the end rather than the start.
+			name:     "dots in the Stage and Target names",
+			input:    strings.ToLower("foo.bar.baz.qux." + id + ".abc1234"),
+			expected: strings.ToLower(id),
+			found:    true,
+		},
+		{
+			name:  "hand-written name",
+			input: "my-promotion",
+		},
+		{
+			name:  "too few segments",
+			input: "tier-2." + strings.ToLower(id),
+		},
+		{
+			name:  "right length, not a ULID",
+			input: "tier-2." + strings.Repeat("!", ulid.EncodedSize) + ".abc1234",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := promotionNameULID(testCase.input)
+			require.Equal(t, testCase.found, ok)
+			require.Equal(t, testCase.expected, got)
+		})
+	}
+}
+
+func Test_comparePromotionNamesByULID(t *testing.T) {
+	t.Parallel()
+
+	earlier := strings.ToLower(ulid.MustNew(ulid.Timestamp(time.Now().Add(-time.Hour)), nil).String())
+	later := strings.ToLower(ulid.MustNew(ulid.Timestamp(time.Now().Add(time.Hour)), nil).String())
+
+	t.Run("earlier ULID wins regardless of Target name", func(t *testing.T) {
+		t.Parallel()
+		// "us-west" sorts after "us-east" lexically; the ULID must decide.
+		require.Negative(t, comparePromotionNamesByULID(
+			"tier-2.us-west."+earlier+".abc1234",
+			"tier-2.us-east."+later+".abc1234",
+		))
+	})
+
+	t.Run("falls back to whole-name compare when a ULID is absent", func(t *testing.T) {
+		t.Parallel()
+		require.Negative(t, comparePromotionNamesByULID("aaa", "bbb"))
+		require.Positive(t, comparePromotionNamesByULID("bbb", "aaa"))
+		require.Zero(t, comparePromotionNamesByULID("same", "same"))
+	})
 }

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -1389,10 +1389,60 @@ func Test_comparePromotionNamesByULID(t *testing.T) {
 		))
 	})
 
-	t.Run("falls back to whole-name compare when a ULID is absent", func(t *testing.T) {
+	t.Run("compares whole names when neither carries a ULID", func(t *testing.T) {
 		t.Parallel()
 		require.Negative(t, comparePromotionNamesByULID("aaa", "bbb"))
 		require.Positive(t, comparePromotionNamesByULID("bbb", "aaa"))
 		require.Zero(t, comparePromotionNamesByULID("same", "same"))
+	})
+
+	// A name without a ULID is bucketed ahead of one with a ULID no matter how
+	// the two compare lexically. Deciding such a pair by comparing the names
+	// instead is what would make the comparator non-transitive.
+	t.Run("a name without a ULID sorts before one with a ULID", func(t *testing.T) {
+		t.Parallel()
+
+		generated := "tier-2.us-east." + earlier + ".abc1234"
+
+		for _, handWritten := range []string{
+			"aaa",                     // lexically before the generated name
+			"zzz",                     // lexically after it
+			"tier-2.us-east.aaa.aaa1", // shares the generated name's prefix
+		} {
+			t.Run(handWritten, func(t *testing.T) {
+				t.Parallel()
+				require.Negative(t, comparePromotionNamesByULID(handWritten, generated))
+				require.Positive(t, comparePromotionNamesByULID(generated, handWritten))
+			})
+		}
+	})
+
+	// The comparator must be a strict weak ordering, or slices.SortFunc -- which
+	// pkg/controller/stages calls to pick a Stage's current Promotion -- makes no
+	// promise about the order it produces. This triple is the counterexample that
+	// a per-pair choice between comparing ULIDs and comparing whole names admits:
+	// deciding a vs b and b vs c lexically while deciding a vs c by ULID yields
+	// a < b < c and a > c at once.
+	t.Run("ordering is transitive across names with and without ULIDs", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			maxULID = "7zzzzzzzzzzzzzzzzzzzzzzzzz"
+			minULID = "00000000000000000000000000"
+		)
+		var (
+			a = "b." + maxULID + ".abc1234"
+			b = "m"
+			c = "z." + minULID + ".abc1234"
+		)
+
+		require.Negative(t, comparePromotionNamesByULID(b, a), "the name without a ULID sorts first")
+		require.Negative(t, comparePromotionNamesByULID(b, c), "the name without a ULID sorts first")
+		require.Negative(t, comparePromotionNamesByULID(c, a), "%q holds the earlier ULID", c)
+
+		names := []string{a, b, c}
+		slices.SortFunc(names, comparePromotionNamesByULID)
+		require.Equal(t, []string{b, c, a}, names)
+		require.True(t, slices.IsSortedFunc(names, comparePromotionNamesByULID))
 	})
 }


### PR DESCRIPTION
`ComparePromotionByPhaseAndCreationTime` says it orders Promotions *"based on the ULID in the Promotion name"*, but compares the names whole:

```go
return strings.Compare(a.Name, b.Name)
```

Those are equivalent only while everything to the left of the ULID is identical. That held until a Promotion could be named after the Target it promotes to (#6834), and it does not hold now.

## The failure is request interleaving, not just Target order

A Stage sorts **every** Promotion it owns — across every `PromotionRequest` — and takes `promotions.Items[0]` as its `currentPromotion`. Two children of one Stage now diverge at the Target segment, so the comparison resolves there and never reaches the ULID.

Request A is created first, request B second. All of A's ULIDs precede all of B's:

```
A: tier-2.us-east.<ulidA>.aaaa111     B: tier-2.us-east.<ulidB>.bbbb444
A: tier-2.us-west.<ulidA>.aaaa111     B: tier-2.us-west.<ulidB>.bbbb444
```

Sorted by whole name:

```
tier-2.us-east.<ulidA>   ← A
tier-2.us-east.<ulidB>   ← B
tier-2.us-west.<ulidA>   ← A
tier-2.us-west.<ulidB>   ← B
```

A's `us-east` runs and finishes; the next non-terminal name is **B's** `us-east`. The Stage begins the newer request while the older one still has `us-west` outstanding. Under the older `<stage>.<ulid>.<hash>` naming every one of A's names preceded every one of B's, so A drained completely before B started — a property that was load-bearing and silently lost.

## The fix

Compare the embedded ULID. Both generated formats place it in the second-to-last dot-separated segment:

```
<stage>.<ulid>.<short-hash>
<stage>.<target>.<ulid>.<short-hash>
```

Locating it **from the end** is what makes this reliable: `KubernetesName` permits dots, so a Stage or Target called `foo.bar` adds segments on the left, while the short hash never contains one. A name with no parseable ULID — hand-written, or predating generated names — falls back to comparing whole names, exactly as before, rather than comparing equal and leaving the sort unstable.

## Tests

`TestComparePromotionByPhaseAndCreationTime_doesNotInterleaveRequests` builds two requests' children, sorts them together, and asserts **every** child of the older request precedes **every** child of the newer. Checking only `promos[0]` would pass while interleaved, so it walks the whole slice.

Verified the test fails against the old comparator before it passed against the new one:

```
--- FAIL: TestComparePromotionByPhaseAndCreationTime_doesNotInterleaveRequests
    "tier-2.us-west.01m0b5sbr54v1dp08z0kz2hc14.aaaa111" belongs to the older
    request but sorts after a child of the newer one; the Stage would start the
    newer request before the older one finished
```

Plus table tests for `promotionNameULID` (both formats, dotted Stage/Target names, hand-written names, right-length non-ULIDs) and for the fallback path.

## Notes

Strictly this was always a latent mismatch between what the function said and what it did; nothing exercised it until names stopped sharing a prefix. Fixing the comparator rather than the naming keeps the Target visible in child names — which is what makes a fan-out greppable — and leaves the ULID authoritative for ordering, as the doc comment always claimed.
