### PR TITLE
feat(controller): Add prometheus metrics

### DIFF
--- a/docs/docs/40-operator-guide/45-monitoring.md
+++ b/docs/docs/40-operator-guide/45-monitoring.md
@@ -77,9 +77,7 @@ labeled by `project`:
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `kargo_promotions_created_total` | Counter | Number of `Promotion` resources the controller has observed being created. |
-| `kargo_promotions_errored_retryable_total` | Counter | Number of retryable errors encountered while executing Promotions. A single Promotion may contribute more than once, since each failed attempt is counted. |
-| `kargo_promotions_errored_terminal_total` | Counter | Number of Promotions that reached the terminal `Errored` phase. |
+| `kargo_promotions_completed_total` | Counter | Number of Promotions that reached a terminal phase, by the phase they finished in. |
 | `kargo_promotions_non_terminal` | Gauge | Number of Promotions currently in a non-terminal phase (`Pending` or `Running`), sampled at scrape time. |
 | `kargo_promotion_duration_seconds` | Histogram | Time each Promotion spent running, from the moment it started until it reached a terminal phase. |
 | `kargo_promotion_step_duration_seconds` | Histogram | Time each individual promotion step spent running, from the moment it started until it reached a terminal status. |
@@ -101,6 +99,35 @@ value when a Project is idle.
 
 :::
 
+### Completed Promotions
+
+`kargo_promotions_completed_total` counts Promotions as they reach a terminal
+phase. Alongside `project`, it carries a `phase` label naming the phase the
+`Promotion` finished in, so a single metric describes both how many Promotions
+are finishing and how they are turning out:
+
+```
+kargo_promotions_completed_total{project="guestbook",phase="Succeeded"}  10
+kargo_promotions_completed_total{project="guestbook",phase="Errored"}     2
+kargo_promotions_completed_total{project="guestbook",phase="Failed"}      3
+kargo_promotions_completed_total{project="guestbook",phase="Aborted"}     1
+kargo_promotions_completed_total{project="wordpress",phase="Succeeded"}   3
+```
+
+The label matches the one on `kargo_promotion_duration_seconds`, so the two
+metrics can be queried and graphed side by side. Only phases actually observed
+produce a series, so use `or vector(0)` in queries that need a value for a
+phase a Project has never reached.
+
+:::note
+
+The counts here are slightly higher than the observation counts of
+`kargo_promotion_duration_seconds`, which excludes Promotions that reached a
+terminal phase without ever having started (one aborted while still `Pending`,
+for instance). Those still count as completed.
+
+:::
+
 ### Promotion Duration
 
 `kargo_promotion_duration_seconds` measures only the time a `Promotion` spent
@@ -109,7 +136,7 @@ timestamps. Time spent `Pending`, waiting for its `Stage` to acknowledge it, is
 excluded, as are Promotions that reached a terminal phase without ever having
 started.
 
-In addition to `project`, it carries an `terminalPhase` label that has the phase
+In addition to `project`, it carries a `phase` label that has the phase
 with which the promotion finished for more granular queries.
 
 Because promotion durations span a very wide range, this histogram also emits a

--- a/docs/docs/40-operator-guide/45-monitoring.md
+++ b/docs/docs/40-operator-guide/45-monitoring.md
@@ -69,6 +69,141 @@ you rename the port for a meshed cluster, keep the `http-` prefix.
 
 :::
 
