### PR TITLE
chore: use latest go for anything that ships

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,7 +243,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: &golangImage golang:1.26.7-trixie
+      image: &golangImage golang:1.27.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.26.7-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
`release-1.8` and `release-1.9` were built with Go v1.25.14.

Go v1.25.x is EOL, but Kargo v1.8.x and v1.9.x are not.

Those branches were updated to build anything that ships using Go v1.27.0.

Although Go v1.26.x, which this branch currently builds with, is not EOL, building anything that ships using the latest available version of Go makes the strategy consistent across all non-EOL minor lines of Kargo.

Note that _tests and linting_ still run using Go v1.26.7. Why? Upgrading to v1.27.0 forces a linter upgrade. The upgraded linter catches new things it didn't previously, so this would require code changes. The expedient thing to do is continue testing with what we were, but ship with something newer.