### PR TITLE
fix(ui): distinguish progressing stages from failures

### DIFF
--- a/ui/src/features/common/stage-status/stage-condition-icon.tsx
+++ b/ui/src/features/common/stage-status/stage-condition-icon.tsx
@@ -11,8 +11,12 @@ import { Tooltip } from 'antd';
 import classNames from 'classnames';
 import { memo, useMemo } from 'react';
 
-import { StageConditionType, StageConditionStatus } from '@ui/features/common/stage-status/utils';
-import { V1Condition } from '@ui/gen/api/v2/models';
+import {
+  isStageProgressing,
+  StageConditionType,
+  StageConditionStatus
+} from '@ui/features/common/stage-status/utils';
+import { Stage, V1Condition } from '@ui/gen/api/v2/models';
 
 import styles from './styles.module.less';
 import { TruckIcon } from './truck-icon/truck-icon';
@@ -26,19 +30,20 @@ interface IconState {
 
 export const StageConditionIcon = memo(
   ({
-    conditions,
+    stage,
     className,
     noTooltip,
     isControllerDead,
     controllerName
   }: {
-    conditions: V1Condition[];
+    stage: Stage;
     className?: string;
     noTooltip?: boolean;
     isControllerDead?: boolean;
     controllerName?: string;
   }) => {
     const { iconState, isPromoting } = useMemo(() => {
+      const conditions = stage.status?.conditions || [];
       // A dead (or absent) controller overrides everything: the
       // conditions on the Stage were written by the very controller that
       // has gone silent, so they cannot be trusted. Surface this as
@@ -84,6 +89,7 @@ export const StageConditionIcon = memo(
       );
 
       const isFailed = readyCondition?.status === StageConditionStatus.False;
+      const isProgressing = isStageProgressing(stage);
 
       const { condition: verifiedCondition, isActive: isVerifying } = hasCondition(
         StageConditionType.Verified,
@@ -98,7 +104,7 @@ export const StageConditionIcon = memo(
         iconClass: 'text-gray-400'
       };
 
-      // Priority: Promoting > Verifying > Reconciling > Failed > Ready
+      // Priority: Promoting > Verifying > Reconciling > Progressing > Failed > Ready
       if (isPromoting && promotingCondition?.reason !== 'NoFreight') {
         iconState = {
           icon: faCircleMinus,
@@ -120,6 +126,13 @@ export const StageConditionIcon = memo(
           tooltipMessage: reconcilingCondition?.message ?? '',
           iconClass: `text-yellow-500 ${styles.rotate}`
         };
+      } else if (isProgressing) {
+        iconState = {
+          icon: faSync,
+          tooltipTitle: 'Progressing',
+          tooltipMessage: stage.status?.health?.issues?.join('; ') ?? readyCondition?.message ?? '',
+          iconClass: `text-blue-500 ${styles.rotate}`
+        };
       } else if (isFailed && readyCondition.reason !== 'NoFreight') {
         iconState = {
           icon: faTimesCircle,
@@ -137,7 +150,7 @@ export const StageConditionIcon = memo(
       }
 
       return { iconState, isPromoting };
-    }, [conditions, isControllerDead, controllerName]);
+    }, [stage, isControllerDead, controllerName]);
 
     const tooltipContent = useMemo(
       () => (

--- a/ui/src/features/common/stage-status/utils.test.ts
+++ b/ui/src/features/common/stage-status/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Stage } from '@ui/gen/api/v2/models';
+
+import { getStagePhase, isStageProgressing } from './utils';
+
+const stageWithConditions = (conditions: NonNullable<Stage['status']>['conditions']): Stage =>
+  ({ status: { conditions } }) as Stage;
+
+describe('stage status', () => {
+  test('reports a progressing Stage instead of failed', () => {
+    const stage = stageWithConditions([{ type: 'Ready', status: 'False', reason: 'Progressing' }]);
+
+    expect(isStageProgressing(stage)).toBe(true);
+    expect(getStagePhase(stage)).toBe('Progressing');
+  });
+
+  test('keeps terminal Stage failures failed', () => {
+    const stage = stageWithConditions([
+      { type: 'Ready', status: 'False', reason: 'VerificationFailed' }
+    ]);
+
+    expect(isStageProgressing(stage)).toBe(false);
+    expect(getStagePhase(stage)).toBe('Failed');
+  });
+});

--- a/ui/src/features/common/stage-status/utils.ts
+++ b/ui/src/features/common/stage-status/utils.ts
@@ -25,6 +25,14 @@ export const hasCondition = (
   };
 };
 
+export const isStageProgressing = (stage: Stage) =>
+  stage.status?.conditions?.some(
+    (condition) =>
+      condition.type === StageConditionType.Ready &&
+      condition.status === StageConditionStatus.False &&
+      condition.reason === 'Progressing'
+  ) ?? false;
+
 export const getStagePhase = (stage: Stage, isControllerDead?: boolean) => {
   // A dead (or absent) controller means any condition the Stage carries
   // was written before the controller stopped reporting and is now stale.
@@ -68,6 +76,10 @@ export const getStagePhase = (stage: Stage, isControllerDead?: boolean) => {
   const ready = hasCondition(StageConditionType.Ready, StageConditionStatus.True, conditions);
 
   const failed = ready.condition?.status === StageConditionStatus.False;
+
+  if (isStageProgressing(stage)) {
+    return 'Progressing';
+  }
 
   if (failed && ready.condition?.reason !== 'NoFreight') {
     return 'Failed';

--- a/ui/src/features/project/pipelines/list/columns/phase-cell.tsx
+++ b/ui/src/features/project/pipelines/list/columns/phase-cell.tsx
@@ -20,7 +20,7 @@ export const PhaseCell = ({ stage }: { stage: Stage }) => {
     <Flex align='center' gap={4}>
       {stagePhase}{' '}
       <StageConditionIcon
-        conditions={stage?.status?.conditions || []}
+        stage={stage}
         noTooltip
         className='text-[10px]'
         isControllerDead={isControllerDead}

--- a/ui/src/features/project/pipelines/nodes/stage-node-phase.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node-phase.tsx
@@ -19,7 +19,7 @@ export const StageNodePhase = (props: { stage: Stage }) => {
       {stagePhase}{' '}
       <StageConditionIcon
         className='text-[10px]'
-        conditions={props.stage?.status?.conditions || []}
+        stage={props.stage}
         noTooltip
         isControllerDead={isControllerDead}
         controllerName={controllerName}

--- a/ui/src/features/stage/stage-details.tsx
+++ b/ui/src/features/stage/stage-details.tsx
@@ -100,8 +100,6 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
 
   const { stageTabs } = useExtensionsContext();
 
-  const stageConditions = useMemo(() => stage.status?.conditions || [], [stage.status?.conditions]);
-
   const { controllerName, isControllerDead } = useStageControllerStatus(stage);
 
   return (
@@ -118,7 +116,7 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
               </Typography.Title>
               <Flex gap={4}>
                 <StageConditionIcon
-                  conditions={stageConditions}
+                  stage={stage}
                   isControllerDead={isControllerDead}
                   controllerName={controllerName}
                 />


### PR DESCRIPTION
Summary
- Shows a Stage as Progressing when Kargo explicitly reports Ready=False with reason=Progressing.

Changes
- Keeps terminal reconciliation, Promotion, and verification failures as Failed.
- Uses a blue spinner and the Kargo health issue in the Stage tooltip while Argo CD is progressing.
- Adds focused status-mapping coverage.

Testing
- pnpm --dir ui lint
- pnpm --dir ui test --run
- pnpm --dir ui typecheck
- pnpm --dir ui build
- gitleaks protect --staged --redact --no-banner

Risks/Notes
- This is display-only. It uses Kargo's existing Ready reason and does not alter Stage, Promotion, or health semantics.