### PR TITLE
feat(credentials): act as Project-specific Azure identities for ACR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,12 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:l
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 h1:L7G3dExHBgUxsO3qpTGhk/P2dgnYyW48yn7AO33Tbek=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0/go.mod h1:Ms6gYEy0+A2knfKrwdatsggTXYA2+ICKug8w7STorFw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=

--- a/pkg/credentials/acr/project_identity.go
+++ b/pkg/credentials/acr/project_identity.go
@@ -1,0 +1,79 @@
+package acr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
+)
+
+const (
+	// projectResourcePrefix precedes a Kargo Project's name in the name of the
+	// Azure managed identity Kargo acts as on that Project's behalf.
+	projectResourcePrefix = "kargo-project-"
+)
+
+// errNoProjectIdentity indicates that no usable Azure identity exists for a
+// Project. It signals that the caller should fall back to the controller's own
+// identity rather than treat the condition as a failure.
+var errNoProjectIdentity = errors.New("no Project-specific Azure identity")
+
+// projectIdentityName returns the name of the Azure managed identity Kargo
+// acts as on behalf of the given Project.
+func projectIdentityName(project string) string {
+	return projectResourcePrefix + project
+}
+
+// userAssignedIdentityGetter is the subset of the Azure Resource Manager
+// managed identity API that this package uses.
+type userAssignedIdentityGetter interface {
+	Get(
+		ctx context.Context,
+		resourceGroupName string,
+		resourceName string,
+		options *armmsi.UserAssignedIdentitiesClientGetOptions,
+	) (armmsi.UserAssignedIdentitiesClientGetResponse, error)
+}
+
+// resolveClientID resolves a Kargo Project to the client ID of the Azure
+// managed identity Kargo acts as on that Project's behalf. Azure addresses
+// identities by GUID, and a GUID cannot be derived from a Project's name the
+// way an AWS role ARN or a GCP service account email can, so a lookup stands in
+// for the naming convention those providers rely on.
+//
+// Nothing is retained between calls. A resolved client ID would be correct
+// until the identity behind it is deleted and recreated, after which a retained
+// one would send every later exchange for that Project to an identity that no
+// longer exists, silently falling back to the controller's own identity until
+// the process restarts. Resolving each time costs one request on a path that
+// already makes several and runs only when a token is actually needed.
+
+func (p *WorkloadIdentityProvider) resolveClientID(
+	ctx context.Context,
+	project string,
+) (string, error) {
+	res, err := p.identities.Get(
+		ctx,
+		p.resourceGroup,
+		projectIdentityName(project),
+		nil,
+	)
+	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) &&
+			respErr.StatusCode == http.StatusNotFound {
+			return "", errNoProjectIdentity
+		}
+		return "", fmt.Errorf(
+			"error getting managed identity %q in resource group %q: %w",
+			projectIdentityName(project), p.resourceGroup, err,
+		)
+	}
+	if res.Properties == nil || res.Properties.ClientID == nil {
+		return "", errNoProjectIdentity
+	}
+	return *res.Properties.ClientID, nil
+}

