### PR TITLE
chore: stop letting dependabot bump Go

### DIFF
--- a/.claude/skills/update-go/SKILL.md
+++ b/.claude/skills/update-go/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: update-go
+description: Bump every pinned Go toolchain version on one or more branches, respecting the ship/test split
+disable-model-invocation: true
+---
+
+Raise the Go versions pinned across a branch's Dockerfiles and workflows, on
+one or more branches at a time, then hand the user a script that commits,
+pushes, and opens the pull requests.
+
+Dependabot cannot do this. Its `docker` ecosystem sees only `Dockerfile` and
+`Dockerfile.dev`; it cannot see the `container.image` pins in the workflows,
+and it cannot tell the two roles below apart. That is why Go is excluded from
+`.github/dependabot.yml` and why this skill exists.
+
+## The two roles
+
+Every Go version pin in this repository serves exactly one of two roles. The
+comments at each site say which. **Read the comment before editing the line.**
+
+| Role | Target version | Why |
+|------|----------------|-----|
+| **ship** | latest stable Go, period | A release branch outlives the Go minor it was cut on. Building on the latest minor keeps released binaries off unsupported toolchains and picks up Go stdlib CVE fixes. |
+| **test** | latest patch **within the minor named by the root `go.mod` `go` directive** | Unit tests, linters, and codegen run here. The minor is capped: a golangci-lint binary built with go1.X hard-panics under go1.(X+1). |
+
+**Never raise the test minor.** Patch bumps inside a minor are always safe. A
+minor raise forces a golangci-lint upgrade, which surfaces new findings needing
+code or config changes -- a separate, human-driven change. Root `go.mod`'s `go`
+directive is the authority on which minor the branch tests against; if the test
+sites disagree with it, stop and report rather than guessing.
+
+## Site inventory
+
+The layout differs by branch, so **discover, do not assume**. Sites seen so
+far:
+
+**ship**
+- `Dockerfile` -- every `FROM ... golang:<ver>-<variant>` stage
+  (`back-end-builder`, `helm-builder`)
+- `.github/workflows/release.yaml` -- `image: &golangImage golang:<ver>-...`
+  and the `actions/setup-go` step's `go-version:`
+- `.github/workflows/ci.yaml` -- the `build-cli` job's `container.image`
+- `.github/actions/setup-go/action.yaml` -- the `go-version` input `default:`
+  (this action's default *is* the ship version; jobs that test override it)
+
+**test**
+- `Dockerfile.dev` -- the `FROM golang:<ver>-<variant>` base image
+- `.github/workflows/ci.yaml` -- `go-version: &goTestVersion "<ver>"` or
+  `image: &golangTestImage golang:<ver>-<variant>`, depending on branch
+
+**Out of scope.** Do not touch:
+- `go`/`toolchain` directives in any `go.mod`. The `go` directive is a language
+  floor, not a toolchain pin; here it is the *input* that tells you the test
+  minor.
+- The golangci-lint pin (`hack/tools.mk` on newer branches, `hack/tools/go.mod`
+  on older ones).
+- Non-Go base images (`node`, `alpine`), which dependabot does manage.
+
+## Phase 1 -- Resolve versions and prepare worktrees
+
+`scripts/go-releases.sh` answers the version questions; it takes no repo state:
+
+```bash
+.claude/skills/update-go/scripts/go-releases.sh latest          # ship target
+.claude/skills/update-go/scripts/go-releases.sh latest-in 1.26  # test target
+.claude/skills/update-go/scripts/go-releases.sh check-tag 1.27.1-trixie
+```
+
+Run `check-tag` for every `<ver>-<variant>` combination you intend to write.
+A Go release can land on go.dev before the Docker Hub image exists, and a
+missing tag breaks every build on the branch.
+
+`scripts/prepare.sh` creates the isolated workspaces:
+
+```bash
+.claude/skills/update-go/scripts/prepare.sh bump-go main release-1.8 release-1.9
+```
+
+It resolves the canonical remote by URL (`github.com/akuity/kargo`) rather than
+by name -- `upstream` is one contributor's convention, not a guarantee --
+fetches it, and puts each target branch in its own worktree at
+`<repo>-worktrees/<repo>-<version>`, on a fresh feature branch cut from the
+canonical tip. Branches are therefore current with respect to the real
+repository by construction; do not merge or rebase afterward. It refuses to
+reuse a worktree with uncommitted changes. Capture its `KEY=value` output --
+the finish script needs the remote, owner, feature branch, and path.
+
+## Phase 2 -- Per branch, classify then edit
+
+In each worktree, independently:
+
+1. Enumerate candidate sites:
+
+   ```bash
+   git grep -nIE 'golang:[0-9]+\.[0-9]+|1\.[0-9]{2}\.[0-9]+' \
+     -- Dockerfile Dockerfile.dev .github/
+   ```
+
+   Match on the version literal, not on `go-version`: the `setup-go` action's
+   ship default sits on a `default:` line, and a `go-version: *anchor`
+   reference carries no version of its own.
+
+2. Read the surrounding comment for each hit and assign it a role. **If a hit
+   matches no entry in the inventory above, or its comment contradicts the
+   role you would have assigned, stop and ask.** A silently misclassified site
+   is the exact failure this skill exists to prevent: a shipped binary built on
+   the capped toolchain still passes CI.
+
+3. Establish the branch's test target: read the root `go.mod` `go` directive,
+   take its minor, and resolve `latest-in <minor>`. Confirm every test site
+   currently sits on that same minor.
+
+4. Rewrite each site to its role's target, preserving the tag variant
+   (`-trixie`, etc.) and the existing quoting style exactly.
+
+5. Verify: re-grep and confirm every remaining Go version is either the ship
+   target or the test target, and that no site kept an old value. Grep the
+   whole branch for the old version strings to catch a site outside the
+   inventory.
+
+## Phase 3 -- Report
+
+Present one table for the whole run, then the diffs:
+
+```
+| Branch       | Role | Current | Target | Sites |
+|--------------|------|---------|--------|-------|
+| main         | ship | 1.27.0  | 1.27.1 | Dockerfile x2, setup-go action |
+| main         | test | 1.27.0  | 1.27.1 | Dockerfile.dev, ci.yaml anchor |
+| release-1.8  | ship | 1.27.0  | 1.27.1 | Dockerfile x2, ci.yaml, release.yaml x2 |
+| release-1.8  | test | 1.25.14 | 1.25.14 (current) | -- |
+```
+
+Call out separately, without acting on any of it:
+- branches whose test minor is behind the latest Go minor, and the
+  golangci-lint upgrade that unblocking would require
+- any site whose role you could not determine
+
+## Phase 4 -- Leave a finish script
+
+Write `bump-go-finish.sh` to the **primary checkout's root** (not a worktree,
+not `/tmp`) so it is visible in the editor. Make it executable. Do not run it
+-- the user commits, pushes, and opens PRs themselves.
+
+The script must, per branch, `cd` to the worktree and:
+
+1. `git commit -s` (DCO sign-off is mandatory) with a subject that names what
+   actually moved:
+   - both roles, same target: `chore(deps): bump Go to <ship>`
+   - both roles, different targets:
+     `chore(deps): bump Go to <ship> and CI Go to <test>`
+   - ship only: `chore(deps): bump Go to <ship> for shipped artifacts`
+   - test only: `chore(deps): bump CI Go to <test>`
+
+   End the message with:
+
+   ```
+   Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+   ```
+
+2. `git push --force-with-lease` to the fork remote resolved in Phase 1.
+
+3. Open the PR against the canonical repository:
+
+   ```bash
+   gh pr create --repo akuity/kargo \
+     --base "<base>" --head "<fork-owner>:<feature-branch>" \
+     --title "..." --body-file - --assignee @me \
+     --label kind/chore --label area/security \
+     --label area/ci-process --label area/release-process \
+     --label priority/normal --label dependencies --label docker
+   ```
+
+   Those labels follow the prior art for this change (#6922, #7011). No
+   `backport/*` label: each branch gets its own PR, so there is nothing to
+   backport. Write PR bodies with one line per paragraph -- GitHub reflows, and
+   hard wraps only make editing harder.
+
+Structure the script so each branch is a self-contained block that can be
+re-run, with `set -euo pipefail` at the top and an echo naming each branch as
+it goes. Skip a branch that already has an open PR for its head, and skip the
+commit when the worktree is clean, so a partial run can be resumed.
+
+## Phase 5 -- Stray dependabot PRs
+
+Dependabot no longer proposes Go bumps, but PRs opened before that exclusion
+landed can still be open. Check:
+
+```bash
+gh pr list --repo akuity/kargo --state open --author app/dependabot \
+  --json number,title,baseRefName \
+  --jq '.[] | select(.title|test("golang")) | "\(.number) (\(.baseRefName)) \(.title)"'
+```
+
+Reference any hit from the corresponding branch's PR body as superseded, and
+tell the user to close it once the replacement is open. Read its diff first --
+say specifically what it got wrong, rather than asserting it was wrong.

--- a/.claude/skills/update-go/scripts/go-releases.sh
+++ b/.claude/skills/update-go/scripts/go-releases.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Reports Go release versions from go.dev and checks golang image tag
+# availability on Docker Hub.
+#
+# Usage:
+#   go-releases.sh latest              # latest stable Go, e.g. 1.27.1
+#   go-releases.sh latest-in 1.26      # latest stable patch of 1.26, e.g. 1.26.8
+#   go-releases.sh check-tag 1.27.1-trixie
+#
+# Requires: curl, python3
+
+set -euo pipefail
+
+fetch() {
+  curl -fsSL 'https://go.dev/dl/?mode=json&include=all'
+}
+
+# Prints every stable version, one per line, newest first.
+stable_versions() {
+  fetch | python3 -c '
+import json, sys
+rels = json.load(sys.stdin)
+vers = []
+for r in rels:
+    if not r.get("stable"):
+        continue
+    v = r["version"]
+    if not v.startswith("go"):
+        continue
+    parts = v[2:].split(".")
+    if len(parts) == 2:          # e.g. go1.27 means go1.27.0
+        parts.append("0")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        continue
+    vers.append(tuple(int(p) for p in parts))
+for v in sorted(set(vers), reverse=True):
+    print("%d.%d.%d" % v)
+'
+}
+
+case "${1:-}" in
+latest)
+  stable_versions | head -1
+  ;;
+latest-in)
+  minor="${2:?usage: go-releases.sh latest-in <major.minor>}"
+  out="$(stable_versions | grep -E "^${minor//./\\.}\." | head -1 || true)"
+  if [ -z "$out" ]; then
+    echo "no stable release found in Go $minor" >&2
+    exit 1
+  fi
+  echo "$out"
+  ;;
+check-tag)
+  tag="${2:?usage: go-releases.sh check-tag <tag>}"
+  code="$(
+    curl -sS -o /dev/null -w '%{http_code}' \
+      "https://hub.docker.com/v2/repositories/library/golang/tags/${tag}"
+  )"
+  if [ "$code" = "200" ]; then
+    echo "ok: golang:${tag} exists"
+  else
+    echo "MISSING: golang:${tag} (HTTP ${code})" >&2
+    exit 1
+  fi
+  ;;
+*)
+  sed -n '2,12p' "$0" >&2
+  exit 64
+  ;;
+esac

