### PR TITLE
fix(ui): clear the authorization code once it has been exchanged

### DIFF
--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -149,6 +149,17 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
 
         onLogin(result.id_token, result.refresh_token);
 
+        // An authorization code is single-use. Clear it, and the PKCE
+        // material that goes with it, as soon as it has been exchanged:
+        // this effect re-runs whenever the discovery query refetches
+        // (`as` gets a new identity), and the guard above only checks that
+        // the code and verifier are PRESENT -- so anything left behind is
+        // replayed against the token endpoint and rejected.
+        sessionStorage.removeItem(codeVerifierKey);
+        sessionStorage.removeItem(stateKey);
+        sessionStorage.removeItem(platformRedirectKey);
+        window.history.replaceState({}, '', window.location.pathname);
+
         if (platformRedirect) {
           const redirectTo = new URLSearchParams(platformRedirect).get('redirectTo');
 


### PR DESCRIPTION
An authorization code is single-use, but the OIDC callback left it in the address bar and left the PKCE material in sessionStorage. The callback effect depends on [as, client, location], and `as` is the discovery useQuery result -- it gets a new identity on every refetch, and refetchOnWindowFocus is on by default. The guard at the top of the effect only checks that the code, state and verifier are PRESENT, so a re-run replayed a consumed code against the token endpoint. The IdP rejects it and the user gets a raw `OIDC: {"error":...}` toast after a login that had already succeeded.

The cleanup that existed could not cover this: it is gated on `platformRedirect`, which is set from `window.location.search` at login time. A user who navigates straight to /login has no query string, so the stored value is '' -- falsy -- and the branch never runs. Arriving via /login?redirectTo=... does take the branch and navigate away, which is why this reproduces for some users and not others.

Clearing the sessionStorage keys is what makes it correct: the existing guard then short-circuits any re-run. replaceState additionally keeps a consumed code out of the address bar and out of the browser history.

`platformRedirect` is already read into a local const, so removing the key before the redirect branch does not change that behaviour.

Closes #7135

<!-- Pull requests must reference an existing issue with no blocking labels unless they affect documentation only or change a total of ten lines or fewer.

PRs that do not meet these criteria will be automatically converted to drafts by the project's governance bot. See the [Contributor Guide](https://docs.kargo.io/contributor-guide) for details. -->

## Description

Closes #<!-- issue number, or delete this line if not applicable -->

<!-- Describe what this PR does and why. -->

## Checklist

### Eligibility

<!-- At least one must be true. -->

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

<!-- Check all that apply. -->

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

<!-- Select one. -->

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [ ] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**
