### PR TITLE
feat: add a release support page

### DIFF
--- a/docs/docs/85-release-support.md
+++ b/docs/docs/85-release-support.md
@@ -1,0 +1,73 @@
+---
+title: Release Support
+sidebar_label: Release Support
+description: Kargo release dates, latest patch versions, and when Critical CVE backport coverage ends for each Kargo release line.
+---
+
+import ReleaseSupportTable from '@site/src/components/ReleaseSupportTable';
+
+# Release Support
+
+Kargo's maintainers publish a new minor release roughly four times a year. This
+page records when each minor release was published, its most recent patch, and
+how long Akuity backports fixes for Critical vulnerabilities to it.
+
+<ReleaseSupportTable />
+
+## What these dates mean
+
+The final column is the end of the Critical CVE backport window for **AKP
+commercial builds of Kargo** — the `ak`-tagged images distributed as part of
+the Akuity Platform. Akuity backports fixes for Critical vulnerabilities to
+AKP builds of any Kargo release published within the previous 12 months.
+
+Coverage is bound by severity as well as by time:
+
+| Severity | Backported to AKP builds of releases published within |
+|----------|-------------------------------------------------------|
+| Critical | the last 12 months |
+| High | the last 6 months |
+| Medium / Low | the current minor release |
+
+Each window is measured from the affected release's publication date — the
+date in the <Hlt>Released</Hlt> column above — and a Kargo instance must be
+running a release still inside the applicable window to be eligible. A
+Critical vulnerability affecting a release published thirteen months ago falls
+outside the window; the fix for it lands in supported releases, and the
+instance running the older release upgrades to receive it.
+
+Critical and High severity fixes in Kargo's own code may be delivered as
+out-of-band, security-only patch releases rather than waiting for the next
+minor release.
+
+## Open source Kargo
+
+The open-source distribution — Apache 2.0, published to
+`ghcr.io/akuity/kargo` — carries no time- or severity-bound backport
+guarantee. Security fixes land in the latest release, and open-source users
+upgrade to receive them. Fixes are not backported to older release lines.
+Maintenance is best-effort and the software is provided "as is" under its
+license.
+
+:::note
+The dates in the table above therefore describe AKP coverage. If you run the
+open-source distribution, the supported version is the latest release, whatever
+the table says about the line you are on.
+:::
+
+Open-source and commercial builds are produced from the same source on the same
+release schedule, so a fix lands in both at the same time. What differs is the
+commitment around it and the range of releases it is backported to.
+
+Open-source users receive the same transparency artifacts Akuity publishes with
+every release:
+
+- A **Software Bill of Materials (SBOM)** enumerating the components in the
+  image.
+- **Signed VEX statements** recording whether each known vulnerability is
+  actually exploitable in Kargo. Scanners commonly flag components that are
+  present in an image but never invoked; VEX dispositions those findings
+  formally so your scanner can filter them. Point your scanner at
+  [vex.akuity.io](https://vex.akuity.io) to ingest them, or read them from the
+  Sigstore attestations attached to each released image.
+- Public security advisories.

--- a/docs/src/components/ReleaseSupportTable.module.css
+++ b/docs/src/components/ReleaseSupportTable.module.css
@@ -1,0 +1,44 @@
+.table {
+  display: table;
+  width: 100%;
+  margin-bottom: var(--ifm-spacing-vertical);
+}
+
+.release {
+  white-space: nowrap;
+}
+
+/* Status dot, echoing the at-a-glance colour coding on endoflife.date. The
+   dot is decorative reinforcement -- the relative phrase beside each date
+   carries the same information as text. */
+.dot {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  margin-right: 0.5rem;
+  border-radius: 50%;
+  vertical-align: baseline;
+  background-color: currentColor;
+}
+
+.relative {
+  display: block;
+  font-size: 0.85em;
+}
+
+.supported {
+  color: var(--ifm-color-success);
+}
+
+.endingSoon {
+  color: var(--ifm-color-warning-darker);
+}
+
+.ended {
+  color: var(--ifm-color-danger);
+}
+
+/* Infima's warning is tuned for light backgrounds and washes out on dark. */
+[data-theme='dark'] .endingSoon {
+  color: var(--ifm-color-warning);
+}

--- a/docs/src/components/ReleaseSupportTable.tsx
+++ b/docs/src/components/ReleaseSupportTable.tsx
@@ -1,0 +1,97 @@
+import React, {useEffect, useState} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import {
+  bestReleasesURL,
+  coverageEnd,
+  fallbackReleases,
+  formatDate,
+  parseBestReleases,
+  parseReleaseDate,
+  relativePhrase,
+  statusLabels,
+  statusOf,
+  type Release,
+} from './releaseSupport';
+import styles from './ReleaseSupportTable.module.css';
+
+export default function ReleaseSupportTable(): JSX.Element {
+  // The absolute dates below are facts and render identically everywhere, but
+  // anything derived from the current time would differ between the build and
+  // the visitor's clock. useIsBrowser is false during SSR and during the first
+  // hydration render, so those cells stay empty until React is live and then
+  // fill in without a hydration mismatch.
+  const isBrowser = useIsBrowser();
+  const now = isBrowser ? new Date() : null;
+
+  // The release workflow republishes best-releases.json on every release, so
+  // fetching it keeps the table current between docs builds. Rendering starts
+  // from the committed snapshot, which is also what the server rendered, so
+  // this refresh never causes a hydration mismatch.
+  const [releases, setReleases] = useState<Release[]>(fallbackReleases);
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(bestReleasesURL, {signal: controller.signal})
+      .then((response) =>
+        response.ok
+          ? response.json()
+          : Promise.reject(new Error(`status ${response.status}`)),
+      )
+      .then((payload) => {
+        const fetched = parseBestReleases(payload);
+        if (fetched.length > 0) {
+          setReleases(fetched);
+        }
+      })
+      .catch(() => {
+        // The snapshot is already on screen. A failed refresh is not something
+        // the reader can act on, so it is not worth surfacing.
+      });
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Release</th>
+          <th>Released</th>
+          <th>Latest patch</th>
+          <th>Critical CVE coverage ends</th>
+        </tr>
+      </thead>
+      <tbody>
+        {releases.map((release) => {
+          const released = parseReleaseDate(release.released);
+          const coverageEnds = coverageEnd(released);
+          const status = now ? statusOf(coverageEnds, now) : null;
+          return (
+            <tr key={release.minor}>
+              <th scope="row" className={styles.release}>
+                {status && (
+                  <span
+                    className={`${styles.dot} ${styles[status]}`}
+                    role="img"
+                    aria-label={statusLabels[status]}
+                  />
+                )}
+                {release.minor}
+              </th>
+              <td>{formatDate(released)}</td>
+              <td>
+                <code>{release.latestPatch}</code>
+              </td>
+              <td>
+                {formatDate(coverageEnds)}
+                {status && (
+                  <span className={`${styles.relative} ${styles[status]}`}>
+                    {relativePhrase(coverageEnds, now!)}
+                  </span>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/docs/src/components/releaseSupport.ts
+++ b/docs/src/components/releaseSupport.ts
@@ -1,0 +1,141 @@
+// Release support data and the date arithmetic over it. Kept free of React and
+// CSS imports so it can be exercised on its own.
+
+export type Release = {
+  minor: string;
+  // Publication date of the x.y.0 release, as recorded by GitHub. The
+  // vulnerability management policy measures backport windows from an
+  // affected release's publication date, so that is the date used here.
+  released: string;
+  latestPatch: string;
+};
+
+// A snapshot of the live data below, rendered server-side and used whenever the
+// fetch cannot complete -- no JavaScript, an offline reader, a GitHub Pages
+// outage. It only needs to be accurate enough to be useful in those cases;
+// refresh it with `go run ./hack/best-releases` from the repository root.
+export const fallbackReleases: Release[] = [
+  {minor: '1.11', released: '2026-07-24', latestPatch: 'v1.11.2'},
+  {minor: '1.10', released: '2026-04-17', latestPatch: 'v1.10.10'},
+  {minor: '1.9', released: '2026-01-29', latestPatch: 'v1.9.10'},
+  {minor: '1.8', released: '2025-10-21', latestPatch: 'v1.8.14'},
+  {minor: '1.7', released: '2025-08-05', latestPatch: 'v1.7.10'},
+  {minor: '1.6', released: '2025-06-27', latestPatch: 'v1.6.4'},
+  {minor: '1.5', released: '2025-05-15', latestPatch: 'v1.5.3'},
+  {minor: '1.4', released: '2025-04-05', latestPatch: 'v1.4.4'},
+  {minor: '1.3', released: '2025-02-25', latestPatch: 'v1.3.4'},
+  {minor: '1.2', released: '2025-01-14', latestPatch: 'v1.2.3'},
+  {minor: '1.1', released: '2024-12-06', latestPatch: 'v1.1.3'},
+  {minor: '1.0', released: '2024-10-19', latestPatch: 'v1.0.4'},
+];
+
+// Published on every release by the publish-best-releases job in
+// .github/workflows/release.yaml, so the table refreshes without a docs build.
+export const bestReleasesURL =
+  'https://akuity.github.io/kargo/best-releases.json';
+
+// Critical CVE fixes are backported to AKP builds of releases published within
+// the last 12 months.
+export const criticalWindowMonths = 12;
+
+// A release whose coverage ends within this many days is flagged so operators
+// have warning before they fall outside the window.
+export const endingSoonDays = 90;
+
+const msPerDay = 86_400_000;
+
+// Release dates are parsed as UTC midnight, so every formatter here must also
+// read them as UTC or the rendered day can slip by one west of Greenwich.
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+const relativeFormatter = new Intl.RelativeTimeFormat('en', {numeric: 'auto'});
+
+export type Status = 'supported' | 'endingSoon' | 'ended';
+
+export const statusLabels: Record<Status, string> = {
+  supported: 'Covered',
+  endingSoon: 'Ending soon',
+  ended: 'Ended',
+};
+
+export function parseReleaseDate(released: string): Date {
+  return new Date(`${released}T00:00:00Z`);
+}
+
+export function formatDate(date: Date): string {
+  return dateFormatter.format(date);
+}
+
+export function coverageEnd(released: Date): Date {
+  const result = new Date(released);
+  result.setUTCMonth(result.getUTCMonth() + criticalWindowMonths);
+  return result;
+}
+
+export function statusOf(coverageEnds: Date, now: Date): Status {
+  const remainingDays = (coverageEnds.getTime() - now.getTime()) / msPerDay;
+  if (remainingDays <= 0) {
+    return 'ended';
+  }
+  if (remainingDays <= endingSoonDays) {
+    return 'endingSoon';
+  }
+  return 'supported';
+}
+
+export function relativePhrase(target: Date, now: Date): string {
+  const days = Math.round((target.getTime() - now.getTime()) / msPerDay);
+  const magnitude = Math.abs(days);
+  if (magnitude < 7) {
+    return relativeFormatter.format(days, 'day');
+  }
+  if (magnitude < 45) {
+    return relativeFormatter.format(Math.round(days / 7), 'week');
+  }
+  if (magnitude < 365) {
+    return relativeFormatter.format(Math.round(days / 30), 'month');
+  }
+  return relativeFormatter.format(Math.round(days / 365), 'year');
+}
+
+const versionPattern = /^v(\d+)\.(\d+)\.\d+$/;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+// parseBestReleases converts a best-releases.json payload into Releases sorted
+// newest first. It is deliberately forgiving: the page has usable data already,
+// so a malformed or unexpected entry is skipped rather than thrown over.
+export function parseBestReleases(payload: unknown): Release[] {
+  const entries = (payload as {releases?: unknown} | null)?.releases;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const parsed: {major: number; minor: number; release: Release}[] = [];
+  for (const entry of entries) {
+    const version = (entry as {version?: unknown})?.version;
+    const released = (entry as {initialReleaseDate?: unknown})
+      ?.initialReleaseDate;
+    if (typeof version !== 'string' || typeof released !== 'string') {
+      continue;
+    }
+    const match = versionPattern.exec(version);
+    if (!match || !datePattern.test(released)) {
+      continue;
+    }
+    parsed.push({
+      major: Number(match[1]),
+      minor: Number(match[2]),
+      release: {
+        minor: `${match[1]}.${match[2]}`,
+        released,
+        latestPatch: version,
+      },
+    });
+  }
+  parsed.sort((a, b) => b.major - a.major || b.minor - a.minor);
+  return parsed.map(({release}) => release);
+}

--- a/hack/best-releases/fetch.go
+++ b/hack/best-releases/fetch.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-cleanhttp"
@@ -90,9 +91,11 @@ func fetchBestReleases(ctx context.Context, baseURL string) ([]Release, error) {
 }
 
 // pickBestReleases takes a slice of releases and returns the latest patch
-// release for each minor version, sorted in descending version order.
+// release for each minor version, sorted in descending version order. Each
+// result also carries the date on which its minor release line opened.
 func pickBestReleases(raw []Release) []Release {
 	best := make(map[string]*Release)
+	first := make(map[string]*Release)
 
 	v1 := semver.MustParse("v1.0.0")
 	for i, r := range raw {
@@ -103,11 +106,21 @@ func pickBestReleases(raw []Release) []Release {
 		if existing, ok := best[key]; !ok || r.Version.GreaterThan(existing.Version) {
 			best[key] = &raw[i]
 		}
+		// A line opens with its x.y.0 release. Tracking the lowest version
+		// rather than the earliest date keeps this correct even if an older
+		// line receives a patch after a newer line has already opened.
+		if existing, ok := first[key]; !ok || r.Version.LessThan(existing.Version) {
+			first[key] = &raw[i]
+		}
 	}
 
 	results := make([]Release, 0, len(best))
-	for _, r := range best {
-		results = append(results, *r)
+	for key, r := range best {
+		release := *r
+		if opener, ok := first[key]; ok && !opener.PublishedAt.IsZero() {
+			release.InitialReleaseDate = opener.PublishedAt.UTC().Format(time.DateOnly)
+		}
+		results = append(results, release)
 	}
 
 	sort.Slice(results, func(i, j int) bool {

--- a/hack/best-releases/fetch.go
+++ b/hack/best-releases/fetch.go
@@ -64,6 +64,15 @@ func fetchBestReleases(ctx context.Context, baseURL string) ([]Release, error) {
 			)
 		}
 
+		// The page is counted before filtering. GitHub's page size counts drafts
+		// and prereleases, which githubReleases discards, so a full page can
+		// yield far fewer usable releases -- and comparing the filtered count
+		// against perPage would end pagination while pages remain.
+		var rawPage []json.RawMessage
+		if err := json.Unmarshal(body, &rawPage); err != nil {
+			return nil, fmt.Errorf("unmarshaling releases page %d: %w", page, err)
+		}
+
 		var pageReleases githubReleases
 		if err := json.Unmarshal(body, &pageReleases); err != nil {
 			return nil, fmt.Errorf("unmarshaling releases: %w", err)
@@ -71,7 +80,7 @@ func fetchBestReleases(ctx context.Context, baseURL string) ([]Release, error) {
 
 		allReleases = append(allReleases, pageReleases...)
 
-		if len(pageReleases) < perPage {
+		if len(rawPage) < perPage {
 			break
 		}
 		page++

--- a/hack/best-releases/fetch_test.go
+++ b/hack/best-releases/fetch_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,5 +180,48 @@ func TestPickBestReleases(t *testing.T) {
 		results := pickBestReleases(raw)
 		require.Len(t, results, 1)
 		assert.True(t, v("1.0.0").Equal(results[0].Version))
+	})
+
+	t.Run("dates each line from its x.y.0 release", func(t *testing.T) {
+		day := func(s string) time.Time {
+			d, err := time.Parse(time.DateOnly, s)
+			require.NoError(t, err)
+			return d
+		}
+		raw := []Release{
+			{Version: v("1.0.0"), PublishedAt: day("2024-10-19")},
+			{Version: v("1.0.4"), PublishedAt: day("2024-12-06")},
+			{Version: v("1.1.0"), PublishedAt: day("2024-12-06")},
+			// An older line patched after a newer line opened must not take
+			// the newer line's date, nor give up its own.
+			{Version: v("1.0.5"), PublishedAt: day("2025-01-30")},
+			{Version: v("1.1.1"), PublishedAt: day("2025-01-28")},
+		}
+
+		results := pickBestReleases(raw)
+
+		require.Len(t, results, 2)
+		assert.True(t, v("1.1.1").Equal(results[0].Version))
+		assert.Equal(t, "2024-12-06", results[0].InitialReleaseDate)
+		assert.True(t, v("1.0.5").Equal(results[1].Version))
+		assert.Equal(t, "2024-10-19", results[1].InitialReleaseDate)
+	})
+
+	t.Run("falls back to the oldest patch when x.y.0 is absent", func(t *testing.T) {
+		published := time.Date(2025, 5, 15, 22, 27, 32, 0, time.UTC)
+		raw := []Release{
+			{Version: v("1.5.2"), PublishedAt: published},
+			{Version: v("1.5.3"), PublishedAt: published.AddDate(0, 1, 0)},
+		}
+
+		results := pickBestReleases(raw)
+		require.Len(t, results, 1)
+		assert.Equal(t, "2025-05-15", results[0].InitialReleaseDate)
+	})
+
+	t.Run("omits the date when publication time is unknown", func(t *testing.T) {
+		results := pickBestReleases([]Release{{Version: v("1.0.0")}})
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].InitialReleaseDate)
 	})
 }

--- a/hack/best-releases/fetch_test.go
+++ b/hack/best-releases/fetch_test.go
@@ -17,8 +17,9 @@ func TestFetchBestReleases(t *testing.T) {
 		BrowserDownloadURL string `json:"browser_download_url"`
 	}
 	type rawRelease struct {
-		TagName string     `json:"tag_name"`
-		Assets  []rawAsset `json:"assets"`
+		TagName    string     `json:"tag_name"`
+		Prerelease bool       `json:"prerelease,omitempty"`
+		Assets     []rawAsset `json:"assets"`
 	}
 
 	t.Run("paginates and returns best releases", func(t *testing.T) {
@@ -67,6 +68,46 @@ func TestFetchBestReleases(t *testing.T) {
 		assert.True(t, results[0].Latest)
 		assert.True(t, v("1.0.99").Equal(results[1].Version))
 		assert.False(t, results[1].Latest)
+	})
+
+	t.Run("keeps paginating when a page is mostly prereleases", func(t *testing.T) {
+		const perPage = 100
+		asset := rawAsset{Name: "kargo-linux-amd64", BrowserDownloadURL: "https://example.com/dl"}
+
+		// A full page of 100 raw releases, most of which are prereleases and
+		// get filtered out. The page is still full, so there is more to fetch.
+		page1 := make([]rawRelease, perPage)
+		for i := range page1 {
+			page1[i] = rawRelease{
+				TagName:    fmt.Sprintf("v1.2.0-rc.%d", i),
+				Prerelease: true,
+				Assets:     []rawAsset{asset},
+			}
+		}
+		page1[0] = rawRelease{TagName: "v1.2.0", Assets: []rawAsset{asset}}
+		page2 := []rawRelease{{TagName: "v1.1.0", Assets: []rawAsset{asset}}}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var data any
+			switch r.URL.Query().Get("page") {
+			case "1", "":
+				data = page1
+			case "2":
+				data = page2
+			default:
+				data = []rawRelease{}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(data) //nolint: errcheck
+		}))
+		defer srv.Close()
+
+		results, err := fetchBestReleases(t.Context(), srv.URL)
+		require.NoError(t, err)
+
+		require.Len(t, results, 2)
+		assert.True(t, v("1.2.0").Equal(results[0].Version))
+		assert.True(t, v("1.1.0").Equal(results[1].Version))
 	})
 
 	t.Run("HTTP error returns error", func(t *testing.T) {

--- a/hack/best-releases/releases.go
+++ b/hack/best-releases/releases.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"regexp"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -55,6 +56,14 @@ type Release struct {
 	Version *semver.Version `json:"version"`
 	// Latest indicates whether this release is the latest release.
 	Latest bool `json:"latest,omitempty"`
+	// PublishedAt is when this specific release was published. It is used to
+	// derive InitialReleaseDate and is not itself part of the JSON output.
+	PublishedAt time.Time `json:"-"`
+	// InitialReleaseDate is the date on which the minor release line this
+	// release belongs to was first published -- the date of its x.y.0 release.
+	// Support and vulnerability backport windows are measured from this date,
+	// so it is expressed as a plain YYYY-MM-DD date rather than a timestamp.
+	InitialReleaseDate string `json:"initialReleaseDate,omitempty"`
 	// CLIBinaries maps OS and architecture combinations to their corresponding
 	// download URLs for the kargo CLI binary.
 	CLIBinaries CLIBinaries `json:"cliBinaries"`
@@ -64,13 +73,15 @@ type Release struct {
 // semver Version to a string.
 func (r Release) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Version     string      `json:"version"`
-		Latest      bool        `json:"latest,omitempty"`
-		CLIBinaries CLIBinaries `json:"cliBinaries"`
+		Version            string      `json:"version"`
+		Latest             bool        `json:"latest,omitempty"`
+		InitialReleaseDate string      `json:"initialReleaseDate,omitempty"`
+		CLIBinaries        CLIBinaries `json:"cliBinaries"`
 	}{
-		Version:     r.Version.Original(),
-		Latest:      r.Latest,
-		CLIBinaries: r.CLIBinaries,
+		Version:            r.Version.Original(),
+		Latest:             r.Latest,
+		InitialReleaseDate: r.InitialReleaseDate,
+		CLIBinaries:        r.CLIBinaries,
 	})
 }
 
@@ -83,8 +94,9 @@ var cliAssetPattern = regexp.MustCompile(`^kargo-([a-z]+)-([a-z0-9]+)(?:\.exe)?$
 // kargo-{os}-{arch}[.exe] naming convention.
 func (r *Release) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		TagName string `json:"tag_name"`
-		Assets  []struct {
+		TagName     string    `json:"tag_name"`
+		PublishedAt time.Time `json:"published_at"`
+		Assets      []struct {
 			Name               string `json:"name"`
 			BrowserDownloadURL string `json:"browser_download_url"`
 		} `json:"assets"`
@@ -97,6 +109,7 @@ func (r *Release) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	r.Version = v
+	r.PublishedAt = raw.PublishedAt
 	r.CLIBinaries = CLIBinaries{}
 	for _, a := range raw.Assets {
 		if m := cliAssetPattern.FindStringSubmatch(a.Name); m != nil {


### PR DESCRIPTION
Adds a Release Support page to the docs recording when each minor release was published, its most recent patch, and when Critical CVE backport coverage for it ends. Styled after [endoflife.date](https://endoflife.date/kubernetes), with each line colour coded as covered, ending soon, or ended.

Preview: `docs/docs/85-release-support.md` → https://docs.kargo.io/release-support

## Framing: this is the AKP commitment, not an OSS one

Worth flagging for review, since it drove the page's structure. The 12-month window is the **Critical** row of the *commercial AKP* backport matrix. The vulnerability management policy is explicit that open source Kargo gets no backports to older release lines — fixes land in the latest release and users upgrade.

Publishing a flat "supported for 1 year" table in the OSS docs would therefore commit us publicly to something we don't offer. The page instead labels the window as AKP coverage and states the open source position separately.

The page does not link the policy, because it isn't public. Its substance is written inline so the page stands alone.

The policy also disagrees with itself on Class B (Section 7 gives dependency and upstream CVEs the 12-month window; Appendix A says current-minor only). The page is silent on Class B rather than picking a side — deliberately deferred, not resolved.

## Staying current

Three things could go stale; each is handled:

| Goes stale | Handled by |
|---|---|
| Supported/ended status | Computed from the reader's clock |
| A new minor line missing | Fetched from `best-releases.json` |
| Latest patch outdated | Same fetch |

`publish-best-releases` already republishes that JSON on every release, so no new CI was needed — only the `.0` date had to be added to it. Dates render server-side from a committed snapshot; the fetch refreshes over the top. Adding a release requires no docs change.

Note: until the next release runs `publish-best-releases`, the deployed JSON has no `initialReleaseDate`, so the page shows the committed snapshot. Verified this degrades silently and correctly.

## Drive-by fix: pagination truncation (`98bd5830`)

Found while checking feasibility. `fetchBestReleases` compared the *post-filter* release count against the page size, but GitHub's page size counts the drafts and prereleases we discard. A page of 100 containing 36 prereleases yielded 64, read as a short page, and ended the loop after page one.

This is a live bug, not a theoretical one: the published JSON listed **8 minor lines instead of 12**, silently omitting 1.0–1.3.

**Reviewer note:** this changes the UI downloads page too. `ui/src/pages/downloads/releases.ts` consumes the same JSON, so its version dropdown grows from 8 entries to 12. Benign — it maps over whatever returns and still defaults via `r.latest` — and arguably a fix, since users on older lines can now get a matching CLI. Worth a second opinion on whether a longer dropdown is wanted.

The fix is self-contained in `98bd5830` and backportable to `release-*` on its own.

## Verification

| Check | Result |
|---|---|
| `go test ./hack/best-releases/` | pass — pagination test written failing first, then passing |
| `make lint-go`, `go vet` | 0 issues |
| Fixed tool vs live API | 12 lines (was 8); all dates match the committed snapshot |
| Parser vs malformed input | null, non-array, junk, bad dates, prereleases all rejected |
| Numeric sort | 1.10 ranks above 1.9 (lexical sort would invert it) |
| Browser, current endpoint | falls back to snapshot, no console errors |
| Browser, simulated future endpoint | 1.12 appears with its own EOL; 1.11 patch updates |
| Docs typecheck + build | pass, light and dark |

Commit `98bd5830` was verified passing in isolation, not just at HEAD.

Note that CI has no docs job — only Netlify builds the site — so the typecheck and build above are the only gate this component has.

### Screen shot

<img width="4020" height="5458" alt="screencapture-localhost-3000-release-support-2026-08-28-10_46_49" src="https://github.com/user-attachments/assets/6c639c8f-98be-49f1-aacc-354aa8a1808b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)