### PR TITLE
feat: Add extra fields to promotion window config.

### DIFF
--- a/api/v1alpha1/promotion_window_types.go
+++ b/api/v1alpha1/promotion_window_types.go
@@ -40,6 +40,17 @@ type PromotionWindow struct {
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	// +akuity:test-kubebuilder-pattern=KubernetesName
 	Name string `json:"name"`
+	// Description is a human-readable description of the window.
+	// May contain reason, author or any clarification for the window.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxLength=1024
+	Description string `json:"description,omitempty"`
+	// Disabled controls whether configured windows should be skipped when calculating the stage window status.
+	// Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.
+	//
+	// +optional
+	Disabled bool `json:"disabled,omitempty"`
 	// StageSelector selects the Stages this window applies to. When omitted, the
 	// window applies to all Stages in scope (project-wide on ProjectConfig,
 	// cluster-wide on ClusterConfig). It reuses PromotionPolicySelector, so it

--- a/charts/kargo/resources/crds/kargo.akuity.io_clusterconfigs.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_clusterconfigs.yaml
@@ -150,6 +150,17 @@ spec:
                     evaluated and enforced only by Kargo Enterprise; OSS carries the API for
                     compatibility, as it does for other Enterprise-only fields.
                   properties:
+                    description:
+                      description: |-
+                        Description is a human-readable description of the window.
+                        May contain reason, author or any clarification for the window.
+                      maxLength: 1024
+                      type: string
+                    disabled:
+                      description: |-
+                        Disabled controls whether configured windows should be skipped when calculating the stage window status.
+                        Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.
+                      type: boolean
                     dtend:
                       description: |-
                         DTEnd is the window's end in the same format as DTStart. When combined with

--- a/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
+++ b/charts/kargo/resources/crds/kargo.akuity.io_projectconfigs.yaml
@@ -255,6 +255,17 @@ spec:
                     evaluated and enforced only by Kargo Enterprise; OSS carries the API for
                     compatibility, as it does for other Enterprise-only fields.
                   properties:
+                    description:
+                      description: |-
+                        Description is a human-readable description of the window.
+                        May contain reason, author or any clarification for the window.
+                      maxLength: 1024
+                      type: string
+                    disabled:
+                      description: |-
+                        Disabled controls whether configured windows should be skipped when calculating the stage window status.
+                        Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.
+                      type: boolean
                     dtend:
                       description: |-
                         DTEnd is the window's end in the same format as DTStart. When combined with

--- a/pkg/x/client/generated/api/openapi.yaml
+++ b/pkg/x/client/generated/api/openapi.yaml
@@ -13752,6 +13752,21 @@ components:
       type: object
     PromotionWindow:
       properties:
+        description:
+          description: |-
+            Description is a human-readable description of the window.
+            May contain reason, author or any clarification for the window.
+
+            +optional
+            +kubebuilder:validation:MaxLength=1024
+          type: string
+        disabled:
+          description: |-
+            Disabled controls whether configured windows should be skipped when calculating the stage window status.
+            Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.
+
+            +optional
+          type: boolean
         dtend:
           description: |-
             DTEnd is the window's end in the same format as DTStart. When combined with

--- a/pkg/x/client/generated/model_promotion_window.go
+++ b/pkg/x/client/generated/model_promotion_window.go
@@ -21,6 +21,10 @@ var _ MappedNullable = &PromotionWindow{}
 
 // PromotionWindow struct for PromotionWindow
 type PromotionWindow struct {
+	// Description is a human-readable description of the window. May contain reason, author or any clarification for the window.  +optional +kubebuilder:validation:MaxLength=1024
+	Description *string `json:"description,omitempty"`
+	// Disabled controls whether configured windows should be skipped when calculating the stage window status. Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.  +optional
+	Disabled *bool `json:"disabled,omitempty"`
 	// DTEnd is the window's end in the same format as DTStart. When combined with RRule, DTEnd - DTStart defines the duration of each occurrence. The value is parsed and validated by Kargo Enterprise.  +optional
 	Dtend *string `json:"dtend,omitempty"`
 	// DTStart is the window's start as an iCal date-time, with an optional \"TZID=\" prefix carrying the time zone (e.g. \"TZID=America/New_York:20260101T090000\"). The value is parsed and validated by Kargo Enterprise.  +optional
@@ -56,6 +60,70 @@ func NewPromotionWindow(kind PromotionWindowKind, name string) *PromotionWindow 
 func NewPromotionWindowWithDefaults() *PromotionWindow {
 	this := PromotionWindow{}
 	return &this
+}
+
+// GetDescription returns the Description field value if set, zero value otherwise.
+func (o *PromotionWindow) GetDescription() string {
+	if o == nil || IsNil(o.Description) {
+		var ret string
+		return ret
+	}
+	return *o.Description
+}
+
+// GetDescriptionOk returns a tuple with the Description field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PromotionWindow) GetDescriptionOk() (*string, bool) {
+	if o == nil || IsNil(o.Description) {
+		return nil, false
+	}
+	return o.Description, true
+}
+
+// HasDescription returns a boolean if a field has been set.
+func (o *PromotionWindow) HasDescription() bool {
+	if o != nil && !IsNil(o.Description) {
+		return true
+	}
+
+	return false
+}
+
+// SetDescription gets a reference to the given string and assigns it to the Description field.
+func (o *PromotionWindow) SetDescription(v string) {
+	o.Description = &v
+}
+
+// GetDisabled returns the Disabled field value if set, zero value otherwise.
+func (o *PromotionWindow) GetDisabled() bool {
+	if o == nil || IsNil(o.Disabled) {
+		var ret bool
+		return ret
+	}
+	return *o.Disabled
+}
+
+// GetDisabledOk returns a tuple with the Disabled field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PromotionWindow) GetDisabledOk() (*bool, bool) {
+	if o == nil || IsNil(o.Disabled) {
+		return nil, false
+	}
+	return o.Disabled, true
+}
+
+// HasDisabled returns a boolean if a field has been set.
+func (o *PromotionWindow) HasDisabled() bool {
+	if o != nil && !IsNil(o.Disabled) {
+		return true
+	}
+
+	return false
+}
+
+// SetDisabled gets a reference to the given bool and assigns it to the Disabled field.
+func (o *PromotionWindow) SetDisabled(v bool) {
+	o.Disabled = &v
 }
 
 // GetDtend returns the Dtend field value if set, zero value otherwise.
