### PR TITLE
refactor(ui): share one presentation per Promotion phase

### DIFF
--- a/ui/src/features/common/promotion-status/promotion-phase.test.ts
+++ b/ui/src/features/common/promotion-status/promotion-phase.test.ts
@@ -1,0 +1,53 @@
+import { faCircleExclamation, faHourglassStart } from '@fortawesome/free-solid-svg-icons';
+import { describe, expect, test } from 'vitest';
+
+import {
+  getPromotionPhasePresentation,
+  isPromotionPhase,
+  promotionPhasePresentations,
+  promotionPhases
+} from './promotion-phase';
+
+describe('isPromotionPhase()', () => {
+  test.each([
+    ['Succeeded', true],
+    ['Aborted', true],
+    ['succeeded', false],
+    ['Unknown', false],
+    ['', false],
+    [undefined, false]
+  ])('%s -> %s', (phase, expected) => {
+    expect(isPromotionPhase(phase)).toBe(expected);
+  });
+});
+
+describe('getPromotionPhasePresentation()', () => {
+  test('returns the presentation for a known phase', () => {
+    expect(getPromotionPhasePresentation('Running')).toBe(promotionPhasePresentations.Running);
+  });
+
+  test('Failed and Errored look alike', () => {
+    const errored = getPromotionPhasePresentation('Errored');
+    expect(errored.icon).toBe(faCircleExclamation);
+    expect(errored.tagColor).toBe('error');
+    expect(getPromotionPhasePresentation('Failed')).toEqual(errored);
+  });
+
+  test.each([undefined, '', 'Unknown'])('%s falls back to Pending', (phase) => {
+    const presentation = getPromotionPhasePresentation(phase);
+    expect(presentation).toBe(promotionPhasePresentations.Pending);
+    expect(presentation.icon).toBe(faHourglassStart);
+    expect(presentation.spin).toBe(false);
+  });
+
+  test('only Running spins', () => {
+    const spinning = promotionPhases.filter((phase) => getPromotionPhasePresentation(phase).spin);
+    expect(spinning).toEqual(['Running']);
+  });
+});
+
+describe('promotionPhases', () => {
+  test('covers every phase exactly once', () => {
+    expect([...promotionPhases].sort()).toEqual(Object.keys(promotionPhasePresentations).sort());
+  });
+});

--- a/ui/src/features/common/promotion-status/promotion-phase.ts
+++ b/ui/src/features/common/promotion-status/promotion-phase.ts
@@ -1,0 +1,65 @@
+import {
+  IconDefinition,
+  faCancel,
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleNotch,
+  faHourglassStart
+} from '@fortawesome/free-solid-svg-icons';
+import { theme } from 'antd';
+
+// PromotionPhase mirrors PromotionPhase on the back end. A PromotionRequest's
+// summary counts child Promotions by these same phases, so both the Promotion
+// and PromotionRequest UIs present them with one shared vocabulary.
+export type PromotionPhase = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Errored' | 'Aborted';
+
+export type PromotionPhasePresentation = {
+  icon: IconDefinition;
+  // iconColor is applied to a standalone FontAwesome icon.
+  iconColor: string;
+  // tagColor is an Ant Design Tag preset.
+  tagColor: 'default' | 'processing' | 'success' | 'error';
+  spin: boolean;
+};
+
+const neutral = { iconColor: 'aaa', tagColor: 'default', spin: false } as const;
+
+const failed: PromotionPhasePresentation = {
+  icon: faCircleExclamation,
+  iconColor: theme.defaultSeed.colorError,
+  tagColor: 'error',
+  spin: false
+};
+
+export const promotionPhasePresentations: Record<PromotionPhase, PromotionPhasePresentation> = {
+  Pending: { ...neutral, icon: faHourglassStart },
+  Running: { ...neutral, icon: faCircleNotch, tagColor: 'processing', spin: true },
+  Succeeded: {
+    icon: faCircleCheck,
+    iconColor: theme.defaultSeed.colorSuccess,
+    tagColor: 'success',
+    spin: false
+  },
+  Failed: failed,
+  Errored: failed,
+  Aborted: { ...neutral, icon: faCancel }
+};
+
+// promotionPhases lists every phase in the order a summary should present
+// them: what went well, what is still happening, then what did not.
+export const promotionPhases: readonly PromotionPhase[] = [
+  'Succeeded',
+  'Running',
+  'Pending',
+  'Failed',
+  'Errored',
+  'Aborted'
+];
+
+export const isPromotionPhase = (phase?: string): phase is PromotionPhase =>
+  !!phase && phase in promotionPhasePresentations;
+
+// getPromotionPhasePresentation treats an unset or unknown phase as Pending,
+// which is what a Promotion is until the controller says otherwise.
+export const getPromotionPhasePresentation = (phase?: string): PromotionPhasePresentation =>
+  promotionPhasePresentations[isPromotionPhase(phase) ? phase : 'Pending'];