--- a/pkg/credentials/acr/project_identity_test.go
+++ b/pkg/credentials/acr/project_identity_test.go
@@ -1,0 +1,131 @@
+package acr
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestProjectIdentityName(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "kargo-project-demo", projectIdentityName("demo"))
+}
+
+// fakeIdentityGetter is a userAssignedIdentityGetter that returns canned
+// results and counts the calls it receives.
+type fakeIdentityGetter struct {
+	clientID string
+	err      error
+	calls    int
+}
+
+func (f *fakeIdentityGetter) Get(
+	context.Context,
+	string,
+	string,
+	*armmsi.UserAssignedIdentitiesClientGetOptions,
+) (armmsi.UserAssignedIdentitiesClientGetResponse, error) {
+	f.calls++
+	if f.err != nil {
+		return armmsi.UserAssignedIdentitiesClientGetResponse{}, f.err
+	}
+	res := armmsi.UserAssignedIdentitiesClientGetResponse{}
+	if f.clientID != "" {
+		res.Properties = &armmsi.UserAssignedIdentityProperties{
+			ClientID: ptr.To(f.clientID),
+		}
+	}
+	return res, nil
+}
+
+// newTestResolvingProvider returns a provider equipped to resolve client IDs
+// through the given getter.
+func newTestResolvingProvider(
+	getter userAssignedIdentityGetter,
+) *WorkloadIdentityProvider {
+	return &WorkloadIdentityProvider{
+		resourceGroup: "test-rg",
+		identities:    getter,
+	}
+}
+
+func TestProjectIdentityResolveClientID(t *testing.T) {
+	const testClientID = "11111111-2222-3333-4444-555555555555"
+
+	testCases := []struct {
+		name   string
+		getter *fakeIdentityGetter
+		assert func(t *testing.T, clientID string, err error)
+	}{
+		{
+			name:   "identity found",
+			getter: &fakeIdentityGetter{clientID: testClientID},
+			assert: func(t *testing.T, clientID string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testClientID, clientID)
+			},
+		},
+		{
+			name: "identity does not exist",
+			getter: &fakeIdentityGetter{
+				err: &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			},
+			assert: func(t *testing.T, _ string, err error) {
+				require.ErrorIs(t, err, errNoProjectIdentity)
+			},
+		},
+		{
+			name: "caller is not authorized",
+			getter: &fakeIdentityGetter{
+				err: &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			},
+			assert: func(t *testing.T, _ string, err error) {
+				require.NotErrorIs(t, err, errNoProjectIdentity)
+				require.ErrorContains(t, err, "error getting managed identity")
+			},
+		},
+		{
+			name:   "identity carries no client ID",
+			getter: &fakeIdentityGetter{},
+			assert: func(t *testing.T, _ string, err error) {
+				require.ErrorIs(t, err, errNoProjectIdentity)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestResolvingProvider(testCase.getter)
+			clientID, err := p.resolveClientID(context.Background(), "demo")
+			testCase.assert(t, clientID, err)
+		})
+	}
+
+	t.Run("every call reaches Azure", func(t *testing.T) {
+		t.Parallel()
+		// Nothing is retained between calls, so an identity deleted and
+		// recreated between them is seen as it is now, not as it was.
+		getter := &fakeIdentityGetter{clientID: testClientID}
+		p := newTestResolvingProvider(getter)
+		for range 3 {
+			clientID, resolveErr := p.resolveClientID(context.Background(), "demo")
+			require.NoError(t, resolveErr)
+			require.Equal(t, testClientID, clientID)
+		}
+		require.Equal(t, 3, getter.calls)
+	})
+
+	t.Run("unexpected error types are not mistaken for absence", func(t *testing.T) {
+		t.Parallel()
+		getter := &fakeIdentityGetter{err: errors.New("connection refused")}
+		p := newTestResolvingProvider(getter)
+		_, err := p.resolveClientID(context.Background(), "demo")
+		require.NotErrorIs(t, err, errNoProjectIdentity)
+	})
+}

--- a/pkg/credentials/acr/workload_identity.go
+++ b/pkg/credentials/acr/workload_identity.go
@@ -2,15 +2,19 @@ package acr
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
 	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
@@ -18,6 +22,15 @@ import (
 )
 
 const (
+	// armScope is the Entra scope a token is obtained for solely to read the
+	// claims it carries about the identity it was issued to.
+	armScope = "https://management.azure.com/.default"
+	// selfDiscoveryTimeout bounds the token acquisition that locates the
+	// controller's own identity. It runs while the process is starting, so it is
+	// short: failing to discover leaves Project-specific identities disabled,
+	// which is a working state, whereas a hung start is not.
+	selfDiscoveryTimeout = 10 * time.Second
+
 	// cacheTTL is how long an ACR token is cached for. ACR refresh tokens expire
 	// after three hours and the exchange API does not report a token's actual
 	// expiry, so no TTL can be derived from one and this is used for all of them.
@@ -57,17 +70,42 @@ func init() {
 	}
 }
 
