### PR TITLE
docs: clarify sync window enforcement for argocd-update step

### DIFF
--- a/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
+++ b/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/argocd-update.md
@@ -51,11 +51,32 @@ Enforcement of Argo CD
 was improved substantially in Argo CD v2.11.0. If you wish for the `argocd-update`
 step to honor sync windows, you must use Argo CD v2.11.0 or later.
 
-_Additionally, it is recommended that if a promotion process is expected to
+Additionally, it is recommended that if a promotion process is expected to
 sometimes encounter an active deny window, the `argocd-update` step should be
 configured with a timeout that is at least as long as the longest expected deny
 window. The step's default timeout of five minutes can be overridden using the
 [`retry.timeout`](../15-promotion-templates.md#step-retries) field.
+
+:::
+
+:::note
+
+Argo CD evaluates sync windows differently for manual and automated syncs, and
+the `argocd-update` step initiates the sync according to how the `Promotion` was
+triggered:
+
+- A `Promotion` created by a user is initiated as a **manual** sync, attributed
+  to that user. This includes a `Promotion` created by an automated process
+  acting under its own credentials, such as a CI job.
+
+- An auto-promotion, having no user behind it, is initiated as an **automated**
+  sync, attributed to `kargo-controller`.
+
+The distinction matters for deny windows configured with `manualSync: true`,
+which permit manual syncs even while the window is active. Under such a window,
+auto-promotions are blocked, but a user-initiated `Promotion` will sync through.
+To block promotions of every kind for the duration of a deny window, set
+`manualSync: false`.
 
 :::
 


### PR DESCRIPTION
## Description

The `argocd-update` reference page documents the Argo CD version requirement for
sync window enforcement and the need to size `retry.timeout` around deny
windows, but says nothing about how the step classifies the sync it initiates.
That classification determines whether a deny window actually blocks a
promotion, so its absence has been a source of confusion.

Argo CD evaluates deny windows differently for manual and automated syncs.
`syncWindowPreventsSync` derives `isManual` from
`status.operationState.operation.initiatedBy.automated`, and `SyncWindows.CanSync`
permits the sync when `isManual` is true and every active deny window sets
`manualSync: true`. The `argocd-update` step sets `initiatedBy` from the
`Promotion`'s `create-actor` annotation: a `Promotion` carrying an actor is
initiated as a manual sync, while an auto-promotion, which carries no actor, is
initiated as automated.

The practical consequence is that under a deny window with `manualSync: true`,
auto-promotions are blocked but user-initiated `Promotion`s sync through. This
is intended behavior, on the reasoning that a user clicking "Promote" is a
manual sync and should be treated as one, but it is easy to misread as a bug
when an operator expects a deny window to hold back every promotion.

This PR adds a `:::note` covering:

- how each kind of `Promotion` is classified, including that a `Promotion`
  created by a CI job under its own credentials is stamped with an actor by the
  mutating webhook and therefore also counts as manual;
- the interaction with `manualSync: true`;
- `manualSync: false` as the way to block promotions of every kind.

Two incidental fixes to the block being edited:

- The existing `Additionally, ...` paragraph opened an emphasis span with `_`
  that was never closed.
- Reflowed the surrounding `:::info` to the file's wrap width.

No behavior change.


<!-- Describe what this PR does and why. -->

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [x] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [ ] Adds or updates corresponding tests.
- [x] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [x] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
