### PR TITLE
chore(deps): bump Go to 1.27.1 for shipped artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
     container:
       # Always use the latest minor version of Go for anything we ship -- see
       # the back-end-builder stage in Dockerfile for why.
-      image: golang:1.27.0-trixie
+      image: golang:1.27.1-trixie
     steps:
     - name: Checkout code
       uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
-        go-version: '1.27.0'
+        go-version: '1.27.1'
     - name: Set version for unstable builds
       id: unstable-version
       run: |
@@ -215,7 +215,7 @@ jobs:
     container:
       # Always use the latest minor version of Go for anything we ship -- see
       # the back-end-builder stage in Dockerfile for why.
-      image: &golangImage golang:1.27.0-trixie
+      image: &golangImage golang:1.27.1-trixie
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN NODE_ENV='production' VERSION=${VERSION} pnpm run build
 # started on may itself reach EOL. Building on the latest minor keeps released
 # binaries off unsupported toolchains and picks up fixes for CVEs in the Go
 # standard library.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS back-end-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS back-end-builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -88,7 +88,7 @@ WORKDIR /kargo/bin
 #
 # As with the back-end-builder stage above, always use the latest minor version
 # of Go for anything we ship.
-FROM --platform=$BUILDPLATFORM golang:1.27.0-trixie AS helm-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-trixie AS helm-builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Ship-side Go only. The test toolchain is capped at the 1.25 minor by this branch's `go.mod`, and 1.25.14 is already the latest patch there.

Supersedes #7045, which got the two `Dockerfile` stages right but also raised `Dockerfile.dev` across two minors to 1.27.1 -- breaking the pinned golangci-lint and desyncing it from the `golangTestImage` anchor -- while missing the ship-side pins in the workflows.

See #7011 for the two roles and why they are pinned separately.