--- a/ui/src/features/common/promotion-status/promotion-status-icon.tsx
+++ b/ui/src/features/common/promotion-status/promotion-status-icon.tsx
@@ -1,14 +1,7 @@
-import {
-  faCancel,
-  faCircleCheck,
-  faCircleExclamation,
-  faCircleNotch,
-  faHourglassStart
-} from '@fortawesome/free-solid-svg-icons';
-import { theme } from 'antd';
-
 import { MessageTooltip } from '@ui/features/project/pipelines/message-tooltip';
 import { PromotionStatus } from '@ui/gen/api/v2/models';
+
+import { getPromotionPhasePresentation } from './promotion-phase';
 
 const PhaseAndMessage = ({ status }: { status: PromotionStatus }) => (
   <div>
@@ -30,37 +23,13 @@ export const PromotionStatusIcon = ({
   if (!status) {
     return null;
   }
-  const message = <PhaseAndMessage status={status} />;
-  let icon = faHourglassStart;
-  let defaultColor = 'aaa';
-  let spin = false;
-  switch (status?.phase) {
-    case 'Succeeded':
-      icon = faCircleCheck;
-      defaultColor = theme.defaultSeed.colorSuccess;
-      break;
-    case 'Failed':
-    case 'Errored':
-      icon = faCircleExclamation;
-      defaultColor = theme.defaultSeed.colorError;
-      break;
-    case 'Running':
-      icon = faCircleNotch;
-      spin = true;
-      break;
-    case 'Aborted':
-      icon = faCancel;
-      break;
-    case 'Pending':
-    default:
-      break;
-  }
+  const { icon, iconColor, spin } = getPromotionPhasePresentation(status.phase);
 
   return (
     <MessageTooltip
-      message={message}
+      message={<PhaseAndMessage status={status} />}
       icon={icon}
-      iconColor={color ? color : defaultColor}
+      iconColor={color ? color : iconColor}
       spin={spin}
       {...props}
     />

--- a/ui/src/features/stage/promotion-requests.tsx
+++ b/ui/src/features/stage/promotion-requests.tsx
@@ -1,11 +1,4 @@
-import {
-  faBullseye,
-  faCancel,
-  faCircleCheck,
-  faCircleExclamation,
-  faCircleNotch,
-  faHourglassStart
-} from '@fortawesome/free-solid-svg-icons';
+import { faBullseye, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert, Flex, Table, Tag, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
@@ -14,10 +7,14 @@ import { useMemo, useState } from 'react';
 import { Link, generatePath, useParams } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
+import {
+  getPromotionPhasePresentation,
+  promotionPhases
+} from '@ui/features/common/promotion-status/promotion-phase';
 import { PromotionStatusIcon } from '@ui/features/common/promotion-status/promotion-status-icon';
 import { getAlias, getShortFreightLabel } from '@ui/features/common/utils';
 import { useListPromotionRequests } from '@ui/gen/api/v2/core/core';
-import { PromotionRequest } from '@ui/gen/api/v2/models';
+import { PromotionRequest, PromotionRequestSummary } from '@ui/gen/api/v2/models';
 import { parseDate } from '@ui/utils/dates';
 
 import { Promotion as PromotionComponent } from '../project/pipelines/promotion/promotion';
@@ -32,28 +29,9 @@ import {
   targetRows
 } from './utils/promotion-request';
 
-const phaseTagColor = (phase?: string) => {
-  switch (phase) {
-    case 'Succeeded':
-      return 'success';
-    case 'Running':
-      return 'processing';
-    case 'Failed':
-    case 'Errored':
-      return 'error';
-    default:
-      return 'default';
-  }
-};
-
-const summaryPhases = [
-  { key: 'succeeded', label: 'succeeded', color: 'success', icon: faCircleCheck },
-  { key: 'running', label: 'running', color: 'processing', icon: faCircleNotch, spin: true },
-  { key: 'pending', label: 'pending', color: 'default', icon: faHourglassStart },
-  { key: 'failed', label: 'failed', color: 'error', icon: faCircleExclamation },
-  { key: 'errored', label: 'errored', color: 'error', icon: faCircleExclamation },
-  { key: 'aborted', label: 'aborted', color: 'default', icon: faCancel }
-] as const;
+// summaryKey maps a phase to its counter in status.summary, whose fields are
+// the lower-cased phase names.
+const summaryKey = (phase: string) => phase.toLowerCase() as keyof PromotionRequestSummary;
 
 // TargetSummary compresses status.summary into one chip per non-zero phase. A
 // request the controller has not yet acted on has no summary, in which case
@@ -74,21 +52,20 @@ const TargetSummary = ({ promotionRequest }: { promotionRequest: PromotionReques
 
   return (
     <Flex gap={4} wrap>
-      {summaryPhases.map((summaryPhase) => {
-        const { key, label, color, icon } = summaryPhase;
-        const count = summary?.[key] ?? (!summary && key === 'pending' ? targetCount : 0);
+      {promotionPhases.map((phase) => {
+        const { icon, tagColor, spin } = getPromotionPhasePresentation(phase);
+        const count =
+          summary?.[summaryKey(phase)] ?? (!summary && phase === 'Pending' ? targetCount : 0);
         if (!count) {
           return null;
         }
-        const description = `${count} ${label} Target${count === 1 ? '' : 's'}`;
+        const description = `${count} ${phase.toLowerCase()} Target${count === 1 ? '' : 's'}`;
         return (
-          <Tooltip key={key} title={description}>
+          <Tooltip key={phase} title={description}>
             <Tag
               className='m-0'
-              color={color}
-              icon={
-                <FontAwesomeIcon icon={icon} spin={'spin' in summaryPhase && summaryPhase.spin} />
-              }
+              color={tagColor}
+              icon={<FontAwesomeIcon icon={icon} spin={spin} />}
               aria-label={description}
             >
               {count}
@@ -202,7 +179,9 @@ export const PromotionRequests = ({ projectName, stageName }: Props) => {
       width: 110,
       render: (_, promotionRequest) => {
         const phase = promotionRequest?.status?.phase;
-        return <Tag color={phaseTagColor(phase)}>{phase || 'Pending'}</Tag>;
+        return (
+          <Tag color={getPromotionPhasePresentation(phase).tagColor}>{phase || 'Pending'}</Tag>
+        );
       }
     },
     {


### PR DESCRIPTION
## Description

Follows up on review feedback on #7004, where @rpelczar pointed out that the
PromotionRequests table defined its own phase-to-icon mapping alongside the one
already in `promotion-status-icon.tsx`.

`PromotionStatusIcon` and the PromotionRequests table each carried a mapping
from a Promotion phase to an icon and color. A PromotionRequest's summary counts
child Promotions by the very same phases, so the two mappings had to agree and
nothing enforced that.

This moves the mapping into `promotion-phase.ts`, where each phase has one
icon, one standalone icon color, one Ant Design Tag preset, and whether it
spins. `PromotionStatusIcon` looks its icon up there, and the PromotionRequests
table derives both its phase Tag and its per-phase Target summary chips from
the same table. Unknown or unset phases still present as Pending, matching the
old switch's default. No visual change is intended.

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
