### PR TITLE
fix: when zooming into a pipeline and refreshing the page

### DIFF
--- a/ui/src/features/project/pipelines/graph/graph.tsx
+++ b/ui/src/features/project/pipelines/graph/graph.tsx
@@ -6,7 +6,8 @@ import {
   MiniMap,
   ReactFlow,
   ReactFlowInstance,
-  useNodesState
+  useNodesState,
+  Viewport
 } from '@xyflow/react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
@@ -36,6 +37,20 @@ const nodeTypes = {
   [reactFlowNodeConstants.CUSTOM_REPO_SUBSCRIPTION_NODE]: CustomRepoSubscriptionNode
 };
 
+const viewportLocalStorageKey = (project: string) => `pipeline-viewport-${project}`;
+
+const getStoredViewport = (project: string): Viewport | undefined => {
+  const raw = localStorage.getItem(viewportLocalStorageKey(project));
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
 export const Graph = (props: GraphProps) => {
   const reactFlowInstance = useRef<ReactFlowInstance | null>(null);
   const filterContext = useFreightTimelineControllerContext();
@@ -59,6 +74,8 @@ export const Graph = (props: GraphProps) => {
   };
 
   const [redraw, setRedraw] = useState(false);
+
+  const [initialViewport] = useState(() => getStoredViewport(props.project));
 
   // Cheap placeholders on first paint; swap to real components on the next tick.
   // ReactFlow mounts every node at least once for measurement, so this avoids
@@ -220,11 +237,20 @@ export const Graph = (props: GraphProps) => {
     return nodes;
   }, [nodes]);
 
+  const hideSubscriptionsSignature = JSON.stringify(
+    filterContext?.preferredFilter?.hideSubscriptions ?? {}
+  );
+  const isInitialHideSubscriptionsRender = useRef(true);
+
   useEffect(() => {
+    if (isInitialHideSubscriptionsRender.current) {
+      isInitialHideSubscriptionsRender.current = false;
+      return;
+    }
     requestAnimationFrame(() => {
       reactFlowInstance.current?.fitView();
     });
-  }, [filterContext?.preferredFilter?.hideSubscriptions]);
+  }, [hideSubscriptionsSignature]);
 
   const stageSearch = filterContext?.stageSearch || '';
   const matchedStageIndices = useMemo(() => {
@@ -294,9 +320,13 @@ export const Graph = (props: GraphProps) => {
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
-        fitView
+        fitView={!initialViewport}
         fitViewOptions={{
           nodes: nodesExcludingSubscriptionNodes
+        }}
+        defaultViewport={initialViewport}
+        onMoveEnd={(_, viewport) => {
+          localStorage.setItem(viewportLocalStorageKey(props.project), JSON.stringify(viewport));
         }}
         proOptions={{ hideAttribution: true }}
         minZoom={nodes.length > 100 ? 0.4 : 0.1}


### PR DESCRIPTION
## Description

Sometimes when I open a project and  I zoom into a pipeline and I refresh the page, the zoom state resets. It also happens when clicking into `Last promotion` and then clicking into the `YAML` next to the Freight. This is now fixed.

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [x] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
