### PR TITLE
feat(controller): promote Targets in parallel, one PromotionRequest at a time

### DIFF
--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -202,6 +202,49 @@ func AbortPromotion(
 	return patchAnnotation(ctx, c, promotion, kargoapi.AnnotationKeyAbort, ar.String())
 }
 
+// promotionRequestKind is the Kind of the one resource permitted to own a
+// Promotion that promotes to a Target.
+const promotionRequestKind = "PromotionRequest"
+
+// StageAwaitsPromotion returns whether the Stage has recorded the Promotion
+// as one it is currently promoting through. The Promotion reconciler does
+// not run a Promotion until the Stage does so; this is what serializes
+// promotions.
+//
+// The Stage's own Promotions are serialized one at a time by the Stage's
+// current Promotion. A Promotion to one of the Stage's Targets is instead
+// admitted by the Stage's current PromotionRequest: all children of the
+// current request run at once -- a request creates at most one child per
+// Target, so Promotions to distinct Targets run in parallel and Promotions
+// to the same Target never contend -- while the children of a queued
+// request wait for the current round of fan-out to end.
+func StageAwaitsPromotion(
+	stage *kargoapi.Stage,
+	promo *kargoapi.Promotion,
+) bool {
+	if promo.Spec.Target != "" {
+		owner := PromotionRequestOwner(promo)
+		return owner != "" &&
+			stage.Status.CurrentPromotionRequest != nil &&
+			owner == stage.Status.CurrentPromotionRequest.Name
+	}
+	return stage.Status.CurrentPromotion != nil &&
+		stage.Status.CurrentPromotion.Name == promo.Name
+}
+
+// PromotionRequestOwner returns the name of the PromotionRequest that owns
+// the Promotion, or an empty string if the Promotion is not the child of
+// one.
+func PromotionRequestOwner(promo *kargoapi.Promotion) string {
+	owner := metav1.GetControllerOf(promo)
+	if owner != nil &&
+		owner.APIVersion == kargoapi.GroupVersion.String() &&
+		owner.Kind == promotionRequestKind {
+		return owner.Name
+	}
+	return ""
+}
+
 // ComparePromotionByPhaseAndCreationTime compares two Promotions by their
 // phase and creation timestamp. It returns a negative value if Promotion `a`
 // should come before Promotion `b`, a positive value if Promotion `a` should

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -262,6 +262,161 @@ func TestAbortPromotion(t *testing.T) {
 	})
 }
 
