### PR TITLE
chore: document how Go versions are selected for builds and CI

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,11 +1,22 @@
 name: Set up Go
 description: >-
-  Installs Go and restores the module and build caches. Keep the default
-  version in sync with the golang image used by the Dockerfile.
+  Installs Go and restores the module and build caches. The default version
+  is the one we ship with; keep it in sync with the Dockerfile. Jobs that
+  must run against the linter-capped toolchain override it.
 inputs:
   go-version:
     description: The Go version to install
     required: false
+    # Always use the latest minor version of Go for anything we ship -- see the
+    # back-end-builder stage in Dockerfile for why.
+    #
+    # Ship is the default because the opposite default would fail silently: a
+    # publish job that named no version would build the released binary on the
+    # capped toolchain and still succeed.
+    #
+    # Jobs that run the linter, the unit tests, or codegen must instead pass
+    # the `goTestVersion` anchor defined in .github/workflows/ci.yaml, which is
+    # capped by the golangci-lint version pinned in hack/tools.mk.
     default: "1.27.0"
 runs:
   using: composite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Go
+      # This is the Go minor version that unit tests, linters, and codegen run
+      # against. It is capped by the golangci-lint version pinned in
+      # hack/tools.mk: a linter binary built with go1.X panics under go1.(X+1),
+      # so raising Go here requires a linter upgrade, which typically surfaces
+      # new findings requiring code or configuration changes.
+      #
+      # It must match the base image in Dockerfile.dev. Everything else,
+      # including anything we ship, uses the default that the setup-go action
+      # defines.
       uses: ./.github/actions/setup-go
+      with:
+        go-version: &goTestVersion "1.27.0"
     - name: Run unit tests
       run: make test-unit
     - name: Remove generated code from report
@@ -88,6 +99,8 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Go
       uses: ./.github/actions/setup-go
+      with:
+        go-version: *goTestVersion
     - name: Cache golangci-lint
       id: cache-golangci-lint
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -176,6 +189,8 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Go
       uses: ./.github/actions/setup-go
+      with:
+        go-version: *goTestVersion
     - name: Install java
       uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production
 ####################################################################################################
 # back-end-builder
 ####################################################################################################
+# Always use the latest minor version of Go for anything we ship. A release
+# branch lives until its EOL, and over that lifetime the Go minor version it
+# started on may itself reach EOL. Building on the latest minor keeps released
+# binaries off unsupported toolchains and picks up fixes for CVEs in the Go
+# standard library.
 FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
 
 ARG TARGETOS
@@ -83,6 +88,9 @@ WORKDIR /kargo/bin
 #
 # Source comes from the Go module proxy, so it is checksum-verified against
 # sum.golang.org rather than trusted from a tarball download.
+#
+# As with the back-end-builder stage above, always use the latest minor version
+# of Go for anything we ship.
 FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS helm-builder
 
 ARG TARGETOS

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,14 @@
+# IMPORTANT: This is the Go minor version that unit tests, linters, and codegen
+# run against. It is capped by the golangci-lint version pinned in
+# hack/tools.mk: a linter binary built with go1.X panics under go1.(X+1), so
+# raising Go here requires a linter upgrade, which typically surfaces new
+# findings requiring code or configuration changes.
+#
+# Anything we actually ship is built with the latest minor version of Go instead
+# (see Dockerfile).
+#
+# This version must match the `goTestVersion` anchor in
+# .github/workflows/ci.yaml.
 FROM golang:1.27.0-trixie
 
 ARG TARGETARCH


### PR DESCRIPTION
Documents why anything we ship is built with the latest minor version of Go — a release branch outlives the Go minor it was cut on, so building on the latest keeps released binaries off EOL toolchains and picks up stdlib CVE fixes.

On `main` the shipped and test Go versions currently coincide, but the two roles are now named separately anyway: the `setup-go` action's default is the shipped version, and `ci.yaml` defines a `goTestVersion` anchor for the jobs that must run on the linter-capped toolchain. Shipped is the default because the opposite default fails silently — a publish job naming no version would build the released binary on the capped toolchain and still succeed.

When `release-1.12` is cut and the two versions diverge, that becomes a change to two values rather than a restructuring.

No behavior change: every site still resolves to the same Go version it did before.