### PR TITLE
fix(chart): honor external webhooks server RBAC setting

### DIFF
--- a/charts/kargo/templates/system-resources-namespace/role-bindings.yaml
+++ b/charts/kargo/templates/system-resources-namespace/role-bindings.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.dataPlane.install .Values.global.systemResources.createRBAC }}
+{{- if .Values.externalWebhooksServer.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -16,6 +17,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: kargo-external-webhooks-server
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/kargo/tests/system-resources-namespace_test.yaml
+++ b/charts/kargo/tests/system-resources-namespace_test.yaml
@@ -115,3 +115,20 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: omits the external webhooks server RoleBinding when disabled
+    set:
+      externalWebhooksServer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: kargo-system-resources-admin
+        isKind:
+          of: RoleBinding
+      - documentSelector:
+          path: metadata.name
+          value: kargo-controller-system-resources-reader
+        isKind:
+          of: RoleBinding


### PR DESCRIPTION
## Description

Closes #6914

Avoid rendering the system-resources RoleBinding for the external webhooks server when that component is disabled. The other system-resources RoleBindings remain unchanged.

Adds a regression test covering the disabled configuration and verifying that the admin and controller RoleBindings are still rendered.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

## Validation

- `make test-chart` (154 tests passed)
- `make lint-charts`