+func TestStageAwaitsPromotion(t *testing.T) {
+	requestChild := func(name, target, request string) *kargoapi.Promotion {
+		controller := true
+		return &kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: kargoapi.GroupVersion.String(),
+					Kind:       "PromotionRequest",
+					Name:       request,
+					Controller: &controller,
+				}},
+			},
+			Spec: kargoapi.PromotionSpec{Stage: "test-stage", Target: target},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		status   kargoapi.StageStatus
+		promo    *kargoapi.Promotion
+		expected bool
+	}{
+		{
+			name: "no current Promotion",
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-promotion"},
+			},
+		},
+		{
+			name: "another Promotion is current",
+			status: kargoapi.StageStatus{
+				CurrentPromotion: &kargoapi.PromotionReference{Name: "other-promotion"},
+			},
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-promotion"},
+			},
+		},
+		{
+			name: "the Promotion is current",
+			status: kargoapi.StageStatus{
+				CurrentPromotion: &kargoapi.PromotionReference{Name: "test-promotion"},
+			},
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-promotion"},
+			},
+			expected: true,
+		},
+		{
+			name: "a Target Promotion is not admitted by the Stage's own slot",
+			status: kargoapi.StageStatus{
+				CurrentPromotion: &kargoapi.PromotionReference{Name: "test-promotion"},
+			},
+			promo: requestChild("test-promotion", "blue", "test-request"),
+		},
+		{
+			name:  "a Target Promotion is not admitted without a current PromotionRequest",
+			promo: requestChild("test-promotion", "blue", "test-request"),
+		},
+		{
+			name: "a Target Promotion of a queued PromotionRequest is not admitted",
+			status: kargoapi.StageStatus{
+				CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+					Name: "current-request",
+				},
+			},
+			promo: requestChild("test-promotion", "blue", "queued-request"),
+		},
+		{
+			name: "a Target Promotion without a PromotionRequest owner is not admitted",
+			status: kargoapi.StageStatus{
+				CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+					Name: "current-request",
+				},
+			},
+			promo: &kargoapi.Promotion{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-promotion"},
+				Spec:       kargoapi.PromotionSpec{Stage: "test-stage", Target: "blue"},
+			},
+		},
+		{
+			name: "a Target Promotion of the current PromotionRequest is admitted",
+			status: kargoapi.StageStatus{
+				CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+					Name: "current-request",
+				},
+			},
+			promo:    requestChild("test-promotion", "blue", "current-request"),
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			stage := &kargoapi.Stage{Status: testCase.status}
+			require.Equal(
+				t,
+				testCase.expected,
+				StageAwaitsPromotion(stage, testCase.promo),
+			)
+		})
+	}
+}
+
+func TestPromotionRequestOwner(t *testing.T) {
+	controller := true
+	testCases := []struct {
+		name     string
+		owner    *metav1.OwnerReference
+		expected string
+	}{
+		{
+			name: "no owner",
+		},
+		{
+			name: "owner of another kind",
+			owner: &metav1.OwnerReference{
+				APIVersion: kargoapi.GroupVersion.String(),
+				Kind:       "Stage",
+				Name:       "test-stage",
+				Controller: &controller,
+			},
+		},
+		{
+			name: "owner of another group",
+			owner: &metav1.OwnerReference{
+				APIVersion: "apps/v1",
+				Kind:       "PromotionRequest",
+				Name:       "test-request",
+				Controller: &controller,
+			},
+		},
+		{
+			name: "PromotionRequest owner",
+			owner: &metav1.OwnerReference{
+				APIVersion: kargoapi.GroupVersion.String(),
+				Kind:       "PromotionRequest",
+				Name:       "test-request",
+				Controller: &controller,
+			},
+			expected: "test-request",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			promo := &kargoapi.Promotion{}
+			if testCase.owner != nil {
+				promo.OwnerReferences = []metav1.OwnerReference{*testCase.owner}
+			}
+			require.Equal(t, testCase.expected, PromotionRequestOwner(promo))
+		})
+	}
+}
+
 func Test_ComparePromotionByPhaseAndCreationTime(t *testing.T) {
 	now := time.Date(2024, time.April, 10, 0, 0, 0, 0, time.UTC)
 	ulidEarlier := ulid.MustNew(ulid.Timestamp(now.Add(-time.Hour)), nil)

--- a/pkg/controller/promotions/promotions.go
+++ b/pkg/controller/promotions/promotions.go
@@ -190,6 +190,7 @@ func SetupReconcilerWithManager(
 			kargoMgr.GetCache(),
 			&kargoapi.Stage{},
 			&PromotionAcknowledgedByStageHandler[*kargoapi.Stage]{
+				kargoClient: kargoMgr.GetClient(),
 				shardPredicate: controller.ResponsibleFor[kargoapi.Stage]{
 					IsDefaultController: cfg.IsDefaultController,
 					ShardName:           cfg.ShardName,
@@ -383,8 +384,11 @@ func (r *reconciler) Reconcile(
 
 	// Confirm that the Stage is awaiting this Promotion.
 	// This effectively prevents the Promotion from running until the Stage
-	// decides it is the next Promotion to run.
-	if stage.Status.CurrentPromotion == nil || stage.Status.CurrentPromotion.Name != promo.Name {
+	// decides it is the next Promotion to run. A Promotion to one of the
+	// Stage's Targets is admitted by the Stage's current PromotionRequest
+	// instead, so all of one request's children -- at most one per Target --
+	// run in parallel while consecutive requests remain serialized.
+	if !api.StageAwaitsPromotion(stage, promo) {
 		// The watch on the Stage will requeue the Promotion if the Stage
 		// acknowledges it.
 		logger.Debug("Stage is not awaiting Promotion", "stage", stage.Name, "promotion", promo.Name)

--- a/pkg/controller/promotions/watches.go
+++ b/pkg/controller/promotions/watches.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+	"github.com/akuity/kargo/pkg/api"
 	"github.com/akuity/kargo/pkg/controller"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/indexer"
@@ -201,19 +202,26 @@ func (u *UpdatedArgoCDAppHandler[T]) enqueueSelectorMatches(
 }
 
 // NewPromotionAcknowledgedByStageHandler creates a new
-// PromotionAcknowledgedByStageHandler with the given shard predicate.
+// PromotionAcknowledgedByStageHandler with the given client and shard
+// predicate.
 func NewPromotionAcknowledgedByStageHandler[T any](
+	kargoClient client.Client,
 	shardPredicate controller.ResponsibleFor[kargoapi.Stage],
 ) *PromotionAcknowledgedByStageHandler[T] {
 	return &PromotionAcknowledgedByStageHandler[T]{
+		kargoClient:    kargoClient,
 		shardPredicate: shardPredicate,
 	}
 }
 
 // PromotionAcknowledgedByStageHandler is an event handler that enqueues a
 // Promotion for reconciliation when it has been acknowledged by the Stage\
-// it is for.
+// it is for. That is the Stage's current Promotion when one changes, and
+// every child of the Stage's current PromotionRequest when that changes: the
+// children of a newly current request -- at most one per Target -- are all
+// admitted at once.
 type PromotionAcknowledgedByStageHandler[T any] struct {
+	kargoClient    client.Client
 	shardPredicate controller.ResponsibleFor[kargoapi.Stage]
 }
 
@@ -272,23 +280,78 @@ func (p *PromotionAcknowledgedByStageHandler[T]) Update(
 		return
 	}
 
-	if newStage.Status.CurrentPromotion == nil {
+	if current := newStage.Status.CurrentPromotion; current != nil {
+		if oldStage.Status.CurrentPromotion == nil ||
+			oldStage.Status.CurrentPromotion.Name != current.Name {
+			wq.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: newStage.Namespace,
+					Name:      current.Name,
+				},
+			})
+			logger.Debug(
+				"enqueued Promotion for reconciliation",
+				"namespace", newStage.Namespace,
+				"promotion", current.Name,
+				"stage", newStage.Name,
+			)
+		}
+	}
+
+	if current := newStage.Status.CurrentPromotionRequest; current != nil {
+		if oldStage.Status.CurrentPromotionRequest == nil ||
+			oldStage.Status.CurrentPromotionRequest.Name != current.Name {
+			p.enqueueChildrenOf(ctx, newStage, current.Name, wq)
+		}
+	}
+}
+
+// enqueueChildrenOf enqueues every non-terminal child Promotion of the named
+// PromotionRequest for reconciliation. It lists the Stage's Promotions by
+// label, since a child carries the Stage label but is owned by the
+// PromotionRequest that created it.
+func (p *PromotionAcknowledgedByStageHandler[T]) enqueueChildrenOf(
+	ctx context.Context,
+	stage *kargoapi.Stage,
+	request string,
+	wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := logging.LoggerFromContext(ctx)
+
+	promotions := &kargoapi.PromotionList{}
+	if err := p.kargoClient.List(
+		ctx,
+		promotions,
+		client.InNamespace(stage.Namespace),
+		client.MatchingLabels{kargoapi.LabelKeyStage: stage.Name},
+	); err != nil {
+		logger.Error(
+			err, "error listing Promotions for Stage",
+			"namespace", stage.Namespace,
+			"stage", stage.Name,
+		)
 		return
 	}
 
-	if oldStage.Status.CurrentPromotion == nil ||
-		oldStage.Status.CurrentPromotion.Name != newStage.Status.CurrentPromotion.Name {
+	for i := range promotions.Items {
+		promo := &promotions.Items[i]
+		if promo.Status.Phase.IsTerminal() {
+			continue
+		}
+		if api.PromotionRequestOwner(promo) != request {
+			continue
+		}
 		wq.Add(reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: newStage.Namespace,
-				Name:      newStage.Status.CurrentPromotion.Name,
+				Namespace: promo.Namespace,
+				Name:      promo.Name,
 			},
 		})
 		logger.Debug(
 			"enqueued Promotion for reconciliation",
-			"namespace", newStage.Namespace,
-			"promotion", newStage.Status.CurrentPromotion.Name,
-			"stage", newStage.Name,
+			"namespace", promo.Namespace,
+			"promotion", promo.Name,
+			"stage", stage.Name,
 		)
 	}
 }

--- a/pkg/controller/promotions/watches.go
+++ b/pkg/controller/promotions/watches.go
@@ -16,6 +16,7 @@ import (
 	"github.com/akuity/kargo/pkg/controller"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/indexer"
+	"github.com/akuity/kargo/pkg/kubernetes"
 	"github.com/akuity/kargo/pkg/logging"
 )
 
@@ -323,7 +324,7 @@ func (p *PromotionAcknowledgedByStageHandler[T]) enqueueChildrenOf(
 		ctx,
 		promotions,
 		client.InNamespace(stage.Namespace),
-		client.MatchingLabels{kargoapi.LabelKeyStage: stage.Name},
+		client.MatchingLabels{kargoapi.LabelKeyStage: kubernetes.ShortenLabelValue(stage.Name)},
 	); err != nil {
 		logger.Error(
 			err, "error listing Promotions for Stage",

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -397,9 +397,35 @@ func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
 }
 
 func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	controllerTrue := true
+	newRequestChild := func(name, target, request string, phase kargoapi.PromotionPhase) *kargoapi.Promotion {
+		return &kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "fake-project",
+				Name:      name,
+				Labels:    map[string]string{kargoapi.LabelKeyStage: "fake-stage"},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: kargoapi.GroupVersion.String(),
+					Kind:       "PromotionRequest",
+					Name:       request,
+					Controller: &controllerTrue,
+				}},
+			},
+			Spec: kargoapi.PromotionSpec{
+				Stage:  "fake-stage",
+				Target: target,
+			},
+			Status: kargoapi.PromotionStatus{Phase: phase},
+		}
+	}
+
 	testCases := []struct {
 		name           string
 		shardPredicate controller.ResponsibleFor[kargoapi.Stage]
+		objects        []client.Object
 		e              event.TypedUpdateEvent[*kargoapi.Stage]
 		assertions     func(
 			*testing.T,
@@ -517,10 +543,96 @@ func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
 				}, item)
 			},
 		},
