### PR TITLE
chore: add advisory-rewrite skill

### DIFF
--- a/.claude/skills/advisory-rewrite/SKILL.md
+++ b/.claude/skills/advisory-rewrite/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: advisory-rewrite
+description: Use when a GitHub security advisory (GHSA) has been reported against Kargo and needs to be verified, scored, and redrafted for publication
+argument-hint: <GHSA-id-or-URL>
+---
+
+# Advisory Rewrite
+
+Turn a reporter's private advisory into a publishable Kargo advisory: verified against source, scored independently with CVSS v4, and written to explain the flaw without handing attackers a roadmap.
+
+**Argument:** `$0` = advisory ID (`GHSA-xxxx-xxxx-xxxx`) or its URL.
+
+Never edit the advisory on GitHub. Everything goes into files in the workspace root.
+
+## Phase 1 -- Capture the original
+
+```bash
+.claude/skills/advisory-rewrite/scripts/fetch-advisory.sh <GHSA-id>
+```
+
+Writes `ADVISORY-<GHSA-id>.md` (verbatim title, URL, description). Read it once, fully. Treat every claim in it -- code, versions, severity, impact -- as a hypothesis to test, not a fact.
+
+## Phase 2 -- Confirm against source
+
+For each claim, find the code that proves or disproves it on `main` **and** on the latest release tag. Record file:line for each.
+
+Then establish the affected range. The reliable method is to inspect the same file (API handler, controller, step runner, UI module -- whatever holds the flaw) at each release tag; `git log -S` is defeated by directory renames. Files move between `internal/` and `pkg/`, lose suffixes like `_v1alpha1`, and the functions they call get renamed too, so match paths and snippets with regexes covering every name they have had. An empty line for a tag means your regex missed, not that the code is absent -- widen it until every tag prints something:
+
+```bash
+for t in $(git tag | grep -E '^v[0-9]+\.[0-9]+\.0$' | sort -V); do
+  f=$(git ls-tree -r --name-only $t | grep -E '(internal|pkg)/(api|server)/refresh_warehouse(_v1alpha1)?\.go$' | head -1)
+  printf '%s: ' $t; [ -n "$f" ] && git show $t:$f | grep -oE 'Refresh(Warehouse|Object)\(ctx, [^,]*'; echo
+done
+```
+
+Once the introducing release is known, find the PR (`git log <prev>..<intro> -- <file>`, then `gh pr view`). Read the PR and any linked issue: the bug is often a deliberate change whose stated intent was not what shipped. That distinction belongs in the Summary.
+
+Range format: `>= <introducing release>, <= <latest release>` while the fix is unreleased; note the fix version as TBD.
+
+A surface present in the latest release but already removed on `main` (e.g. a legacy RPC) is still affected. List it with the versions it exists in. Never describe the state of `main` or unreleased work in the public text.
+
+If the vulnerability is **not** confirmed, stop and report why with the evidence. Do not draft.
+
+## Phase 3 -- Score with CVSS v4
+
+Score from your own understanding of impact, before re-reading the reporter's severity language. Reporter framing is an input to *what to verify*, never to *the score*.
+
+Compute with the `cvss` Python package (install to scratch: `pip3 install --target <scratch>/pylib cvss`). Score your primary vector **and** each plausible alternative for every metric you found debatable. Record whether the rating moves.
+
+Scoping rules used in prior Kargo advisories:
+- The control plane's Kubernetes cluster is part of the vulnerable system, not a subsequent system.
+- Only *direct* consequences count. Follow-on attacks that need extra infrastructure or victim action score as None (note the limitation in prose if it matters).
+- `PR:L` = any authenticated Kargo user, including one with zero Kargo permissions. `PR:H` = permissions a project admin must deliberately grant (create/update Stage, `promote`).
+- Attacker cannot inject artifact content unless repositories are also compromised. Promoting *legitimate* Freight the pipeline should have gated is `SI:L`; merely changing *when* legitimate Freight moves is `SI:N`.
+- Responses that reveal whether a named resource exists in a Project the caller cannot see are `VC:L`.
+- An unauthorized write to another tenant's resource that cannot alter its `spec` (e.g. an annotation) is `VI:L`, the same "bounded state corruption" used for unauthorized Stage transitions.
+- An unmetered way to make controllers do work on demand is `VA:L`. When that work exercises a victim Project's credentials against its Git/registry/chart providers, it is also `SA:L` (precedent: GHSA-w5wv-wvrp-v5m5). The provider call is a direct consequence, not a follow-on attack.
+
+## Phase 4 -- Draft
+
+Write `ADVISORY-DRAFT-<GHSA-id>.md` following `reference/format.md` exactly. One line per paragraph; no hard wraps.
+
+The public text is for users deciding whether to upgrade. It is not a reply to the reporter, and it is not a fix plan.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Rating severity from the reporter's tone | Score first, compare after; explain divergence in the notes block |
+| Distinguishing this bug from a prior GHSA in the public text | Cut it. Summaries of both advisories already differ; this is arguing, not informing |
+| Reproducing PoC scripts, request sequences, or enumeration recipes | List endpoints and the nature of the gap; nothing operational |
+| Including remediation design or code suggestions | Omit. Fix is in the PR; the advisory describes the flaw |
+| Stating the affected range from the reporter or from `git log -S` | Walk the release tags (Phase 2) |
+| Telling the user what you omitted only in chat | Record it in the notes block so the file stands alone |
+| Mentioning `main`, unreleased removals, or the pending fix in the public text | Public text speaks only of released versions |
+| Asserting audit/observability behavior you inferred | Claim only what a specific line of code shows (e.g. an annotation carries a timestamp) |

