### PR TITLE
chore: document how Go versions are selected for builds and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,17 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      # IMPORTANT: Do not upgrade this image to a newer minor version of Go.
+      # Anything we actually ship is built with the latest minor version of Go
+      # (see Dockerfile), but the jobs anchored to this image run unit tests,
+      # linters, and codegen against the minor version this branch targets. The
+      # cap is the golangci-lint version pinned in hack/tools/go.mod: a linter
+      # binary built with go1.X panics under go1.(X+1), so bumping Go here
+      # forces a linter upgrade, which typically surfaces new findings
+      # requiring code or configuration changes.
+      #
+      # This version must match the base image in Dockerfile.dev.
+      image: &golangTestImage golang:1.25.14-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in
@@ -81,7 +91,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: *golangTestImage
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -104,7 +114,7 @@ jobs:
   lint-charts:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: *golangTestImage
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -129,7 +139,7 @@ jobs:
       checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: *golangTestImage
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -152,7 +162,7 @@ jobs:
   check-codegen:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      image: *golangTestImage
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -228,7 +238,9 @@ jobs:
     needs: [test-unit, lint-go, lint-charts, lint-proto, lint-and-typecheck-ui, check-codegen]
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25.14-trixie
+      # Always use the latest minor version of Go for anything we ship -- see
+      # the back-end-builder stage in Dockerfile for why.
+      image: golang:1.27.0-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
-        go-version: '1.25.14'
+        go-version: '1.27.0'
     - name: Set version for unstable builds
       id: unstable-version
       run: |
@@ -213,7 +213,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     container:
-      image: golang:1.27.0-trixie
+      # Always use the latest minor version of Go for anything we ship -- see
+      # the back-end-builder stage in Dockerfile for why.
+      image: &golangImage golang:1.27.0-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -278,7 +280,7 @@ jobs:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.27.0-trixie
+      image: *golangImage
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
+# Always use the latest minor version of Go for anything we ship. A release
+# branch lives until its EOL, and over that lifetime the Go minor version it
+# started on may itself reach EOL. Building on the latest minor keeps released
+# binaries off unsupported toolchains and picks up fixes for CVEs in the Go
+# standard library.
 FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
 
 ARG TARGETOS
@@ -80,6 +85,9 @@ WORKDIR /kargo/bin
 #
 # Source comes from the Go module proxy, so it is checksum-verified against
 # sum.golang.org rather than trusted from a tarball download.
+#
+# As with the back-end-builder stage above, always use the latest minor version
+# of Go for anything we ship.
 FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS helm-builder
 
 ARG TARGETOS

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,13 @@
+# IMPORTANT: Do not upgrade the base image to a newer minor version of Go.
+# Anything we actually ship is built with the latest minor version of Go (see
+# Dockerfile), but this image exists to run unit tests, the linter, and codegen
+# against the minor version this branch targets. The cap is the golangci-lint
+# version pinned in hack/tools/go.mod: a linter binary built with go1.X panics
+# under go1.(X+1), so bumping Go here forces a linter upgrade, which typically
+# surfaces new findings requiring code or configuration changes.
+#
+# This version must match the `golangTestImage` anchor in
+# .github/workflows/ci.yaml.
 FROM golang:1.25.14-trixie
 
 ARG TARGETARCH


### PR DESCRIPTION
Documents why this branch builds shipped artifacts with the latest minor version of Go while running unit tests, linters, and codegen on an older one — the latter is capped by the pinned golangci-lint, and a linter binary built with go1.X panics under go1.(X+1).

Every Go version selection site now states which of the two roles it serves, and `Dockerfile.dev` and `ci.yaml` cross-reference each other so the pair cannot drift silently.

Also corrects the sites that were selecting the test version where they should have been selecting the shipped one: `build-cli` in `ci.yaml`, and the `setup-go` step in `release.yaml`. Those are the only behavior changes here; everything else is comments.