+		{
+			name: "children of a newly current PromotionRequest are all enqueued",
+			shardPredicate: controller.ResponsibleFor[kargoapi.Stage]{
+				IsDefaultController: true,
+				ShardName:           "fake-shard",
+			},
+			objects: []client.Object{
+				newRequestChild("blue-promotion", "blue", "current-request", kargoapi.PromotionPhasePending),
+				newRequestChild("green-promotion", "green", "current-request", kargoapi.PromotionPhasePending),
+				// Terminal children and children of other requests are not
+				// enqueued.
+				newRequestChild("red-promotion", "red", "current-request", kargoapi.PromotionPhaseErrored),
+				newRequestChild("queued-promotion", "blue", "queued-request", kargoapi.PromotionPhasePending),
+			},
+			e: event.TypedUpdateEvent[*kargoapi.Stage]{
+				ObjectOld: &kargoapi.Stage{},
+				ObjectNew: &kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "fake-stage",
+					},
+					Status: kargoapi.StageStatus{
+						CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+							Name: "current-request",
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+			) {
+				require.Equal(t, 2, wq.Len())
+				enqueued := make([]string, 0, 2)
+				for range 2 {
+					item, _ := wq.Get()
+					require.Equal(t, "fake-project", item.Namespace)
+					enqueued = append(enqueued, item.Name)
+				}
+				require.ElementsMatch(
+					t,
+					[]string{"blue-promotion", "green-promotion"},
+					enqueued,
+				)
+			},
+		},
+		{
+			name: "an unchanged current PromotionRequest enqueues nothing",
+			shardPredicate: controller.ResponsibleFor[kargoapi.Stage]{
+				IsDefaultController: true,
+				ShardName:           "fake-shard",
+			},
+			objects: []client.Object{
+				newRequestChild("blue-promotion", "blue", "current-request", kargoapi.PromotionPhasePending),
+			},
+			e: event.TypedUpdateEvent[*kargoapi.Stage]{
+				ObjectOld: &kargoapi.Stage{
+					Status: kargoapi.StageStatus{
+						CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+							Name: "current-request",
+						},
+					},
+				},
+				ObjectNew: &kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "fake-stage",
+					},
+					Status: kargoapi.StageStatus{
+						CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+							Name: "current-request",
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+			) {
+				require.Equal(t, 0, wq.Len())
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			p := &PromotionAcknowledgedByStageHandler[*kargoapi.Stage]{
+				kargoClient: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(testCase.objects...).
+					Build(),
 				shardPredicate: testCase.shardPredicate,
 			}
 

--- a/pkg/controller/promotions/watches_test.go
+++ b/pkg/controller/promotions/watches_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/akuity/kargo/pkg/controller"
 	argocd "github.com/akuity/kargo/pkg/controller/argocd/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/indexer"
+	"github.com/akuity/kargo/pkg/kubernetes"
 )
 
 func TestUpdatedArgoCDAppHandler_Update(t *testing.T) {
@@ -401,6 +402,9 @@ func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
 	require.NoError(t, kargoapi.AddToScheme(scheme))
 
 	controllerTrue := true
+	// Longer than the 63 characters a label value may hold.
+	longStageName := strings.Repeat("a", 70)
+	require.Greater(t, len(longStageName), 63)
 	newRequestChild := func(name, target, request string, phase kargoapi.PromotionPhase) *kargoapi.Promotion {
 		return &kargoapi.Promotion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -587,6 +591,60 @@ func TestPromotionAcknowledgedByStageHandler_Update(t *testing.T) {
 					[]string{"blue-promotion", "green-promotion"},
 					enqueued,
 				)
+			},
+		},
+		{
+			// The Promotion webhook shortens the Stage label to fit the 63
+			// character limit on label values, so children must be found by the
+			// shortened value, not the raw Stage name.
+			name: "children are found by the shortened Stage label",
+			shardPredicate: controller.ResponsibleFor[kargoapi.Stage]{
+				IsDefaultController: true,
+				ShardName:           "fake-shard",
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      "blue-promotion",
+						Labels: map[string]string{
+							kargoapi.LabelKeyStage: kubernetes.ShortenLabelValue(longStageName),
+						},
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: kargoapi.GroupVersion.String(),
+							Kind:       "PromotionRequest",
+							Name:       "current-request",
+							Controller: &controllerTrue,
+						}},
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage:  longStageName,
+						Target: "blue",
+					},
+					Status: kargoapi.PromotionStatus{Phase: kargoapi.PromotionPhasePending},
+				},
+			},
+			e: event.TypedUpdateEvent[*kargoapi.Stage]{
+				ObjectOld: &kargoapi.Stage{},
+				ObjectNew: &kargoapi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      longStageName,
+					},
+					Status: kargoapi.StageStatus{
+						CurrentPromotionRequest: &kargoapi.PromotionRequestReference{
+							Name: "current-request",
+						},
+					},
+				},
+			},
+			assertions: func(
+				t *testing.T,
+				wq workqueue.TypedRateLimitingInterface[reconcile.Request],
+			) {
+				require.Equal(t, 1, wq.Len())
+				item, _ := wq.Get()
+				require.Equal(t, "blue-promotion", item.Name)
 			},
 		},
 		{

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -645,6 +645,25 @@ func (r *RegularStageReconciler) reconcile(
 	return newStatus, requestRequeue, nil
 }
 
+// withoutTargetPromotions removes Promotions to one of the Stage's Targets (the
+// children of a PromotionRequest) from a list of the Stage's Promotions, and
+// returns what remains. Children take no part in the Stage's own promotion
+// flow: their admission is decided by the Stage's current PromotionRequest --
+// see api.StageAwaitsPromotion -- and their outcomes are the business of
+// whatever governs the Target, so the Stage records nothing about them.
+// Every place the Stage reconciler lists its own Promotions filters through
+// this, so that the invariant holds structurally rather than by accident of
+// which annotations or code paths children happen to reach.
+//
+// spec.target is a sound discriminator because admission enforces it: the
+// Promotion webhook rejects a Promotion that names a Target but is not owned
+// by a PromotionRequest.
+func withoutTargetPromotions(promos []kargoapi.Promotion) []kargoapi.Promotion {
+	return slices.DeleteFunc(promos, func(promo kargoapi.Promotion) bool {
+		return promo.Spec.Target != ""
+	})
+}
+
 // syncPromotions synchronizes the Promotions for a Stage. It determines the
 // current state of the Stage based on the Promotions that are running or have
 // completed.
@@ -682,22 +701,11 @@ func (r *RegularStageReconciler) syncPromotions(
 		return newStatus, false, err
 	}
 
-	// Partition out Promotions to one of the Stage's Targets (the children of
-	// a PromotionRequest): they take no part in the Stage's own promotion
-	// flow. Their admission is decided by the Stage's current
-	// PromotionRequest -- see api.StageAwaitsPromotion -- and their outcomes
-	// are the business of whatever governs the Target, so the Stage records
-	// nothing about them. Without this, a child would occupy the Stage's own
-	// single Promotion slot, serializing the very Promotions the request
-	// fanned out to run in parallel -- and its terminal phases would replay
-	// into the Stage's Freight history.
-	var stagePromos []kargoapi.Promotion
-	for _, promo := range promotions.Items {
-		if promo.Spec.Target == "" {
-			stagePromos = append(stagePromos, promo)
-		}
-	}
-	promotions.Items = stagePromos
+	// Without this, a child would occupy the Stage's own single Promotion
+	// slot, serializing the very Promotions the request fanned out to run in
+	// parallel -- and its terminal phases would replay into the Stage's
+	// Freight history.
+	promotions.Items = withoutTargetPromotions(promotions.Items)
 
 	// Build a map of origin keys that are currently requested by this Stage,
 	// used both to filter new holds and to evict stale ones.
@@ -2040,6 +2048,8 @@ func (r *RegularStageReconciler) computeEffectiveAutoPromotionHolds(
 		)
 	}
 