--- a/.claude/skills/advisory-rewrite/reference/format.md
+++ b/.claude/skills/advisory-rewrite/reference/format.md
@@ -1,0 +1,72 @@
+# Advisory draft format
+
+The draft file has two parts: a notes block for the maintainer (never published) and the advisory text (published as-is). Paragraphs are single lines. Format-check against published examples: GHSA-f72x-6fm6-94rq, GHSA-5vvm-67pj-72g4, GHSA-7g9x-cp9g-92mr, GHSA-j94x-8wcp-x7hm, GHSA-g7gw-m874-7rmf (`gh api repos/akuity/kargo/security-advisories/<id> --jq .description`).
+
+## Notes block
+
+A blockquote at the top of the file, followed by `---`. Required items:
+
+- **Proposed title** -- `<Weakness> Vulnerability in <Affected Surface>` (e.g. "Missing Authorization Vulnerability in Resource Refresh API Endpoints", "SSRF in Promotion http/http-download Steps ...", "Open Redirect in UI OIDC Login Flow ...")
+- **CWE** -- one ID
+- **CVSS v4** -- vector, score, rating; reporter's score if any; which metrics were judgment calls and whether alternatives change the rating
+- **Affected versions** -- range with introducing PR/issue and the evidence used
+- **Omitted deliberately** -- what from the original was left out and why
+
+## Advisory text
+
+```markdown
+## Summary
+
+<What the feature is, in one or two sentences, for a reader who does not know it.>
+
+<What the code does wrong, and, where known, how it came to be that way (intended change vs. shipped change).>
+
+<Only when the vulnerable surface is a discrete, enumerable set (API endpoints, promotion steps, CLI commands, webhook receivers), list it:>
+
+The affected <endpoints|steps|...> are:
+
+1. `...`
+2. ...
+
+<Otherwise name the surface in prose: a component, a flow (e.g. UI login), a library path.>
+
+<Who can exploit it and what they can and cannot do. State the bounds as plainly as the exposure.>
+
+## Base Metrics
+
+The following sections provide the rationale for the values selected for each of CVSS v4's base metrics.
+
+### Attack Vector (AV): <value>
+### Attack Complexity (AC): <value>
+### Attack Requirements (AT): <value>
+### Privileges Required (PR): <value>
+### User Interaction (UI): <value>
+### Confidentiality Impact to Vulnerable System (VC): <value>
+### Integrity Impact to Vulnerable System (VI): <value>
+### Availability Impact to Vulnerable System (VA): <value>
+### Confidentiality Impact to Subsequent Systems (SC): <value>
+### Integrity Impact to Subsequent Systems (SI): <value>
+### Availability Impact to Subsequent Systems (SA): <value>
+
+## Mitigating Factors
+
+- <Precondition the attacker must satisfy.>
+- <What the attacker cannot do.>
+- <Observability / audit trail, only if a cited line of code establishes it.>
+- There is no evidence of exploitation in the wild.
+```
+
+Any list of affected surfaces names released surfaces only. When a surface does not exist in every affected version, append its range in parentheses: `` 6. The legacy `RefreshResource` RPC (v1.9.0 and later) ``. Verify each range against the tag walk; do not assume a surface spans the whole affected range.
+
+Each metric heading is followed by one short paragraph justifying the value. A `None` still gets a sentence saying why.
+
+If the computed score understates real-world risk (CVSS v4 ignores multi-step attacks), say so in the Summary or a paragraph after the Base Metrics intro and give a qualitative rating with the reason -- see GHSA-g7gw-m874-7rmf.
+
+## What stays out of the published text
+
+- PoC scripts, exact request sequences, timing/loop demonstrations
+- Recipes for enumeration or reconnaissance
+- Fix designs, code suggestions, structural refactoring advice
+- Comparisons with, or rebuttals of, other advisories or the reporter's claims
+- Reporter's rhetoric ("critically", "trivially", "the maintainer should")
+- Hard line wraps