+// tokenRequest identifies the token a single acquisition obtains. A Project is
+// part of it because a single controller acts for many Projects against a
+// single registry, and each is entitled to a different level of access.
+type tokenRequest struct {
+	project      string
+	registryName string
+}
+
+// cacheKey returns the key under which this request's token is cached.
+func (t tokenRequest) cacheKey() string {
+	return t.project + "/" + t.registryName
+}
+
 // WorkloadIdentityProvider implements credentials.Provider for Azure Container
 // Registry Workload Identity.
 type WorkloadIdentityProvider struct {
 	// tokenCache is an in-memory cache of ACR registry access tokens keyed by
-	// registry name. It fills its own misses, coalescing concurrent loads for any
-	// given registry.
-	tokenCache coalescing.Cache[string, string]
+	// Project and registry name. It fills its own misses, coalescing concurrent
+	// loads for any given key.
+	tokenCache coalescing.Cache[tokenRequest, string]
 
+	// credential is the controller's own identity.
 	credential azcore.TokenCredential
 
-	getAccessTokenFn func(ctx context.Context, registryName string) (string, error)
+	// resourceGroup and identities are what acting as a Project-specific
+	// identity requires. They are unset when the prerequisites for doing so are
+	// absent, in which case the controller's own identity is the only one used.
+	resourceGroup string
+	identities    userAssignedIdentityGetter
+
+	getAccessTokenFn func(context.Context, tokenRequest) (string, error)
+	exchangeFn       func(
+		ctx context.Context,
+		cred azcore.TokenCredential,
+		registryName string,
+	) (string, error)
 }
 
 // NewWorkloadIdentityProvider returns a new WorkloadIdentityProvider if Azure