+	promotions.Items = withoutTargetPromotions(promotions.Items)
+
 	lastPromo := stage.Status.LastPromotion
 	for _, req := range stage.Spec.RequestedFreight {
 		originKey := req.Origin.String()
@@ -2397,6 +2407,7 @@ func (r *RegularStageReconciler) unprocessedPromotionExistsForStageFreight(
 	); err != nil {
 		return false, err
 	}
+	promotions.Items = withoutTargetPromotions(promotions.Items)
 	lastPromo := stage.Status.LastPromotion
 	for i := range promotions.Items {
 		promo := &promotions.Items[i]
@@ -2437,6 +2448,7 @@ func (r *RegularStageReconciler) newestTerminalPromotionForStageFreight(
 	); err != nil {
 		return nil, err
 	}
+	promotions.Items = withoutTargetPromotions(promotions.Items)
 	if len(promotions.Items) == 0 {
 		return nil, nil
 	}

--- a/pkg/controller/stages/regular_stages.go
+++ b/pkg/controller/stages/regular_stages.go
@@ -682,6 +682,23 @@ func (r *RegularStageReconciler) syncPromotions(
 		return newStatus, false, err
 	}
 
+	// Partition out Promotions to one of the Stage's Targets (the children of
+	// a PromotionRequest): they take no part in the Stage's own promotion
+	// flow. Their admission is decided by the Stage's current
+	// PromotionRequest -- see api.StageAwaitsPromotion -- and their outcomes
+	// are the business of whatever governs the Target, so the Stage records
+	// nothing about them. Without this, a child would occupy the Stage's own
+	// single Promotion slot, serializing the very Promotions the request
+	// fanned out to run in parallel -- and its terminal phases would replay
+	// into the Stage's Freight history.
+	var stagePromos []kargoapi.Promotion
+	for _, promo := range promotions.Items {
+		if promo.Spec.Target == "" {
+			stagePromos = append(stagePromos, promo)
+		}
+	}
+	promotions.Items = stagePromos
+
 	// Build a map of origin keys that are currently requested by this Stage,
 	// used both to filter new holds and to evict stale ones.
 	requestedOrigins := make(map[string]struct{}, len(stage.Spec.RequestedFreight))
@@ -935,11 +952,15 @@ func (r *RegularStageReconciler) syncPromotions(
 // currently fanning Freight out to the Stage's Targets, and which was the last
 // to reach a terminal phase.
 //
-// Both references are mirrors, kept so that a reader of the Stage can see the
-// round of fan-out it is in, and how the previous round ended, without listing
-// PromotionRequests. Nothing in the Stage's own progression is decided from
-// them: a PromotionRequest effects no promotion itself, and the Promotions it
-// creates reach the Stage through syncPromotions like any other.
+// The current reference is the mutex that serializes rounds of fan-out: the
+// Promotion reconciler runs a Promotion to one of the Stage's Targets only
+// while the PromotionRequest that owns it is the Stage's current one -- see
+// api.StageAwaitsPromotion. All of one request's children (at most one per
+// Target) are admitted at once, so Promotions to distinct Targets run in
+// parallel, while the children of a queued request wait for the current
+// round to end. The last reference remains a mirror, kept so that a reader
+// of the Stage can see how the previous round ended without listing
+// PromotionRequests.
 //
 // A Stage can have more than one PromotionRequest in flight, exactly as it can
 // have more than one Promotion in flight: auto-promotion creates a request only

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -6595,6 +6595,24 @@ func TestRegularStageReconciler_computeEffectiveAutoPromotionHolds(t *testing.T)
 			},
 		},
 		{
+			// A PromotionRequest's child Promotions take no part in the Stage's
+			// own flow, whatever annotations they carry.
+			name:                 "hold-intent child Promotion is ignored",
+			autoPromotionEnabled: true,
+			stage:                stage(nil),
+			objects: []client.Object{
+				func() *kargoapi.Promotion {
+					promo := holdPromo("promo-01", kargoapi.PromotionPhaseRunning)
+					promo.Spec.Target = "blue"
+					return promo
+				}(),
+			},
+			assert: func(t *testing.T, holds map[string]kargoapi.AutoPromotionHold, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, holds)
+			},
+		},
+		{
 			name:                 "running release-intent Promotion clears the origin",
 			autoPromotionEnabled: true,
 			stage:                stage(durableHold),
@@ -9449,6 +9467,69 @@ func Test_buildFreightSummary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildFreightSummary(tt.requested, tt.current)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWithoutTargetPromotions(t *testing.T) {
+	stagePromo := func(name string) kargoapi.Promotion {
+		return kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       kargoapi.PromotionSpec{Stage: "test-stage"},
+		}
+	}
+	targetPromo := func(name, target string) kargoapi.Promotion {
+		return kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       kargoapi.PromotionSpec{Stage: "test-stage", Target: target},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		promos   []kargoapi.Promotion
+		expected []string
+	}{
+		{
+			name:     "nil list",
+			promos:   nil,
+			expected: nil,
+		},
+		{
+			name:     "no children",
+			promos:   []kargoapi.Promotion{stagePromo("a"), stagePromo("b")},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "only children",
+			promos:   []kargoapi.Promotion{targetPromo("a", "blue"), targetPromo("b", "green")},
+			expected: []string{},
+		},
+		{
+			name: "children are removed and order is preserved",
+			promos: []kargoapi.Promotion{
+				targetPromo("a", "blue"),
+				stagePromo("b"),
+				targetPromo("c", "green"),
+				stagePromo("d"),
+			},
+			expected: []string{"b", "d"},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			result := withoutTargetPromotions(testCase.promos)
+			names := make([]string, 0, len(result))
+			for _, promo := range result {
+				require.Empty(t, promo.Spec.Target)
+				names = append(names, promo.Name)
+			}
+			if testCase.expected == nil {
+				require.Empty(t, names)
+				return
+			}
+			require.Equal(t, testCase.expected, names)
 		})
 	}
 }

