### PR TITLE
chore(ci): freeze Helm and Connect on the release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -212,6 +212,8 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -237,6 +239,8 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -264,6 +268,8 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -343,6 +349,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -369,6 +377,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -395,6 +405,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -421,6 +433,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -500,6 +514,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -526,6 +542,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -552,6 +570,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -631,6 +651,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -657,6 +679,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -683,6 +707,8 @@ updates:
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
     - dependency-name: "oras.land/*"
+    - dependency-name: "helm.sh/helm/v3"
+    - dependency-name: "connectrpc.com/connect"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:


### PR DESCRIPTION
Both appear in the `go-minor` group PRs currently open against every release branch: #7110, #7111, #7112, #7113.

Helm's minor releases move to newer Kubernetes libraries — 3.20 requires k8s v0.35, 3.21 requires v0.36 — so they drag the dependencies frozen in #7060 forward with them. Connect falls under the same umbrella the `release-1.11` comment already states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)