--- a/.claude/skills/update-go/scripts/prepare.sh
+++ b/.claude/skills/update-go/scripts/prepare.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Prepares one isolated worktree per target branch, each on a fresh feature
+# branch cut from the canonical remote's tip.
+#
+# Usage: prepare.sh <slug> <branch>...
+#   e.g. prepare.sh bump-go main release-1.8 release-1.9
+#
+# Emits a `KEY=value` block per branch on stdout for the caller to consume.
+# Refuses to touch a worktree with uncommitted changes.
+
+set -euo pipefail
+
+CANONICAL_SLUG="akuity/kargo"
+
+slug="${1:?usage: prepare.sh <slug> <branch>...}"
+shift
+[ "$#" -gt 0 ] || { echo "no target branches given" >&2; exit 64; }
+
+repo_root="$(git rev-parse --show-toplevel)"
+repo_name="$(basename "$repo_root")"
+worktree_parent="$(dirname "$repo_root")/${repo_name}-worktrees"
+
+# normalize turns any GitHub remote URL into <owner>/<repo>.
+normalize() {
+  printf '%s' "$1" |
+    sed -E \
+      -e 's#^git@github\.com:#/#' \
+      -e 's#^ssh://git@github\.com/#/#' \
+      -e 's#^https?://[^/]*github\.com/#/#' \
+      -e 's#\.git$##' \
+      -e 's#^/##'
+}
+
+# Resolve the canonical remote by URL, never by name -- "upstream" is one
+# person's convention, not a guarantee.
+canonical=""
+for r in $(git remote); do
+  if [ "$(normalize "$(git remote get-url "$r")")" = "$CANONICAL_SLUG" ]; then
+    canonical="$r"
+    break
+  fi
+done
+if [ -z "$canonical" ]; then
+  echo "no remote points at https://github.com/${CANONICAL_SLUG}" >&2
+  exit 1
+fi
+
+login="$(gh api user --jq .login)"
+
+# Resolve the fork to push to: a remote owned by the authenticated user.
+# Prefer an SSH push URL when the same fork is configured more than once.
+fork=""
+for r in $(git remote); do
+  owner="$(normalize "$(git remote get-url "$r")")"
+  owner="${owner%%/*}"
+  [ "$owner" = "$login" ] || continue
+  if [ -z "$fork" ]; then
+    fork="$r"
+  elif [[ "$(git remote get-url --push "$r")" == git@* ]] &&
+       [[ "$(git remote get-url --push "$fork")" != git@* ]]; then
+    fork="$r"
+  fi
+done
+if [ -z "$fork" ]; then
+  echo "WARNING: no remote owned by ${login}; falling back to ${canonical}" >&2
+  fork="$canonical"
+fi
+
+echo "CANONICAL_REMOTE=$canonical"
+echo "FORK_REMOTE=$fork"
+echo "FORK_OWNER=$login"
+echo "WORKTREE_PARENT=$worktree_parent"
+echo
+
+git fetch --quiet "$canonical" "$@"
+
+mkdir -p "$worktree_parent"
+
+for base in "$@"; do
+  # main -> "main"; release-1.8 -> "1.8"
+  version="${base#release-}"
+  path="${worktree_parent}/${repo_name}-${version}"
+  if [ "$base" = "main" ]; then
+    feature="${login}/${slug}"
+  else
+    feature="${login}/${slug}-${version}"
+  fi
+
+  if [ -d "$path" ] && git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+    if [ -n "$(git -C "$path" status --porcelain)" ]; then
+      echo "REFUSING: ${path} has uncommitted changes" >&2
+      exit 1
+    fi
+    git -C "$path" switch --quiet --force-create "$feature" \
+      "${canonical}/${base}"
+  else
+    git worktree add --quiet -B "$feature" "$path" "${canonical}/${base}"
+  fi
+
+  echo "BASE=$base"
+  echo "VERSION=$version"
+  echo "FEATURE_BRANCH=$feature"
+  echo "WORKTREE=$path"
+  echo "TIP=$(git -C "$path" rev-parse --short HEAD)"
+  echo
+done

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@
 #
 # Each branch runs on its own day of the week so that update PRs arrive a
 # branch at a time rather than all at once.