+## Kargo Metrics
+
+Alongside the Go runtime and controller-runtime metrics that every component
+reports, the controller exports its own metrics, all prefixed with `kargo_` and
+labeled by `project`:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `kargo_promotions_created_total` | Counter | Number of `Promotion` resources the controller has observed being created. |
+| `kargo_promotions_errored_retryable_total` | Counter | Number of retryable errors encountered while executing Promotions. A single Promotion may contribute more than once, since each failed attempt is counted. |
+| `kargo_promotions_errored_terminal_total` | Counter | Number of Promotions that reached the terminal `Errored` phase. |
+| `kargo_promotions_non_terminal` | Gauge | Number of Promotions currently in a non-terminal phase (`Pending` or `Running`), sampled at scrape time. |
+| `kargo_promotion_duration_seconds` | Histogram | Time each Promotion spent running, from the moment it started until it reached a terminal phase. |
+| `kargo_promotion_step_duration_seconds` | Histogram | Time each individual promotion step spent running, from the moment it started until it reached a terminal status. |
+| `kargo_stages_by_ready_reason` | Gauge | Number of Stages in each readiness state, by Project, sampled at scrape time. Control flow Stages are omitted. |
+
+:::note
+
+The `project` label is the name of the Kargo `Project` (namespace) the
+`Promotion` belongs to. Each controller only reports on the Promotions it is
+responsible for, so queries spanning a sharded topology should aggregate across
+controllers. Your scrape config should include a desired shard name to attach as
+a label to the metrics, so that you can filter by shard in queries.
+
+The two gauges are sampled from the controller's cache at scrape time and
+report only the Projects that currently have something to report. A Project
+with no non-terminal Promotions produces no `kargo_promotions_non_terminal`
+series at all, rather than a zero, so use `or vector(0)` in queries that need a
+value when a Project is idle.
+
+:::
+
+### Promotion Duration
+
+`kargo_promotion_duration_seconds` measures only the time a `Promotion` spent
+actually running: the interval between its `startedAt` and `finishedAt`
+timestamps. Time spent `Pending`, waiting for its `Stage` to acknowledge it, is
+excluded, as are Promotions that reached a terminal phase without ever having
+started.
+
+In addition to `project`, it carries an `terminalPhase` label that has the phase
+with which the promotion finished for more granular queries.
+
+Because promotion durations span a very wide range, this histogram also emits a
+[native histogram](https://prometheus.io/docs/specs/native_histograms/).
+Scraping the native histogram rather than the static buckets gives a much more
+accurate view of the distribution, if your Prometheus server supports it.
+
+### Promotion Step Duration
+
+`kargo_promotion_step_duration_seconds` breaks the same interval down by
+individual step. A step's clock starts the first time it runs and stops when it
+reaches a terminal status, so a step that waits across several reconciliations
+-- one waiting on a pull request to merge, for instance -- reports its whole
+lifetime, not just the attempt that finished it. Steps that were skipped, and
+steps still waiting, are not recorded.
+
+In addition to `project`, it carries a `stepKind` label with the step's kind
+(`git-clone`, `argocd-update`, and so on) and a `terminalStatus` label with the
+status the step ended in:
+
+| `terminalStatus` | Meaning |
+|------------------|---------|
+| `Succeeded` | The step completed successfully. |
+| `Failed` | The step failed for non-technical reasons. This is terminal -- the step is not retried. |
+| `Errored` | The step failed for technical reasons. Kargo retries the step until its error threshold is met, so the observed duration covers every attempt. |
+
+Skipped steps are not recorded, whether they were skipped by their `if`
+condition or determined on their own that they had nothing to do.
+
+Because step durations span a very wide range, this histogram also emits a
+[native histogram](https://prometheus.io/docs/specs/native_histograms/).
+Scraping the native histogram rather than the static buckets gives a much more
+accurate view of the distribution, if your Prometheus server supports it.
+
+### Stages by Ready Reason
+
+Unlike a `Promotion`, a `Stage` has no single phase. Its state is expressed
+through Kubernetes conditions, and the controller already collapses those into
+a single `Ready` condition whose `reason` names the most important thing
+currently true of the Stage. `kargo_stages_by_ready_reason` counts Stages by
+that reason, so every Stage lands in exactly one series and the series sum to
+the number of Stages in the Project (excluding control flow Stages, see below).
+
+Alongside `project`, it carries a `reason` label:
+
+```
+kargo_stages_by_ready_reason{project="guestbook",reason="Verified"}         10
+kargo_stages_by_ready_reason{project="guestbook",reason="ActivePromotion"}   3
+kargo_stages_by_ready_reason{project="guestbook",reason="Unhealthy"}         1
+```
+
+This table summarizes the reasons that Stages report, and what they mean:
+
+| Reason | Meaning |
+|--------|---------|
+| `ReconcileError` | The controller hit an error reconciling the Stage and will retry. |
+| `ActivePromotion`, `ListPromotionsFailed` | A Promotion is in progress, or the controller could not determine whether one is. |
+| `LastPromotionFailed`, `LastPromotionErrored`, `LastPromotionAborted` | No Promotion is running, but the last one did not succeed. |
+| `Unhealthy`, `Progressing`, `NoFreight`, `WaitingForHealthCheck`, `LastPromotion*` | The Stage is not healthy, or its health cannot yet be assessed. |
+| `PendingVerification`, `VerificationPending`, `VerificationRunning`, `VerificationFailed`, `VerificationError`, `VerificationAborted`, `VerificationInconclusive` | The Stage is healthy, but its Freight is not verified. |
+| `Verified` | The Stage is ready. |
+| `Unknown` | The controller has not reconciled the Stage yet, so it has no `Ready` condition. |
+
+Control flow Stages are omitted. Their `Ready` condition is set directly and
+never accounts for health or verification, so the reason they report conveys no
+useful information. A Project containing only control flow Stages reports no
+series at all.
+
+:::note
+
+A Stage is only `Verified` once it is healthy **and** its Freight has passed
+verification. Stages with no `spec.verification` are not stuck: the controller
+records a synthetic successful verification for them, so they reach `Verified`
+like any other Stage.
+
+Conversely, not-`Verified` is a broad bucket. It covers genuinely broken Stages
+alongside entirely normal ones: a Stage that is mid-promotion, or one that
+has never been promoted at all. Your alerts should trigger on specific reasons
+rather than on "everything that is not `Verified`".
+
+:::
+
+:::info
+
+This gauge is sampled from the controller's cache at scrape time, and a
+per-Project breakdown has to walk every Stage to produce it, so its cost scales
+with the number of Stages in the cluster.
+
+Only the states actually observed are reported. A reason that hasn't been
+reported by any Stage in the project produces no series at all rather than a
+zero, so use `or vector(0)` in queries that need a value when a state is empty.
+
+:::
+
 ## Scraping With the Prometheus Operator
 
 If your cluster runs the

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,8 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/rs/cors v1.11.1
 	github.com/sosedoff/gitkit v0.4.0
 	github.com/spf13/cobra v1.10.2
@@ -257,8 +259,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.24.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/pkg/controller/metrics/promotions.go
+++ b/pkg/controller/metrics/promotions.go
@@ -1,0 +1,198 @@
+// Package metrics defines the Prometheus metrics exported by Kargo's
+// controller. Collectors are registered with the controller-runtime registry,
+// which backs the metrics endpoint served by the controller's manager.
+package metrics
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/indexer"
+	"github.com/akuity/kargo/pkg/logging"
+	"github.com/akuity/kargo/pkg/metrics"
+)
+
+const (
+	// terminalPhaseLabel is the label under which the terminal phase value of a Promotion is
+	// recorded.
+	terminalPhaseLabel = "terminalPhase"
+)
+
+// durationBuckets are the histogram buckets for Promotion durations. Promotions
+// commonly run from a few seconds to several minutes -- steps that wait on an
+// external system (an Argo CD sync, for instance) can run considerably longer
+// -- so the buckets span one second to one hour.
+var durationBuckets = []float64{30, 60, 120, 300, 600, 1800, 3600}
+
+var (
+	metricsOnce = sync.Once{}
+	promMetrics *PromotionMetrics
+)
+
+// PromotionMetrics describes Promotion activity observed by the controller. All
+// of its collectors are labeled by the Project the Promotion belongs to.
+type PromotionMetrics struct {
+	// Created counts Promotions the controller has observed being created.
+	Created *prometheus.CounterVec
+	// RetryableErrors counts errors encountered while executing Promotions that
+	// a subsequent attempt may recover from. A single Promotion can contribute
+	// more than once.
+	RetryableErrors *prometheus.CounterVec
+	// TerminalErrors counts Promotions that have errored unrecoverably.
+	TerminalErrors *prometheus.CounterVec
+	// Duration observes, in seconds, how long each Promotion spent running --
+	// measured from the moment it transitioned to Running until it reached a
+	// terminal phase. It is additionally labeled by outcome. Promotions that
+	// end without ever having started are not observed.
+	Duration *prometheus.HistogramVec
+}
+
+// NewPromotionMetrics returns PromotionMetrics whose collectors have been registered with the
+// controller-runtime registry. It panics if any of the collectors is already registered. Calling
+// this function multiple times will return the same PromotionMetrics instance.
+func NewPromotionMetrics(
+	c client.Client,
+) *PromotionMetrics {
+	metricsOnce.Do(func() {
+		promMetrics = initPromotionMetrics(c)
+	})
+	return promMetrics
+}
+
+func initPromotionMetrics(
+	c client.Client,
+) *PromotionMetrics {
+	m := &PromotionMetrics{
+		Created: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metrics.Namespace,
+				Name:      "promotions_created_total",
+				Help:      "Number of Promotions the controller has observed being created.",
+			},
+			[]string{metrics.ProjectLabel},
+		),
+		RetryableErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metrics.Namespace,
+				Name:      "promotions_errored_retryable_total",
+				Help:      "Number of retryable errors encountered while executing Promotions.",
+			},
+			[]string{metrics.ProjectLabel},
+		),
+		TerminalErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metrics.Namespace,
+				Name:      "promotions_errored_terminal_total",
+				Help:      "Number of Promotions that have terminally errored.",
+			},
+			[]string{metrics.ProjectLabel},
+		),
+		Duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: metrics.Namespace,
+				Name:      "promotion_duration_seconds",
+				Help: "Time a Promotion spent running, from the moment it started " +
+					"until it reached a terminal phase.",
+				Buckets: durationBuckets,
+				// Because of the wide range of promotion durations, we also enable Native
+				// Histograms if the Prometheus server supports them. Notes on each of the settings
+				// is in the main metrics package
+
+				NativeHistogramBucketFactor:     metrics.NativeHistogramBucketFactor,
+				NativeHistogramMaxBucketNumber:  metrics.NativeHistogramMaxBucketNumber,
+				NativeHistogramMinResetDuration: metrics.NativeHistogramMinResetDuration,
+			},
+			[]string{metrics.ProjectLabel, terminalPhaseLabel},
+		),
+	}
+
+	// This one is sampled at scrape time rather than recorded, so nothing needs to hold on to it
+	// beyond registering it.
+	nonTerminalCollector := newPromotionNonTerminalCollector(c)
+
+	// NOTE: These must be registered with the controller-runtime registry, not the default one. The
+	// manager's metrics endpoint serves only the former.
+	ctrlmetrics.Registry.MustRegister(
+		m.Created,
+		m.RetryableErrors,
+		m.TerminalErrors,
+		m.Duration,
+		nonTerminalCollector,
+	)
+	return m
+}
+
+// promotionNonTerminalCollector counts non-terminal Promotions by Project. It implements
+// prometheus.Collector rather than using a GaugeFunc because a GaugeFunc's labels have to be known
+// when it is constructed, and Projects are created and deleted while the controller runs.
+type promotionNonTerminalCollector struct {
+	client client.Client
+	desc   *prometheus.Desc
+}
+
+func newPromotionNonTerminalCollector(c client.Client) *promotionNonTerminalCollector {
+	return &promotionNonTerminalCollector{
+		client: c,
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, "", "promotions_non_terminal"),
+			"Number of Promotions that are in a non-terminal state (Pending or Running).",
+			[]string{metrics.ProjectLabel},
+			nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (p *promotionNonTerminalCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- p.desc
+}
+
+// Collect implements prometheus.Collector. Unlike the Stage collector, this one can still lean on
+// an index: non-terminal Promotions are typically a small fraction of all Promotions, so selecting
+// them up front keeps a scrape from walking every Promotion the cache holds.
+func (p *promotionNonTerminalCollector) Collect(ch chan<- prometheus.Metric) {
+	promotions := &kargoapi.PromotionList{}
+	// Create a background context with a timeout to avoid blocking on a return or in case of
+	// shutdown. We're ok with not plumbing through a top-level context here because this is
+	// short and really doesn't matter if it is interrupted
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	if err := p.client.List(
+		ctx,
+		promotions,
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector(
+				indexer.PromotionsByNonTerminalField,
+				strconv.FormatBool(true),
+			),
+		},
+	); err != nil {
+		logging.LoggerFromContext(ctx).Error(
+			err, "Error when attempting to list promotion cache during metrics scrape",
+		)
+		return
+	}
+
+	for project, count := range countPromotionsByProject(promotions.Items) {
+		ch <- prometheus.MustNewConstMetric(p.desc, prometheus.GaugeValue, count, project)
+	}
+}
+
+// countPromotionsByProject buckets the given Promotions by the Project they belong to. Only the
+// Projects actually represented are reported, so a Project's series disappears once it has no
+// Promotions left in the list.
+func countPromotionsByProject(promotions []kargoapi.Promotion) map[string]float64 {
+	counts := make(map[string]float64)
+	for _, promotion := range promotions {
+		counts[promotion.Namespace]++
+	}
+	return counts
+}