@@ -86,6 +124,9 @@ func NewWorkloadIdentityProvider(ctx context.Context) credentials.Provider {
 
 	p := &WorkloadIdentityProvider{credential: credential}
 	p.getAccessTokenFn = p.getAccessToken
+	p.exchangeFn = p.exchangeForACRToken
+	p.initProjectIdentities(ctx)
+
 	tokenCache, err := coalescing.NewCache(
 		p.loadAccessToken,
 		&coalescing.CacheOptions{
@@ -102,6 +143,105 @@ func NewWorkloadIdentityProvider(ctx context.Context) credentials.Provider {
 	}
 	p.tokenCache = tokenCache
 	return p
+}
+
+// initProjectIdentities equips the provider to act as Project-specific
+// identities. Those are looked up in the subscription and resource group
+// holding the controller's own identity, which a token issued to that identity
+// names, so an operator states nothing. Failing to discover any of it leaves
+// the provider able to act only as the controller's own identity, which is what
+// it falls back to in any case.
+func (p *WorkloadIdentityProvider) initProjectIdentities(ctx context.Context) {
+	logger := logging.LoggerFromContext(ctx)
+
+	subscriptionID, resourceGroup, err := p.discoverIdentityLocation(ctx)
+	if err != nil {
+		logger.Info(
+			"Azure Project-specific identities are unavailable; the controller's "+
+				"own identity will be used for all Projects",
+			"error", err.Error(),
+		)
+		return
+	}
+
+	identities, err := armmsi.NewUserAssignedIdentitiesClient(
+		subscriptionID, p.credential, nil,
+	)
+	if err != nil {
+		logger.Error(err, "error creating managed identity client")
+		return
+	}
+
+	p.resourceGroup = resourceGroup
+	p.identities = identities
+
+	logger.Info(
+		"Azure Project-specific identities enabled",
+		"resourceGroup", resourceGroup,
+	)
+}
+
+func (p *WorkloadIdentityProvider) discoverIdentityLocation(
+	ctx context.Context,
+) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, selfDiscoveryTimeout)
+	defer cancel()
+
+	token, err := p.credential.GetToken(
+		ctx,
+		policy.TokenRequestOptions{Scopes: []string{armScope}},
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("error obtaining a token for the controller's own identity: %w", err)
+	}
+	return parseIdentityResourceID(token.Token)
+}
+
+// parseIdentityResourceID returns the subscription and resource group named by
+// the xms_mirid claim of the given token. The token is not verified; Entra
+// issued it moments earlier and it is read only for what it says about its own
+// subject.
+func parseIdentityResourceID(token string) (string, string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", "", errors.New("token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("error decoding token payload: %w", err)
+	}
+	claims := struct {
+		ResourceID string `json:"xms_mirid"`
+	}{}
+	if err = json.Unmarshal(payload, &claims); err != nil {
+		return "", "", fmt.Errorf("error unmarshaling token payload: %w", err)
+	}
+	if claims.ResourceID == "" {
+		return "", "", errors.New(
+			"token carries no xms_mirid claim; the controller does not appear to " +
+				"run as a user-assigned managed identity",
+		)
+	}
+
+	// ARM resource IDs are of the form /<type>/<name>/<type>/<name>/..., and ARM
+	// is not consistent about the case of the type segments.
+	var subscriptionID, resourceGroup string
+	segments := strings.Split(strings.Trim(claims.ResourceID, "/"), "/")
+	for i := 0; i+1 < len(segments); i += 2 {
+		switch strings.ToLower(segments[i]) {
+		case "subscriptions":
+			subscriptionID = segments[i+1]
+		case "resourcegroups":
+			resourceGroup = segments[i+1]
+		}
+	}
+	if subscriptionID == "" || resourceGroup == "" {
+		return "", "", fmt.Errorf(
+			"could not read a subscription and resource group from %q",
+			claims.ResourceID,
+		)
+	}
+	return subscriptionID, resourceGroup, nil
 }
 
 func (p *WorkloadIdentityProvider) Supports(
@@ -124,15 +264,19 @@ func (p *WorkloadIdentityProvider) GetCredentials(
 	if len(matches) != 2 { // This doesn't look like an ACR URL
 		return nil, nil
 	}
-	registryName := matches[1]
+	tokenReq := tokenRequest{
+		project:      req.Project,
+		registryName: matches[1],
+	}
 
 	logger := logging.LoggerFromContext(ctx).WithValues(
 		"provider", "acrWorkloadIdentity",
+		"project", req.Project,
 		"repoURL", req.RepoURL,
 	)
 	ctx = logging.ContextWithLogger(ctx, logger)
 
-	accessToken, err := p.tokenCache.Get(ctx, registryName, registryName)
+	accessToken, err := p.tokenCache.Get(ctx, tokenReq.cacheKey(), tokenReq)
 	if err != nil {
 		return nil, err
 	}
@@ -148,16 +292,21 @@ func (p *WorkloadIdentityProvider) GetCredentials(
 	}, nil
 }
 
-// loadAccessToken obtains an ACR access token for the given registry. It is the
+// loadAccessToken obtains an ACR access token for the given request. It is the
 // Loader for this provider's token cache.
 func (p *WorkloadIdentityProvider) loadAccessToken(
 	ctx context.Context,
-	registryName string,
+	req tokenRequest,
 ) (string, *time.Duration, error) {
 	logger := logging.LoggerFromContext(ctx)
 
-	accessToken, err := p.getAccessTokenFn(ctx, registryName)
+	accessToken, err := p.getAccessTokenFn(ctx, req)
 	if err != nil {
+		// TODO(krancour): Failures are not cached, so a Project that can never
+		// obtain a token re-attempts as often as its callers ask rather than at the
+		// interval a cached token would imply. Attempting the Project-specific
+		// identity first makes each of those attempts cost more than it used to.
+		// This would be nice to solve.
 		return "", nil, fmt.Errorf("error getting ACR access token: %w", err)
 	}
 
@@ -179,15 +328,89 @@ func (p *WorkloadIdentityProvider) loadAccessToken(
 		nil
 }
 
-// getAccessToken returns an ACR refresh token using Azure workload identity.
+// getAccessToken returns an ACR refresh token for the given request. It first
+// attempts to obtain one as the Project's own Azure identity, which is what
+// confines a Project to the registries it has been granted. Failing that, it
+// obtains one as the controller's own identity, which forgoes Project-level
+// isolation and is therefore the last resort.
 func (p *WorkloadIdentityProvider) getAccessToken(
 	ctx context.Context,
+	req tokenRequest,
+) (string, error) {
+	logger := logging.LoggerFromContext(ctx)
+
+	if cred := p.projectCredential(ctx, req.project); cred != nil {
+		accessToken, err := p.exchangeFn(ctx, cred, req.registryName)
+		if err == nil {
+			logger.Debug("obtained token as Project-specific identity")
+			return accessToken, nil
+		}
+		logger.Debug(
+			"error obtaining token as Project-specific identity; "+
+				"falling back to the controller's own identity",
+			"error", err.Error(),
+		)
+	}
+
+	return p.exchangeFn(ctx, p.credential, req.registryName)
+}
+
+// projectCredential returns a credential for the given Project's own Azure
+// identity, or nil if one cannot be obtained. A nil return is not an error
+// condition: a Project without an identity of its own is expected, and the
+// caller falls back to the controller's own identity.
+func (p *WorkloadIdentityProvider) projectCredential(
+	ctx context.Context,
+	project string,
+) azcore.TokenCredential {
+	logger := logging.LoggerFromContext(ctx)
+
+	if p.identities == nil || project == "" {
+		return nil
+	}
+
+	// IMPORTANT: The identity is named by the Project being acted on and is
+	// never taken from a request. Every Project-specific identity trusts the
+	// same ServiceAccount, so Entra cannot tell one Project from another and
+	// this derivation is the only thing confining a Project to its own
+	// identity. An identity a Project could influence would make this provider
+	// a confused deputy.
+	clientID, err := p.resolveClientID(ctx, project)
+	if err != nil {
+		if errors.Is(err, errNoProjectIdentity) {
+			logger.Debug("no Project-specific identity exists")
+		} else {
+			logger.Error(err, "error resolving Project-specific identity")
+		}
+		return nil
+	}
+
+	// The assertion is the controller's own projected ServiceAccount token, and
+	// the tenant is the controller's own tenant. Only the identity the token is
+	// redeemed for differs, so only that is specified here; the rest is read
+	// from the environment Azure's workload identity webhook established.
+	cred, err := azidentity.NewWorkloadIdentityCredential(
+		&azidentity.WorkloadIdentityCredentialOptions{ClientID: clientID},
+	)
+	if err != nil {
+		logger.Error(err, "error creating Project-specific credential")
+		return nil
+	}
+	return cred
+}
+
+// exchangeForACRToken returns an ACR refresh token for the given registry,
+// obtained as the given identity.
+func (p *WorkloadIdentityProvider) exchangeForACRToken(
+	ctx context.Context,
+	cred azcore.TokenCredential,
 	registryName string,
 ) (string, error) {
 	// Get Azure AD access token with the standard ACR scope
-	token, err := p.credential.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{acrScope},
-	})
+	token, err := cred.GetToken(
+		ctx,
+		policy.TokenRequestOptions{Scopes: []string{acrScope}},
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Azure AD access token for ACR: %w", err)
 	}

--- a/pkg/credentials/acr/workload_identity_test.go
+++ b/pkg/credentials/acr/workload_identity_test.go
@@ -2,8 +2,12 @@ package acr
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +19,55 @@ import (
 	"github.com/akuity/kargo/pkg/cache/coalescing"
 	"github.com/akuity/kargo/pkg/credentials"
 )
+
+func TestACRURLRegex(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected bool
+		registry string
+	}{
+		{
+			name:     "ACR URL",
+			url:      "myregistry.azurecr.io/repo",
+			expected: true,
+			registry: "myregistry",
+		},
+		{
+			name:     "Docker Hub URL",
+			url:      "docker.io/library/nginx",
+			expected: false,
+		},
+		{
+			name:     "ECR URL",
+			url:      "123456789012.dkr.ecr.us-west-2.amazonaws.com/repo",
+			expected: false,
+		},
+		{
+			name:     "Google Artifact Registry URL",
+			url:      "us-central1-docker.pkg.dev/project/repo",
+			expected: false,
+		},
+		{
+			name:     "ACR URL with complex registry name",
+			url:      "my-registry-123.azurecr.io/namespace/repo",
+			expected: true,
+			registry: "my-registry-123",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			matches := acrURLRegex.FindStringSubmatch(testCase.url)
+			if testCase.expected {
+				assert.Len(t, matches, 2)
+				assert.Equal(t, testCase.registry, matches[1])
+			} else {
+				assert.Nil(t, matches, "Expected regex not to match")
+			}
+		})
+	}
+}
 
 func TestNewWorkloadIdentityProvider(t *testing.T) {
 	const azFederatedTokenFile = "AZURE_FEDERATED_TOKEN_FILE"
@@ -39,6 +92,86 @@ func TestNewWorkloadIdentityProvider(t *testing.T) {
 		t.Setenv(azTenantID, nonsense)
 		require.NotNil(t, NewWorkloadIdentityProvider(t.Context()))
 	})
