### PR TITLE
fix: isolate kustomize OpenAPI schema state

### DIFF
--- a/pkg/promotion/runner/builtin/kustomize_builder.go
+++ b/pkg/promotion/runner/builtin/kustomize_builder.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resource"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/yaml"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
@@ -144,6 +145,11 @@ func (k *kustomizeBuilder) writeResult(rm resmap.ResMap, outPath string, outputF
 func kustomizeBuild(kusFS filesys.FileSystem, path string, pluginCfg *builtin.Plugin) (_ resmap.ResMap, err error) {
 	kustomizeRenderMutex.Lock()
 	defer kustomizeRenderMutex.Unlock()
+
+	// Kustomize stores custom OpenAPI schemas in package-level state. Reset it
+	// before and after every build to isolate independent Promotion steps.
+	openapi.ResetOpenAPI()
+	defer openapi.ResetOpenAPI()
 
 	// Kustomize can panic in unpredicted ways due to (accidental)
 	// invalid object data; recover when this happens to ensure

--- a/pkg/promotion/runner/builtin/kustomize_builder_test.go
+++ b/pkg/promotion/runner/builtin/kustomize_builder_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/utils/ptr"
+	kustfilesys "sigs.k8s.io/kustomize/kyaml/filesys"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/io/fs"
@@ -474,4 +475,107 @@ metadata:
 			tt.assertions(t, tempDir, result, err)
 		})
 	}
+}
+
+func Test_kustomizeBuild_resetsOpenAPIBetweenBuilds(t *testing.T) {
+	kusFS := kustfilesys.MakeFsOnDisk()
+
+	firstDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(firstDir, "kustomization.yaml"), []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- configmap.yaml
+openapi:
+  path: schema.json
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(firstDir, "configmap.yaml"), []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: first-build
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(firstDir, "schema.json"), []byte(`
+{"definitions": {}}
+`), 0o600))
+
+	_, err := kustomizeBuild(kusFS, firstDir, nil)
+	require.NoError(t, err)
+
+	secondDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(secondDir, "component"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(secondDir, "kustomization.yaml"), []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- widget.yaml
+components:
+- component
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(secondDir, "widget.yaml"), []byte(`
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: example
+spec:
+  items:
+  - name: item
+    value: preserved
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(secondDir, "component", "kustomization.yaml"), []byte(`
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+openapi:
+  path: schema.json
+patches:
+- path: patch.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(secondDir, "component", "patch.yaml"), []byte(`
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: example
+spec:
+  items:
+  - name: item
+    changed: true
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(secondDir, "component", "schema.json"), []byte(`
+{
+  "definitions": {
+    "example.com.v1.Widget": {
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "example.com",
+          "version": "v1",
+          "kind": "Widget"
+        }
+      ],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "x-kubernetes-patch-merge-key": "name",
+              "x-kubernetes-patch-strategy": "merge"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`), 0o600))
+
+	rm, err := kustomizeBuild(kusFS, secondDir, nil)
+	require.NoError(t, err)
+	result, err := rm.AsYaml()
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "value: preserved")
+	assert.Contains(t, string(result), "changed: true")
 }


### PR DESCRIPTION
## Summary
- reset Kustomize's process-global OpenAPI schema state around each serialized build
- prevent independent `kustomize-build` Promotion steps from influencing later renders
- add regression coverage for schemas loaded from nested components

Closes #7028

## Test plan
- [x] Regression test passes with the fix and fails without it
- [x] Non-Helm Kustomize builder tests
- [x] Regression test with the race detector
- [x] `go vet ./pkg/promotion/runner/builtin`
- [ ] Full package test locally; the existing Helm test invokes a Helm 3 flag that local Helm 4.1.3 rejects

## Checklist
- [x] Linked to an eligible existing issue
- [x] Adds corresponding tests
- [x] All commits are signed off
- [x] Written by AI with human supervision; human review completed after opening