--- a/pkg/controller/metrics/promotions.go
+++ b/pkg/controller/metrics/promotions.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	// terminalPhaseLabel is the label under which the terminal phase value of a Promotion is
+	// phaseLabel is the label under which the terminal phase value of a Promotion is
 	// recorded.
-	terminalPhaseLabel = "terminalPhase"
+	phaseLabel = "phase"
 )
 
 // durationBuckets are the histogram buckets for Promotion durations. Promotions
@@ -40,14 +40,10 @@ var (
 // PromotionMetrics describes Promotion activity observed by the controller. All
 // of its collectors are labeled by the Project the Promotion belongs to.
 type PromotionMetrics struct {
-	// Created counts Promotions the controller has observed being created.
-	Created *prometheus.CounterVec
-	// RetryableErrors counts errors encountered while executing Promotions that
-	// a subsequent attempt may recover from. A single Promotion can contribute
-	// more than once.
-	RetryableErrors *prometheus.CounterVec
-	// TerminalErrors counts Promotions that have errored unrecoverably.
-	TerminalErrors *prometheus.CounterVec
+	// Completed counts Promotions that have reached a terminal phase. It is
+	// additionally labeled by that phase, so a single series describes both how
+	// many Promotions finished and how they finished.
+	Completed *prometheus.CounterVec
 	// Duration observes, in seconds, how long each Promotion spent running --
 	// measured from the moment it transitioned to Running until it reached a
 	// terminal phase. It is additionally labeled by outcome. Promotions that
@@ -71,29 +67,13 @@ func initPromotionMetrics(
 	c client.Client,
 ) *PromotionMetrics {
 	m := &PromotionMetrics{
-		Created: prometheus.NewCounterVec(
+		Completed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: metrics.Namespace,
-				Name:      "promotions_created_total",
-				Help:      "Number of Promotions the controller has observed being created.",
+				Name:      "promotions_completed_total",
+				Help:      "Number of Promotions that have reached a terminal phase.",
 			},
-			[]string{metrics.ProjectLabel},
-		),
-		RetryableErrors: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: metrics.Namespace,
-				Name:      "promotions_errored_retryable_total",
-				Help:      "Number of retryable errors encountered while executing Promotions.",
-			},
-			[]string{metrics.ProjectLabel},
-		),
-		TerminalErrors: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: metrics.Namespace,
-				Name:      "promotions_errored_terminal_total",
-				Help:      "Number of Promotions that have terminally errored.",
-			},
-			[]string{metrics.ProjectLabel},
+			[]string{metrics.ProjectLabel, phaseLabel},
 		),
 		Duration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -110,7 +90,7 @@ func initPromotionMetrics(
 				NativeHistogramMaxBucketNumber:  metrics.NativeHistogramMaxBucketNumber,
 				NativeHistogramMinResetDuration: metrics.NativeHistogramMinResetDuration,
 			},
-			[]string{metrics.ProjectLabel, terminalPhaseLabel},
+			[]string{metrics.ProjectLabel, phaseLabel},
 		),
 	}
 
@@ -121,9 +101,7 @@ func initPromotionMetrics(
 	// NOTE: These must be registered with the controller-runtime registry, not the default one. The
 	// manager's metrics endpoint serves only the former.
 	ctrlmetrics.Registry.MustRegister(
-		m.Created,
-		m.RetryableErrors,
-		m.TerminalErrors,
+		m.Completed,
 		m.Duration,
 		nonTerminalCollector,
 	)

--- a/pkg/controller/metrics/promotions_test.go
+++ b/pkg/controller/metrics/promotions_test.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func Test_countPromotionsByProject(t *testing.T) {
+	t.Parallel()
+
+	promotion := func(project string) kargoapi.Promotion {
+		return kargoapi.Promotion{ObjectMeta: metav1.ObjectMeta{Namespace: project}}
+	}
+
+	testCases := []struct {
+		name       string
+		promotions []kargoapi.Promotion
+		expected   map[string]float64
+	}{
+		{
+			name:     "no Promotions yields no Projects",
+			expected: map[string]float64{},
+		},
+		{
+			name: "Promotions are counted per Project",
+			promotions: []kargoapi.Promotion{
+				promotion("project-a"),
+				promotion("project-a"),
+				promotion("project-b"),
+			},
+			expected: map[string]float64{"project-a": 2, "project-b": 1},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, testCase.expected, countPromotionsByProject(testCase.promotions))
+		})
+	}
+}

