### PR TITLE
chore(deps): bump Go to 1.27.1 and CI Go to 1.26.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       # requiring code or configuration changes.
       #
       # This version must match the base image in Dockerfile.dev.
-      image: &golangTestImage golang:1.26.7-trixie
+      image: &golangTestImage golang:1.26.8-trixie
     steps:
     # Install Git from "trixie" repository to get a more recent version than
     # the one available in "stable". This can be removed once the version in
@@ -336,7 +336,7 @@ jobs:
     container:
       # Always use the latest minor version of Go for anything we ship -- see
       # the back-end-builder stage in Dockerfile for why.
-      image: golang:1.27.0-trixie
+      image: golang:1.27.1-trixie
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: '1.27.0'
+        go-version: '1.27.1'
     - name: Set version for unstable builds
       id: unstable-version
       run: |
@@ -245,7 +245,7 @@ jobs:
     container:
       # Always use the latest minor version of Go for anything we ship -- see
       # the back-end-builder stage in Dockerfile for why.
-      image: &golangImage golang:1.27.0-trixie
+      image: &golangImage golang:1.27.1-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store NODE_ENV='production
 # started on may itself reach EOL. Building on the latest minor keeps released
 # binaries off unsupported toolchains and picks up fixes for CVEs in the Go
 # standard library.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -91,7 +91,7 @@ WORKDIR /kargo/bin
 #
 # As with the back-end-builder stage above, always use the latest minor version
 # of Go for anything we ship.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS helm-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS helm-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,7 +8,7 @@
 #
 # This version must match the `golangTestImage` anchor in
 # .github/workflows/ci.yaml.
-FROM golang:1.26.7-trixie
+FROM golang:1.26.8-trixie
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Ship-side Go to 1.27.1, the latest stable release. The toolchain that runs unit tests, linters, and codegen goes to 1.26.8, the latest patch of the 1.26 minor that this branch's `go.mod` caps it at.

See #7011 for the two roles and why they are pinned separately.