--- a/pkg/controller/stages/regular_stages_test.go
+++ b/pkg/controller/stages/regular_stages_test.go
@@ -2288,6 +2288,129 @@ func TestRegularStageReconciler_syncPromotions(t *testing.T) {
 	}
 }
 
+func TestRegularStageReconciler_syncPromotions_partitionsTargetPromotions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+	stagePromoName := api.GeneratePromotionName("test-stage", "test-freight")
+	childPromoName := api.GenerateChildPromotionName("test-stage", "blue", "test-freight")
+
+	newChildPromo := func(phase kargoapi.PromotionPhase, finishedAt *metav1.Time) *kargoapi.Promotion {
+		return &kargoapi.Promotion{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "fake-project",
+				Name:      childPromoName,
+			},
+			Spec: kargoapi.PromotionSpec{
+				Stage:   "test-stage",
+				Freight: "test-freight",
+				Target:  "blue",
+			},
+			Status: kargoapi.PromotionStatus{
+				Phase:      phase,
+				FinishedAt: finishedAt,
+				FreightCollection: &kargoapi.FreightCollection{
+					Freight: map[string]kargoapi.FreightReference{
+						"Warehouse/test-warehouse": {Name: "test-freight"},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		stage      *kargoapi.Stage
+		objects    []client.Object
+		assertions func(*testing.T, kargoapi.StageStatus, bool, error)
+	}{
+		{
+			name: "a child Promotion does not occupy the Stage's own slot",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				&kargoapi.Promotion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fake-project",
+						Name:      stagePromoName,
+					},
+					Spec: kargoapi.PromotionSpec{
+						Stage:   "test-stage",
+						Freight: "test-freight",
+					},
+					Status: kargoapi.PromotionStatus{
+						Phase: kargoapi.PromotionPhaseRunning,
+					},
+				},
+				newChildPromo(kargoapi.PromotionPhaseRunning, nil),
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.True(t, hasPendingPromotions)
+
+				// The Stage's own slot admits the Stage's own Promotion, not
+				// the alphabetically-earlier child.
+				require.NotNil(t, status.CurrentPromotion)
+				assert.Equal(t, stagePromoName, status.CurrentPromotion.Name)
+			},
+		},
+		{
+			name: "a child Promotion's success leaves the Stage's own state alone",
+			stage: &kargoapi.Stage{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fake-project",
+					Name:      "test-stage",
+				},
+			},
+			objects: []client.Object{
+				newChildPromo(kargoapi.PromotionPhaseSucceeded, &now),
+			},
+			assertions: func(t *testing.T, status kargoapi.StageStatus, hasPendingPromotions bool, err error) {
+				require.NoError(t, err)
+				assert.False(t, hasPendingPromotions)
+
+				// Nothing Stage-scoped absorbed the child's success.
+				assert.Nil(t, status.CurrentPromotion)
+				assert.Nil(t, status.LastPromotion)
+				assert.Empty(t, status.FreightHistory)
+				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypeHealthy))
+				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypeVerified))
+				assert.Nil(t, conditions.Get(&status, kargoapi.ConditionTypePromoting))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []client.Object{tt.stage.DeepCopy()}
+			objects = append(objects, tt.objects...)
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				WithIndex(
+					&kargoapi.Promotion{},
+					indexer.PromotionsByStageField,
+					indexer.PromotionsByStage,
+				).
+				WithStatusSubresource(&kargoapi.Stage{}, &kargoapi.Promotion{}).
+				Build()
+
+			r := &RegularStageReconciler{
+				client:      c,
+				eventSender: k8sevent.NewEventSender(fakeevent.NewEventRecorder(10)),
+			}
+
+			status, hasPendingPromotions, err := r.syncPromotions(t.Context(), tt.stage, false)
+			tt.assertions(t, status, hasPendingPromotions, err)
+		})
+	}
+}
+
 func TestRegularStageReconciler_syncPromotionRequests(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, kargoapi.AddToScheme(scheme))