--- a/pkg/controller/metrics/stages.go
+++ b/pkg/controller/metrics/stages.go
@@ -1,0 +1,131 @@
+// Package metrics defines the Prometheus metrics exported by Kargo's
+// controller. Collectors are registered with the controller-runtime registry,
+// which backs the metrics endpoint served by the controller's manager.
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/conditions"
+	"github.com/akuity/kargo/pkg/logging"
+	"github.com/akuity/kargo/pkg/metrics"
+)
+
+const (
+	// reasonLabel is the label under which the reason on a Stage's Ready condition is recorded.
+	reasonLabel = "reason"
+)
+
+// reasonUnknown is the reason reported for a Stage that has no Ready condition yet, because the
+// controller has not reconciled it since it was created.
+const reasonUnknown = "Unknown"
+
+var stageMetricsOnce = sync.Once{}
+
+// RegisterStageMetrics registers the Stage metrics with the controller-runtime registry. They are
+// all sampled from the cache at scrape time rather than recorded to, so there is nothing for a
+// caller to hold on to and nothing is returned. It panics if any of the collectors is already
+// registered. Calling this function more than once registers nothing further.
+func RegisterStageMetrics(c client.Client) {
+	stageMetricsOnce.Do(func() {
+		// NOTE: These must be registered with the controller-runtime registry, not the default one.
+		// The manager's metrics endpoint serves only the former.
+		ctrlmetrics.Registry.MustRegister(newStageReadyCollector(c))
+	})
+}
+
+// stageReadyCollector counts Stages by Project and by the reason on their Ready condition. It
+// implements prometheus.Collector rather than using a GaugeFunc because a GaugeFunc's labels have
+// to be known when it is constructed, and both Projects and reasons vary at runtime.
+type stageReadyCollector struct {
+	client client.Client
+	desc   *prometheus.Desc
+}
+
+func newStageReadyCollector(c client.Client) *stageReadyCollector {
+	return &stageReadyCollector{
+		client: c,
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, "", "stages_by_ready_reason"),
+			"Number of Stages in each readiness state, by the reason on their Ready condition. A "+
+				"Stage is counted exactly once. Control flow Stages are omitted: their Ready "+
+				"condition is set directly and never accounts for health or verification, so the "+
+				"reason they report conveys no useful information.",
+			[]string{metrics.ProjectLabel, reasonLabel},
+			nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (s *stageReadyCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- s.desc
+}
+
+// Collect implements prometheus.Collector. It lists every Stage once and buckets them in memory.
+// There is no index to lean on here the way the Promotion gauge does: breaking counts down by
+// Project means every Stage has to be seen anyway.
+func (s *stageReadyCollector) Collect(ch chan<- prometheus.Metric) {
+	// Create a background context with a timeout to avoid blocking on a return or in case of
+	// shutdown. We're ok with not plumbing through a top-level context here because this is
+	// short and really doesn't matter if it is interrupted
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	stages := &kargoapi.StageList{}
+	if err := s.client.List(ctx, stages); err != nil {
+		logging.LoggerFromContext(ctx).Error(
+			err, "Error when attempting to list stage cache during metrics scrape",
+		)
+		return
+	}
+
+	for project, counts := range countStagesByReadyReason(stages.Items) {
+		for reason, count := range counts {
+			ch <- prometheus.MustNewConstMetric(
+				s.desc,
+				prometheus.GaugeValue,
+				count,
+				project,
+				reason,
+			)
+		}
+	}
+}
+
+// countStagesByReadyReason buckets Stages by Project and by the reason on their Ready condition.
+// The reconciler collapses everything it knows about a Stage into that one condition in a fixed
+// precedence, so the reason already names the most important thing true of the Stage. See
+// summarizeConditions in pkg/controller/stages.
+//
+// Control flow Stages are skipped. Only the states actually observed are reported, so a series
+// disappears once no Stage is in that state.
+func countStagesByReadyReason(
+	stages []kargoapi.Stage,
+) map[string]map[string]float64 {
+	counts := make(map[string]map[string]float64)
+	for i := range stages {
+		stage := &stages[i]
+		if stage.IsControlFlow() {
+			continue
+		}
+
+		reason := reasonUnknown
+		if ready := conditions.Get(&stage.Status, kargoapi.ConditionTypeReady); ready != nil {
+			reason = ready.Reason
+		}
+
+		if counts[stage.Namespace] == nil {
+			counts[stage.Namespace] = make(map[string]float64)
+		}
+		counts[stage.Namespace][reason]++
+	}
+	return counts
+}

--- a/pkg/controller/metrics/stages_test.go
+++ b/pkg/controller/metrics/stages_test.go
@@ -1,0 +1,162 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+func Test_countStagesByReadyReason(t *testing.T) {
+	t.Parallel()
+
+	// regular returns a Stage with a promotion template, which is what makes it
+	// a regular rather than a control flow Stage.
+	regular := func(project string, conditions ...metav1.Condition) kargoapi.Stage {
+		return kargoapi.Stage{
+			ObjectMeta: metav1.ObjectMeta{Namespace: project},
+			Spec: kargoapi.StageSpec{
+				PromotionTemplate: &kargoapi.PromotionTemplate{
+					Spec: kargoapi.PromotionTemplateSpec{
+						Steps: []kargoapi.PromotionStep{{Uses: "fake-step"}},
+					},
+				},
+			},
+			Status: kargoapi.StageStatus{Conditions: conditions},
+		}
+	}
+
+	controlFlow := func(project string, conditions ...metav1.Condition) kargoapi.Stage {
+		return kargoapi.Stage{
+			ObjectMeta: metav1.ObjectMeta{Namespace: project},
+			Status:     kargoapi.StageStatus{Conditions: conditions},
+		}
+	}
+
+	ready := metav1.Condition{
+		Type:   kargoapi.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "Verified",
+	}
+	unhealthy := metav1.Condition{
+		Type:   kargoapi.ConditionTypeReady,
+		Status: metav1.ConditionFalse,
+		Reason: "Unhealthy",
+	}
+
+	testCases := []struct {
+		name   string
+		stages []kargoapi.Stage
+		assert func(*testing.T, map[string]map[string]float64)
+	}{
+		{
+			name: "no Stages yields no Projects",
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Empty(t, counts)
+			},
+		},
+		{
+			name: "Stages are counted by reason, per Project",
+			stages: []kargoapi.Stage{
+				regular("project-a", ready),
+				regular("project-a", ready),
+				regular("project-a", unhealthy),
+				regular("project-b", unhealthy),
+			},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Len(t, counts, 2)
+				require.Equal(t, float64(2), counts["project-a"]["Verified"])
+				require.Equal(t, float64(1), counts["project-a"]["Unhealthy"])
+				require.Equal(t, float64(1), counts["project-b"]["Unhealthy"])
+			},
+		},
+		{
+			// Unlike the per-condition metric this replaced, a Stage lands in
+			// exactly one series, so the series do sum to the Stage count.
+			name: "each Stage is counted exactly once",
+			stages: []kargoapi.Stage{
+				regular("project-a", ready),
+				regular("project-a", unhealthy),
+			},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				var total float64
+				for _, count := range counts["project-a"] {
+					total += count
+				}
+				require.Equal(t, float64(2), total)
+			},
+		},
+		{
+			// A control flow Stage's Ready condition is set directly and never
+			// reflects health or verification, so it is left out entirely.
+			name: "control flow Stages are omitted",
+			stages: []kargoapi.Stage{
+				regular("project-a", ready),
+				controlFlow("project-a", metav1.Condition{
+					Type:   kargoapi.ConditionTypeReady,
+					Status: metav1.ConditionTrue,
+					Reason: kargoapi.ConditionTypeReady,
+				}),
+			},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Len(t, counts["project-a"], 1)
+				require.Equal(t, float64(1), counts["project-a"]["Verified"])
+			},
+		},
+		{
+			name: "a Project of only control flow Stages is not reported",
+			stages: []kargoapi.Stage{
+				controlFlow("project-a", ready),
+			},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Empty(t, counts)
+			},
+		},
+		{
+			// A Stage the controller has not reconciled yet has no Ready
+			// condition at all.
+			name:   "a Stage with no Ready condition reports an unknown reason",
+			stages: []kargoapi.Stage{regular("project-a")},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Equal(t, float64(1), counts["project-a"][reasonUnknown])
+			},
+		},
+		{
+			// Only Ready is consulted. The conditions it is derived from are
+			// ignored, so a Stage never lands in more than one series.
+			name: "other conditions are ignored",
+			stages: []kargoapi.Stage{
+				regular(
+					"project-a",
+					metav1.Condition{
+						Type:   kargoapi.ConditionTypeHealthy,
+						Status: metav1.ConditionFalse,
+						Reason: "Unhealthy",
+					},
+					metav1.Condition{
+						Type:   kargoapi.ConditionTypePromoting,
+						Status: metav1.ConditionTrue,
+						Reason: "ActivePromotion",
+					},
+					metav1.Condition{
+						Type:   kargoapi.ConditionTypeReady,
+						Status: metav1.ConditionFalse,
+						Reason: "ActivePromotion",
+					},
+				),
+			},
+			assert: func(t *testing.T, counts map[string]map[string]float64) {
+				require.Len(t, counts["project-a"], 1)
+				require.Equal(t, float64(1), counts["project-a"]["ActivePromotion"])
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testCase.assert(t, countStagesByReadyReason(testCase.stages))
+		})
+	}
+}

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -357,7 +357,6 @@ func (r *reconciler) Reconcile(
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
-		r.promoMetrics.Created.WithLabelValues(promo.Namespace).Inc()
 	}
 
 	// Retrieve the Stage associated with the Promotion.
