### PR TITLE
feat(webhook): reject manual Promotions on target-aware Stages

### DIFF
--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -343,13 +343,27 @@ func (w *webhook) Default(ctx context.Context, promo *kargoapi.Promotion) error 
 	// Stage-based garbage collection entirely, whereas a PromotionRequest is
 	// itself owned by its Stage, so deleting the Stage still cascades to the
 	// Promotion through it.
-	if owner := metav1.GetControllerOf(promo); owner == nil ||
-		owner.APIVersion != kargoapi.GroupVersion.String() ||
-		owner.Kind != promotionRequestKind {
+	if !isPromotionRequestChild(promo) {
 		ownerRef := metav1.NewControllerRef(stage, kargoapi.GroupVersion.WithKind("Stage"))
 		promo.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
 	return nil
+}
+
+// isPromotionRequestChild returns true if the Promotion was created by a
+// PromotionRequest as one part of that request's fan-out to Targets, rather
+// than on its own.
+//
+// Ownership is the signal because it is the one a caller cannot usefully forge:
+// Kubernetes garbage collection deletes an object whose controller owner does
+// not exist, so a reference to a PromotionRequest that was never created takes
+// the Promotion with it. Defaulting and validation share this function so that
+// the owner reference Default preserves is exactly the one validation accepts.
+func isPromotionRequestChild(promo *kargoapi.Promotion) bool {
+	owner := metav1.GetControllerOf(promo)
+	return owner != nil &&
+		owner.APIVersion == kargoapi.GroupVersion.String() &&
+		owner.Kind == promotionRequestKind
 }
 
 // resolveOriginToFreight resolves promo's origin to the Freight that the
@@ -560,6 +574,17 @@ func (w *webhook) ValidateCreate(
 		return nil, apierrors.NewInternalError(fmt.Errorf("get stage: %w", err))
 	}
 
+	var errs field.ErrorList
+	if fieldErr := validateTargetIsPromotionRequestChild(promo); fieldErr != nil {
+		errs = append(errs, fieldErr)
+	}
+	if fieldErr := validateTargetAwareStageIsPromotedByRequest(promo, stage); fieldErr != nil {
+		errs = append(errs, fieldErr)
+	}
+	if len(errs) > 0 {
+		return nil, apierrors.NewInvalid(promotionGroupKind, promo.Name, errs)
+	}
+
 	freight, err := w.getFreightFn(ctx, w.client, types.NamespacedName{
 		Namespace: promo.Namespace,
 		Name:      promo.Spec.Freight,
@@ -590,6 +615,66 @@ func (w *webhook) ValidateCreate(
 	return nil, nil
 }
 
+// validateTargetIsPromotionRequestChild enforces that a Promotion naming a
+// Target is a child of a PromotionRequest.
+//
+// spec.target is not a field a user fills in. A Target belongs to the fan-out a
+// PromotionRequest describes: the request resolves the Stage's selectors once,
+// records the result in its own spec.targets, and each of its Promotions
+// carries one of those names. Letting a Promotion name a Target on its own
+// would produce work no PromotionRequest is counting, so a Stage's Targets
+// could advance without any record of it having been requested.
+//
+// Note this deliberately does not check that the Stage currently governs the
+// named Target. The Target came from a snapshot the PromotionRequest took when
+// it was created, and re-resolving selectors here would let a label edit
+// invalidate a Promotion already in flight -- the same reasoning that keeps the
+// PromotionRequest webhook from re-checking its own spec.targets.
+func validateTargetIsPromotionRequestChild(
+	promo *kargoapi.Promotion,
+) *field.Error {
+	if promo.Spec.Target == "" || isPromotionRequestChild(promo) {
+		return nil
+	}
+	return field.Invalid(
+		field.NewPath("spec", "target"),
+		promo.Spec.Target,
+		"a Promotion may name a Target only when created by a PromotionRequest",
+	)
+}
+
+// validateTargetAwareStageIsPromotedByRequest enforces the converse: a Stage
+// that governs Targets is promoted to only through a PromotionRequest.
+//
+// A Stage promotes Freight either to itself or to the Targets it governs, never
+// both, so a Promotion created directly against a target-aware Stage would
+// promote to a destination the Stage does not have. Every in-tree caller -- the
+// promote-to-stage and promote-downstream endpoints, and the auto-promotion
+// loop -- already routes such a Stage to a PromotionRequest; this closes the
+// path a client can still reach by creating the Promotion itself.
+//
+// Only creates are checked. A Stage can gain a targets block while Promotions
+// created before it are still running, and those must remain updatable -- an
+// abort request is an update, and refusing it would leave a running Promotion
+// with no way to stop.
+func validateTargetAwareStageIsPromotedByRequest(
+	promo *kargoapi.Promotion,
+	stage *kargoapi.Stage,
+) *field.Error {
+	if !api.IsTargetAware(stage) || isPromotionRequestChild(promo) {
+		return nil
+	}
+	return field.Invalid(
+		field.NewPath("spec", "stage"),
+		promo.Spec.Stage,
+		fmt.Sprintf(
+			"Stage %q selects Targets; it is promoted to with a PromotionRequest "+
+				"rather than a Promotion",
+			promo.Spec.Stage,
+		),
+	)
+}
+
 func (w *webhook) ValidateUpdate(
 	ctx context.Context,
 	oldPromo *kargoapi.Promotion,
@@ -611,6 +696,19 @@ func (w *webhook) ValidateUpdate(
 					"spec is immutable",
 				),
 			},
+		)
+	}
+
+	// spec.target is immutable by the check above, but the owner reference that
+	// justifies it is metadata and is not. Re-check it so a Promotion cannot be
+	// severed from the PromotionRequest that created it -- by an apply whose
+	// manifest simply omits ownerReferences, if nothing else -- and go on
+	// promoting to a Target as an orphan.
+	if fieldErr := validateTargetIsPromotionRequestChild(promo); fieldErr != nil {
+		return nil, apierrors.NewInvalid(
+			promotionGroupKind,
+			promo.Name,
+			field.ErrorList{fieldErr},
 		)
 	}
 

--- a/pkg/webhook/kubernetes/promotion/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotion/webhook_test.go
@@ -2006,6 +2006,171 @@ func Test_webhook_ValidateCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "manual Promotion for a target-aware Stage is rejected",
+			webhook: &webhook{
+				validateProjectFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+				authorizeFn: func(context.Context, *kargoapi.Promotion, string) error {
+					return nil
+				},
+				admissionRequestFromContextFn: admission.RequestFromContext,
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{
+						Spec: kargoapi.StageSpec{Targets: &kargoapi.StageTargets{}},
+					}, nil
+				},
+			},
+			promotion: &kargoapi.Promotion{
+				Spec: kargoapi.PromotionSpec{
+					Stage:   "fake-stage",
+					Freight: "fake-freight",
+				},
+			},
+			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
+				var statusErr *apierrors.StatusError
+				require.True(t, errors.As(err, &statusErr))
+				require.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+				require.Contains(
+					t,
+					statusErr.ErrStatus.Message,
+					"it is promoted to with a PromotionRequest rather than a Promotion",
+				)
+			},
+		},
+		{
+			name: "Promotion naming a Target without a PromotionRequest owner is rejected",
+			webhook: &webhook{
+				validateProjectFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+				authorizeFn: func(context.Context, *kargoapi.Promotion, string) error {
+					return nil
+				},
+				admissionRequestFromContextFn: admission.RequestFromContext,
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{}, nil
+				},
+				getFreightFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{}, nil
+				},
+			},
+			promotion: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					// A Stage owner is what defaulting gives a Promotion that no
+					// PromotionRequest claimed.
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: kargoapi.GroupVersion.String(),
+						Kind:       "Stage",
+						Name:       "fake-stage",
+						Controller: ptr.To(true),
+					}},
+				},
+				Spec: kargoapi.PromotionSpec{
+					Stage:   "fake-stage",
+					Freight: "fake-freight",
+					Target:  "fake-target",
+				},
+			},
+			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
+				var statusErr *apierrors.StatusError
+				require.True(t, errors.As(err, &statusErr))
+				require.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+				require.Contains(
+					t,
+					statusErr.ErrStatus.Message,
+					"a Promotion may name a Target only when created by a PromotionRequest",
+				)
+			},
+		},
+		{
+			name: "a PromotionRequest's child may promote a target-aware Stage",
+			webhook: &webhook{
+				validateProjectFn: func(
+					context.Context,
+					client.Client,
+					client.Object,
+				) error {
+					return nil
+				},
+				authorizeFn: func(context.Context, *kargoapi.Promotion, string) error {
+					return nil
+				},
+				admissionRequestFromContextFn: admission.RequestFromContext,
+				getStageFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Stage, error) {
+					return &kargoapi.Stage{
+						Spec: kargoapi.StageSpec{
+							Targets: &kargoapi.StageTargets{},
+							RequestedFreight: []kargoapi.FreightRequest{{
+								Origin: kargoapi.FreightOrigin{
+									Kind: kargoapi.FreightOriginKindWarehouse,
+									Name: testWarehouse,
+								},
+								Sources: kargoapi.FreightSources{Direct: true},
+							}},
+						},
+					}, nil
+				},
+				getFreightFn: func(
+					context.Context,
+					client.Client,
+					types.NamespacedName,
+				) (*kargoapi.Freight, error) {
+					return &kargoapi.Freight{
+						Origin: kargoapi.FreightOrigin{
+							Kind: kargoapi.FreightOriginKindWarehouse,
+							Name: testWarehouse,
+						},
+					}, nil
+				},
+				isRequestFromKargoControlplaneFn: func(admission.Request) bool {
+					return true
+				},
+			},
+			promotion: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: kargoapi.GroupVersion.String(),
+						Kind:       "PromotionRequest",
+						Name:       "fake-request",
+						Controller: ptr.To(true),
+					}},
+				},
+				Spec: kargoapi.PromotionSpec{
+					Stage:   "fake-stage",
+					Freight: "fake-freight",
+					Target:  "fake-target",
+				},
+			},
+			assertions: func(t *testing.T, _ *fakeevent.EventRecorder, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
 			name: "error getting Freight",
 			webhook: &webhook{
 				validateProjectFn: func(
@@ -2289,6 +2454,81 @@ func Test_webhook_ValidateUpdate(t *testing.T) {
 				require.True(t, errors.As(err, &statusErr))
 				require.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
 				require.Contains(t, statusErr.ErrStatus.Message, "spec is immutable")
+			},
+		},
+
+		{
+			name: "detaching a Target-naming Promotion from its PromotionRequest",
+			setup: func() (*kargoapi.Promotion, *kargoapi.Promotion) {
+				oldPromo := &kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-name",
+						Namespace: "fake-namespace",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: kargoapi.GroupVersion.String(),
+							Kind:       "PromotionRequest",
+							Name:       "fake-request",
+							Controller: ptr.To(true),
+						}},
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage:   "fake-stage",
+						Freight: "fake-freight",
+						Target:  "fake-target",
+					},
+				}
+				newPromo := oldPromo.DeepCopy()
+				newPromo.OwnerReferences = nil
+				return oldPromo, newPromo
+			},
+			authorizeFn: func(context.Context, *kargoapi.Promotion, string) error {
+				return nil
+			},
+			assertions: func(t *testing.T, err error) {
+				var statusErr *apierrors.StatusError
+				require.True(t, errors.As(err, &statusErr))
+				require.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+				require.Contains(
+					t,
+					statusErr.ErrStatus.Message,
+					"a Promotion may name a Target only when created by a PromotionRequest",
+				)
+			},
+		},
+
+		{
+			name: "update of a Promotion that keeps its PromotionRequest",
+			setup: func() (*kargoapi.Promotion, *kargoapi.Promotion) {
+				oldPromo := &kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-name",
+						Namespace: "fake-namespace",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: kargoapi.GroupVersion.String(),
+							Kind:       "PromotionRequest",
+							Name:       "fake-request",
+							Controller: ptr.To(true),
+						}},
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage:   "fake-stage",
+						Freight: "fake-freight",
+						Target:  "fake-target",
+					},
+				}
+				newPromo := oldPromo.DeepCopy()
+				// An abort request is an update, and must keep working for a
+				// Promotion a PromotionRequest is driving.
+				newPromo.Annotations = map[string]string{
+					kargoapi.AnnotationKeyAbort: "fake-abort-id",
+				}
+				return oldPromo, newPromo
+			},
+			authorizeFn: func(context.Context, *kargoapi.Promotion, string) error {
+				return nil
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
 			},
 		},
 