+#
+# Go itself is excluded from the docker ecosystem. Its version pins serve two
+# distinct roles -- the toolchain that builds shipped artifacts, and the older,
+# golangci-lint-capped toolchain that runs unit tests, linters, and codegen --
+# and most of them live in the workflows, where the docker ecosystem cannot see
+# them at all. Dependabot can neither tell the roles apart nor move a role's
+# pins in lock-step, so raising Go is a coordinated, whole-branch change made
+# by hand. The comment at each pin says which role it serves.
 version: 2
 updates:
   # ----------------------------- main -----------------------------
@@ -34,6 +42,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+    - dependency-name: "golang"
     commit-message:
       prefix: "chore(deps):"
 
@@ -155,6 +165,7 @@ updates:
       day: "monday"
     target-branch: "release-1.11"
     ignore:
+    - dependency-name: "golang"
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
@@ -265,6 +276,7 @@ updates:
       day: "tuesday"
     target-branch: "release-1.10"
     ignore:
+    - dependency-name: "golang"
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
@@ -393,6 +405,7 @@ updates:
       day: "wednesday"
     target-branch: "release-1.9"
     ignore:
+    - dependency-name: "golang"
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
@@ -501,6 +514,7 @@ updates:
       day: "thursday"
     target-branch: "release-1.8"
     ignore:
+    - dependency-name: "golang"
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"


### PR DESCRIPTION
Dependabot's `docker` ecosystem sees `Dockerfile` and `Dockerfile.dev` and nothing else, so it cannot see the Go pins in `ci.yaml`, `release.yaml`, or the `setup-go` action, and it cannot tell the ship-side toolchain apart from the golangci-lint-capped one that runs tests, linters, and codegen. #7045 is what that looks like in practice: two correct `Dockerfile` bumps, one `Dockerfile.dev` bump across two minors that breaks the pinned linter and desyncs it from the `golangTestImage` anchor, and four ship-side pins left behind.

So `golang` is now ignored in every `docker` entry, and the coordinated bump moves to a skill that reads the role comment at each pin, takes the test minor from `go.mod`, and works a branch at a time in its own worktree.

See #7011 for the two roles.

The new skill in this PR was already used to create:

* #7054
* #7055
* #7056 
* #7057 
* #7058