@@ -451,10 +450,7 @@ func (r *reconciler) Reconcile(
 	if newStatus.Phase.IsTerminal() {
 		newStatus.FinishedAt = &metav1.Time{Time: time.Now()}
 		logger.Info("promotion", "phase", newStatus.Phase)
-		if newStatus.Phase == kargoapi.PromotionPhaseErrored {
-			r.promoMetrics.TerminalErrors.WithLabelValues(promo.Namespace).Inc()
-		}
-		r.recordDuration(promo.Namespace, newStatus)
+		r.recordTerminalMetrics(promo.Namespace, newStatus)
 	}
 
 	// Record the current refresh token as having been handled.
@@ -556,7 +552,6 @@ func (r *reconciler) Reconcile(
 	if newStatus.Phase == kargoapi.PromotionPhaseRunning {
 		if promoteErr != nil {
 			// Retryable error: use progressive backoff.
-			r.promoMetrics.RetryableErrors.WithLabelValues(promo.Namespace).Inc()
 			return ctrl.Result{}, promoteErr
 		}
 		// Waiting for external condition: use calculated interval.
@@ -772,7 +767,7 @@ func (r *reconciler) terminatePromotion(
 		return err
 	}
 
-	r.recordDuration(promo.Namespace, newStatus)
+	r.recordTerminalMetrics(promo.Namespace, newStatus)
 
 	// Best-effort cleanup of working directory.
 	r.cleanupWorkDirFn(ctx, promo.UID)
@@ -786,15 +781,17 @@ func (r *reconciler) terminatePromotion(
 	return nil
 }
 
-// recordDuration observes how long the Promotion described by the given
-// terminal status spent running, labeled by the Project it belongs to and by
-// whether it succeeded. A Promotion that reached a terminal phase without ever
-// having started -- one aborted while still Pending, for instance -- has no
-// running time to report and is skipped.
-func (r *reconciler) recordDuration(
+// recordTerminalMetrics counts the Promotion described by the given terminal
+// status as completed and observes how long it spent running, both labeled by
+// the Project it belongs to and by the phase it finished in. A Promotion that
+// reached a terminal phase without ever having started -- one aborted while
+// still Pending, for instance -- still counts as completed, but has no running
+// time to report.
+func (r *reconciler) recordTerminalMetrics(
 	project string,
 	status *kargoapi.PromotionStatus,
 ) {
+	r.promoMetrics.Completed.WithLabelValues(project, string(status.Phase)).Inc()
 	if status.StartedAt == nil || status.FinishedAt == nil {
 		return
 	}

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/akuity/kargo/pkg/api"
 	"github.com/akuity/kargo/pkg/controller"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/controller/metrics"
 	"github.com/akuity/kargo/pkg/event"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	"github.com/akuity/kargo/pkg/indexer"
@@ -67,6 +68,8 @@ type reconciler struct {
 	cfg ReconcilerConfig
 
 	sender event.Sender
+
+	promoMetrics *metrics.PromotionMetrics
 
 	// The following behaviors are overridable for testing purposes:
 
@@ -131,6 +134,17 @@ func SetupReconcilerWithManager(
 		),
 	); err != nil {
 		return fmt.Errorf("index running Promotions by Argo CD selectors: %w", err)
+	}
+
+	// Index non-terminal Promotions for use by prometheus metrics. This allows the metrics to be
+	// calculated without scanning all Promotions.
+	if err := kargoMgr.GetFieldIndexer().IndexField(
+		ctx,
+		&kargoapi.Promotion{},
+		indexer.PromotionsByNonTerminalField,
+		indexer.PromotionsByNonTerminal,
+	); err != nil {
+		return fmt.Errorf("index non-terminal Promotions: %w", err)
 	}
 
 	reconciler := newReconciler(
@@ -236,11 +250,12 @@ func newReconciler(
 	cfg ReconcilerConfig,
 ) *reconciler {
 	r := &reconciler{
-		kargoClient: kargoClient,
-		apiReader:   apiReader,
-		promoEngine: promoEngine,
-		sender:      sender,
-		cfg:         cfg,
+		kargoClient:  kargoClient,
+		apiReader:    apiReader,
+		promoEngine:  promoEngine,
+		sender:       sender,
+		promoMetrics: metrics.NewPromotionMetrics(kargoClient),
+		cfg:          cfg,
 		shardPredicate: controller.ResponsibleFor[kargoapi.Promotion]{
 			IsDefaultController: cfg.IsDefaultController,
 			ShardName:           cfg.ShardName,
@@ -342,6 +357,7 @@ func (r *reconciler) Reconcile(
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.promoMetrics.Created.WithLabelValues(promo.Namespace).Inc()
 	}
 
 	// Retrieve the Stage associated with the Promotion.
@@ -435,6 +451,10 @@ func (r *reconciler) Reconcile(
 	if newStatus.Phase.IsTerminal() {
 		newStatus.FinishedAt = &metav1.Time{Time: time.Now()}
 		logger.Info("promotion", "phase", newStatus.Phase)
+		if newStatus.Phase == kargoapi.PromotionPhaseErrored {
+			r.promoMetrics.TerminalErrors.WithLabelValues(promo.Namespace).Inc()
+		}
+		r.recordDuration(promo.Namespace, newStatus)
 	}
 
 	// Record the current refresh token as having been handled.
@@ -536,6 +556,7 @@ func (r *reconciler) Reconcile(
 	if newStatus.Phase == kargoapi.PromotionPhaseRunning {
 		if promoteErr != nil {
 			// Retryable error: use progressive backoff.
+			r.promoMetrics.RetryableErrors.WithLabelValues(promo.Namespace).Inc()
 			return ctrl.Result{}, promoteErr
 		}
 		// Waiting for external condition: use calculated interval.
@@ -751,6 +772,8 @@ func (r *reconciler) terminatePromotion(
 		return err
 	}
 
+	r.recordDuration(promo.Namespace, newStatus)
+
 	// Best-effort cleanup of working directory.
 	r.cleanupWorkDirFn(ctx, promo.UID)
 
@@ -761,6 +784,24 @@ func (r *reconciler) terminatePromotion(
 	}
 
 	return nil
+}
+
+// recordDuration observes how long the Promotion described by the given
+// terminal status spent running, labeled by the Project it belongs to and by
+// whether it succeeded. A Promotion that reached a terminal phase without ever
+// having started -- one aborted while still Pending, for instance -- has no
+// running time to report and is skipped.
+func (r *reconciler) recordDuration(
+	project string,
+	status *kargoapi.PromotionStatus,
+) {
+	if status.StartedAt == nil || status.FinishedAt == nil {
+		return
+	}
+	r.promoMetrics.Duration.WithLabelValues(
+		project,
+		string(status.Phase),
+	).Observe(status.FinishedAt.Sub(status.StartedAt.Time).Seconds())
 }
 
 // setupDeleteCleanup registers an informer event handler that performs

--- a/pkg/controller/promotions/promotions_test.go
+++ b/pkg/controller/promotions/promotions_test.go
@@ -1157,15 +1157,19 @@ func newPromo(namespace, name, stage string,
 	}
 }
 
-func Test_reconciler_recordDuration(t *testing.T) {
+func Test_reconciler_recordTerminalMetrics(t *testing.T) {
 	started := metav1.Time{Time: now.Add(-90 * time.Second)}
+
+	phases := []string{"Succeeded", "Errored", "Aborted"}
 
 	testCases := []struct {
 		name   string
 		status kargoapi.PromotionStatus
-		// expected maps a terminalPhase label value to the number of
-		// observations expected under it.
-		expected map[string]uint64
+		// expectedCompletions and expectedObservations map a phase
+		// label value to the counter increments and histogram observations
+		// expected under it.
+		expectedCompletions  map[string]float64
+		expectedObservations map[string]uint64
 	}{
 		{
 			name: "succeeded Promotion",
@@ -1174,7 +1178,8 @@ func Test_reconciler_recordDuration(t *testing.T) {
 				StartedAt:  &started,
 				FinishedAt: &now,
 			},
-			expected: map[string]uint64{"Succeeded": 1, "Errored": 0, "Aborted": 0},
+			expectedCompletions:  map[string]float64{"Succeeded": 1, "Errored": 0, "Aborted": 0},
+			expectedObservations: map[string]uint64{"Succeeded": 1, "Errored": 0, "Aborted": 0},
 		},
 		{
 			name: "errored Promotion",
@@ -1183,7 +1188,8 @@ func Test_reconciler_recordDuration(t *testing.T) {
 				StartedAt:  &started,
 				FinishedAt: &now,
 			},
-			expected: map[string]uint64{"Succeeded": 0, "Errored": 1, "Aborted": 0},
+			expectedCompletions:  map[string]float64{"Succeeded": 0, "Errored": 1, "Aborted": 0},
+			expectedObservations: map[string]uint64{"Succeeded": 0, "Errored": 1, "Aborted": 0},
 		},
 		{
 			name: "aborted Promotion",
@@ -1192,38 +1198,61 @@ func Test_reconciler_recordDuration(t *testing.T) {
 				StartedAt:  &started,
 				FinishedAt: &now,
 			},
-			expected: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 1},
+			expectedCompletions:  map[string]float64{"Succeeded": 0, "Errored": 0, "Aborted": 1},
+			expectedObservations: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 1},
 		},
 		{
-			name: "Promotion that never started is not observed",
+			name: "Promotion that never started counts, but has no duration",
 			status: kargoapi.PromotionStatus{
 				Phase:      kargoapi.PromotionPhaseAborted,
 				FinishedAt: &now,
 			},
-			expected: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 0},
+			expectedCompletions:  map[string]float64{"Succeeded": 0, "Errored": 0, "Aborted": 1},
+			expectedObservations: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 0},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Each case needs its own histogram, but PromotionMetrics is a
-			// process-wide singleton, so swap in a standalone one.
+			// Each case needs its own collectors, but PromotionMetrics is a
+			// process-wide singleton, so swap in standalone ones.
+			completed := prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_completed_total"},
+				[]string{"project", "phase"},
+			)
 			duration := prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{Name: "test_duration_seconds"},
-				[]string{"project", "terminalPhase"},
+				[]string{"project", "phase"},
 			)
-			r := &reconciler{promoMetrics: &metrics.PromotionMetrics{Duration: duration}}
+			r := &reconciler{
+				promoMetrics: &metrics.PromotionMetrics{
+					Completed: completed,
+					Duration:  duration,
+				},
+			}
 
-			r.recordDuration("fake-project", &testCase.status)
+			r.recordTerminalMetrics("fake-project", &testCase.status)
 
-			for phase, expected := range testCase.expected {
+			for _, phase := range phases {
+				var m dto.Metric
+
+				counter := completed.WithLabelValues("fake-project", phase)
+				require.NoError(t, counter.Write(&m))
+				require.Equal(
+					t,
+					testCase.expectedCompletions[phase],
+					m.GetCounter().GetValue(),
+					"phase %q", phase,
+				)
+
 				observer, ok := duration.
 					WithLabelValues("fake-project", phase).(prometheus.Metric)
 				require.True(t, ok)
 
-				var m dto.Metric
+				m = dto.Metric{}
 				require.NoError(t, observer.Write(&m))
+				expected := testCase.expectedObservations[phase]
 				require.Equal(
-					t, expected, m.GetHistogram().GetSampleCount(), "terminalPhase %q", phase,
+					t, expected, m.GetHistogram().GetSampleCount(), "phase %q", phase,
 				)
 				if expected > 0 {
 					require.Equal(t, 90.0, m.GetHistogram().GetSampleSum())

--- a/pkg/controller/promotions/promotions_test.go
+++ b/pkg/controller/promotions/promotions_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/controller/metrics"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	fakeevent "github.com/akuity/kargo/pkg/kubernetes/event/fake"
 	"github.com/akuity/kargo/pkg/promotion"
@@ -655,9 +658,10 @@ func Test_reconciler_terminatePromotion(t *testing.T) {
 			recorder := fakeevent.NewEventRecorder(1)
 
 			r := &reconciler{
-				kargoClient: c,
-				apiReader:   c,
-				sender:      k8sevent.NewEventSender(recorder),
+				kargoClient:  c,
+				apiReader:    c,
+				sender:       k8sevent.NewEventSender(recorder),
+				promoMetrics: metrics.NewPromotionMetrics(c),
 				cleanupWorkDirFn: func(context.Context, types.UID) {
 					// no-op for tests
 				},
@@ -790,9 +794,10 @@ func Test_reconciler_terminatePromotion_cleansUpWorkDir(t *testing.T) {
 
 	cleanupCalled := false
 	r := &reconciler{
-		kargoClient: c,
-		apiReader:   c,
-		sender:      k8sevent.NewEventSender(recorder),
+		kargoClient:  c,
+		apiReader:    c,
+		sender:       k8sevent.NewEventSender(recorder),
+		promoMetrics: metrics.NewPromotionMetrics(c),
 		cleanupWorkDirFn: func(context.Context, types.UID) {
 			cleanupCalled = true
 		},
@@ -1149,6 +1154,82 @@ func newPromo(namespace, name, stage string,
 		Status: kargoapi.PromotionStatus{
 			Phase: phase,
 		},
+	}
+}
+
+func Test_reconciler_recordDuration(t *testing.T) {
+	started := metav1.Time{Time: now.Add(-90 * time.Second)}
+
+	testCases := []struct {
+		name   string
+		status kargoapi.PromotionStatus
+		// expected maps a terminalPhase label value to the number of
+		// observations expected under it.
+		expected map[string]uint64
+	}{
+		{
+			name: "succeeded Promotion",
+			status: kargoapi.PromotionStatus{
+				Phase:      kargoapi.PromotionPhaseSucceeded,
+				StartedAt:  &started,
+				FinishedAt: &now,
+			},
+			expected: map[string]uint64{"Succeeded": 1, "Errored": 0, "Aborted": 0},
+		},
+		{
+			name: "errored Promotion",
+			status: kargoapi.PromotionStatus{
+				Phase:      kargoapi.PromotionPhaseErrored,
+				StartedAt:  &started,
+				FinishedAt: &now,
+			},
+			expected: map[string]uint64{"Succeeded": 0, "Errored": 1, "Aborted": 0},
+		},
+		{
+			name: "aborted Promotion",
+			status: kargoapi.PromotionStatus{
+				Phase:      kargoapi.PromotionPhaseAborted,
+				StartedAt:  &started,
+				FinishedAt: &now,
+			},
+			expected: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 1},
+		},
+		{
+			name: "Promotion that never started is not observed",
+			status: kargoapi.PromotionStatus{
+				Phase:      kargoapi.PromotionPhaseAborted,
+				FinishedAt: &now,
+			},
+			expected: map[string]uint64{"Succeeded": 0, "Errored": 0, "Aborted": 0},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Each case needs its own histogram, but PromotionMetrics is a
+			// process-wide singleton, so swap in a standalone one.
+			duration := prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{Name: "test_duration_seconds"},
+				[]string{"project", "terminalPhase"},
+			)
+			r := &reconciler{promoMetrics: &metrics.PromotionMetrics{Duration: duration}}
+
+			r.recordDuration("fake-project", &testCase.status)
+
+			for phase, expected := range testCase.expected {
+				observer, ok := duration.
+					WithLabelValues("fake-project", phase).(prometheus.Metric)
+				require.True(t, ok)
+
+				var m dto.Metric
+				require.NoError(t, observer.Write(&m))
+				require.Equal(
+					t, expected, m.GetHistogram().GetSampleCount(), "terminalPhase %q", phase,
+				)
+				if expected > 0 {
+					require.Equal(t, 90.0, m.GetHistogram().GetSampleSum())
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -33,6 +33,7 @@ import (
 	"github.com/akuity/kargo/pkg/conditions"
 	"github.com/akuity/kargo/pkg/controller"
 	argocdapi "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/controller/metrics"
 	kargoEvent "github.com/akuity/kargo/pkg/event"
 	k8sevent "github.com/akuity/kargo/pkg/event/kubernetes"
 	exprfn "github.com/akuity/kargo/pkg/expressions/function"
@@ -212,6 +213,8 @@ func (r *RegularStageReconciler) SetupWithManager(
 	); err != nil {
 		return fmt.Errorf("index Freight by Stages for which it has been approved: %w", err)
 	}
+
+	metrics.RegisterStageMetrics(r.client)
 
 	// Build the controller with the reconciler.
 	c, err := ctrl.NewControllerManagedBy(kargoMgr).

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -32,6 +32,7 @@ const (
 	PromotionsByStageAndFreightField = "stageAndFreight"
 	PromotionsByStageField           = "stage"
 	PromotionsByTerminalField        = "terminal"
+	PromotionsByNonTerminalField     = "nonTerminal"
 
 	PromotionRequestsByStageAndFreightField = "stageAndFreight"
 	PromotionRequestsByStageField           = "stage"
@@ -122,6 +123,16 @@ func PromotionsByTerminal(obj client.Object) []string {
 		return nil
 	}
 	return []string{strconv.FormatBool(promo.Status.Phase.IsTerminal())}
+}
+
+// PromotionsByNonTerminal returns a client.IndexerFunc that indexes Promotions by
+// whether or not that are in a non-terminal phase.
+func PromotionsByNonTerminal(obj client.Object) []string {
+	promo, ok := obj.(*kargoapi.Promotion)
+	if !ok {
+		return nil
+	}
+	return []string{strconv.FormatBool(!promo.Status.Phase.IsTerminal())}
 }
 
 // RunningPromotionsByArgoCDApplications returns a client.IndexerFunc that

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,43 @@
+// Package metrics is a small helper package containing constants and other shared behaviors for
+// Kargo metrics. Actual metric definitions should be done in the packages that define and/or
+// implement the resources being measured
+package metrics
+
+import "time"
+
+const (
+	// Namespace is the prefix shared by all Kargo metric names.
+	Namespace = "kargo"
+
+	// ProjectLabel is the label under which the name of the Kargo Project a resource
+	// belongs to is recorded.
+	ProjectLabel = "project"
+
+	// NOTE(thomastaylor312): These are the main constants used for long duration steps and
+	// promotions for native histograms. Because of the wide range of time values, native is a
+	// better fit. Each of the values below has documentation for why it was chosen.
+
+	// NativeHistogramBucketFactor is the factor passed to HistogramOpts for our long-running
+	// metrics. This is 10% growth between buckets, shouldn't give us too many. According to the
+	// source code, this is 8 buckets per doubling of the duration
+	NativeHistogramBucketFactor = 1.1
+	// NativeHistogramMaxBucketNumber is the max number of buckets we support. Assuming we run
+	// anywhere from about 2s to 6h, the amount of doubling to cover that range of seconds (i.e.
+	// log2(21600s)) gives us about 14 doublings, which is 14 * 8 = 112 buckets. If for some reason
+	// a 12 hour value comes in, the same formula gives us about 15 and a half doublings, which is
+	// 15.5 * 8 = 124 buckets. We set this to 200 to give us plenty of headroom over that, but not
+	// anything that would cause runaway buckets
+	//
+	// NOTE(thomastaylor312): As far as I could tell from my reading of how this all
+	// works (which could be flawed), this should be safe from a memory perspective. I
+	// think each max bucket number will be bounded per unique combination of labels at
+	// 200. Because each unique combo will have a smaller data set it is unlikely that
+	// we will hit the max bucket number. But if we ever start having memory issues with
+	// this, this is a good place to start looking
+	NativeHistogramMaxBucketNumber = 200
+	// NativeHistogramMinResetDuration is the minimum time the histogram can collect before it
+	// resets. This is set so we don't avoid resetting the histogram too early in case we hit the
+	// max bucket number or any other default limit. Given that some steps can run for a while, we
+	// want to make sure we don't reset the histogram too early and lose data.
+	NativeHistogramMinResetDuration = time.Hour
+)

--- a/pkg/promotion/local_orchestrator.go
+++ b/pkg/promotion/local_orchestrator.go
@@ -3,6 +3,7 @@ package promotion
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -12,6 +13,7 @@ import (
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/health"
+	"github.com/akuity/kargo/pkg/promotion/metrics"
 )
 
 // LocalOrchestrator is an implementation of the Orchestrator interface that
@@ -22,6 +24,7 @@ type LocalOrchestrator struct {
 	registry  StepRunnerRegistry
 	client    client.Client
 	cacheFunc ExprDataCacheFn
+	metrics   *metrics.StepMetrics
 }
 
 // NewLocalOrchestrator creates a new LocalOrchestrator instance with the
@@ -44,6 +47,7 @@ func NewLocalOrchestrator(
 		registry:  registry,
 		client:    kargoClient,
 		cacheFunc: cacheFunc,
+		metrics:   metrics.NewStepMetrics(),
 	}
 }
 
@@ -82,6 +86,7 @@ func (o *LocalOrchestrator) ExecuteSteps(
 					"step %q was canceled due to context cancellation: %s",
 					step.Alias, ctx.Err(),
 				).Finished()
+				o.recordStepDuration(promoCtx.Project, step, meta)
 			}
 			return Result{
 				Status:                kargoapi.PromotionPhaseErrored,
@@ -169,6 +174,7 @@ func (o *LocalOrchestrator) ExecuteSteps(
 			meta.WithStatus(kargoapi.PromotionStepStatusErrored).WithMessagef(
 				"step %q returned an invalid status: %s", step.Alias, result.Status,
 			).Finished()
+			o.recordStepDuration(promoCtx.Project, step, meta)
 			continue
 		}
 
@@ -187,6 +193,9 @@ func (o *LocalOrchestrator) ExecuteSteps(
 				RetryAfter:            result.RetryAfter,
 			}, err
 		}
+
+		// The step reached a terminal status on this attempt.
+		o.recordStepDuration(promoCtx.Project, step, meta)
 
 		// If the step succeeded, we can add any health checks to the list.
 		if meta.Status == kargoapi.PromotionStepStatusSucceeded {
@@ -209,6 +218,31 @@ func (o *LocalOrchestrator) ExecuteSteps(
 	}, nil
 }
 
+// recordStepDuration observes how long a step spent running, from the moment it
+// first started until it reached a terminal status, labeled by the Project it
+// belongs to, its kind, and the status it ended in. Because a step's StartedAt
+// survives across reconciliations, this covers the step's whole lifetime, not
+// just the attempt that happened to finish it.
+//
+// A step with no start or no finish has no running time to report and is not
+// observed; neither are skipped steps, whose duration says nothing about the
+// work the step represents.
+func (o *LocalOrchestrator) recordStepDuration(
+	project string,
+	step Step,
+	meta *StepMetadata,
+) {
+	if meta == nil || meta.StartedAt == nil || meta.FinishedAt == nil ||
+		meta.Status == kargoapi.PromotionStepStatusSkipped {
+		return
+	}
+	o.metrics.Duration.WithLabelValues(
+		project,
+		step.Kind,
+		string(meta.Status),
+	).Observe(meta.FinishedAt.Sub(meta.StartedAt.Time).Seconds())
+}
+
 func (o *LocalOrchestrator) propagateStepOutput(
 	promoCtx Context,
 	step Step,
@@ -225,9 +259,8 @@ func (o *LocalOrchestrator) propagateStepOutput(
 			if promoCtx.State[aliasNamespace] == nil {
 				promoCtx.State[aliasNamespace] = make(map[string]any)
 			}
-			for k, v := range result.Output {
-				promoCtx.State[aliasNamespace].(map[string]any)[k] = v // nolint: forcetypeassert
-			}
+			// nolint: forcetypeassert
+			maps.Copy(promoCtx.State[aliasNamespace].(map[string]any), result.Output)
 		}
 	}
 }

--- a/pkg/promotion/local_orchestrator_test.go
+++ b/pkg/promotion/local_orchestrator_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/promotion/metrics"
 )
 
 func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
@@ -352,7 +354,7 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 			promoCtx: Context{
 				StepExecutionMetadata: kargoapi.StepExecutionMetadataList{{
 					// Start time is set to an hour ago
-					StartedAt: ptr.To(metav1.NewTime(time.Now().Add(-time.Hour))),
+					StartedAt: new(metav1.NewTime(time.Now().Add(-time.Hour))),
 				}},
 			},
 			steps: []Step{
@@ -385,7 +387,7 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 			promoCtx: Context{
 				StepExecutionMetadata: kargoapi.StepExecutionMetadataList{{
 					// Start time is set to an hour ago
-					StartedAt: ptr.To(metav1.NewTime(time.Now().Add(-time.Hour))),
+					StartedAt: new(metav1.NewTime(time.Now().Add(-time.Hour))),
 				}},
 			},
 			steps: []Step{
@@ -537,7 +539,7 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 			promoCtx: Context{
 				StepExecutionMetadata: kargoapi.StepExecutionMetadataList{{
 					Alias:     "step1",
-					StartedAt: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute))),
+					StartedAt: new(metav1.NewTime(time.Now().Add(-time.Minute))),
 					Status:    kargoapi.PromotionStepStatusFailed,
 					Message:   "previous failure",
 				}},
@@ -724,6 +726,108 @@ func TestLocalOrchestrator_ExecuteSteps(t *testing.T) {
 
 			result, err := orchestrator.ExecuteSteps(ctx, tt.promoCtx, tt.steps)
 			tt.assertions(t, result, err)
+		})
+	}
+}
+
+func TestLocalOrchestrator_recordStepDuration(t *testing.T) {
+	started := metav1.Time{Time: time.Now().Add(-45 * time.Second)}
+	finished := metav1.Time{Time: time.Now()}
+
+	// noneObserved is the expectation for a step that is not observed at all.
+	noneObserved := map[string]uint64{"Succeeded": 0, "Failed": 0, "Errored": 0, "Skipped": 0}
+
+	tests := []struct {
+		name string
+		meta *StepMetadata
+		// expected maps a terminalStatus label value to the number of
+		// observations expected under it.
+		expected map[string]uint64
+	}{
+		{
+			name: "succeeded step",
+			meta: &StepMetadata{
+				Status:     kargoapi.PromotionStepStatusSucceeded,
+				StartedAt:  &started,
+				FinishedAt: &finished,
+			},
+			expected: map[string]uint64{"Succeeded": 1, "Failed": 0, "Errored": 0, "Skipped": 0},
+		},
+		{
+			// A terminal, non-technical failure. Distinct from Errored.
+			name: "failed step",
+			meta: &StepMetadata{
+				Status:     kargoapi.PromotionStepStatusFailed,
+				StartedAt:  &started,
+				FinishedAt: &finished,
+			},
+			expected: map[string]uint64{"Succeeded": 0, "Failed": 1, "Errored": 0, "Skipped": 0},
+		},
+		{
+			// A technical failure, retried until the step's error threshold.
+			name: "errored step",
+			meta: &StepMetadata{
+				Status:     kargoapi.PromotionStepStatusErrored,
+				StartedAt:  &started,
+				FinishedAt: &finished,
+			},
+			expected: map[string]uint64{"Succeeded": 0, "Failed": 0, "Errored": 1, "Skipped": 0},
+		},
+		{
+			// Even a step that ran before self-determining it should be skipped
+			// is not observed; its duration says nothing about the work it
+			// represents.
+			name: "skipped step is not observed",
+			meta: &StepMetadata{
+				Status:     kargoapi.PromotionStepStatusSkipped,
+				StartedAt:  &started,
+				FinishedAt: &finished,
+			},
+			expected: noneObserved,
+		},
+		{
+			name: "step still running is not observed",
+			meta: &StepMetadata{
+				Status:    kargoapi.PromotionStepStatusRunning,
+				StartedAt: &started,
+			},
+			expected: noneObserved,
+		},
+		{
+			name: "step that never started is not observed",
+			meta: &StepMetadata{
+				Status:     kargoapi.PromotionStepStatusSucceeded,
+				FinishedAt: &finished,
+			},
+			expected: noneObserved,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// StepMetrics is a process-wide singleton, so each case swaps in a
+			// standalone histogram to observe against.
+			duration := prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{Name: "test_step_duration_seconds"},
+				[]string{"project", "stepKind", "terminalStatus"},
+			)
+			o := &LocalOrchestrator{metrics: &metrics.StepMetrics{Duration: duration}}
+
+			o.recordStepDuration("fake-project", Step{Kind: "fake-kind"}, tt.meta)
+
+			for status, expected := range tt.expected {
+				observer, ok := duration.
+					WithLabelValues("fake-project", "fake-kind", status).(prometheus.Metric)
+				require.True(t, ok)
+
+				var m dto.Metric
+				require.NoError(t, observer.Write(&m))
+				require.Equal(
+					t, expected, m.GetHistogram().GetSampleCount(), "terminalStatus=%s", status,
+				)
+				if expected > 0 {
+					require.InDelta(t, 45.0, m.GetHistogram().GetSampleSum(), 1.0)
+				}
+			}
 		})
 	}
 }

--- a/pkg/promotion/metrics/metrics.go
+++ b/pkg/promotion/metrics/metrics.go
@@ -1,0 +1,85 @@
+// Package metrics defines the Prometheus metrics exported by Kargo's
+// controller. Collectors are registered with the controller-runtime registry,
+// which backs the metrics endpoint served by the controller's manager.
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/akuity/kargo/pkg/metrics"
+)
+
+const (
+	// stepKindLabel is the label under which the kind of Step is recorded.
+	stepKindLabel = "stepKind"
+	// terminalStatusLabel is the label under which the step's terminal status is recorded:
+	// Succeeded, Failed (a terminal, non-technical failure), or Errored (a technical failure,
+	// which is retried until the step's error threshold is met). Skipped steps are not recorded.
+	terminalStatusLabel = "terminalStatus"
+)
+
+// durationBuckets are the histogram buckets for step durations. Steps can vary widely in how long
+// they take to run. Some are just a few seconds, but some that wait (like waiting for a PR) can
+// take a long time. For this reason we also enable Native Histograms if the Prometheus server
+// supports them, which will allow us to get a more accurate view of the distribution of step
+// durations.
+var durationBuckets = []float64{5, 10, 30, 60, 120, 300, 600, 1800, 3600}
+
+var (
+	metricsOnce = sync.Once{}
+	stepMetrics *StepMetrics
+)
+
+// StepMetrics describes Step activity observed by the promotion engine. All
+// of its collectors are labeled by the Project the Step belongs to.
+type StepMetrics struct {
+	// Duration observes, in seconds, how long each step took to run, labeled by the project they
+	// belong to, the step kind, and the terminal status the step ended in.
+	Duration *prometheus.HistogramVec
+}
+
+// NewStepMetrics returns StepMetrics whose collectors have been registered with the
+// controller-runtime registry. It panics if any of the collectors is already registered. Calling
+// this function multiple times will return the same StepMetrics instance.
+func NewStepMetrics() *StepMetrics {
+	metricsOnce.Do(func() {
+		stepMetrics = initStepMetrics()
+	})
+	return stepMetrics
+}
+
+func initStepMetrics() *StepMetrics {
+	m := &StepMetrics{
+		Duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: metrics.Namespace,
+				Name:      "promotion_step_duration_seconds",
+				Help: "Time a Promotion step spent running, from the moment it started until it reached a " +
+					"terminal phase. It is recommended to scrape Native Histograms instead of the static " +
+					"buckets, if the Prometheus server supports them.",
+				Buckets: durationBuckets,
+				// Because of the wide range of step durations, we also enable Native Histograms if
+				// the Prometheus server supports them. Notes on each of the settings is in the main
+				// metrics package
+
+				NativeHistogramBucketFactor:     metrics.NativeHistogramBucketFactor,
+				NativeHistogramMaxBucketNumber:  metrics.NativeHistogramMaxBucketNumber,
+				NativeHistogramMinResetDuration: metrics.NativeHistogramMinResetDuration,
+			},
+			// NOTE(thomastaylor312): Project label is the only one of these labels that is truly
+			// unbounded. Steps will continue to increase, but slowly and won't ever be massive. If
+			// we start having cardinality issues, project is probably the first thing to drop
+			[]string{metrics.ProjectLabel, stepKindLabel, terminalStatusLabel},
+		),
+	}
+
+	// NOTE: These must be registered with the controller-runtime registry, not the default one. The
+	// manager's metrics endpoint serves only the former.
+	ctrlmetrics.Registry.MustRegister(
+		m.Duration,
+	)
+	return m
+}


### PR DESCRIPTION
This adds an initial set of metrics to promotions and stages to give more insight into current work. I kept these fairly constrained for now, but they should be easy to extend in the future

Closes #6876