### PR TITLE
feat(ui): read a target-aware Stage's promotion state from its PromotionRequests

### DIFF
--- a/ui/src/features/common/promotion-status/promotion-status-icon.tsx
+++ b/ui/src/features/common/promotion-status/promotion-status-icon.tsx
@@ -3,19 +3,26 @@ import { PromotionStatus } from '@ui/gen/api/v2/models';
 
 import { getPromotionPhasePresentation } from './promotion-phase';
 
-const PhaseAndMessage = ({ status }: { status: PromotionStatus }) => (
+const PhaseAndMessage = ({ status, subject }: { status: PromotionStatus; subject: string }) => (
   <div>
-    <div className='font-semibold'>Promotion {status.phase}</div>
+    <div className='font-semibold'>
+      {subject} {status.phase}
+    </div>
     <div>{status.message}</div>
   </div>
 );
 
 export const PromotionStatusIcon = ({
   status,
+  subject = 'Promotion',
   color,
   ...props
 }: {
   status?: PromotionStatus;
+  // subject names what the phase belongs to in the tooltip. A
+  // PromotionRequest's phases share the Promotion vocabulary, so the same icon
+  // presents both.
+  subject?: string;
   placement?: 'right' | 'top';
   color?: string;
   size?: 'lg' | '1x';
@@ -27,7 +34,7 @@ export const PromotionStatusIcon = ({
 
   return (
     <MessageTooltip
-      message={<PhaseAndMessage status={status} />}
+      message={<PhaseAndMessage status={status} subject={subject} />}
       icon={icon}
       iconColor={color ? color : iconColor}
       spin={spin}

--- a/ui/src/features/common/stage-tag.tsx
+++ b/ui/src/features/common/stage-tag.tsx
@@ -1,5 +1,9 @@
 import { Tooltip } from 'antd';
 
+import {
+  getCurrentPromotionRef,
+  getLastPromotionRef
+} from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { Stage } from '@ui/gen/api/v2/models';
 
 import { StagePopover } from '../project/list/project-item/stage-popover';
@@ -17,13 +21,14 @@ export const StageTag = ({
   projectName: string;
   stageColorMap: ColorMap;
 }) => {
+  const currentPromotion = getCurrentPromotionRef(stage);
+  const lastPromotion = getLastPromotionRef(stage);
+
   return (
     <Tooltip
       key={stage.metadata?.name}
       placement='bottom'
-      title={
-        stage?.status?.lastPromotion?.name && <StagePopover project={projectName} stage={stage} />
-      }
+      title={lastPromotion?.name && <StagePopover project={projectName} stage={stage} />}
     >
       <div
         className='flex items-center mb-2 text-white rounded py-1 px-2 font-semibold bg-gray-600'
@@ -34,11 +39,14 @@ export const StageTag = ({
             <HealthStatusIcon health={stage.status?.health} hideColor={true} />
           </div>
         )}
-        {!stage?.status?.currentPromotion && stage.status?.lastPromotion && (
+        {!currentPromotion && lastPromotion && (
           <div className='mr-2'>
             <PromotionStatusIcon
               placement='top'
-              status={stage.status?.lastPromotion?.status}
+              status={{ phase: lastPromotion.phase, message: lastPromotion.message }}
+              subject={
+                lastPromotion.kind === 'PromotionRequest' ? 'Promotion Request' : 'Promotion'
+              }
               color='white'
               size='1x'
             />

--- a/ui/src/features/project/list/project-item/stage-popover.tsx
+++ b/ui/src/features/project/list/project-item/stage-popover.tsx
@@ -6,16 +6,24 @@ import { generatePath, useNavigate } from 'react-router-dom';
 
 import { paths } from '@ui/config/paths';
 import { getAlias } from '@ui/features/common/utils';
+import { getLastPromotionRef } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { getGetFreightQueryOptions, useGetPromotion } from '@ui/gen/api/v2/core/core';
 import { FreightReference, Stage } from '@ui/gen/api/v2/models';
 
 export const StagePopover = ({ project, stage }: { project?: string; stage?: Stage }) => {
-  const getPromotionQuery = useGetPromotion(
-    project || '',
-    stage?.status?.lastPromotion?.name || ''
-  );
+  const lastPromotion = getLastPromotionRef(stage);
 
-  const promotion = getPromotionQuery.data?.data;
+  // A classic Stage's last promotion is a Promotion, which is read to date it
+  // by its creation. A target-aware Stage's is a PromotionRequest, for which
+  // the Stage's own reference already carries the time it finished.
+  const isPromotion = lastPromotion?.kind === 'Promotion';
+  const getPromotionQuery = useGetPromotion(project || '', lastPromotion?.name || '', {
+    query: { enabled: isPromotion && !!lastPromotion?.name }
+  });
+
+  const lastPromotedAt = isPromotion
+    ? getPromotionQuery.data?.data?.metadata?.creationTimestamp
+    : lastPromotion?.finishedAt;
 
   const freightData = useQueries({
     queries: Object.values(stage?.status?.freightHistory?.[0]?.items || {}).map(
@@ -36,7 +44,7 @@ export const StagePopover = ({ project, stage }: { project?: string; stage?: Sta
       <_label>LAST PROMOTED</_label>
       <div className='flex items-center mb-4'>
         <FontAwesomeIcon icon={faClock} className='mr-2' />
-        <div>{moment(promotion?.metadata?.creationTimestamp).format('MMM do yyyy HH:mm:ss')}</div>
+        <div>{moment(lastPromotedAt).format('MMM do yyyy HH:mm:ss')}</div>
       </div>
       <_label>CURRENT FREIGHT</_label>
       {Object.values(stage?.status?.freightHistory?.[0]?.items || {}).map((_, i) => (

--- a/ui/src/features/project/pipelines/list/columns/last-promotion-column.tsx
+++ b/ui/src/features/project/pipelines/list/columns/last-promotion-column.tsx
@@ -1,10 +1,10 @@
 import { ColumnType } from 'antd/es/table';
 import { formatDistance } from 'date-fns';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { paths } from '@ui/config/paths';
 import {
   getLastPromotionDate,
+  getLastPromotionRef,
   isStageControlFlow
 } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { Stage } from '@ui/gen/api/v2/models';
@@ -23,18 +23,10 @@ export const lastPromotionColumn = (): ColumnType<Stage> => ({
       return '-';
     }
 
-    const date = lastPromotion;
+    const label = formatDistance(lastPromotion, new Date(), { addSuffix: true });
+    const path = getLastPromotionRef(stage)?.path;
 
-    return (
-      <Link
-        to={generatePath(paths.promotion, {
-          name: stage?.metadata?.namespace,
-          promotionId: stage?.status?.lastPromotion?.name
-        })}
-      >
-        {formatDistance(date, new Date(), { addSuffix: true })}
-      </Link>
-    );
+    return path ? <Link to={path}>{label}</Link> : label;
   },
   sorter: (stage1, stage2) => {
     if (isStageControlFlow(stage1)) {

--- a/ui/src/features/project/pipelines/list/columns/phase-cell.tsx
+++ b/ui/src/features/project/pipelines/list/columns/phase-cell.tsx
@@ -1,11 +1,11 @@
 import { Flex } from 'antd';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { paths } from '@ui/config/paths';
 import { StageConditionIcon } from '@ui/features/common/stage-status/stage-condition-icon';
 import { useStageControllerStatus } from '@ui/features/common/stage-status/use-stage-controller-status';
 import { getStagePhase } from '@ui/features/common/stage-status/utils';
 import { getCurrentFreight } from '@ui/features/common/utils';
+import { getCurrentPromotionRef } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { Stage } from '@ui/gen/api/v2/models';
 
 export const PhaseCell = ({ stage }: { stage: Stage }) => {
@@ -29,17 +29,10 @@ export const PhaseCell = ({ stage }: { stage: Stage }) => {
     </Flex>
   );
 
-  if (stagePhase === 'Promoting') {
-    return (
-      <Link
-        to={generatePath(paths.promotion, {
-          name: stage?.metadata?.namespace,
-          promotionId: stage?.status?.currentPromotion?.name
-        })}
-      >
-        {Comp}
-      </Link>
-    );
+  const currentPromotionPath = getCurrentPromotionRef(stage)?.path;
+
+  if (stagePhase === 'Promoting' && currentPromotionPath) {
+    return <Link to={currentPromotionPath}>{Comp}</Link>;
   }
 
   return Comp;

--- a/ui/src/features/project/pipelines/nodes/stage-meta-utils.test.ts
+++ b/ui/src/features/project/pipelines/nodes/stage-meta-utils.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'vitest';
+
+import { Stage } from '@ui/gen/api/v2/models';
+
+import {
+  getCurrentPromotion,
+  getCurrentPromotionRef,
+  getLastPromotionDate,
+  getLastPromotionRef,
+  isStageTargetAware
+} from './stage-meta-utils';
+
+const stage = (partial: Partial<Stage>): Stage =>
+  ({
+    metadata: { namespace: 'my-project', name: 'prod' },
+    ...partial
+  }) as Stage;
+
+// classic promotes through Promotions: no targets block.
+const classic = (status: Stage['status']) => stage({ status });
+
+// targetAware promotes through PromotionRequests: a targets block is present,
+// whether or not it currently matches anything.
+const targetAware = (status: Stage['status']) => stage({ spec: { targets: {} }, status });
+
+describe('isStageTargetAware()', () => {
+  test('a Stage with a targets block is target-aware', () => {
+    expect(isStageTargetAware(targetAware({}))).toBe(true);
+  });
+
+  test('a Stage without one is not', () => {
+    expect(isStageTargetAware(classic({}))).toBe(false);
+    expect(isStageTargetAware(undefined)).toBe(false);
+  });
+});
+
+describe('getCurrentPromotionRef()', () => {
+  test('classic Stage: undefined when nothing is running', () => {
+    expect(getCurrentPromotionRef(classic({}))).toBeUndefined();
+  });
+
+  test('classic Stage: the current Promotion, linking to its page', () => {
+    expect(
+      getCurrentPromotionRef(
+        classic({
+          currentPromotion: {
+            name: 'prod.01abc.deadbeef',
+            status: { phase: 'Running', message: 'working' },
+            freight: { name: 'freight-1' }
+          }
+        })
+      )
+    ).toEqual({
+      kind: 'Promotion',
+      name: 'prod.01abc.deadbeef',
+      phase: 'Running',
+      message: 'working',
+      finishedAt: undefined,
+      freightName: 'freight-1',
+      path: '/project/my-project/promotion/prod.01abc.deadbeef'
+    });
+  });
+
+  test('target-aware Stage: undefined when no request is fanning out', () => {
+    expect(getCurrentPromotionRef(targetAware({}))).toBeUndefined();
+  });
+
+  test('target-aware Stage: the current PromotionRequest, linking to the Stage page', () => {
+    expect(
+      getCurrentPromotionRef(
+        targetAware({
+          currentPromotionRequest: {
+            name: 'prod.01abc.deadbeef',
+            phase: 'Running',
+            freight: { name: 'freight-1' }
+          }
+        })
+      )
+    ).toEqual({
+      kind: 'PromotionRequest',
+      name: 'prod.01abc.deadbeef',
+      phase: 'Running',
+      finishedAt: undefined,
+      freightName: 'freight-1',
+      path: '/project/my-project/stage/prod'
+    });
+  });
+
+  test('target-aware Stage: ignores the Promotion fields, which name one child at most', () => {
+    const ref = getCurrentPromotionRef(
+      targetAware({
+        currentPromotion: { name: 'prod.target-a.01abc.deadbeef' }
+      })
+    );
+    expect(ref).toBeUndefined();
+  });
+});
+
+describe('getLastPromotionRef()', () => {
+  test('classic Stage: the last Promotion', () => {
+    expect(
+      getLastPromotionRef(
+        classic({
+          lastPromotion: {
+            name: 'prod.01abc.deadbeef',
+            finishedAt: '2026-09-01T10:00:00Z',
+            status: { phase: 'Succeeded' }
+          }
+        })
+      )
+    ).toMatchObject({
+      kind: 'Promotion',
+      name: 'prod.01abc.deadbeef',
+      phase: 'Succeeded',
+      finishedAt: '2026-09-01T10:00:00Z',
+      path: '/project/my-project/promotion/prod.01abc.deadbeef'
+    });
+  });
+
+  test('target-aware Stage: the last PromotionRequest', () => {
+    expect(
+      getLastPromotionRef(
+        targetAware({
+          lastPromotion: { name: 'prod.target-a.01abc.deadbeef' },
+          lastPromotionRequest: {
+            name: 'prod.01abc.deadbeef',
+            finishedAt: '2026-09-01T10:00:00Z',
+            phase: 'Failed',
+            freight: { name: 'freight-1' }
+          }
+        })
+      )
+    ).toMatchObject({
+      kind: 'PromotionRequest',
+      name: 'prod.01abc.deadbeef',
+      phase: 'Failed',
+      finishedAt: '2026-09-01T10:00:00Z',
+      freightName: 'freight-1',
+      path: '/project/my-project/stage/prod'
+    });
+  });
+
+  test('no path when the Stage cannot be located', () => {
+    expect(
+      getLastPromotionRef(
+        stage({
+          metadata: {},
+          spec: { targets: {} },
+          status: { lastPromotionRequest: { name: 'x' } }
+        })
+      )?.path
+    ).toBeUndefined();
+    expect(
+      getLastPromotionRef(
+        stage({ status: { lastPromotion: { finishedAt: '2026-09-01T10:00:00Z' } } })
+      )?.path
+    ).toBeUndefined();
+  });
+});
+
+describe('getLastPromotionDate()', () => {
+  test('null when nothing has finished', () => {
+    expect(getLastPromotionDate(classic({}))).toBeNull();
+    expect(getLastPromotionDate(targetAware({}))).toBeNull();
+    expect(getLastPromotionDate(classic({ lastPromotion: { name: 'x' } }))).toBeNull();
+  });
+
+  test('classic Stage: when the last Promotion finished', () => {
+    expect(
+      getLastPromotionDate(
+        classic({ lastPromotion: { name: 'x', finishedAt: '2026-09-01T10:00:00Z' } })
+      )
+    ).toEqual(new Date('2026-09-01T10:00:00Z'));
+  });
+
+  test('target-aware Stage: when the last PromotionRequest finished', () => {
+    expect(
+      getLastPromotionDate(
+        targetAware({
+          lastPromotion: { name: 'x', finishedAt: '2026-08-01T10:00:00Z' },
+          lastPromotionRequest: { name: 'y', finishedAt: '2026-09-01T10:00:00Z' }
+        })
+      )
+    ).toEqual(new Date('2026-09-01T10:00:00Z'));
+  });
+});
+
+describe('getCurrentPromotion()', () => {
+  test('classic Stage: the current Promotion name', () => {
+    expect(getCurrentPromotion(classic({ currentPromotion: { name: 'x' } }))).toBe('x');
+  });
+
+  test('target-aware Stage: never a single Promotion', () => {
+    expect(
+      getCurrentPromotion(
+        targetAware({
+          currentPromotion: { name: 'x' },
+          currentPromotionRequest: { name: 'y' }
+        })
+      )
+    ).toBeUndefined();
+  });
+});

--- a/ui/src/features/project/pipelines/nodes/stage-meta-utils.ts
+++ b/ui/src/features/project/pipelines/nodes/stage-meta-utils.ts
@@ -1,9 +1,11 @@
 import { CSSProperties, useContext, useMemo } from 'react';
+import { generatePath } from 'react-router-dom';
 
+import { paths } from '@ui/config/paths';
 import { ColorContext } from '@ui/context/colors';
 import { ColorMapHex, parseColorAnnotation } from '@ui/features/stage/utils';
 import { useGetPromotion } from '@ui/gen/api/v2/core/core';
-import { Stage } from '@ui/gen/api/v2/models';
+import { PromotionReference, PromotionRequestReference, Stage } from '@ui/gen/api/v2/models';
 import { getContrastTextColor } from '@ui/utils/get-contrast-text-color';
 
 import { IAction, useActionContext } from '../context/action-context';
@@ -29,12 +31,97 @@ export const useIsColorsUsed = () => {
   return freightTimelineControllerContext?.preferredFilter?.showColors;
 };
 
-export const getLastPromotionDate = (stage: Stage) =>
-  stage?.status?.lastPromotion?.finishedAt
-    ? new Date(stage?.status?.lastPromotion?.finishedAt)
-    : null;
+// StagePromotionRef is a Stage's account of what it is promoting now, or what
+// it last promoted, in one shape regardless of how the Stage promotes.
+//
+// A classic Stage promotes through a Promotion and records it in
+// status.currentPromotion and status.lastPromotion. A target-aware Stage
+// promotes through a PromotionRequest, which fans out one child Promotion per
+// Target, and records the request in status.currentPromotionRequest and
+// status.lastPromotionRequest instead. For such a Stage the Promotion fields
+// name at most one of the children, so they never stand for the round.
+export type StagePromotionRef = {
+  kind: 'Promotion' | 'PromotionRequest';
+  name?: string;
+  phase?: string;
+  message?: string;
+  finishedAt?: string;
+  freightName?: string;
+  // path is where the UI shows the referenced promotion activity. A Promotion
+  // has a page of its own. A PromotionRequest does not: it is listed on the
+  // Stage page, whose Promotions tab leads with the Stage's PromotionRequests
+  // and expands the one currently fanning out.
+  path?: string;
+};
 
-export const getCurrentPromotion = (stage: Stage) => stage?.status?.currentPromotion?.name;
+const promotionPath = (stage?: Stage, promotion?: string) =>
+  promotion
+    ? generatePath(paths.promotion, {
+        name: stage?.metadata?.namespace || '',
+        promotionId: promotion
+      })
+    : undefined;
+
+const stagePath = (stage?: Stage) =>
+  stage?.metadata?.namespace && stage?.metadata?.name
+    ? generatePath(paths.stage, {
+        name: stage.metadata.namespace,
+        stageName: stage.metadata.name
+      })
+    : undefined;
+
+const promotionRef = (stage?: Stage, ref?: PromotionReference): StagePromotionRef | undefined =>
+  ref && {
+    kind: 'Promotion',
+    name: ref.name,
+    phase: ref.status?.phase,
+    message: ref.status?.message,
+    finishedAt: ref.finishedAt,
+    freightName: ref.freight?.name,
+    path: promotionPath(stage, ref.name)
+  };
+
+const promotionRequestRef = (
+  stage?: Stage,
+  ref?: PromotionRequestReference
+): StagePromotionRef | undefined =>
+  ref && {
+    kind: 'PromotionRequest',
+    name: ref.name,
+    phase: ref.phase,
+    finishedAt: ref.finishedAt,
+    freightName: ref.freight?.name,
+    path: stagePath(stage)
+  };
+
+// getCurrentPromotionRef describes what the Stage is promoting right now, if
+// anything.
+export const getCurrentPromotionRef = (stage?: Stage): StagePromotionRef | undefined =>
+  isStageTargetAware(stage)
+    ? promotionRequestRef(stage, stage?.status?.currentPromotionRequest)
+    : promotionRef(stage, stage?.status?.currentPromotion);
+
+// getLastPromotionRef describes the last promotion the Stage saw through to a
+// terminal phase, if any.
+export const getLastPromotionRef = (stage?: Stage): StagePromotionRef | undefined =>
+  isStageTargetAware(stage)
+    ? promotionRequestRef(stage, stage?.status?.lastPromotionRequest)
+    : promotionRef(stage, stage?.status?.lastPromotion);
+
+export const getLastPromotionDate = (stage: Stage) => {
+  const finishedAt = getLastPromotionRef(stage)?.finishedAt;
+  return finishedAt ? new Date(finishedAt) : null;
+};
+
+// getCurrentPromotion names the Promotion a Stage is currently promoting
+// through, for callers that need to read the Promotion itself. A target-aware
+// Stage promotes through a PromotionRequest, whose child Promotions target
+// distinct Targets and run in parallel, so no single Promotion describes what
+// it is doing: for such a Stage this is always undefined.
+export const getCurrentPromotion = (stage: Stage) => {
+  const current = getCurrentPromotionRef(stage);
+  return current?.kind === 'Promotion' ? current.name : undefined;
+};
 
 export const useCurrentPromotion = (stage: Stage) => {
   const currentPromotion = getCurrentPromotion(stage);

--- a/ui/src/features/project/pipelines/nodes/stage-node-phase.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node-phase.tsx
@@ -1,18 +1,19 @@
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Flex } from 'antd';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { paths } from '@ui/config/paths';
 import { StageConditionIcon } from '@ui/features/common/stage-status/stage-condition-icon';
 import { useStageControllerStatus } from '@ui/features/common/stage-status/use-stage-controller-status';
 import { getStagePhase } from '@ui/features/common/stage-status/utils';
 import { Stage } from '@ui/gen/api/v2/models';
 
+import { getCurrentPromotionRef } from './stage-meta-utils';
+
 export const StageNodePhase = (props: { stage: Stage }) => {
-  const projectName = props.stage?.metadata?.namespace || '';
   const { controllerName, isControllerDead } = useStageControllerStatus(props.stage);
   const stagePhase = getStagePhase(props.stage, isControllerDead);
+  const currentPromotionPath = getCurrentPromotionRef(props.stage)?.path;
 
   const Phase = (
     <Flex align='center' gap={4}>
@@ -24,23 +25,14 @@ export const StageNodePhase = (props: { stage: Stage }) => {
         isControllerDead={isControllerDead}
         controllerName={controllerName}
       />
-      {stagePhase === 'Promoting' && (
+      {stagePhase === 'Promoting' && currentPromotionPath && (
         <FontAwesomeIcon icon={faExternalLink} className='text-[8px]' />
       )}
     </Flex>
   );
 
-  if (stagePhase === 'Promoting') {
-    return (
-      <Link
-        to={generatePath(paths.promotion, {
-          name: projectName,
-          promotionId: props.stage?.status?.currentPromotion?.name || ''
-        })}
-      >
-        {Phase}
-      </Link>
-    );
+  if (stagePhase === 'Promoting' && currentPromotionPath) {
+    return <Link to={currentPromotionPath}>{Phase}</Link>;
   }
 
   return Phase;

--- a/ui/src/features/project/pipelines/nodes/stage-node.tsx
+++ b/ui/src/features/project/pipelines/nodes/stage-node.tsx
@@ -35,6 +35,7 @@ import { PullRequestLink } from './pull-request-link';
 import { StageFreight } from './stage-freight';
 import {
   getLastPromotionDate,
+  getLastPromotionRef,
   getStageHealth,
   isStageControlFlow,
   useHideStageIfInPromotionMode,
@@ -90,6 +91,7 @@ export const StageNode = (props: { stage: Stage }) => {
   let descriptionItems: ReactNode;
 
   const lastPromotion = getLastPromotionDate(props.stage);
+  const lastPromotionPath = getLastPromotionRef(props.stage)?.path;
 
   if (!controlFlow) {
     descriptionItems = (
@@ -245,13 +247,8 @@ export const StageNode = (props: { stage: Stage }) => {
           )}
         </div>
 
-        {lastPromotion && (
-          <Link
-            to={generatePath(paths.promotion, {
-              name: props.stage?.metadata?.namespace,
-              promotionId: props.stage?.status?.lastPromotion?.name
-            })}
-          >
+        {lastPromotion && lastPromotionPath && (
+          <Link to={lastPromotionPath}>
             <Flex gap={4} align='center' justify='center' className='text-[10px]'>
               <span>Last Promotion: </span>
               <span title={lastPromotion?.toString()}>

--- a/ui/src/features/stage/stage-details.tsx
+++ b/ui/src/features/stage/stage-details.tsx
@@ -20,6 +20,7 @@ import { Description } from '@ui/features/common/description';
 import { HealthStatusIcon } from '@ui/features/common/health-status/health-status-icon';
 import { useStageControllerStatus } from '@ui/features/common/stage-status/use-stage-controller-status';
 import { getCurrentFreightByWarehouse } from '@ui/features/common/utils';
+import { getLastPromotionRef } from '@ui/features/project/pipelines/nodes/stage-meta-utils';
 import { getAutoPromotionHoldEntries } from '@ui/features/project/pipelines/promotion/auto-promotion';
 import { ResumeAutoPromotionDrawer } from '@ui/features/project/pipelines/promotion/resume-auto-promotion-drawer';
 import { useGetStage } from '@ui/gen/api/v2/core/core';
@@ -193,7 +194,7 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
                     <FreightHistory
                       requestedFreights={stage?.spec?.requestedFreight || []}
                       freightHistory={stage?.status?.freightHistory}
-                      currentActiveFreight={stage?.status?.lastPromotion?.freight?.name}
+                      currentActiveFreight={getLastPromotionRef(stage)?.freightName}
                       projectName={projectName || ''}
                       stageName={stageName || ''}
                     />


### PR DESCRIPTION
## Problem

A target-aware Stage promotes Freight through a PromotionRequest, which fans out
one child Promotion per Target. Its `status.lastPromotion` is therefore never
populated — verified on a live Enterprise cluster, where a Stage mid-promotion
with three children in flight still reports an empty `currentPromotion` and
`lastPromotion`.

The UI read those fields as the Stage's promotion state, so for a target-aware
Stage it had nothing to show. Stage status already records the request in
`currentPromotionRequest` / `lastPromotionRequest` (added in #6843).

## Approach

Two helpers in `stage-meta-utils.ts`, `getCurrentPromotionRef` and
`getLastPromotionRef`, normalize the two shapes into one `StagePromotionRef`
carrying kind, name, phase, message, finish time, Freight name, and a link path.
Classic Stages read the Promotion fields exactly as before; target-aware Stages
read the PromotionRequest fields. Consumers branch once, in one place, on the
existing `isStageTargetAware`.

A Promotion has a page of its own, so its ref links there. A PromotionRequest
does not, so its ref links to the Stage page, whose Promotions tab already leads
with the Stage's requests and expands the one fanning out (#7004). This PR adds
no per-request route or drawer.

## What changes visibly

Verified against a live Enterprise cluster by running this branch and its parent
commit side by side:

- **Pipeline graph node** — target-aware Stages gain the "Last Promotion: N ago"
  footer, which previously did not render at all. It links to the Stage page.
- **List view "Last Promotion" column** — `-` becomes a real relative time for
  target-aware Stages, likewise linking to the Stage page.

Classic Stages are pixel-identical in both. Screenshots available on request.

## What is defensive rather than a live fix

Worth a reviewer's attention, since it may argue for trimming this PR. I
verified each of these on the cluster rather than assuming:

- **Phase-indicator links** (`stage-node-phase.tsx`, `phase-cell.tsx`) — a
  target-aware Stage never reports `Promoting`. Its conditions are
  `Ready=False (TargetAwareStage)`, `Healthy=Unknown`, `Verified=Unknown`, so the
  phase renders as `Verifying` and this branch never executes. Whether such a
  Stage *should* report `Promoting` looks like a separate question.
- **Step-label suppression** (`useCurrentPromotion`, consumed by
  `StepWaitingLabel` and `PullRequestLink`) — `currentPromotion` is already
  empty on these Stages, so the query was already disabled. This only makes the
  intent explicit.
- **Stage tag and popover** (`stage-tag.tsx`, `stage-popover.tsx`) — the only
  call site, `requested-freight.tsx`, passes a name-only stub
  (`{ metadata: { name: stage } } as Stage`) with no `spec` and no `status`, so
  both helpers return undefined and neither the icon nor the popover renders.
  Confirmed: the rendered chip contains zero SVG icons.

The one behavior these do change is for **classic** Stages: a `Promoting`
indicator with no Promotion to link to now renders as plain text instead of a
link to `/project/<p>/promotion/` with an empty name.

If reviewers prefer this tight, it can shrink to `stage-meta-utils.ts`,
`stage-node.tsx` and `last-promotion-column.tsx`.

## Also touched

- `promotion-status-icon.tsx` gains an optional `subject` prop so a tooltip can
  read "Promotion Request Errored". Additive; the default is unchanged.
- `stage-details.tsx` sources the Freight History `currentActiveFreight`
  highlight from the ref. Not visually verified.

## Testing

- `stage-meta-utils.test.ts`, 15 cases: classic and target-aware for both
  current and last, link paths, the absent-path cases, and that a target-aware
  Stage never yields a single current Promotion.
- `pnpm typecheck`, `pnpm lint` and the full `pnpm vitest run` (30 files, 340
  tests) all pass.
- End-to-end on a live Enterprise cluster: promoted a target-aware Stage, held a
  request `Running` by pausing the promotion controller to observe three parallel
  children, and confirmed the rendered links and timestamps.

## Note on the commit message

The commit body claims the phase indicator "links to one arbitrary Target's
Promotion (or a broken link)" and that the step labels "read one Promotion's
steps". Both predate the verification above and are inaccurate, since
`currentPromotion` is never set on these Stages. Happy to amend the commit if
preferred.

