### PR TITLE
fix(ui): stop infinite Freight refetch loop in useSyncFreight

### DIFF
--- a/ui/src/features/project/pipelines/use-sync-freight.test.ts
+++ b/ui/src/features/project/pipelines/use-sync-freight.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { Freight, Stage } from '@ui/gen/api/v2/models';
+
+import { missingFreightNames } from './use-sync-freight';
+
+const freights = (...names: string[]): Record<string, Freight> =>
+  Object.fromEntries(names.map((name) => [name, { metadata: { name } } as Freight]));
+
+const freightInStages = (...names: string[]): Record<string, Stage[]> =>
+  Object.fromEntries(names.map((name) => [name, [] as Stage[]]));
+
+describe('missingFreightNames', () => {
+  it('returns nothing when the list holds everything the Stages do', () => {
+    expect(missingFreightNames(freights('a', 'b'), freightInStages('a', 'b'))).toEqual([]);
+  });
+
+  it('returns nothing when no Stage holds Freight', () => {
+    expect(missingFreightNames(freights('a'), {})).toEqual([]);
+  });
+
+  it('returns Freight a Stage holds that the list does not contain', () => {
+    expect(missingFreightNames(freights('a'), freightInStages('a', 'b'))).toEqual(['b']);
+  });
+
+  it('ignores list Freight that no Stage holds', () => {
+    expect(missingFreightNames(freights('a', 'b', 'c'), freightInStages('b'))).toEqual([]);
+  });
+
+  it('reports Freight from a Warehouse the origin-filtered list excludes', () => {
+    expect(missingFreightNames(freights('from-a'), freightInStages('from-a', 'from-b'))).toEqual([
+      'from-b'
+    ]);
+  });
+
+  it('sorts, keeping the effect dependency stable across equal inputs', () => {
+    const a = missingFreightNames({}, freightInStages('c', 'a', 'b')).join(',');
+    const b = missingFreightNames({}, freightInStages('b', 'c', 'a')).join(',');
+
+    expect(Object.is(a, b)).toBe(true);
+  });
+});

--- a/ui/src/features/project/pipelines/use-sync-freight.ts
+++ b/ui/src/features/project/pipelines/use-sync-freight.ts
@@ -1,24 +1,46 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { queryCache } from '@ui/features/utils/cache';
 import { Freight, Stage } from '@ui/gen/api/v2/models';
 
+// Freight that Stages hold but the Freight list lacks, sorted so the joined
+// form is a stable effect dependency.
+export const missingFreightNames = (
+  freights: Record<string, Freight>,
+  freightInStages: Record<string, Stage[]>
+): string[] =>
+  Object.keys(freightInStages)
+    .filter((name) => !freights[name])
+    .sort();
+
+// Refetches the Freight list when a Stage holds Freight the list lacks, meaning
+// the list is stale. At most once per name: the gap can be permanent (deleted
+// Freight, or a Warehouse the origin filter excludes while the Stage still
+// reports one piece of Freight per Warehouse), and retrying would loop -- every
+// response is a new object, so every refetch re-renders.
 export const useSyncFreight = (payload: {
   project: string;
   freights?: Record<string, Freight>;
   freightInStages?: Record<string, Stage[]>;
 }) => {
-  useEffect(() => {
-    if (payload.freights && payload.freightInStages) {
-      const freights = Object.keys(payload.freights || {});
-      const freightInStages = Object.keys(payload.freightInStages || {});
+  const { project, freights, freightInStages } = payload;
 
-      for (const freightInStage of freightInStages) {
-        if (!freights.find((f) => f === freightInStage)) {
-          queryCache.freight.refetchQueryFreight(payload.project);
-          return;
-        }
-      }
+  const refetchedFor = useRef(new Set<string>());
+
+  const missingKey =
+    freights && freightInStages ? missingFreightNames(freights, freightInStages).join(',') : '';
+
+  useEffect(() => {
+    const unseen = missingKey.split(',').filter((name) => name && !refetchedFor.current.has(name));
+
+    if (!unseen.length) {
+      return;
     }
-  }, [payload]);
+
+    for (const name of unseen) {
+      refetchedFor.current.add(name);
+    }
+
+    queryCache.freight.refetchQueryFreight(project);
+  }, [project, missingKey]);
 };


### PR DESCRIPTION
<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

`useSyncFreight` refetches the Freight list when a Stage holds Freight the list
lacks. Its effect depended on `[payload]` — a fresh object every render — and
under a Warehouse filter that gap is permanent, since the list is filtered by
`origins` but Stage status reports one piece of Freight per Warehouse. Every
refetch re-rendered, and every render refetched again.

Now the effect depends on a stable key and refetches at most once per name.

Closes #6871

<!-- Describe what this PR does and why. -->

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [ ] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
