### PR TITLE
chore(deps): bump Go to 1.27.1

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -17,7 +17,7 @@ inputs:
     # Jobs that run the linter, the unit tests, or codegen must instead pass
     # the `goTestVersion` anchor defined in .github/workflows/ci.yaml, which is
     # capped by the golangci-lint version pinned in hack/tools.mk.
-    default: "1.27.0"
+    default: "1.27.1"
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       # defines.
       uses: ./.github/actions/setup-go
       with:
-        go-version: &goTestVersion "1.27.0"
+        go-version: &goTestVersion "1.27.1"
     - name: Run unit tests
       run: make test-unit
     - name: Remove generated code from report

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production
 # started on may itself reach EOL. Building on the latest minor keeps released
 # binaries off unsupported toolchains and picks up fixes for CVEs in the Go
 # standard library.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -91,7 +91,7 @@ WORKDIR /kargo/bin
 #
 # As with the back-end-builder stage above, always use the latest minor version
 # of Go for anything we ship.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS helm-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS helm-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@
 #
 # This version must match the `goTestVersion` anchor in
 # .github/workflows/ci.yaml.
-FROM golang:1.27.0-trixie
+FROM golang:1.27.1-trixie
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Both Go roles land on 1.27.1 here: shipped artifacts always track the latest stable Go, and `go 1.27.0` in `go.mod` caps the test toolchain at the 1.27 minor, whose latest patch is also 1.27.1.

See #7011 for the two roles and why they are pinned separately.