### PR TITLE
fix(ui): show a failed promotion step's own error message

### DIFF
--- a/ui/src/features/stage/promotion-steps.tsx
+++ b/ui/src/features/stage/promotion-steps.tsx
@@ -37,15 +37,25 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
   const message = props.promotion?.status?.message;
 
   // A failed step's message becomes the Promotion's, so it is already on screen.
-  const shownUnderStep = (props.promotion.status?.stepExecutionMetadata ?? []).some(
-    (meta, i) => isFailedStep(i, props.promotion.status) && !!meta.message
-  );
+  const hasIndividualPromotionStepTerminalMessage = (
+    props.promotion.status?.stepExecutionMetadata ?? []
+  ).some((meta, i) => isFailedStep(i, props.promotion.status) && !!meta.message);
 
-  const shouldShowMessage =
-    isPromotionPhaseTerminal(phase) &&
-    phase !== PromotionStatusPhase.SUCCEEDED &&
-    !!message &&
-    !shownUnderStep;
+  let shouldShowMessage = false;
+
+  if (isPromotionPhaseTerminal(phase)) {
+    switch (phase) {
+      case PromotionStatusPhase.FAILED:
+      case PromotionStatusPhase.ERRORED:
+        // The failing step already shows this message, so don't repeat it.
+        shouldShowMessage = !hasIndividualPromotionStepTerminalMessage;
+        break;
+      case PromotionStatusPhase.ABORTED:
+        // An abort is not attributable to any one step.
+        shouldShowMessage = true;
+        break;
+    }
+  }
 
   const steps = props.promotion?.spec?.steps ?? [];
 
@@ -113,7 +123,7 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
         activeKey={activeKeys}
         onChange={(keys) => setActiveKeys(typeof keys === 'string' ? [keys] : keys)}
       />
-      {shouldShowMessage && <Alert message={message} type='error' className='mt-4' />}
+      {shouldShowMessage && !!message && <Alert message={message} type='error' className='mt-4' />}
     </>
   );
 };

--- a/ui/src/features/stage/promotion-steps.tsx
+++ b/ui/src/features/stage/promotion-steps.tsx
@@ -34,21 +34,20 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
 
   const phase = getPromotionStatusPhase(props.promotion);
 
+  const message = props.promotion?.status?.message;
+
+  // A failed step's message becomes the Promotion's, so it is already on screen.
+  const shownUnderStep = (props.promotion.status?.stepExecutionMetadata ?? []).some(
+    (meta, i) => isFailedStep(i, props.promotion.status) && !!meta.message
+  );
+
   const shouldShowMessage =
     isPromotionPhaseTerminal(phase) &&
     phase !== PromotionStatusPhase.SUCCEEDED &&
-    phase !== PromotionStatusPhase.ERRORED && // because its already handled at individual step level
-    !!props.promotion?.status?.message;
+    !!message &&
+    !shownUnderStep;
 
   const steps = props.promotion?.spec?.steps ?? [];
-
-  const errorItem = {
-    key: 'error',
-    label: <Alert message={props.promotion.status?.message} type='error' />,
-    showArrow: false,
-    collapsible: 'disabled' as const,
-    styles: { header: { paddingTop: 0 } }
-  };
 
   // Steps with a registered extension are interactive
   const hasExtension = (step: (typeof steps)[number]) =>
@@ -76,9 +75,26 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
       key
     };
 
-    return isFailedStep(i, props.promotion.status)
-      ? [{ ...item, className: `${item.className || ''} !border-none` }, errorItem]
-      : [item];
+    if (!isFailedStep(i, props.promotion.status)) {
+      return [item];
+    }
+
+    const stepMessage = props.promotion.status?.stepExecutionMetadata?.[i]?.message;
+
+    if (!stepMessage) {
+      return [item];
+    }
+
+    return [
+      { ...item, className: `${item.className || ''} !border-none` },
+      {
+        key: `${key}-error`,
+        label: <Alert message={stepMessage} type='error' />,
+        showArrow: false,
+        collapsible: 'disabled' as const,
+        styles: { header: { paddingTop: 0 } }
+      }
+    ];
   });
 
   useEffect(() => {
@@ -97,9 +113,7 @@ export const PromotionSteps = (props: PromotionStepsProps) => {
         activeKey={activeKeys}
         onChange={(keys) => setActiveKeys(typeof keys === 'string' ? [keys] : keys)}
       />
-      {shouldShowMessage && (
-        <Alert message={props.promotion.status?.message} type='error' className='mt-4' />
-      )}
+      {shouldShowMessage && <Alert message={message} type='error' className='mt-4' />}
     </>
   );
 };


### PR DESCRIPTION
Closes #6851

The alert under a failed step read `promotion.status.message`. That message keeps changing as later steps execute, so it flickers; with `continueOnError` it never reflects the failed step at all; and with multiple failures it showed one step's error under every failed step, leaving the others unreachable. It now reads `status.stepExecutionMetadata[i].message`.

Working through it, we found the old alert was also serving as the promotion-level message, anchored under the last step -- which is why `Errored` was excluded from the bottom alert. So repointing the inline alert left that message homeless. It keeps its place after the last step, now shown only when no step surfaced an error of its own.

That last condition is structural rather than a text comparison, following the backend's branches: `DetermineFinalPhase` copies the worst step's message verbatim (already inline), while abort, pre-step and workdir failures leave the step message empty and so still render. Known gap: a panic or status-patch failure *after* a step failed is suppressed -- recovering it needs provenance the status doesn't carry, so it belongs backend-side.

Also fixes duplicate React keys when `continueOnError` lets two steps fail.

**Test plan**
- `pnpm typecheck`, `pnpm lint`, `pnpm vitest run` (277 pass) -- all clean
- Manual: a promotion where step 2 fails and step 3 keeps running -- step 2's alert stays pinned to its own error
- Manual: abort a running promotion -- "Promotion terminated by ..." still shows after the last step

No unit test: `ui/` has vitest only, no jsdom/RTL, and the fix is inline rather than an extracted helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)