### PR TITLE
chore: use latest go for anything that ships

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,7 +213,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: golang:1.27.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -278,7 +278,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: golang:1.27.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.25.14-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
`release-1.9` is was built with Go v1.25.14.

Go v1.25.x is EOL, but Kargo v1.8.x is not.

This builds anything we ship using Go v1.27.0.

Note that _tests and linting_ still run using Go v1.25.14. Why? Upgrading to v1.26.0 or beyond forces a linter upgrade. The upgraded linter catches new things it didn't previously, so this would require code changes. The expedient thing to do is continue testing with what we were, but ship with something newer.