### PR TITLE
feat: Move DiscoveryLimit to the generic RepoSubscription level.

### DIFF
--- a/api/v1alpha1/warehouse_types.go
+++ b/api/v1alpha1/warehouse_types.go
@@ -116,10 +116,10 @@ type WarehouseSpec struct {
 
 var legacySubscriptionTypes = []string{"chart", "git", "image"}
 
-// subscriptionNameKey is the one top-level key of a subscription that does not
-// name a subscription type. It qualifies the subscription instead. No
-// subscription type may use this name.
+// subscriptionNameKey and subscriptionDiscoveryLimitKey are top-level keys of a subscription that do not
+// name a subscription type. They apply to the subscription instead. No subscription type may use these names.
 const subscriptionNameKey = "name"
+const subscriptionDiscoveryLimitKey = "discoveryLimit"
 
 // UnmarshalJSON unmarshals the JSON data into WarehouseSpec, converting the
 // JSON from the Subscriptions field into typed RepoSubscription objects in
@@ -157,15 +157,15 @@ func (w *WarehouseSpec) UnmarshalJSON(data []byte) error {
 			// Only the reserved name key may accompany it.
 			typeKeys := make([]string, 0, len(rawMap))
 			for k := range rawMap {
-				if k != subscriptionNameKey {
+				if k != subscriptionNameKey && k != subscriptionDiscoveryLimitKey {
 					typeKeys = append(typeKeys, k)
 				}
 			}
 			if len(typeKeys) != 1 {
 				return fmt.Errorf(
 					"subscription at index %d must have exactly one top-level field "+
-						"naming its type, apart from an optional %q field, but has %d",
-					i, subscriptionNameKey, len(typeKeys),
+						"naming its type, apart from shared %q and %q fields, but has %d",
+					i, subscriptionNameKey, subscriptionDiscoveryLimitKey, len(typeKeys),
 				)
 			}
 			key := typeKeys[0]
@@ -334,6 +334,14 @@ type RepoSubscription struct {
 	// Subscription describes a subscription to something that is not a Git, container
 	// image, or Helm chart repository.
 	Subscription *Subscription `json:"subscription,omitempty"`
+	// DiscoveryLimit is an optional limit on the number of artifacts that can be
+	// discovered for this subscription. When left unspecified, the field is
+	// implicitly treated as if its value were 20. The upper limit is 100.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=100
+	// +kubebuilder:validation:Optional
+	DiscoveryLimit int64 `json:"discoveryLimit,omitempty"`
 }
 
 // Subscription represents a subscription to some kind of artifact repository.

--- a/api/v1alpha1/warehouse_types_test.go
+++ b/api/v1alpha1/warehouse_types_test.go
@@ -580,6 +580,17 @@ func TestWarehouseSpecUnmarshalValidation(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "valid Git subscription with discoveryLimit",
+			jsonData:    `{"subscriptions":[{"discoveryLimit":20,"git":{"repoURL":"https://github.com/example/repo.git"}}]}`,
+			expectError: false,
+		},
+		{
+			name: "valid named Git subscription with discoveryLimit",
+			// nolint: lll
+			jsonData:    `{"subscriptions":[{"name":"fake-sub","discoveryLimit":20,"git":{"repoURL":"https://github.com/example/repo.git"}}]}`,
+			expectError: false,
+		},
+		{
 			name:        "valid named generic subscription",
 			jsonData:    `{"subscriptions":[{"name":"fake-sub","s3":{"config":{"bucket":"fake-bucket"}}}]}`,
 			expectError: false,
@@ -593,6 +604,12 @@ func TestWarehouseSpecUnmarshalValidation(t *testing.T) {
 		{
 			name:        "invalid subscription with name only",
 			jsonData:    `{"subscriptions":[{"name":"fake-sub"}]}`,
+			expectError: true,
+			errorMsg:    "must have exactly one top-level field naming its type",
+		},
+		{
+			name:        "invalid subscription with discoveryLimit only",
+			jsonData:    `{"subscriptions":[{"discoveryLimit":20}]}`,
 			expectError: true,
 			errorMsg:    "must have exactly one top-level field naming its type",
 		},

--- a/api/v1alpha1/zz_subscription_types.go
+++ b/api/v1alpha1/zz_subscription_types.go
@@ -8,7 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type ChartSubscription struct {
 	// DiscoveryLimit is an optional limit on the number of chart versions that can be
 	// discovered for this subscription. The limit is applied after filtering charts based on
-	// the semverConstraint field. The upper limit for this field is 100.
+	// the semverConstraint field. The upper limit for this field is 100. Deprecated: Set
+	// discoveryLimit on the subscription (as a sibling of the chart field) instead.
 	DiscoveryLimit int64 `json:"discoveryLimit,omitempty"`
 	// InsecureSkipTLSVerify specifies whether certificate verification errors should be ignored
 	// when connecting to the repository. This should be enabled only with great caution.
@@ -56,7 +57,8 @@ type GitSubscription struct {
 	// interest in the repository specified by the RepoURL field.
 	CommitSelectionStrategy CommitSelectionStrategy `json:"commitSelectionStrategy,omitempty"`
 	// DiscoveryLimit is an optional limit on the number of commits that can be discovered for
-	// this subscription. The upper limit is 100.
+	// this subscription. The upper limit is 100. Deprecated: Set discoveryLimit on the
+	// subscription (as a sibling of the git field) instead.
 	DiscoveryLimit int64 `json:"discoveryLimit,omitempty"`
 	// ExcludePaths is a list of selectors that designate paths in the repository that should
 	// NOT trigger the production of new Freight when changes are detected therein.
@@ -120,6 +122,8 @@ type ImageSubscription struct {
 	// discovered for this subscription. The limit is applied after filtering images based on
 	// the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is
 	// implicitly treated as if its value were "20". The upper limit for this field is 100.
+	// Deprecated: Set discoveryLimit on the subscription (as a sibling of the image field)
+	// instead.
 	DiscoveryLimit int64 `json:"discoveryLimit,omitempty"`
 	// IgnoreTags is a list of tags that must be ignored when determining the newest version of
 	// an image. No regular expressions or glob patterns are supported yet. This field is

--- a/docs/docs/20-quickstart/index.md
+++ b/docs/docs/20-quickstart/index.md
@@ -371,7 +371,7 @@ spec:
   - image:
       repoURL: public.ecr.aws/nginx/nginx
       constraint: ^1.29.0
-      discoveryLimit: 5
+    discoveryLimit: 5
 ---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: PromotionTask
@@ -538,7 +538,7 @@ spec:
   - image:
       repoURL: public.ecr.aws/nginx/nginx
       constraint: ^1.29.0
-      discoveryLimit: 5
+    discoveryLimit: 5
 ---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: PromotionTask

--- a/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
+++ b/docs/docs/50-user-guide/20-how-to-guides/30-working-with-warehouses.md
@@ -59,6 +59,7 @@ A subscription may be given a name:
 spec:
   subscriptions:
   - name: frontend
+    discoveryLimit: 20
     image:
       repoURL: public.ecr.aws/nginx/nginx
       constraint: ^1.26.0
@@ -67,8 +68,8 @@ spec:
       repoURL: public.ecr.aws/myorg/backend
 ```
 
-The `name` field is a sibling of the field identifying the subscription's type
--- `image` in the example above -- and not a field within it.
+The `name` and `discoveryLimit` fields are siblings of the field identifying the subscription's type
+-- `image` in the example above -- and are not fields within it.
 
 A name must be unique among all of a `Warehouse`'s subscriptions and must be a
 valid [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123) label: no more
@@ -100,6 +101,26 @@ that has already produced `Freight` may result in the one-time production of new
 name.
 
 :::
+
+- `discoveryLimit`: Artifact discovery often times do not select a _single_ artifact;
+  rather they find the n best fits for the specified constraints.
+  The _best_ fit is the zero element in the list.
+  `discoveryLimit` specifies how many artifacts to discover.
+
+  The default is `20`.
+
+  :::note
+
+  For poorly performing `Warehouse`s -- for instance ones frequently
+  encountering rate limits -- decreasing this limit may improve performance.
+  :::
+
+  :::note
+
+  This field was moved from specific subscriptions (`image`, `git`, `chart`) spec
+  to generalize the setting.
+  :::
+
 
 ### Container Image Subscriptions
 
@@ -143,6 +164,12 @@ fields:
 
   For poorly performing `Warehouse`s -- for instance ones frequently
   encountering rate limits -- decreasing this limit may improve performance.
+  :::
+
+  :::warning[Deprecated]
+
+  This field is now deprecated and will be removed in favour of `discoveryLimit`
+  on the base subscription level.
   :::
 
 - `insecureSkipTLSVerify`: Set to `true` to disable validation of the
@@ -392,6 +419,13 @@ Git repository subscriptions can be defined using the following fields:
   subscription.
   :::
 
+  :::warning[Deprecated]
+
+  This field is now deprecated and will be removed in favour of `discoveryLimit`
+  on the base subscription level.
+  :::
+
+
 - `since`: An optional date in RFC 3339 format (e.g. `2026-01-01T00:00:00Z`)
   that bounds how far back commit discovery will look. When specified, only
   commits at or after this date are considered. When left unspecified, there is
@@ -403,7 +437,7 @@ Git repository subscriptions can be defined using the following fields:
   `NewestFromBranch` (or unspecified, since `NewestFromBranch` is the default).
   It is particularly useful for large repositories with long histories where
   `discoveryLimit` alone is not sufficient to prevent slow lookbacks.
-  
+
   :::
 
 - `insecureSkipTLSVerify`: Set to `true` to disable validation of the
@@ -844,6 +878,12 @@ Helm chart repository subscriptions can be defined using the following fields:
   charts. `discoveryLimit` specifies how many chart versions to discover.
 
   The default is `20`.
+
+  :::warning[Deprecated]
+
+  This field is now deprecated and will be removed in favour of `discoveryLimit`
+  on the base subscription level.
+  :::
 
 - `insecureSkipTLSVerify`: Set to `true` to disable validation of the
   repository's TLS certificate.

--- a/pkg/controller/git/commit/base_selector.go
+++ b/pkg/controller/git/commit/base_selector.go
@@ -42,6 +42,7 @@ type baseSelector struct {
 
 func newBaseSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (*baseSelector, error) {
 	s := &baseSelector{
@@ -49,7 +50,7 @@ func newBaseSelector(
 		creds:                 creds,
 		insecureSkipTLSVerify: sub.InsecureSkipTLSVerify,
 		blobless:              sub.Blobless != nil && *sub.Blobless,
-		discoveryLimit:        int(sub.DiscoveryLimit),
+		discoveryLimit:        discoveryLimit,
 		gitCloneFn:            git.Clone,
 		lsRemoteFn:            git.LsRemote,
 	}

--- a/pkg/controller/git/commit/base_selector_test.go
+++ b/pkg/controller/git/commit/base_selector_test.go
@@ -11,14 +11,16 @@ import (
 
 func TestNewBaseSelector(t *testing.T) {
 	testCases := []struct {
-		name       string
-		sub        kargoapi.GitSubscription
-		creds      *git.RepoCredentials
-		assertions func(*testing.T, *baseSelector, error)
+		name           string
+		sub            kargoapi.GitSubscription
+		discoveryLimit int
+		creds          *git.RepoCredentials
+		assertions     func(*testing.T, *baseSelector, error)
 	}{
 		{
-			name: "error parsing filter expression",
-			sub:  kargoapi.GitSubscription{ExpressionFilter: "(1 + 2"},
+			name:           "error parsing filter expression",
+			sub:            kargoapi.GitSubscription{ExpressionFilter: "(1 + 2"},
+			discoveryLimit: 20,
 			assertions: func(t *testing.T, _ *baseSelector, err error) {
 				require.ErrorContains(t, err, "error compiling filter expression")
 			},
@@ -28,6 +30,7 @@ func TestNewBaseSelector(t *testing.T) {
 			sub: kargoapi.GitSubscription{
 				IncludePaths: []string{"regex:["}, // Bad regex
 			},
+			discoveryLimit: 20,
 			assertions: func(t *testing.T, _ *baseSelector, err error) {
 				require.ErrorContains(t, err, "error parsing include path selectors")
 			},
@@ -37,6 +40,7 @@ func TestNewBaseSelector(t *testing.T) {
 			sub: kargoapi.GitSubscription{
 				ExcludePaths: []string{"regex:["}, // Bad regex
 			},
+			discoveryLimit: 20,
 			assertions: func(t *testing.T, _ *baseSelector, err error) {
 				require.ErrorContains(t, err, "error parsing exclude path selectors")
 			},
@@ -49,8 +53,8 @@ func TestNewBaseSelector(t *testing.T) {
 				ExpressionFilter:      "false",
 				IncludePaths:          []string{"apps/"},
 				ExcludePaths:          []string{"hack/"},
-				DiscoveryLimit:        5,
 			},
+			discoveryLimit: 5,
 			creds: &git.RepoCredentials{
 				Username: "foo",
 				Password: "bar",
@@ -76,7 +80,7 @@ func TestNewBaseSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newBaseSelector(testCase.sub, testCase.creds)
+			s, err := newBaseSelector(testCase.sub, testCase.discoveryLimit, testCase.creds)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/controller/git/commit/lexical_selector.go
+++ b/pkg/controller/git/commit/lexical_selector.go
@@ -30,9 +30,10 @@ type lexicalSelector struct {
 
 func newLexicalSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/controller/git/commit/lexical_selector_test.go
+++ b/pkg/controller/git/commit/lexical_selector_test.go
@@ -41,7 +41,7 @@ func TestNewLexicalSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newLexicalSelector(testCase.sub, nil)
+			s, err := newLexicalSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/controller/git/commit/newest_from_branch_selector.go
+++ b/pkg/controller/git/commit/newest_from_branch_selector.go
@@ -57,9 +57,10 @@ type newestFromBranchSelector struct {
 
 func newNewestFromBranchSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (Selector, error) {
-	base, err := newBaseSelector(sub, creds)
+	base, err := newBaseSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building base selector: %w", err)
 	}

--- a/pkg/controller/git/commit/newest_from_branch_selector_test.go
+++ b/pkg/controller/git/commit/newest_from_branch_selector_test.go
@@ -62,7 +62,7 @@ func TestNewNewestFromBranchSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newNewestFromBranchSelector(testCase.sub, nil)
+			s, err := newNewestFromBranchSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/controller/git/commit/newest_tag_selector.go
+++ b/pkg/controller/git/commit/newest_tag_selector.go
@@ -28,9 +28,10 @@ type newestTagSelector struct {
 
 func newNewestTagSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/controller/git/commit/newest_tag_selector_test.go
+++ b/pkg/controller/git/commit/newest_tag_selector_test.go
@@ -41,7 +41,7 @@ func TestNewNewestTagSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newNewestTagSelector(testCase.sub, nil)
+			s, err := newNewestTagSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/controller/git/commit/registry.go
+++ b/pkg/controller/git/commit/registry.go
@@ -21,6 +21,7 @@ type (
 	// selectorFactory is a function that returns an implementation of Selector.
 	selectorFactory = func(
 		kargoapi.GitSubscription,
+		int,
 		*git.RepoCredentials,
 	) (Selector, error)
 

--- a/pkg/controller/git/commit/selector.go
+++ b/pkg/controller/git/commit/selector.go
@@ -34,6 +34,7 @@ type Selector interface {
 func NewSelector(
 	ctx context.Context,
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (Selector, error) {
 	// Pick an appropriate Selector implementation based on the subscription
@@ -43,5 +44,5 @@ func NewSelector(
 		return nil, fmt.Errorf("error getting selector factory")
 	}
 	factory := reg.Value
-	return factory(sub, creds)
+	return factory(sub, discoveryLimit, creds)
 }

--- a/pkg/controller/git/commit/semver_selector.go
+++ b/pkg/controller/git/commit/semver_selector.go
@@ -35,9 +35,10 @@ type semverSelector struct {
 
 func newSemverSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/controller/git/commit/semver_selector_test.go
+++ b/pkg/controller/git/commit/semver_selector_test.go
@@ -85,7 +85,7 @@ func TestNewSemverSelectorTest(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newSemverSelector(testCase.sub, nil)
+			s, err := newSemverSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/controller/git/commit/tag_based_selector.go
+++ b/pkg/controller/git/commit/tag_based_selector.go
@@ -58,9 +58,10 @@ func compileRegexes(regexStrs []string) ([]*regexp.Regexp, error) {
 
 func newTagBasedSelector(
 	sub kargoapi.GitSubscription,
+	discoveryLimit int,
 	creds *git.RepoCredentials,
 ) (*tagBasedSelector, error) {
-	base, err := newBaseSelector(sub, creds)
+	base, err := newBaseSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building base selector: %w", err)
 	}

--- a/pkg/controller/git/commit/tag_based_selector_test.go
+++ b/pkg/controller/git/commit/tag_based_selector_test.go
@@ -185,7 +185,7 @@ func TestNewTagBasedSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newTagBasedSelector(testCase.sub, nil)
+			s, err := newTagBasedSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/helm/chart/base_selector.go
+++ b/pkg/helm/chart/base_selector.go
@@ -22,10 +22,11 @@ type baseSelector struct {
 
 func newBaseSelector(
 	sub kargoapi.ChartSubscription,
+	discoveryLimit int,
 ) (*baseSelector, error) {
 	s := &baseSelector{
 		repoURL:               sub.RepoURL,
-		discoveryLimit:        int(sub.DiscoveryLimit),
+		discoveryLimit:        discoveryLimit,
 		insecureSkipTLSVerify: sub.InsecureSkipTLSVerify,
 	}
 	if sub.SemverConstraint != "" {

--- a/pkg/helm/chart/http_selector.go
+++ b/pkg/helm/chart/http_selector.go
@@ -35,9 +35,10 @@ type httpSelector struct {
 
 func newHTTPSelector(
 	sub kargoapi.ChartSubscription,
+	discoveryLimit int,
 	creds *helm.Credentials,
 ) (Selector, error) {
-	base, err := newBaseSelector(sub)
+	base, err := newBaseSelector(sub, discoveryLimit)
 	if err != nil {
 		return nil, fmt.Errorf("error building base selector: %w", err)
 	}

--- a/pkg/helm/chart/http_selector_test.go
+++ b/pkg/helm/chart/http_selector_test.go
@@ -63,7 +63,7 @@ func TestNewHTTPSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newHTTPSelector(testCase.sub, testCase.creds)
+			s, err := newHTTPSelector(testCase.sub, 20, testCase.creds)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/helm/chart/oci_selector.go
+++ b/pkg/helm/chart/oci_selector.go
@@ -23,9 +23,10 @@ type ociSelector struct {
 func newOCISelector(
 	ctx context.Context,
 	sub kargoapi.ChartSubscription,
+	discoveryLimit int,
 	creds *helm.Credentials,
 ) (Selector, error) {
-	base, err := newBaseSelector(sub)
+	base, err := newBaseSelector(sub, discoveryLimit)
 	if err != nil {
 		return nil, fmt.Errorf("error building base selector: %w", err)
 	}

--- a/pkg/helm/chart/oci_selector_test.go
+++ b/pkg/helm/chart/oci_selector_test.go
@@ -62,7 +62,7 @@ func TestNewOCISelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newOCISelector(t.Context(), testCase.sub, nil)
+			s, err := newOCISelector(t.Context(), testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}
@@ -76,6 +76,7 @@ func Test_ociSelector_Select(t *testing.T) {
 		kargoapi.ChartSubscription{
 			RepoURL: "oci://ghcr.io/akuity/kargo-charts/kargo",
 		},
+		20,
 		nil,
 	)
 	require.NoError(t, err)

--- a/pkg/helm/chart/selector.go
+++ b/pkg/helm/chart/selector.go
@@ -26,14 +26,15 @@ type Selector interface {
 func NewSelector(
 	ctx context.Context,
 	sub kargoapi.ChartSubscription,
+	discoveryLimit int,
 	creds *helm.Credentials,
 ) (Selector, error) {
 	switch {
 	case strings.HasPrefix(sub.RepoURL, "http://"),
 		strings.HasPrefix(sub.RepoURL, "https://"):
-		return newHTTPSelector(sub, creds)
+		return newHTTPSelector(sub, discoveryLimit, creds)
 	case strings.HasPrefix(sub.RepoURL, "oci://"):
-		return newOCISelector(ctx, sub, creds)
+		return newOCISelector(ctx, sub, discoveryLimit, creds)
 	default:
 		return nil, fmt.Errorf("repository URL %q is invalid", sub.RepoURL)
 	}

--- a/pkg/image/digest_selector.go
+++ b/pkg/image/digest_selector.go
@@ -32,6 +32,7 @@ type digestSelector struct {
 
 func newDigestSelector(
 	sub kargoapi.ImageSubscription,
+	_ int,
 	creds *Credentials,
 ) (Selector, error) {
 	base, err := newBaseSelector(

--- a/pkg/image/digest_selector_test.go
+++ b/pkg/image/digest_selector_test.go
@@ -37,7 +37,7 @@ func TestNewDigestSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newDigestSelector(testCase.sub, nil)
+			s, err := newDigestSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/image/lexical_selector.go
+++ b/pkg/image/lexical_selector.go
@@ -28,9 +28,10 @@ type lexicalSelector struct {
 
 func newLexicalSelector(
 	sub kargoapi.ImageSubscription,
+	discoveryLimit int,
 	creds *Credentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/image/lexical_selector_test.go
+++ b/pkg/image/lexical_selector_test.go
@@ -37,7 +37,7 @@ func TestNewLexicalSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newLexicalSelector(testCase.sub, nil)
+			s, err := newLexicalSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/image/newest_build_selector.go
+++ b/pkg/image/newest_build_selector.go
@@ -30,9 +30,10 @@ type newestBuildSelector struct {
 
 func newNewestBuildSelector(
 	sub kargoapi.ImageSubscription,
+	discoveryLimit int,
 	creds *Credentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/image/newest_build_selector_test.go
+++ b/pkg/image/newest_build_selector_test.go
@@ -38,7 +38,7 @@ func TestNewNewestBuildSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newNewestBuildSelector(testCase.sub, nil)
+			s, err := newNewestBuildSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/image/selector.go
+++ b/pkg/image/selector.go
@@ -23,6 +23,7 @@ type Selector interface {
 func NewSelector(
 	ctx context.Context,
 	sub kargoapi.ImageSubscription,
+	discoveryLimit int,
 	creds *Credentials,
 ) (Selector, error) {
 	// Pick an appropriate Selector implementation based on the subscription
@@ -32,5 +33,5 @@ func NewSelector(
 		return nil, fmt.Errorf("error getting selector factory")
 	}
 	factory := reg.Value
-	return factory(sub, creds)
+	return factory(sub, discoveryLimit, creds)
 }

--- a/pkg/image/selector_docker_hub_test.go
+++ b/pkg/image/selector_docker_hub_test.go
@@ -38,8 +38,8 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 					Constraint:             "fake-constraint",
-					DiscoveryLimit:         1,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -56,8 +56,8 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 					Constraint:             "bookworm",
-					DiscoveryLimit:         1,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -81,8 +81,8 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 					Constraint:             "bookworm",
 					Platform:               "linux/made-up-arch",
-					DiscoveryLimit:         1,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -100,8 +100,8 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 					Constraint:             "bookworm",
 					Platform:               platform,
-					DiscoveryLimit:         1,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -127,9 +127,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyLexical,
 					AllowTagsRegexes:       []string{"^nothing-matches-this$"},
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -145,7 +145,6 @@ func TestSelectImageDockerHub(t *testing.T) {
 				kargoapi.ImageSubscription{
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyLexical,
-					DiscoveryLimit:         1,
 					// Limit tags to JUST "trixie" and "wheezy" to avoid blowing past
 					// Docker Hub rate limits. We'll expect to get "wheezy" back as the
 					// lexically greatest tag matching that constraint.
@@ -155,6 +154,7 @@ func TestSelectImageDockerHub(t *testing.T) {
 					},
 					CacheByTag: true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -181,10 +181,10 @@ func TestSelectImageDockerHub(t *testing.T) {
 						`^trixie$`,
 						`^wheezy$`,
 					},
-					Platform:       "linux/made-up-arch",
-					DiscoveryLimit: 1,
-					CacheByTag:     true,
+					Platform:   "linux/made-up-arch",
+					CacheByTag: true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -207,10 +207,10 @@ func TestSelectImageDockerHub(t *testing.T) {
 						`^trixie$`,
 						`^wheezy$`,
 					},
-					Platform:       platform,
-					DiscoveryLimit: 1,
-					CacheByTag:     true,
+					Platform:   platform,
+					CacheByTag: true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -236,9 +236,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 					AllowTagsRegexes:       []string{"nothing-matches-this"},
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -255,9 +255,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -280,9 +280,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
 					Platform:               "linux/made-up-arch",
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -300,9 +300,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 					AllowTagsRegexes:       []string{`^bookworm-202310\d\d$`},
 					Platform:               platform,
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -328,9 +328,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 					Constraint:             "^99.0",
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -347,9 +347,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					RepoURL:                debianRepo,
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 					Constraint:             "^12.0",
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -376,9 +376,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 					Constraint:             "^12.0",
 					Platform:               "linux/made-up-arch",
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)
@@ -396,9 +396,9 @@ func TestSelectImageDockerHub(t *testing.T) {
 					ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 					Constraint:             "^12.0",
 					Platform:               platform,
-					DiscoveryLimit:         1,
 					CacheByTag:             true,
 				},
+				1,
 				getDockerHubCreds(),
 			)
 			require.NoError(t, err)

--- a/pkg/image/selector_ghcr_test.go
+++ b/pkg/image/selector_ghcr_test.go
@@ -32,8 +32,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 				Constraint:             constraint,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -57,8 +57,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 				Constraint:             constraint,
 				Platform:               platform,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -79,8 +79,8 @@ func TestSelectImageGHCR(t *testing.T) {
 			kargoapi.ImageSubscription{
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyLexical,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -101,8 +101,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyLexical,
 				Platform:               platform,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -123,8 +123,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 				AllowTagsRegexes:       []string{`^v0.1.0-rc.2\d$`},
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -147,8 +147,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyNewestBuild,
 				AllowTagsRegexes:       []string{`^v0.1.0-rc.2\d$`},
 				Platform:               platform,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -169,8 +169,8 @@ func TestSelectImageGHCR(t *testing.T) {
 			kargoapi.ImageSubscription{
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -196,8 +196,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				RepoURL:                kargoRepo,
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategySemVer,
 				Platform:               platform,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -227,8 +227,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				RepoURL:                "ghcr.io/akuity/kargo-test",
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 				Constraint:             tag,
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)
@@ -251,8 +251,8 @@ func TestSelectImageGHCR(t *testing.T) {
 				ImageSelectionStrategy: kargoapi.ImageSelectionStrategyDigest,
 				Constraint:             "v0.1.0",
 				Platform:               "linux/made-up-arch",
-				DiscoveryLimit:         1,
 			},
+			1,
 			nil,
 		)
 		require.NoError(t, err)

--- a/pkg/image/selector_registry.go
+++ b/pkg/image/selector_registry.go
@@ -20,6 +20,7 @@ type (
 	// selectorFactor is a function that returns an implementation of Selector.
 	selectorFactory = func(
 		kargoapi.ImageSubscription,
+		int,
 		*Credentials,
 	) (Selector, error)
 

--- a/pkg/image/semver_selector.go
+++ b/pkg/image/semver_selector.go
@@ -35,9 +35,10 @@ type semverSelector struct {
 
 func newSemverSelector(
 	sub kargoapi.ImageSubscription,
+	discoveryLimit int,
 	creds *Credentials,
 ) (Selector, error) {
-	tagBased, err := newTagBasedSelector(sub, creds)
+	tagBased, err := newTagBasedSelector(sub, discoveryLimit, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error building tag based selector: %w", err)
 	}

--- a/pkg/image/semver_selector_test.go
+++ b/pkg/image/semver_selector_test.go
@@ -60,7 +60,7 @@ func TestNewSemverSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newSemverSelector(testCase.sub, nil)
+			s, err := newSemverSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/image/tag_based_selector.go
+++ b/pkg/image/tag_based_selector.go
@@ -39,6 +39,7 @@ func compileRegexes(regexStrs []string) ([]*regexp.Regexp, error) {
 
 func newTagBasedSelector(
 	sub kargoapi.ImageSubscription,
+	discoveryLimit int,
 	creds *Credentials,
 ) (*tagBasedSelector, error) {
 	base, err := newBaseSelector(sub, creds, sub.CacheByTag)
@@ -47,7 +48,7 @@ func newTagBasedSelector(
 	}
 	s := &tagBasedSelector{
 		baseSelector:   base,
-		discoveryLimit: int(sub.DiscoveryLimit),
+		discoveryLimit: discoveryLimit,
 	}
 
 	if s.allowTagsRegexes, err = compileRegexes(sub.AllowTagsRegexes); err != nil {

--- a/pkg/image/tag_based_selector_test.go
+++ b/pkg/image/tag_based_selector_test.go
@@ -83,7 +83,7 @@ func TestNewTagBasedSelector(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			s, err := newTagBasedSelector(testCase.sub, nil)
+			s, err := newTagBasedSelector(testCase.sub, 20, nil)
 			testCase.assertions(t, s, err)
 		})
 	}

--- a/pkg/subscription/chart.go
+++ b/pkg/subscription/chart.go
@@ -38,6 +38,7 @@ type chartSubscriber struct {
 	newSelectorFn func(
 		ctx context.Context,
 		sub kargoapi.ChartSubscription,
+		discoveryLimit int,
 		creds *helm.Credentials,
 	) (chart.Selector, error)
 }
@@ -57,14 +58,8 @@ func newChartSubscriber(
 // ApplySubscriptionDefaults implements Subscriber.
 func (c *chartSubscriber) ApplySubscriptionDefaults(
 	_ context.Context,
-	sub *kargoapi.RepoSubscription,
+	_ *kargoapi.RepoSubscription,
 ) error {
-	if sub == nil || sub.Chart == nil {
-		return nil
-	}
-	if sub.Chart != nil && sub.Chart.DiscoveryLimit == 0 {
-		sub.Chart.DiscoveryLimit = 20
-	}
 	return nil
 }
 
@@ -125,10 +120,9 @@ func (c *chartSubscriber) ValidateSubscription(
 		errs = append(errs, err)
 	}
 
-	// Validate DiscoveryLimit: Minimum=1, Maximum=100
-	if sub.DiscoveryLimit < 1 {
-		errs = append(errs, field.Invalid(f.Child("discoveryLimit"), sub.DiscoveryLimit, "must be >= 1"))
-	} else if sub.DiscoveryLimit > 100 {
+	// Lower-bound validation is moved to base subscription validation
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit > 100 {
 		errs = append(errs, field.Invalid(f.Child("discoveryLimit"), sub.DiscoveryLimit, "must be <= 100"))
 	}
 
@@ -177,7 +171,14 @@ func (c *chartSubscriber) DiscoverArtifacts(
 		logger.Debug("found no credentials for chart repo")
 	}
 
-	selector, err := c.newSelectorFn(ctx, *chartSub, helmCreds)
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	discoveryLimit := sub.DiscoveryLimit
+	if discoveryLimit == 0 {
+		// Fallback to internal limit
+		discoveryLimit = chartSub.DiscoveryLimit
+	}
+
+	selector, err := c.newSelectorFn(ctx, *chartSub, int(discoveryLimit), helmCreds)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error obtaining selector for chart versions from helm chart repo %q: %w",
@@ -201,7 +202,7 @@ func (c *chartSubscriber) DiscoverArtifacts(
 		RepoURL:          chartSub.RepoURL,
 		Name:             chartSub.Name,
 		SemverConstraint: chartSub.SemverConstraint,
-		Versions:         trimSlice(versions, int(chartSub.DiscoveryLimit)),
+		Versions:         trimSlice(versions, int(discoveryLimit)),
 		SubscriptionName: sub.Name,
 	}, nil
 }

--- a/pkg/subscription/chart_test.go
+++ b/pkg/subscription/chart_test.go
@@ -17,13 +17,6 @@ import (
 func Test_chartSubscriber_ApplySubscriptionDefaults(t *testing.T) {
 	s := &chartSubscriber{}
 
-	t.Run("defaults discoveryLimit", func(t *testing.T) {
-		sub := &kargoapi.RepoSubscription{Chart: &kargoapi.ChartSubscription{}}
-		err := s.ApplySubscriptionDefaults(t.Context(), sub)
-		require.NoError(t, err)
-		require.Equal(t, int64(20), sub.Chart.DiscoveryLimit)
-	})
-
 	t.Run("preserves non-zero discoveryLimit", func(t *testing.T) {
 		sub := &kargoapi.RepoSubscription{Chart: &kargoapi.ChartSubscription{DiscoveryLimit: 13}}
 		err := s.ApplySubscriptionDefaults(t.Context(), sub)
@@ -147,16 +140,13 @@ func Test_chartSubscriber_ValidateSubscription(t *testing.T) {
 			},
 		},
 		{
-			name: "DiscoveryLimit too small",
+			name: "DiscoveryLimit lower bound is not validated",
 			sub: kargoapi.ChartSubscription{
 				RepoURL:        "oci://ghcr.io/example/chart",
 				DiscoveryLimit: 0,
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {
-				require.NotNil(t, errs)
-				require.True(t, len(errs) > 0)
-				require.Equal(t, "chart.discoveryLimit", errs[0].Field)
-				require.Equal(t, field.ErrorTypeInvalid, errs[0].Type)
+				require.Nil(t, errs)
 			},
 		},
 		{
@@ -271,6 +261,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					_ kargoapi.ChartSubscription,
+					_ int,
 					creds *helm.Credentials,
 				) (chart.Selector, error) {
 					require.NotNil(t, creds)
@@ -297,6 +288,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					_ kargoapi.ChartSubscription,
+					_ int,
 					creds *helm.Credentials,
 				) (chart.Selector, error) {
 					require.Nil(t, creds)
@@ -319,6 +311,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ChartSubscription,
+					int,
 					*helm.Credentials,
 				) (chart.Selector, error) {
 					return nil, errors.New("something went wrong")
@@ -338,6 +331,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ChartSubscription,
+					int,
 					*helm.Credentials,
 				) (chart.Selector, error) {
 					return &fakeChartSelector{
@@ -363,6 +357,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ChartSubscription,
+					int,
 					*helm.Credentials,
 				) (chart.Selector, error) {
 					return &fakeChartSelector{
@@ -384,12 +379,44 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 			},
 		},
 		{
+			// The Selector is entrusted with the whole subscription, discovery limit
+			// included, but the limit is enforced here regardless.
+			name: "discovered versions are trimmed to the repo sub discovery limit",
+			subscriber: &chartSubscriber{
+				credentialsDB: &credentials.FakeDB{},
+				newSelectorFn: func(
+					context.Context,
+					kargoapi.ChartSubscription,
+					int,
+					*helm.Credentials,
+				) (chart.Selector, error) {
+					return &fakeChartSelector{
+						selectFn: func(context.Context) ([]string, error) {
+							return []string{"3.0.0", "2.0.0", "1.0.0"}, nil
+						},
+					}, nil
+				},
+			},
+			sub: kargoapi.RepoSubscription{
+				DiscoveryLimit: 2,
+				Chart: &kargoapi.ChartSubscription{
+					RepoURL: "fake-url",
+				}},
+			assertions: func(t *testing.T, res any, err error) {
+				require.NoError(t, err)
+				result, ok := res.(kargoapi.ChartDiscoveryResult)
+				require.True(t, ok)
+				require.Equal(t, []string{"3.0.0", "2.0.0"}, result.Versions)
+			},
+		},
+		{
 			name: "success -- named subscription",
 			subscriber: &chartSubscriber{
 				credentialsDB: &credentials.FakeDB{},
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ChartSubscription,
+					int,
 					*helm.Credentials,
 				) (chart.Selector, error) {
 					return &fakeChartSelector{
@@ -400,12 +427,12 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				},
 			},
 			sub: kargoapi.RepoSubscription{
-				Name: "fake-sub",
+				Name:           "fake-sub",
+				DiscoveryLimit: 20,
 				Chart: &kargoapi.ChartSubscription{
 					RepoURL:          "fake-url",
 					Name:             "fake-chart",
 					SemverConstraint: "^1.0.0",
-					DiscoveryLimit:   20,
 				},
 			},
 			assertions: func(t *testing.T, res any, err error) {
@@ -430,6 +457,7 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ChartSubscription,
+					int,
 					*helm.Credentials,
 				) (chart.Selector, error) {
 					return &fakeChartSelector{
@@ -439,10 +467,11 @@ func Test_chartSubscriber_DiscoverArtifacts(t *testing.T) {
 					}, nil
 				},
 			},
-			sub: kargoapi.RepoSubscription{Chart: &kargoapi.ChartSubscription{
-				RepoURL:        "fake-url",
+			sub: kargoapi.RepoSubscription{
 				DiscoveryLimit: 20,
-			}},
+				Chart: &kargoapi.ChartSubscription{
+					RepoURL: "fake-url",
+				}},
 			assertions: func(t *testing.T, res any, err error) {
 				require.NoError(t, err)
 				result, ok := res.(kargoapi.ChartDiscoveryResult)

--- a/pkg/subscription/git.go
+++ b/pkg/subscription/git.go
@@ -39,6 +39,7 @@ type gitSubscriber struct {
 	newSelectorFn func(
 		ctx context.Context,
 		sub kargoapi.GitSubscription,
+		discoveryLimit int,
 		creds *git.RepoCredentials,
 	) (commit.Selector, error)
 }
@@ -84,9 +85,6 @@ func (g *gitSubscriber) ApplySubscriptionDefaults(
 	}
 	if sub.Git.StrictSemvers == nil {
 		sub.Git.StrictSemvers = ptr.To(true)
-	}
-	if sub.Git.DiscoveryLimit == 0 {
-		sub.Git.DiscoveryLimit = 20
 	}
 	return nil
 }
@@ -149,15 +147,9 @@ func (g *gitSubscriber) ValidateSubscription(
 	); err != nil {
 		errs = append(errs, err)
 	}
-
-	// Validate DiscoveryLimit: Minimum=1, Maximum=100
-	if sub.DiscoveryLimit < 1 {
-		errs = append(errs, field.Invalid(
-			f.Child("discoveryLimit"),
-			sub.DiscoveryLimit,
-			"must be >= 1",
-		))
-	} else if sub.DiscoveryLimit > 100 {
+	// Lower-bound validation is moved to base subscription validation
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit > 100 {
 		errs = append(errs, field.Invalid(
 			f.Child("discoveryLimit"),
 			sub.DiscoveryLimit,
@@ -223,7 +215,14 @@ func (g *gitSubscriber) DiscoverArtifacts(
 		logger.Debug("found no credentials for git repo")
 	}
 
-	selector, err := g.newSelectorFn(ctx, *gitSub, repoCreds)
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	discoveryLimit := sub.DiscoveryLimit
+	if discoveryLimit == 0 {
+		// Fallback to internal limit
+		discoveryLimit = gitSub.DiscoveryLimit
+	}
+
+	selector, err := g.newSelectorFn(ctx, *gitSub, int(discoveryLimit), repoCreds)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error obtaining selector for commits from git repo %q: %w",

--- a/pkg/subscription/git_test.go
+++ b/pkg/subscription/git_test.go
@@ -59,6 +59,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -96,6 +97,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -132,6 +134,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -165,6 +168,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -193,6 +197,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -227,6 +232,7 @@ func Test_gitSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.GitSubscription,
+					int,
 					*git.RepoCredentials,
 				) (commit.Selector, error) {
 					return &fakeSelector{
@@ -349,7 +355,6 @@ func Test_gitSubscriber_ApplySubscriptionDefaults(t *testing.T) {
 		require.Equal(t, kargoapi.CommitSelectionStrategyNewestFromBranch, sub.Git.CommitSelectionStrategy)
 		require.NotNil(t, sub.Git.StrictSemvers)
 		require.True(t, *sub.Git.StrictSemvers)
-		require.Equal(t, int64(20), sub.Git.DiscoveryLimit)
 	})
 
 	t.Run("preserves non-zero values", func(t *testing.T) {
@@ -556,16 +561,13 @@ func Test_gitSubscriber_ValidateSubscription(t *testing.T) {
 			},
 		},
 		{
-			name: "DiscoveryLimit too small",
+			name: "DiscoveryLimit too lower bound is not validated",
 			sub: kargoapi.GitSubscription{
 				RepoURL:        "https://github.com/akuity/kargo.git",
 				DiscoveryLimit: 0,
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {
-				require.NotNil(t, errs)
-				require.True(t, len(errs) > 0)
-				require.Equal(t, "git.discoveryLimit", errs[0].Field)
-				require.Equal(t, field.ErrorTypeInvalid, errs[0].Type)
+				require.Nil(t, errs)
 			},
 		},
 		{

--- a/pkg/subscription/image.go
+++ b/pkg/subscription/image.go
@@ -65,6 +65,7 @@ type imageSubscriber struct {
 	newSelectorFn func(
 		ctx context.Context,
 		sub kargoapi.ImageSubscription,
+		discoveryLimit int,
 		creds *image.Credentials,
 	) (image.Selector, error)
 }
@@ -100,9 +101,6 @@ func (i *imageSubscriber) ApplySubscriptionDefaults(
 	}
 	if sub.Image.StrictSemvers == nil {
 		sub.Image.StrictSemvers = ptr.To(true)
-	}
-	if sub.Image.DiscoveryLimit == 0 {
-		sub.Image.DiscoveryLimit = 20
 	}
 	return nil
 }
@@ -200,14 +198,9 @@ func (i *imageSubscriber) ValidateSubscription(
 		)
 	}
 
-	// Validate DiscoveryLimit: Minimum=1, Maximum=100
-	if sub.DiscoveryLimit < 1 {
-		errs = append(errs, field.Invalid(
-			f.Child("discoveryLimit"),
-			sub.DiscoveryLimit,
-			"must be >= 1",
-		))
-	} else if sub.DiscoveryLimit > 100 {
+	// Lower-bound validation is moved to base subscription validation
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit > 100 {
 		errs = append(errs, field.Invalid(
 			f.Child("discoveryLimit"),
 			sub.DiscoveryLimit,
@@ -290,7 +283,14 @@ func (i *imageSubscriber) DiscoverArtifacts(
 		imgSub.CacheByTag = true
 	}
 
-	selector, err := i.newSelectorFn(ctx, *imgSub, regCreds)
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	discoveryLimit := sub.DiscoveryLimit
+	if discoveryLimit == 0 {
+		// Fallback to internal limit
+		discoveryLimit = imgSub.DiscoveryLimit
+	}
+
+	selector, err := i.newSelectorFn(ctx, *imgSub, int(discoveryLimit), regCreds)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error obtaining selector for image %q: %w",

--- a/pkg/subscription/image_test.go
+++ b/pkg/subscription/image_test.go
@@ -23,7 +23,6 @@ func Test_imageSubscriber_ApplySubscriptionDefaults(t *testing.T) {
 		require.Equal(t, kargoapi.ImageSelectionStrategySemVer, sub.Image.ImageSelectionStrategy)
 		require.NotNil(t, sub.Image.StrictSemvers)
 		require.True(t, *sub.Image.StrictSemvers)
-		require.Equal(t, int64(20), sub.Image.DiscoveryLimit)
 	})
 
 	t.Run("preserves non-zero values", func(t *testing.T) {
@@ -172,17 +171,14 @@ func Test_imageSubscriber_ValidateSubscription(t *testing.T) {
 			},
 		},
 		{
-			name: "DiscoveryLimit too small",
+			name: "DiscoveryLimit lower bound is not validated",
 			sub: kargoapi.ImageSubscription{
 				RepoURL:        "ghcr.io/akuity/kargo",
 				CacheByTag:     true,
 				DiscoveryLimit: 0,
 			},
 			assertions: func(t *testing.T, errs field.ErrorList) {
-				require.NotNil(t, errs)
-				require.True(t, len(errs) > 0)
-				require.Equal(t, "image.discoveryLimit", errs[0].Field)
-				require.Equal(t, field.ErrorTypeInvalid, errs[0].Type)
+				require.Nil(t, errs)
 			},
 		},
 		{
@@ -291,6 +287,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					_ kargoapi.ImageSubscription,
+					_ int,
 					creds *image.Credentials,
 				) (image.Selector, error) {
 					require.NotNil(t, creds)
@@ -317,6 +314,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					_ kargoapi.ImageSubscription,
+					_ int,
 					creds *image.Credentials,
 				) (image.Selector, error) {
 					require.Nil(t, creds)
@@ -342,6 +340,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					sub kargoapi.ImageSubscription,
+					_ int,
 					_ *image.Credentials,
 				) (image.Selector, error) {
 					require.False(t, sub.CacheByTag)
@@ -368,6 +367,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					sub kargoapi.ImageSubscription,
+					_ int,
 					_ *image.Credentials,
 				) (image.Selector, error) {
 					require.True(t, sub.CacheByTag)
@@ -406,6 +406,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					sub kargoapi.ImageSubscription,
+					_ int,
 					_ *image.Credentials,
 				) (image.Selector, error) {
 					require.True(t, sub.CacheByTag)
@@ -434,6 +435,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					_ context.Context,
 					sub kargoapi.ImageSubscription,
+					_ int,
 					_ *image.Credentials,
 				) (image.Selector, error) {
 					require.True(t, sub.CacheByTag)
@@ -456,6 +458,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ImageSubscription,
+					int,
 					*image.Credentials,
 				) (image.Selector, error) {
 					return nil, errors.New("something went wrong")
@@ -475,6 +478,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ImageSubscription,
+					int,
 					*image.Credentials,
 				) (image.Selector, error) {
 					return &fakeImageSelector{
@@ -498,6 +502,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ImageSubscription,
+					int,
 					*image.Credentials,
 				) (image.Selector, error) {
 					return &fakeImageSelector{
@@ -535,6 +540,7 @@ func Test_imageSubscriber_DiscoverArtifacts(t *testing.T) {
 				newSelectorFn: func(
 					context.Context,
 					kargoapi.ImageSubscription,
+					int,
 					*image.Credentials,
 				) (image.Selector, error) {
 					return &fakeImageSelector{

--- a/pkg/subscription/schemas/chart.json
+++ b/pkg/subscription/schemas/chart.json
@@ -21,7 +21,7 @@
         },
         "discoveryLimit": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 100,
             "default": 20,
             "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the chart field) instead."

--- a/pkg/subscription/schemas/chart.json
+++ b/pkg/subscription/schemas/chart.json
@@ -24,7 +24,7 @@
             "minimum": 1,
             "maximum": 100,
             "default": 20,
-            "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100."
+            "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the chart field) instead."
         },
         "insecureSkipTLSVerify": {
             "type": "boolean",

--- a/pkg/subscription/schemas/git.json
+++ b/pkg/subscription/schemas/git.json
@@ -89,7 +89,7 @@
             "minimum": 1,
             "maximum": 100,
             "default": 20,
-            "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100."
+            "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the git field) instead."
         },
         "since": {
             "type": "string",

--- a/pkg/subscription/schemas/git.json
+++ b/pkg/subscription/schemas/git.json
@@ -86,7 +86,7 @@
         },
         "discoveryLimit": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 100,
             "default": 20,
             "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the git field) instead."

--- a/pkg/subscription/schemas/image.json
+++ b/pkg/subscription/schemas/image.json
@@ -56,7 +56,7 @@
         },
         "discoveryLimit": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 100,
             "default": 20,
             "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the image field) instead."

--- a/pkg/subscription/schemas/image.json
+++ b/pkg/subscription/schemas/image.json
@@ -59,7 +59,7 @@
             "minimum": 1,
             "maximum": 100,
             "default": 20,
-            "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100."
+            "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the image field) instead."
         },
         "cacheByTag": {
             "type": "boolean",

--- a/pkg/webhook/external/refresh.go
+++ b/pkg/webhook/external/refresh.go
@@ -265,7 +265,13 @@ func shouldRefresh(
 	for _, s := range wh.Spec.InternalSubscriptions {
 		switch {
 		case s.Git != nil && urls.NormalizeGit(s.Git.RepoURL) == repoURL:
-			selector, err := commit.NewSelector(ctx, *s.Git, nil)
+			// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+			discoveryLimit := s.DiscoveryLimit
+			if discoveryLimit == 0 {
+				// Fallback to internal limit
+				discoveryLimit = s.Git.DiscoveryLimit
+			}
+			selector, err := commit.NewSelector(ctx, *s.Git, int(discoveryLimit), nil)
 			if err != nil {
 				return false, fmt.Errorf("error creating commit selector for Git subscription %q: %w",
 					s.Git.RepoURL, err,
@@ -276,7 +282,13 @@ func shouldRefresh(
 				return true, nil
 			}
 		case s.Image != nil && urls.NormalizeImage(s.Image.RepoURL) == repoURL:
-			selector, err := image.NewSelector(ctx, *s.Image, nil)
+			// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+			discoveryLimit := s.DiscoveryLimit
+			if discoveryLimit == 0 {
+				// Fallback to internal limit
+				discoveryLimit = s.Image.DiscoveryLimit
+			}
+			selector, err := image.NewSelector(ctx, *s.Image, int(discoveryLimit), nil)
 			if err != nil {
 				return false, fmt.Errorf("error creating image selector for Image subscription %q: %w",
 					s.Image.RepoURL, err,
@@ -286,7 +298,13 @@ func shouldRefresh(
 				return true, nil
 			}
 		case s.Chart != nil && urls.NormalizeChart(s.Chart.RepoURL) == repoURL:
-			selector, err := chart.NewSelector(ctx, *s.Chart, nil)
+			// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+			discoveryLimit := s.DiscoveryLimit
+			if discoveryLimit == 0 {
+				// Fallback to internal limit
+				discoveryLimit = s.Chart.DiscoveryLimit
+			}
+			selector, err := chart.NewSelector(ctx, *s.Chart, int(discoveryLimit), nil)
 			if err != nil {
 				return false, fmt.Errorf("error creating chart selector for Chart subscription %q: %w",
 					s.Chart.RepoURL, err,

--- a/pkg/webhook/kubernetes/warehouse/webhook.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook.go
@@ -52,7 +52,7 @@ func newWebhook(
 	}
 }
 
-const defaultDiscoveryLimit = int32(20)
+const defaultDiscoveryLimit = int64(20)
 
 func (w *webhook) Default(ctx context.Context, warehouse *kargoapi.Warehouse) error {
 	// Sync the shard label to the convenience shard field
@@ -77,12 +77,8 @@ func (w *webhook) Default(ctx context.Context, warehouse *kargoapi.Warehouse) er
 			return fmt.Errorf("error instantiating subscriber: %w", err)
 		}
 
-		// Default common elements of generic subscriptions
-		if sub.Subscription != nil {
-			if sub.Subscription.DiscoveryLimit == 0 {
-				sub.Subscription.DiscoveryLimit = defaultDiscoveryLimit
-			}
-		}
+		// Apply DiscoveryLimit defaults.
+		w.applyDiscoveryLimitDefaults(sub)
 
 		if err := subscriber.ApplySubscriptionDefaults(ctx, sub); err != nil {
 			return fmt.Errorf("error applying defaults to subscriptions: %w", err)
@@ -90,6 +86,29 @@ func (w *webhook) Default(ctx context.Context, warehouse *kargoapi.Warehouse) er
 	}
 
 	return nil
+}
+
+func (w *webhook) applyDiscoveryLimitDefaults(sub *kargoapi.RepoSubscription) {
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	subLimit := 0
+	switch {
+	case sub.Chart != nil:
+		subLimit = int(sub.Chart.DiscoveryLimit)
+	case sub.Git != nil:
+		subLimit = int(sub.Git.DiscoveryLimit)
+	case sub.Image != nil:
+		subLimit = int(sub.Image.DiscoveryLimit)
+	case sub.Subscription != nil:
+		subLimit = int(sub.Subscription.DiscoveryLimit)
+	}
+
+	// Subscription lower-level limit is not set, we can set a top-level default
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if subLimit == 0 {
+		if sub.DiscoveryLimit == 0 {
+			sub.DiscoveryLimit = defaultDiscoveryLimit
+		}
+	}
 }
 
 func (w *webhook) ValidateCreate(
@@ -194,28 +213,36 @@ func (w *webhook) validateSubs(
 
 func (w *webhook) validateSub(
 	ctx context.Context,
-	f *field.Path,
+	basePath *field.Path,
 	sub kargoapi.RepoSubscription,
 	seen uniqueSubSet,
 ) field.ErrorList {
+
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	innerDiscoveryLimit := 0
+	var subPath *field.Path
 	// A small bit of special-casing is required here because, unlike generic
 	// subscriptions, the original three subscription types do not have a field
 	// that indicates their type.
 	switch {
 	case sub.Chart != nil:
-		f = f.Child("chart")
+		subPath = basePath.Child("chart")
+		innerDiscoveryLimit = int(sub.Chart.DiscoveryLimit)
 	case sub.Git != nil:
-		f = f.Child("git")
+		subPath = basePath.Child("git")
+		innerDiscoveryLimit = int(sub.Git.DiscoveryLimit)
 	case sub.Image != nil:
-		f = f.Child("image")
+		subPath = basePath.Child("image")
+		innerDiscoveryLimit = int(sub.Image.DiscoveryLimit)
 	case sub.Subscription != nil:
-		f = f.Child(sub.Subscription.SubscriptionType)
+		subPath = basePath.Child(sub.Subscription.SubscriptionType)
+		innerDiscoveryLimit = int(sub.Subscription.DiscoveryLimit)
 	}
 
 	subReg, err := w.subscriberRegistry.Get(ctx, sub)
 	if err != nil {
 		return field.ErrorList{field.Invalid(
-			f,
+			subPath,
 			"",
 			fmt.Sprintf("subscriber registry lookup failed: %v", err),
 		)}
@@ -224,7 +251,7 @@ func (w *webhook) validateSub(
 	subscriber, err := subReg.Value(ctx, nil)
 	if err != nil {
 		return field.ErrorList{field.Invalid(
-			f,
+			subPath,
 			"",
 			fmt.Sprintf("subscriber instantiation failed: %v", err),
 		)}
@@ -232,19 +259,58 @@ func (w *webhook) validateSub(
 
 	var errs field.ErrorList
 
+	// Validate base level subscription
+	errs = append(errs, w.validateBaseSub(basePath, subPath, sub, innerDiscoveryLimit)...)
+
 	// Validate the common elements of generic subscriptions
 	if sub.Subscription != nil {
-		errs = append(errs, w.validateGenericSub(f, *sub.Subscription)...)
+		errs = append(errs, w.validateGenericSub(subPath, *sub.Subscription)...)
 	}
 
 	// Subscriber-specific validation
-	errs = append(errs, subscriber.ValidateSubscription(ctx, f, sub)...)
+	errs = append(errs, subscriber.ValidateSubscription(ctx, subPath, sub)...)
 
 	// Validate uniqueness
-	if err := seen.addSub(f, sub); err != nil {
+	if err := seen.addSub(basePath, sub); err != nil {
 		errs = append(errs, err)
 	}
 
+	return errs
+}
+
+func (w *webhook) validateBaseSub(
+	basePath *field.Path,
+	subPath *field.Path,
+	sub kargoapi.RepoSubscription,
+	innerDiscoveryLimit int,
+) field.ErrorList {
+	var errs field.ErrorList
+
+	// Prohibit both limits being set at the same time
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit != 0 && innerDiscoveryLimit != 0 {
+		errs = append(errs, field.Invalid(
+			subPath.Child("discoveryLimit"),
+			innerDiscoveryLimit,
+			"cannot be set at the same time as discoveryLimit at the subscription level",
+		))
+	}
+
+	// Validate top level DiscoveryLimit if inner limit is not set
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit < 1 && innerDiscoveryLimit < 1 {
+		errs = append(errs, field.Invalid(
+			basePath.Child("discoveryLimit"),
+			sub.DiscoveryLimit,
+			"must be >= 1",
+		))
+	} else if sub.DiscoveryLimit > 100 {
+		errs = append(errs, field.Invalid(
+			basePath.Child("discoveryLimit"),
+			sub.DiscoveryLimit,
+			"must be <= 100",
+		))
+	}
 	return errs
 }
 
@@ -263,14 +329,9 @@ func (w *webhook) validateGenericSub(
 		errs = append(errs, err)
 	}
 
-	// Validate DiscoveryLimit: Minimum=1, Maximum=100
-	if sub.DiscoveryLimit < 1 {
-		errs = append(errs, field.Invalid(
-			f.Child("discoveryLimit"),
-			sub.DiscoveryLimit,
-			"must be >= 1",
-		))
-	} else if sub.DiscoveryLimit > 100 {
+	// Lower-bound validation is moved to base subscription validation
+	// TODO: clean this up when removing DiscoveryLimits from specific subscriptions
+	if sub.DiscoveryLimit > 100 {
 		errs = append(errs, field.Invalid(
 			f.Child("discoveryLimit"),
 			sub.DiscoveryLimit,

--- a/pkg/webhook/kubernetes/warehouse/webhook_test.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook_test.go
@@ -121,7 +121,28 @@ func Test_webhook_Default(t *testing.T) {
 		require.False(t, ok)
 	})
 
-	t.Run("defaulting is delegated to subscribers", func(t *testing.T) {
+	t.Run("discovery limit default is set of RepoSubscription", func(t *testing.T) {
+		warehouse := &kargoapi.Warehouse{
+			Spec: kargoapi.WarehouseSpec{
+				InternalSubscriptions: []kargoapi.RepoSubscription{
+					// The one mock subscriber in the test registry will apply
+					// predicated changes to each of these subscriptions.
+					{Git: &kargoapi.GitSubscription{}},
+					{Image: &kargoapi.ImageSubscription{}},
+					{Chart: &kargoapi.ChartSubscription{}},
+					{Subscription: &kargoapi.Subscription{SubscriptionType: "fake"}},
+				},
+			},
+		}
+		err := w.Default(t.Context(), warehouse)
+		require.NoError(t, err)
+		const testDiscoveryLimit int64 = 20
+		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[0].DiscoveryLimit)
+		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[1].DiscoveryLimit)
+		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[2].DiscoveryLimit)
+	})
+
+	t.Run("defaulting in subscribers", func(t *testing.T) {
 		warehouse := &kargoapi.Warehouse{
 			Spec: kargoapi.WarehouseSpec{
 				InternalSubscriptions: []kargoapi.RepoSubscription{
@@ -141,23 +162,6 @@ func Test_webhook_Default(t *testing.T) {
 		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[1].Image.DiscoveryLimit)
 		require.Equal(t, testDiscoveryLimit, warehouse.Spec.InternalSubscriptions[2].Chart.DiscoveryLimit)
 		require.Equal(t, "fake", warehouse.Spec.InternalSubscriptions[3].Name)
-	})
-
-	t.Run("common elements of generic subscriptions are defaulted", func(t *testing.T) {
-		warehouse := &kargoapi.Warehouse{
-			Spec: kargoapi.WarehouseSpec{
-				InternalSubscriptions: []kargoapi.RepoSubscription{
-					{Subscription: &kargoapi.Subscription{SubscriptionType: "fake"}},
-				},
-			},
-		}
-		err := w.Default(t.Context(), warehouse)
-		require.NoError(t, err)
-		require.Equal(
-			t,
-			defaultDiscoveryLimit,
-			warehouse.Spec.InternalSubscriptions[0].Subscription.DiscoveryLimit,
-		)
 	})
 }
 
@@ -588,7 +592,7 @@ func TestValidateSpec(t *testing.T) {
 					fields[i] = err.Field
 				}
 				require.Contains(t, fields, "spec.subscriptions[0].name")
-				require.Contains(t, fields, "spec.subscriptions[0].fake.discoveryLimit")
+				require.Contains(t, fields, "spec.subscriptions[0].discoveryLimit")
 				require.Contains(t, fields, "spec.subscriptions[1].fake.discoveryLimit")
 			},
 		},

--- a/ui/src/extend/types.ts
+++ b/ui/src/extend/types.ts
@@ -48,6 +48,7 @@ export type Subscription = {
 
 export type RepoSubscription = {
   name?: string;
+  discoveryLimit?: number;
   git?: GitSubscription;
   image?: ImageSubscription;
   chart?: ChartSubscription;

--- a/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
+++ b/ui/src/features/project/pipelines/warehouse/repo-subscriptions.tsx
@@ -45,12 +45,12 @@ export const RepoSubscriptions = ({ subscriptions }: Props) => {
                 </Typography.Link>
               </Descriptions.Item>
 
-              {!!subscription?.chart?.discoveryLimit && (
+              {(!!subscription?.discoveryLimit || !!subscription?.chart?.discoveryLimit) && (
                 <Descriptions.Item
                   label='discovery limit'
                   styles={{ label: DescriptionsLabelStyle }}
                 >
-                  {subscription?.chart?.discoveryLimit}
+                  {subscription?.discoveryLimit || subscription?.chart?.discoveryLimit}
                 </Descriptions.Item>
               )}
 
@@ -82,12 +82,12 @@ export const RepoSubscriptions = ({ subscriptions }: Props) => {
                 </Typography.Link>
               </Descriptions.Item>
 
-              {!!subscription?.git?.discoveryLimit && (
+              {(!!subscription?.discoveryLimit || !!subscription?.git?.discoveryLimit) && (
                 <Descriptions.Item
                   label='discovery limit'
                   styles={{ label: DescriptionsLabelStyle }}
                 >
-                  {subscription?.git?.discoveryLimit}
+                  {subscription?.discoveryLimit || subscription?.git?.discoveryLimit}
                 </Descriptions.Item>
               )}
 
@@ -138,12 +138,12 @@ export const RepoSubscriptions = ({ subscriptions }: Props) => {
                 </Typography.Link>
               </Descriptions.Item>
 
-              {!!subscription?.image?.discoveryLimit && (
+              {(!!subscription?.discoveryLimit || !!subscription?.image?.discoveryLimit) && (
                 <Descriptions.Item
                   label='discovery limit'
                   styles={{ label: DescriptionsLabelStyle }}
                 >
-                  {subscription?.image?.discoveryLimit}
+                  {subscription?.discoveryLimit || subscription?.image?.discoveryLimit}
                 </Descriptions.Item>
               )}
 
@@ -180,7 +180,7 @@ export const RepoSubscriptions = ({ subscriptions }: Props) => {
                 {subscription.subscription.subscriptionType}
               </Descriptions.Item>
               <Descriptions.Item label='discovery limit'>
-                {subscription.subscription.discoveryLimit}
+                {subscription?.discoveryLimit || subscription?.subscription?.discoveryLimit}
               </Descriptions.Item>
             </Descriptions>
           )}

--- a/ui/src/features/stage/create-warehouse/subscription-wizard.tsx
+++ b/ui/src/features/stage/create-warehouse/subscription-wizard.tsx
@@ -3,7 +3,7 @@ import { faEye, faTrash, IconDefinition } from '@fortawesome/free-solid-svg-icon
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Form from '@rjsf/antd';
 import validator from '@rjsf/validator-ajv8';
-import { Button, Card, Collapse, Input, Modal, Select, Tag, Typography } from 'antd';
+import { Button, Card, Collapse, Input, InputNumber, Modal, Select, Tag, Typography } from 'antd';
 import AntdFormLabel from 'antd/es/form/FormItemLabel';
 import classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
@@ -33,6 +33,8 @@ export const SubscriptionWizard = (props: {
   );
 
   const [name, setName] = useState('');
+
+  const [discoveryLimit, setDiscoveryLimit] = useState<number | null>(null);
 
   return (
     <>
@@ -75,6 +77,21 @@ export const SubscriptionWizard = (props: {
               placeholder='Optional'
             />
           </div>
+          <div>
+            <AntdFormLabel
+              prefixCls=''
+              label='Discovery Limit'
+              htmlFor='subscription-discovery-limit'
+            />
+            <InputNumber
+              id='subscription-discovery-limit'
+              className='mt-2 w-full'
+              min={1}
+              value={discoveryLimit}
+              onChange={(value) => setDiscoveryLimit(value)}
+              placeholder='Optional'
+            />
+          </div>
           <Collapse
             items={[
               {
@@ -104,10 +121,12 @@ export const SubscriptionWizard = (props: {
                         ...props.subscriptions,
                         {
                           ...(name ? { name } : {}),
+                          ...(discoveryLimit ? { discoveryLimit } : {}),
                           [selectedNewSubscription]: data.formData
                         }
                       ]);
                       setName('');
+                      setDiscoveryLimit(null);
                     }}
                   >
                     <Button htmlType='submit' icon={<IconSetByKargoTerminology.subscription />}>
@@ -132,8 +151,9 @@ SubscriptionWizard.Subscription = (props: {
   let icon: IconDefinition | null = null;
 
   // one of git, image or chart
-  const subscriptionType = (Object.keys(props.subscription).filter((k) => k !== 'name')[0] ||
-    '') as keyof RepoSubscription | '';
+  const subscriptionType = (Object.keys(props.subscription).filter(
+    (k) => k !== 'name' && k !== 'discoveryLimit'
+  )[0] || '') as keyof RepoSubscription | '';
 
   if (subscriptionType === '') {
     return <Tag color='red'>Corrupt Subscription! Please Check YAML</Tag>;

--- a/ui/src/gen/subscriptions/chart.json
+++ b/ui/src/gen/subscriptions/chart.json
@@ -20,7 +20,7 @@
   },
   "discoveryLimit": {
    "type": "integer",
-   "minimum": 1,
+   "minimum": 0,
    "maximum": 100,
    "default": 20,
    "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the chart field) instead."

--- a/ui/src/gen/subscriptions/chart.json
+++ b/ui/src/gen/subscriptions/chart.json
@@ -23,7 +23,7 @@
    "minimum": 1,
    "maximum": 100,
    "default": 20,
-   "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100."
+   "description": "DiscoveryLimit is an optional limit on the number of chart versions that can be discovered for this subscription. The limit is applied after filtering charts based on the semverConstraint field. The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the chart field) instead."
   },
   "insecureSkipTLSVerify": {
    "type": "boolean",

--- a/ui/src/gen/subscriptions/git.json
+++ b/ui/src/gen/subscriptions/git.json
@@ -93,7 +93,7 @@
    "minimum": 1,
    "maximum": 100,
    "default": 20,
-   "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100."
+   "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the git field) instead."
   },
   "since": {
    "type": "string",

--- a/ui/src/gen/subscriptions/git.json
+++ b/ui/src/gen/subscriptions/git.json
@@ -90,7 +90,7 @@
   },
   "discoveryLimit": {
    "type": "integer",
-   "minimum": 1,
+   "minimum": 0,
    "maximum": 100,
    "default": 20,
    "description": "DiscoveryLimit is an optional limit on the number of commits that can be discovered for this subscription. The upper limit is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the git field) instead."

--- a/ui/src/gen/subscriptions/image.json
+++ b/ui/src/gen/subscriptions/image.json
@@ -66,7 +66,7 @@
   },
   "discoveryLimit": {
    "type": "integer",
-   "minimum": 1,
+   "minimum": 0,
    "maximum": 100,
    "default": 20,
    "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the image field) instead."

--- a/ui/src/gen/subscriptions/image.json
+++ b/ui/src/gen/subscriptions/image.json
@@ -69,7 +69,7 @@
    "minimum": 1,
    "maximum": 100,
    "default": 20,
-   "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100."
+   "description": "DiscoveryLimit is an optional limit on the number of image references that can be discovered for this subscription. The limit is applied after filtering images based on the AllowTagsRegexes and IgnoreTagsRegexes fields. When left unspecified, the field is implicitly treated as if its value were \"20\". The upper limit for this field is 100. Deprecated: Set discoveryLimit on the subscription (as a sibling of the image field) instead."
   },
   "cacheByTag": {
    "type": "boolean",


### PR DESCRIPTION
Implements https://github.com/akuity/kargo/issues/6723

#### Changes:
- New DiscoveryLimit field in RepoSubscription.
- Added deprecation comment for DiscoveryLimit in specific subscription types

#### Defaulting webhook:
- If specific type limit is set, do not set RepoSubscription default
- Removed setting defaults for specific types

#### Validating webhook:
- RepoSubscription limit check for 0 is conditional on specific type value being
- Removed specific type limit check for 0

#### Execution:
- Using the RepoSubscription DiscoveryLimit with a fallback to the specific type DiscoveryLimit if the RepoSubscriptions value is 0.
- Added an argument for NewSelector functions for all subscription implementations.