### PR DESCRIPTION
Builds on **#6843** (merged), which recorded `currentPromotionRequest` on the Stage.

## Summary

Promotions to a target-aware Stage's Targets — the children a PromotionRequest
fans out — were serialized by the same single slot that serializes the Stage's
own Promotions: `stage.status.currentPromotion` admits exactly one Promotion at
a time, so N Targets promoted strictly one after another, and, because a child's
generated name carries a Target segment ahead of the ULID, in alphabetical order
of Target name rather than creation order.

The mutex for children is now the Stage's **current PromotionRequest**, which
the Stage already records. A request creates at most one child per Target, so
admitting all of the current request's children at once lets Promotions to
distinct Targets run in parallel with no same-Target contention, while the
children of a queued request wait for the current round of fan-out to end.
Rounds remain a barrier by construction: consecutive PromotionRequests stay
serialized by the same phase-and-ULID ordering as before. No new API is needed —
`currentPromotionRequest` simply stops being a passive mirror and becomes the
admission token, the same role `currentPromotion` plays for everything else.

## The pieces

- **The Promotion reconciler's gate becomes `api.StageAwaitsPromotion`**: a
  child runs while the PromotionRequest that owns it is the Stage's current
  one; everything else gates on the Stage's own `currentPromotion` exactly as
  before. Ownership (the controller OwnerReference) is the signal, as in the
  Promotion webhook, because it is the one a caller cannot usefully forge.