@@ -276,6 +344,12 @@ func (o PromotionWindow) MarshalJSON() ([]byte, error) {
 
 func (o PromotionWindow) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Description) {
+		toSerialize["description"] = o.Description
+	}
+	if !IsNil(o.Disabled) {
+		toSerialize["disabled"] = o.Disabled
+	}
 	if !IsNil(o.Dtend) {
 		toSerialize["dtend"] = o.Dtend
 	}

--- a/swagger.json
+++ b/swagger.json
@@ -8127,6 +8127,14 @@
     "PromotionWindow": {
       "type": "object",
       "properties": {
+        "description": {
+          "description": "Description is a human-readable description of the window.\nMay contain reason, author or any clarification for the window.\n\n+optional\n+kubebuilder:validation:MaxLength=1024",
+          "type": "string"
+        },
+        "disabled": {
+          "description": "Disabled controls whether configured windows should be skipped when calculating the stage window status.\nOptional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.\n\n+optional",
+          "type": "boolean"
+        },
         "dtend": {
           "description": "DTEnd is the window's end in the same format as DTStart. When combined with\nRRule, DTEnd - DTStart defines the duration of each occurrence. The value\nis parsed and validated by Kargo Enterprise.\n\n+optional",
           "type": "string"

--- a/ui/src/gen/api/v2/models/promotionWindow.ts
+++ b/ui/src/gen/api/v2/models/promotionWindow.ts
@@ -9,6 +9,17 @@ import type { PromotionWindowKind } from './promotionWindowKind';
 import type { PromotionPolicySelector } from './promotionPolicySelector';
 
 export interface PromotionWindow {
+  /** Description is a human-readable description of the window.
+May contain reason, author or any clarification for the window.
+
++optional
++kubebuilder:validation:MaxLength=1024 */
+  description?: string;
+  /** Disabled controls whether configured windows should be skipped when calculating the stage window status.
+Optional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.
+
++optional */
+  disabled?: boolean;
   /** DTEnd is the window's end in the same format as DTStart. When combined with
 RRule, DTEnd - DTStart defines the duration of each occurrence. The value
 is parsed and validated by Kargo Enterprise.

--- a/ui/src/gen/schema/clusterconfigs.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/clusterconfigs.kargo.akuity.io_v1alpha1.json
@@ -86,6 +86,15 @@
           "items": {
             "description": "PromotionWindow describes a recurring or one-shot time window that gates\npromotions for the Stages it matches. Windows may appear on both\nProjectConfig and ClusterConfig; a Stage's effective schedule is the union of\nall matching windows from both. A schedule is open at a given time when no\nmatching Deny window is active and, if any Allow windows match the Stage, at\nleast one of them is active. Windows gate all promotions uniformly (auto,\nmanual, and rollback).\n\nKargo Enterprise only: This type is ignored in Kargo OSS. The schedule is\nevaluated and enforced only by Kargo Enterprise; OSS carries the API for\ncompatibility, as it does for other Enterprise-only fields.",
             "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the window.\nMay contain reason, author or any clarification for the window.",
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "disabled": {
+                "description": "Disabled controls whether configured windows should be skipped when calculating the stage window status.\nOptional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.",
+                "type": "boolean"
+              },
               "dtend": {
                 "description": "DTEnd is the window's end in the same format as DTStart. When combined with\nRRule, DTEnd - DTStart defines the duration of each occurrence. The value\nis parsed and validated by Kargo Enterprise.",
                 "type": "string"

--- a/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
+++ b/ui/src/gen/schema/projectconfigs.kargo.akuity.io_v1alpha1.json
@@ -172,6 +172,15 @@
           "items": {
             "description": "PromotionWindow describes a recurring or one-shot time window that gates\npromotions for the Stages it matches. Windows may appear on both\nProjectConfig and ClusterConfig; a Stage's effective schedule is the union of\nall matching windows from both. A schedule is open at a given time when no\nmatching Deny window is active and, if any Allow windows match the Stage, at\nleast one of them is active. Windows gate all promotions uniformly (auto,\nmanual, and rollback).\n\nKargo Enterprise only: This type is ignored in Kargo OSS. The schedule is\nevaluated and enforced only by Kargo Enterprise; OSS carries the API for\ncompatibility, as it does for other Enterprise-only fields.",
             "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the window.\nMay contain reason, author or any clarification for the window.",
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "disabled": {
+                "description": "Disabled controls whether configured windows should be skipped when calculating the stage window status.\nOptional. Default is `false`. Unless set to `true` the window will impact the stages it's configured for.",
+                "type": "boolean"
+              },
               "dtend": {
                 "description": "DTEnd is the window's end in the same format as DTStart. When combined with\nRRule, DTEnd - DTStart defines the duration of each occurrence. The value\nis parsed and validated by Kargo Enterprise.",
                 "type": "string"


### PR DESCRIPTION
Added `Description` and `Disabled` fields for promotion window config.

**NOTE:** These fields only used in Kargo EE, changes here are needed for `ProjectConfig` structure.