--- a/.claude/skills/advisory-rewrite/scripts/fetch-advisory.sh
+++ b/.claude/skills/advisory-rewrite/scripts/fetch-advisory.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Fetch a Kargo GitHub security advisory and save its title, URL, and
+# description verbatim to ADVISORY-<id>.md in the current directory.
+#
+# Usage: fetch-advisory.sh <GHSA-id | advisory URL>
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <GHSA-id | advisory URL>" >&2
+  exit 1
+fi
+
+id=$(printf '%s' "$1" | grep -oE 'GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}' | head -1)
+if [ -z "$id" ]; then
+  echo "could not parse a GHSA id from: $1" >&2
+  exit 1
+fi
+
+out="ADVISORY-${id}.md"
+
+gh api "repos/akuity/kargo/security-advisories/${id}" \
+  --jq '"# \(.ghsa_id): \(.summary)\n\n\(.html_url)\n\nReporter severity: \(.severity // "none")  CVSS: \(.cvss_severities.cvss_v4.vector_string // .cvss.vector_string // "none")\n\n\(.description)"' \
+  | sed 's/\r$//' > "$out"
+
+echo "wrote $out ($(wc -l < "$out" | tr -d ' ') lines)"


### PR DESCRIPTION
Community-reported GHSAs typically arrive with step-by-step reproduction and exploitation instructions. Those details are invaluable while we recognize, analyze, and mitigate the vulnerability, but they should not survive into the published advisory -- an honest write-up tells users what they need to decide whether to upgrade without handing attackers a working exploit. This skill exists to sanitize and reformat a reported advisory into text fit for publication.

Along the way it verifies each of the reporter's claims against source, establishes the affected version range by walking release tags, and scores the vulnerability independently with CVSS v4 using the scoping precedents from Kargo's prior advisories.

The skill never touches the advisory on GitHub. It hands the maintainer a private local markdown file containing the rewritten advisory text plus a notes block -- proposed title, CWE, CVSS rationale, affected-range evidence, and what was deliberately omitted. What to do with it remains the maintainer's call.