- **`syncPromotions` partitions children out of the Stage's own flow.** Without
  this, a child would occupy the Stage's single Promotion slot — the very
  serialization being removed — and its terminal phases would replay into the
  Stage's `lastPromotion`, Freight history, health, and verification state,
  none of which are the Stage's business for a Target: the Stage only
  arbitrates which request is current. The `spec.target` discriminator is
  admission-enforced: the webhook rejects any Promotion that names a Target but
  is not owned by a PromotionRequest.
- **`PromotionAcknowledgedByStageHandler` now also enqueues every non-terminal
  child of a newly current PromotionRequest**, so a queued round starts the
  moment the Stage acknowledges it rather than waiting for a resync. Children
  are found by the Stage label and filtered by owner, and the handler gains the
  client this requires.

## Deliberately not done

- **Naming is untouched.** ULID-sortability of child Promotion names stops
  mattering once all of a request's children run in parallel — there is no
  ordering among them to preserve. Ordering only matters between
  PromotionRequests, whose names carry no Target segment and sort by ULID as
  before.
- **The stricter alternative** — a per-Target current-Promotion slot in Stage
  status — would also let Targets pipeline across rounds. It remains open if
  ever wanted; this is deliberately the simplest mutex that parallelizes a
  round.

## Interim state: `freightHistory` on target-aware Stages stops advancing