+}
+
+// testResourceID is the xms_mirid claim as Entra actually issues it, observed
+// against a real tenant. Note that ARM writes "resourcegroups" in lower case.
+const testResourceID = "/subscriptions/544972a9-f7be-4152-a73d-7d4b31416a4a" +
+	"/resourcegroups/kargo-identity-spike" +
+	"/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kargo-project-demo"
+
+func TestParseIdentityResourceID(t *testing.T) {
+	const testSubscriptionID = "544972a9-f7be-4152-a73d-7d4b31416a4a"
+	const testResourceGroup = "kargo-identity-spike"
+
+	testCases := []struct {
+		name string
+		// claims, when set, are marshaled into a JWT payload. rawToken is used
+		// instead for inputs that are not JWTs at all.
+		claims   map[string]any
+		rawToken string
+		assert   func(t *testing.T, subscriptionID, resourceGroup string, err error)
+	}{
+		{
+			name:   "claim as issued",
+			claims: map[string]any{"xms_mirid": testResourceID},
+			assert: func(t *testing.T, subscriptionID, resourceGroup string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testSubscriptionID, subscriptionID)
+				require.Equal(t, testResourceGroup, resourceGroup)
+			},
+		},
+		{
+			// ARM is not consistent about the case of type segments.
+			name: "mixed case segments",
+			claims: map[string]any{
+				"xms_mirid": strings.Replace(
+					testResourceID, "/resourcegroups/", "/resourceGroups/", 1,
+				),
+			},
+			assert: func(t *testing.T, subscriptionID, resourceGroup string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testSubscriptionID, subscriptionID)
+				require.Equal(t, testResourceGroup, resourceGroup)
+			},
+		},
+		{
+			// A system-assigned identity or a plain app registration carries no
+			// such claim, and neither can be located this way.
+			name:   "no xms_mirid claim",
+			claims: map[string]any{"aud": "https://management.azure.com"},
+			assert: func(t *testing.T, _, _ string, err error) {
+				require.ErrorContains(t, err, "carries no xms_mirid claim")
+			},
+		},
+		{
+			name: "resource ID names no resource group",
+			claims: map[string]any{
+				"xms_mirid": "/subscriptions/" + testSubscriptionID,
+			},
+			assert: func(t *testing.T, _, _ string, err error) {
+				require.ErrorContains(t, err, "could not read a subscription and resource group")
+			},
+		},
+		{
+			name:     "not a JWT",
+			rawToken: "nonsense",
+			assert: func(t *testing.T, _, _ string, err error) {
+				require.ErrorContains(t, err, "not a JWT")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			token := testCase.rawToken
+			if testCase.claims != nil {
+				token = testToken(t, testCase.claims)
+			}
+			subscriptionID, resourceGroup, err := parseIdentityResourceID(token)
+			testCase.assert(t, subscriptionID, resourceGroup, err)
+		})
+	}
 }
 
 func TestWorkloadIdentityProvider_Supports(t *testing.T) {
@@ -135,7 +268,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 		{
 			name: "token obtained",
 			provider: &WorkloadIdentityProvider{
-				getAccessTokenFn: func(_ context.Context, _ string) (string, error) {
+				getAccessTokenFn: func(_ context.Context, _ tokenRequest) (string, error) {
 					return testToken, nil
 				},
 			},
@@ -151,7 +284,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 		{
 			name: "error in getAccessToken",
 			provider: &WorkloadIdentityProvider{
-				getAccessTokenFn: func(_ context.Context, _ string) (string, error) {
+				getAccessTokenFn: func(_ context.Context, _ tokenRequest) (string, error) {
 					return "", errors.New("access token error")
 				},
 			},
@@ -165,7 +298,7 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 		{
 			name: "empty token from getAccessToken",
 			provider: &WorkloadIdentityProvider{
-				getAccessTokenFn: func(_ context.Context, _ string) (string, error) {
+				getAccessTokenFn: func(_ context.Context, _ tokenRequest) (string, error) {
 					return "", nil
 				},
 			},
@@ -205,66 +338,6 @@ func TestWorkloadIdentityProvider_GetCredentials(t *testing.T) {
 	}
 }
 
-func TestACRURLRegex(t *testing.T) {
-	testCases := []struct {
-		name     string
-		url      string
-		expected bool
-		registry string
-	}{
-		{
-			name:     "ACR URL",
-			url:      "myregistry.azurecr.io/repo",
-			expected: true,
-			registry: "myregistry",
-		},
-		{
-			name:     "Docker Hub URL",
-			url:      "docker.io/library/nginx",
-			expected: false,
-		},
-		{
-			name:     "ECR URL",
-			url:      "123456789012.dkr.ecr.us-west-2.amazonaws.com/repo",
-			expected: false,
-		},
-		{
-			name:     "Google Artifact Registry URL",
-			url:      "us-central1-docker.pkg.dev/project/repo",
-			expected: false,
-		},
-		{
-			name:     "ACR URL with complex registry name",
-			url:      "my-registry-123.azurecr.io/namespace/repo",
-			expected: true,
-			registry: "my-registry-123",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			matches := acrURLRegex.FindStringSubmatch(testCase.url)
-			if testCase.expected {
-				assert.Len(t, matches, 2)
-				assert.Equal(t, testCase.registry, matches[1])
-			} else {
-				assert.Nil(t, matches, "Expected regex not to match")
-			}
-		})
-	}
-}
-
-// mockCredential is a mock implementation of azcore.TokenCredential for testing
-type mockCredential struct{}
-
-func (m *mockCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	// Return a mock token for testing
-	return azcore.AccessToken{
-		Token:     "mock-access-token",
-		ExpiresOn: time.Now().Add(time.Hour),
-	}, nil
-}
-
 func TestWorkloadIdentityProvider_GetCredentials_perRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -278,10 +351,10 @@ func TestWorkloadIdentityProvider_GetCredentials_perRegistry(t *testing.T) {
 		credential: &mockCredential{},
 		getAccessTokenFn: func(
 			_ context.Context,
-			registryName string,
+			req tokenRequest,
 		) (string, error) {
 			// The token identifies the registry it was obtained for.
-			return "token-for-" + registryName, nil
+			return "token-for-" + req.registryName, nil
 		},
 	}
 	tokenCache, err := coalescing.NewCache(
@@ -307,4 +380,169 @@ func TestWorkloadIdentityProvider_GetCredentials_perRegistry(t *testing.T) {
 		require.Equal(t, acrTokenUsername, creds.Username)
 		require.Equal(t, "token-for-"+registry, creds.Password)
 	}
+}
+
+func TestWorkloadIdentityProvider_GetCredentials_perProject(t *testing.T) {
+	t.Parallel()
+
+	// A single controller acts for many Projects against a single registry. What
+	// this provider is responsible for is that the key it caches under describes
+	// the Project as well as the registry, so that no Project is ever served
+	// another's token.
+
+	provider := &WorkloadIdentityProvider{
+		credential: &mockCredential{},
+		getAccessTokenFn: func(
+			_ context.Context,
+			req tokenRequest,
+		) (string, error) {
+			return "token-for-" + req.project + "/" + req.registryName, nil
+		},
+	}
+	tokenCache, err := coalescing.NewCache(
+		provider.loadAccessToken,
+		&coalescing.CacheOptions{
+			LoadTimeout: new(tokenAcquisitionTimeout),
+			DefaultTTL:  new(time.Hour),
+		},
+	)
+	require.NoError(t, err)
+	provider.tokenCache = tokenCache
+
+	for _, project := range []string{"project-a", "project-b", "project-a"} {
+		creds, err := provider.GetCredentials(
+			t.Context(),
+			credentials.Request{
+				Project: project,
+				Type:    credentials.TypeImage,
+				RepoURL: "shared.azurecr.io/repo",
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		require.Equal(
+			t, "token-for-"+project+"/shared", creds.Password,
+		)
+	}
+}
+
+func TestWorkloadIdentityProvider_getAccessToken(t *testing.T) {
+	const testProject = "demo"
+	const testClientID = "11111111-2222-3333-4444-555555555555"
+
+	// Building a Project-specific credential reads the tenant and the token file
+	// from the environment Azure's workload identity webhook establishes. Nothing
+	// here reads the file itself; the exchange is faked below. This is why these
+	// subtests do not run in parallel.
+	t.Setenv("AZURE_TENANT_ID", "test-tenant")
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/token")
+
+	testCases := []struct {
+		name string
+		// getter, when set, equips the provider to act as Project-specific
+		// identities. Without it, the controller's own identity is all it has.
+		getter      *fakeIdentityGetter
+		exchangeErr error
+		assert      func(t *testing.T, token string, err error)
+	}{
+		{
+			name: "Project-specific identities not configured",
+			assert: func(t *testing.T, token string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "controller-token", token)
+			},
+		},
+		{
+			name: "no Project-specific identity exists",
+			getter: &fakeIdentityGetter{
+				err: &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			},
+			assert: func(t *testing.T, token string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "controller-token", token)
+			},
+		},
+		{
+			name:   "identity resolution fails",
+			getter: &fakeIdentityGetter{err: errors.New("ARM is unhappy")},
+			assert: func(t *testing.T, token string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "controller-token", token)
+			},
+		},
+		{
+			// An identity that exists but cannot reach the registry must not be a
+			// hard failure. Falling back preserves the behavior operators have
+			// today while they roll per-Project identities out.
+			name:        "Project-specific identity cannot reach the registry",
+			getter:      &fakeIdentityGetter{clientID: testClientID},
+			exchangeErr: errors.New("AcrPull not granted"),
+			assert: func(t *testing.T, token string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "controller-token", token)
+			},
+		},
+		{
+			name:   "Project-specific identity used",
+			getter: &fakeIdentityGetter{clientID: testClientID},
+			assert: func(t *testing.T, token string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "project-token", token)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			controllerCred := &mockCredential{}
+			p := &WorkloadIdentityProvider{credential: controllerCred}
+			if testCase.getter != nil {
+				p.resourceGroup = "test-rg"
+				p.identities = testCase.getter
+			}
+
+			p.exchangeFn = func(
+				_ context.Context,
+				cred azcore.TokenCredential,
+				_ string,
+			) (string, error) {
+				if cred == azcore.TokenCredential(controllerCred) {
+					return "controller-token", nil
+				}
+				if testCase.exchangeErr != nil {
+					return "", testCase.exchangeErr
+				}
+				return "project-token", nil
+			}
+
+			token, err := p.getAccessToken(
+				t.Context(),
+				tokenRequest{project: testProject, registryName: "myregistry"},
+			)
+			testCase.assert(t, token, err)
+		})
+	}
+}
+
+// testToken returns an unsigned JWT carrying the given claims. Only the payload
+// is read by the code under test.
+func testToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return "header." +
+		base64.RawURLEncoding.EncodeToString(payload) +
+		".signature"
+}
+
+// mockCredential is a mock implementation of azcore.TokenCredential for testing
+type mockCredential struct{}
+
+func (m *mockCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	// Return a mock token for testing
+	return azcore.AccessToken{
+		Token:     "mock-access-token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
 }


### PR DESCRIPTION
Implements the proposal in #6912, faithfully and in full: the ACR credential provider now attempts a Project-specific Azure managed identity before falling back to the controller's own, and needs no configuration to do it.

This has been observed working against a real Entra tenant. A Warehouse subscribed to an ACR repository discovered images through a Project-specific identity, confirmed by the controller's own logs.

It is a draft because several things around it are not finished.

**Project-specific Azure identities are undocumented.** [The ambient credentials guide](docs/docs/40-operator-guide/40-security/50-ambient-credentials.md) already covers enabling Azure workload identity, but would require updates to cover this new feature.

**Verification is thin.** One path, one tenant, one manual exercise. Someone needs to bang on it more.

**Load on Azure Resource Manager has not been tuned.** The absence of a Project-specific identity is not remembered, so a Project that has none is looked up again on every token cache miss. This is worth solving.

Azure DevOps support, which motivated the proposal, is not addressed here. This removes the obstacle; it does not do the work.

None of this is a priority for the maintainers. Anyone who wants the feature is welcome to take it the rest of the way.