### PR DESCRIPTION
A Stage promotes Freight either to itself or to the Targets it governs, never both. Every in-tree caller already honors that split — the promote-to-stage and promote-downstream endpoints and the auto-promotion loop all create a PromotionRequest for a target-aware Stage — but a client creating the Promotion itself could still promote such a Stage to a destination it does not have.

This closes that path at admission, and with it establishes the invariant the rest of the Target work can rely on: **a Promotion naming a Target is always a child of a PromotionRequest, and a target-aware Stage is only ever promoted to through one.**

## What the webhook now rejects

- A Promotion with `spec.target` set that is not controlled by a PromotionRequest (reported on `spec.target`).
- A Promotion against a target-aware Stage (`spec.targets != nil`) that is not controlled by a PromotionRequest (reported on `spec.stage`, worded to mirror the message the PromotionRequest webhook already gives for the opposite case).

## Notes on the design

**Ownership is the signal for "child."** It is the one a caller cannot usefully forge: Kubernetes garbage collection deletes an object whose controller owner does not exist, so a reference to a PromotionRequest that was never created takes the Promotion with it. Defaulting and validation now share `isPromotionRequestChild`, so the owner reference `Default` preserves is exactly the one validation accepts.

**The Target check also runs on update.** Spec immutability already pins `spec.target`, but the owner reference that justifies it is metadata and is not covered — an apply whose manifest simply omits `ownerReferences` could otherwise orphan a child and leave it promoting to a Target.

**The target-aware Stage check is create-only, deliberately.** A Stage can gain a `targets` block while Promotions created before it are still running, and those must remain updatable: aborting one is an update, and refusing it would leave a running Promotion with no way to stop.

**No selector re-check.** This does not verify that the Stage currently governs the named Target. That name came from the snapshot the PromotionRequest took at creation, and re-resolving selectors here would let a label edit invalidate a Promotion already in flight — the same reasoning that keeps the PromotionRequest webhook from re-checking its own `spec.targets`.

## Testing

Five new cases (three on create, two on update). `go test -race` passes for the webhook package and for `pkg/api`, `pkg/server`, `pkg/controller/stages`, and `pkg/controller/promotionrequests`; `make lint-go` is clean. I also confirmed the new tests are not vacuous by temporarily forcing `isPromotionRequestChild` to return true — all three rejection cases fail without the check.

Docs are unchanged: `docs/docs/` does not cover PromotionRequests or Targets yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)