### PR TITLE
fix: restore grpc_health_probe to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,22 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
       helm.sh/helm/v3/cmd/helm
 
 ####################################################################################################
+# tools
+####################################################################################################
+# `tools` stage allows us to take the leverage of the parallel build.
+# For example, this stage can be cached and re-used when we have to rebuild code base.
+FROM curlimages/curl:8.18.0 AS tools
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /tools
+
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.56 && \
+    curl -fL -o /tools/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
+    chmod +x /tools/grpc_health_probe
+
+####################################################################################################
 # back-end-dev
 # - no UI
 # - relies on go build that runs on host
@@ -151,6 +167,7 @@ FROM ${BASE_IMAGE}:latest-${TARGETARCH} AS final
 
 COPY --from=back-end-builder /kargo/bin/ /usr/local/bin/
 COPY --from=helm-builder /helm-build/helm /usr/local/bin/helm
+COPY --from=tools /tools/grpc_health_probe /usr/local/bin/grpc_health_probe
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/usr/local/bin/kargo"]


### PR DESCRIPTION
The API deployment's liveness and readiness probes exec `/usr/local/bin/grpc_health_probe`, but the binary was inadvertently dropped from the Dockerfile in #6901 as part of a vulnerability sweep, so probes have been failing since v1.9.11. This restores it at v0.4.56, which carries no known vulnerabilities.

Verified by building the image: `grpc_health_probe` is present and reports `0.4.56`, and a Grype scan attributes **0** findings to it — the image total is unchanged from before the restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)