### PR TITLE
chore(ci): stop Dependabot proposing upgrades the release branches cannot take

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,6 +134,11 @@ updates:
         - "major"
 
   # ----------------------------- release-1.11 -----------------------------
+  #
+  # Kubernetes resources, our own CRDs among them, cannot be represented as
+  # protocol buffers under newer versions of Kubernetes. Everything k8s,
+  # gRPC, or protobuf related is therefore frozen at its current version
+  # here.
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -191,6 +196,11 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -211,6 +221,11 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -233,6 +248,11 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -244,6 +264,10 @@ updates:
         - "minor"
 
   # ----------------------------- release-1.10 -----------------------------
+  #
+  # k8s, gRPC, and protobuf are frozen for the reason given under
+  # release-1.11. oras is frozen as well because any upgrade of it, patches
+  # included, would require code changes.
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -301,6 +325,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -321,6 +351,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -341,6 +377,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -361,6 +403,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -372,6 +420,10 @@ updates:
         - "minor"
 
   # ----------------------------- release-1.9 -----------------------------
+  #
+  # k8s, gRPC, and protobuf are frozen for the reason given under
+  # release-1.11. oras is frozen as well because any upgrade of it, patches
+  # included, would require code changes.
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -429,6 +481,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -449,6 +507,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -469,6 +533,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -480,6 +550,10 @@ updates:
         - "minor"
 
   # ----------------------------- release-1.8 -----------------------------
+  #
+  # k8s, gRPC, and protobuf are frozen for the reason given under
+  # release-1.11. oras is frozen as well because any upgrade of it, patches
+  # included, would require code changes.
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -537,6 +611,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -557,6 +637,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -577,6 +663,12 @@ updates:
     - dependency-name: "*"
       update-types:
       - "version-update:semver-major"
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "github.com/grpc-ecosystem/*"
+    - dependency-name: "*protobuf*"
+    - dependency-name: "oras.land/*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:


### PR DESCRIPTION
Dependabot keeps proposing Go upgrades on the release branches that cannot be applied there.

On release-1.8 through release-1.11, anything k8s, gRPC, or protobuf related has to stay frozen: Kubernetes resources, our own CRDs among them, cannot be represented as protocol buffers under newer versions of Kubernetes.

On release-1.8 through release-1.10, any oras upgrade -- patches included -- would require code changes. release-1.11 can take oras freely.

This adds the corresponding `ignore` entries to every `gomod` update targeting those branches, with the reason stated in each branch's section of the config.

`main` is untouched. Nothing we know of currently prevents dependencies from being freely upgraded.