`FreightHistory.Record` has exactly one call site — `syncPromotions`, when a
succeeded Promotion becomes `lastPromotion` — and this PR removes children from
that path. Since a target-aware Stage's only Promotions *are* children (manual
Promotions on such Stages are rejected at admission, and auto-promotion creates
PromotionRequests), its `freightHistory` no longer advances at all after this
PR. That is deliberate: today each succeeded child records essentially the same
collection in turn — N Targets means up to N records, N health wipes, and N
rounds of Stage-level verification gating — and per-Target outcomes are not the
Stage's business. This PR fires the wrong writer; a follow-up hires the right
one, recording `freightHistory` from succeeded PromotionRequests instead.

Until that follow-up lands, on target-aware Stages `FreightHistory.Current()`
is nil (or frozen), and its consumers feel it:

- Stage-level verification cannot run or be tracked; reverify/abort return
  "stage has no current freight". Verification for Targets is meant to surface
  on the PromotionRequest side instead.
- Freight is never marked verified in a target-aware Stage, so downstream
  Stages requesting Freight from one will not see it as available.
- Auto-promotion loses its "already current" dedup signal, leaving only the
  no-request-in-flight guard between a terminal round and re-promoting the
  same Freight.
- `freightSummary` and the UI's current-Freight display are empty for
  target-aware Stages.

Ordinary Stages are untouched: non-child Promotions hit the `Record` path
exactly as before.

## Follow-up 

Promotion reconciler carries a duplicate of the old gate and
constructs `PromotionAcknowledgedByStageHandler`, whose constructor now takes a
client — the dependency bump is a compile break that forces both adaptations.
Follow-up tickets for the interim `freightHistory` state above are tracked on
the E side as well.

