### PR TITLE
fix(webhook): stop mutating admission webhooks from rewriting untouched duration fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.41.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0
 	google.golang.org/api v0.292.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.21.4
@@ -319,7 +320,6 @@ require (
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.1 // indirect

--- a/pkg/webhook/kubernetes/defaulting.go
+++ b/pkg/webhook/kubernetes/defaulting.go
@@ -36,7 +36,7 @@ func RegisterDefaultingWebhook[T runtime.Object](
 ) error {
 	gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
 	if err != nil {
-		return fmt.Errorf("get GroupVersionKind for %T: %w", obj, err)
+		return fmt.Errorf("error getting GroupVersionKind for %T: %w", obj, err)
 	}
 	wh, err := NewDefaultingWebhook(mgr.GetScheme(), obj, defaulter)
 	if err != nil {
@@ -67,7 +67,7 @@ func NewDefaultingWebhook[T runtime.Object](
 ) (*admission.Webhook, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
-		return nil, fmt.Errorf("get GroupVersionKind for %T: %w", obj, err)
+		return nil, fmt.Errorf("error getting GroupVersionKind for %T: %w", obj, err)
 	}
 	return &admission.Webhook{
 		Handler: &defaultingHandler[T]{

--- a/pkg/webhook/kubernetes/defaulting.go
+++ b/pkg/webhook/kubernetes/defaulting.go
@@ -21,6 +21,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// SetupValidatingAndDefaultingWebhook registers both a validating webhook and
+// a defaulting webhook (see RegisterDefaultingWebhook) for obj's type on mgr,
+// using h for both.
+func SetupValidatingAndDefaultingWebhook[T runtime.Object](
+	mgr ctrl.Manager,
+	obj T,
+	h interface {
+		admission.Validator[T]
+		admission.Defaulter[T]
+	},
+) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, obj).
+		WithValidator(h).
+		Complete(); err != nil {
+		return fmt.Errorf("error creating validating webhook for %T: %w", obj, err)
+	}
+	return RegisterDefaultingWebhook(mgr, obj, h)
+}
+
 // RegisterDefaultingWebhook registers a mutating admission webhook for obj's
 // type on mgr's webhook server, running defaulter's Default() method the way
 // ctrl.NewWebhookManagedBy(mgr, obj).WithDefaulter(defaulter) would, except

--- a/pkg/webhook/kubernetes/defaulting.go
+++ b/pkg/webhook/kubernetes/defaulting.go
@@ -6,12 +6,53 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 
+	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+// RegisterDefaultingWebhook registers a mutating admission webhook for obj's
+// type on mgr's webhook server, running defaulter's Default() method the way
+// ctrl.NewWebhookManagedBy(mgr, obj).WithDefaulter(defaulter) would, except
+// for how the resulting JSON patch is computed. See NewDefaultingWebhook.
+//
+// Like controller-runtime's own webhook registration, this panics if called
+// twice for the same path against the same manager, so a given obj type must
+// only be registered once per manager.
+func RegisterDefaultingWebhook[T runtime.Object](
+	mgr ctrl.Manager,
+	obj T,
+	defaulter admission.Defaulter[T],
+) error {
+	gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
+	if err != nil {
+		return fmt.Errorf("get GroupVersionKind for %T: %w", obj, err)
+	}
+	wh, err := NewDefaultingWebhook(mgr.GetScheme(), obj, defaulter)
+	if err != nil {
+		return err
+	}
+	mgr.GetWebhookServer().Register(mutatePath(gvk), wh)
+	return nil
+}
+
+// mutatePath reproduces controller-runtime's own formula for generating a
+// defaulting webhook's path from its GVK, so it can't drift from the paths
+// hand-configured in the Helm chart.
+func mutatePath(gvk schema.GroupVersionKind) string {
+	return "/mutate-" + strings.ReplaceAll(gvk.Group, ".", "-") + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+}
 
 // NewDefaultingWebhook is like admission.WithDefaulter, except its patch
 // diffs obj as marshaled before and after Default() runs, rather than the
@@ -23,7 +64,11 @@ func NewDefaultingWebhook[T runtime.Object](
 	scheme *runtime.Scheme,
 	obj T,
 	defaulter admission.Defaulter[T],
-) *admission.Webhook {
+) (*admission.Webhook, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("get GroupVersionKind for %T: %w", obj, err)
+	}
 	return &admission.Webhook{
 		Handler: &defaultingHandler[T]{
 			defaulter: defaulter,
@@ -36,6 +81,24 @@ func NewDefaultingWebhook[T runtime.Object](
 				return copied
 			},
 		},
+		LogConstructor: defaultingLogConstructor(gvk),
+	}, nil
+}
+
+// defaultingLogConstructor adds the same fields to the logger that
+// controller-runtime's own webhook builder would.
+func defaultingLogConstructor(gvk schema.GroupVersionKind) func(logr.Logger, *admission.Request) logr.Logger {
+	return func(base logr.Logger, req *admission.Request) logr.Logger {
+		log := base.WithValues("webhookGroup", gvk.Group, "webhookKind", gvk.Kind)
+		if req == nil {
+			return log
+		}
+		return log.WithValues(
+			gvk.Kind, klog.KRef(req.Namespace, req.Name),
+			"namespace", req.Namespace, "name", req.Name,
+			"resource", req.Resource, "user", req.UserInfo.Username,
+			"requestID", req.UID,
+		)
 	}
 }
 
@@ -48,7 +111,10 @@ type defaultingHandler[T runtime.Object] struct {
 func (h *defaultingHandler[T]) Handle(ctx context.Context, req admission.Request) admission.Response {
 	if req.Operation == admissionv1.Delete {
 		return admission.Response{
-			AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true},
+			AdmissionResponse: admissionv1.AdmissionResponse{
+				Allowed: true,
+				Result:  &metav1.Status{Code: http.StatusOK},
+			},
 		}
 	}
 
@@ -58,11 +124,7 @@ func (h *defaultingHandler[T]) Handle(ctx context.Context, req admission.Request
 	if err := h.decoder.Decode(req, obj); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
-	before, err := json.Marshal(obj)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
+	orig := obj.DeepCopyObject()
 
 	if defaultErr := h.defaulter.Default(ctx, obj); defaultErr != nil {
 		var apiStatus apierrors.APIStatus
@@ -78,6 +140,18 @@ func (h *defaultingHandler[T]) Handle(ctx context.Context, req admission.Request
 		return admission.Denied(defaultErr.Error())
 	}
 
+	// Default() left the object unchanged: skip the marshal/diff below, just
+	// like controller-runtime's own no-op short-circuit.
+	if reflect.DeepEqual(orig, obj) {
+		return admission.Response{
+			AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true},
+		}
+	}
+
+	before, err := json.Marshal(orig)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
 	after, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/kubernetes/defaulting.go
+++ b/pkg/webhook/kubernetes/defaulting.go
@@ -1,0 +1,87 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// NewDefaultingWebhook is like admission.WithDefaulter, except its patch
+// diffs obj as marshaled before and after Default() runs, rather than the
+// raw request against the marshaled object. This avoids spurious patches for
+// fields that don't round-trip byte-for-byte through JSON, such as
+// metav1.Duration ("1h" remarshals as "1h0m0s"), when Default() never
+// touched them. See https://github.com/akuityio/akuity-platform/issues/12384.
+func NewDefaultingWebhook[T runtime.Object](
+	scheme *runtime.Scheme,
+	obj T,
+	defaulter admission.Defaulter[T],
+) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &defaultingHandler[T]{
+			defaulter: defaulter,
+			decoder:   admission.NewDecoder(scheme),
+			new: func() T {
+				copied, ok := obj.DeepCopyObject().(T)
+				if !ok {
+					panic(fmt.Sprintf("defaulting webhook: DeepCopyObject() did not return a %T", obj))
+				}
+				return copied
+			},
+		},
+	}
+}
+
+type defaultingHandler[T runtime.Object] struct {
+	defaulter admission.Defaulter[T]
+	decoder   admission.Decoder
+	new       func() T
+}
+
+func (h *defaultingHandler[T]) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation == admissionv1.Delete {
+		return admission.Response{
+			AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true},
+		}
+	}
+
+	ctx = admission.NewContextWithRequest(ctx, req)
+
+	obj := h.new()
+	if err := h.decoder.Decode(req, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	before, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	if defaultErr := h.defaulter.Default(ctx, obj); defaultErr != nil {
+		var apiStatus apierrors.APIStatus
+		if errors.As(defaultErr, &apiStatus) {
+			status := apiStatus.Status()
+			return admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: false,
+					Result:  &status,
+				},
+			}
+		}
+		return admission.Denied(defaultErr.Error())
+	}
+
+	after, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(before, after)
+}

--- a/pkg/webhook/kubernetes/defaulting_test.go
+++ b/pkg/webhook/kubernetes/defaulting_test.go
@@ -1,0 +1,177 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kargoapi "github.com/akuity/kargo/api/v1alpha1"
+)
+
+type fakeStageDefaulter struct {
+	defaultFn func(ctx context.Context, stage *kargoapi.Stage) error
+}
+
+func (f fakeStageDefaulter) Default(ctx context.Context, stage *kargoapi.Stage) error {
+	return f.defaultFn(ctx, stage)
+}
+
+func TestNewDefaultingWebhook(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	// A shorthand duration ("1h") that Default() never touches. It should
+	// survive untouched, not get remarshaled to "1h0m0s".
+	rawStage := []byte(`{
+		"apiVersion": "kargo.akuity.io/v1alpha1",
+		"kind": "Stage",
+		"metadata": {"name": "test-stage", "namespace": "test-project"},
+		"spec": {
+			"promotionTemplate": {
+				"spec": {
+					"steps": [{"uses": "git-clone", "retry": {"timeout": "1h"}}]
+				}
+			}
+		}
+	}`)
+	const untouchedDurationPath = "/spec/promotionTemplate/spec/steps/0/retry/timeout"
+
+	testCases := []struct {
+		name       string
+		req        admission.Request
+		defaultFn  func(ctx context.Context, stage *kargoapi.Stage) error
+		assertions func(*testing.T, admission.Response)
+	}{
+		{
+			name: "delete operation is always allowed without decoding",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+				},
+			},
+			defaultFn: func(context.Context, *kargoapi.Stage) error {
+				t.Fatal("Default() should not be called for a Delete operation")
+				return nil
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Empty(t, resp.Patches)
+			},
+		},
+		{
+			name: "no-op defaulter produces no patch",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: rawStage},
+				},
+			},
+			defaultFn: func(context.Context, *kargoapi.Stage) error {
+				return nil
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Empty(t, resp.Patches)
+			},
+		},
+		{
+			name: "genuine mutation is patched without disturbing untouched duration field",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: rawStage},
+				},
+			},
+			defaultFn: func(_ context.Context, stage *kargoapi.Stage) error {
+				stage.Labels = map[string]string{kargoapi.LabelKeyShard: "fake-shard"}
+				return nil
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.True(t, resp.Allowed)
+
+				var sawLabelPatch bool
+				for _, p := range resp.Patches {
+					require.NotEqualf(
+						t, untouchedDurationPath, p.Path,
+						"Default() did not touch this field, but it was patched to %v", p.Value,
+					)
+					if p.Path == "/metadata/labels" {
+						sawLabelPatch = true
+					}
+				}
+				require.True(t, sawLabelPatch, "expected a patch adding the shard label")
+			},
+		},
+		{
+			name: "plain defaulter error is denied",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: rawStage},
+				},
+			},
+			defaultFn: func(context.Context, *kargoapi.Stage) error {
+				return errors.New("something went wrong")
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.False(t, resp.Allowed)
+				require.NotNil(t, resp.Result)
+				require.Contains(t, resp.Result.Message, "something went wrong")
+			},
+		},
+		{
+			name: "apierrors-typed defaulter error carries its status",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: rawStage},
+				},
+			},
+			defaultFn: func(context.Context, *kargoapi.Stage) error {
+				return apierrors.NewBadRequest("invalid spec")
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.False(t, resp.Allowed)
+				require.NotNil(t, resp.Result)
+				require.Equal(t, metav1.StatusReasonBadRequest, resp.Result.Reason)
+			},
+		},
+		{
+			name: "malformed request body fails to decode",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: []byte("not json")},
+				},
+			},
+			defaultFn: func(context.Context, *kargoapi.Stage) error {
+				t.Fatal("Default() should not be called when decoding fails")
+				return nil
+			},
+			assertions: func(t *testing.T, resp admission.Response) {
+				require.False(t, resp.Allowed)
+				require.NotNil(t, resp.Result)
+				require.EqualValues(t, 400, resp.Result.Code)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			wh := NewDefaultingWebhook(
+				scheme,
+				&kargoapi.Stage{},
+				fakeStageDefaulter{defaultFn: testCase.defaultFn},
+			)
+			ctx := admission.NewContextWithRequest(context.Background(), testCase.req)
+			testCase.assertions(t, wh.Handle(ctx, testCase.req))
+		})
+	}
+}

--- a/pkg/webhook/kubernetes/defaulting_test.go
+++ b/pkg/webhook/kubernetes/defaulting_test.go
@@ -165,13 +165,34 @@ func TestNewDefaultingWebhook(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			wh := NewDefaultingWebhook(
+			wh, err := NewDefaultingWebhook(
 				scheme,
 				&kargoapi.Stage{},
 				fakeStageDefaulter{defaultFn: testCase.defaultFn},
 			)
+			require.NoError(t, err)
 			ctx := admission.NewContextWithRequest(context.Background(), testCase.req)
 			testCase.assertions(t, wh.Handle(ctx, testCase.req))
+		})
+	}
+}
+
+// TestMutatePath pins mutatePath's output to the paths hand-configured for
+// these webhooks in charts/kargo/templates/kubernetes-webhooks-server/webhooks.yaml.
+func TestMutatePath(t *testing.T) {
+	testCases := []struct {
+		kind string
+		want string
+	}{
+		{kind: "Freight", want: "/mutate-kargo-akuity-io-v1alpha1-freight"},
+		{kind: "Promotion", want: "/mutate-kargo-akuity-io-v1alpha1-promotion"},
+		{kind: "Stage", want: "/mutate-kargo-akuity-io-v1alpha1-stage"},
+		{kind: "Warehouse", want: "/mutate-kargo-akuity-io-v1alpha1-warehouse"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.kind, func(t *testing.T) {
+			gvk := kargoapi.GroupVersion.WithKind(testCase.kind)
+			require.Equal(t, testCase.want, mutatePath(gvk))
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/freight/webhook.go
+++ b/pkg/webhook/kubernetes/freight/webhook.go
@@ -40,6 +40,10 @@ var (
 	}
 )
 
+// mutateWebhookPath must match the path configured for this webhook in the
+// Helm chart.
+const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-freight"
+
 type webhook struct {
 	client                client.Client
 	freightAliasGenerator moniker.Namer
@@ -86,10 +90,16 @@ func SetupWebhookWithManager(
 		mgr.GetClient(),
 		k8sevent.NewEventSender(libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), "freight-webhook")),
 	)
-	return ctrl.NewWebhookManagedBy(mgr, &kargoapi.Freight{}).
+	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Freight{}).
 		WithValidator(w).
-		WithDefaulter(w).
-		Complete()
+		Complete(); err != nil {
+		return err
+	}
+	mgr.GetWebhookServer().Register(
+		mutateWebhookPath,
+		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Freight{}, w),
+	)
+	return nil
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/freight/webhook.go
+++ b/pkg/webhook/kubernetes/freight/webhook.go
@@ -86,12 +86,7 @@ func SetupWebhookWithManager(
 		mgr.GetClient(),
 		k8sevent.NewEventSender(libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), "freight-webhook")),
 	)
-	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Freight{}).
-		WithValidator(w).
-		Complete(); err != nil {
-		return err
-	}
-	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Freight{}, w)
+	return libWebhook.SetupValidatingAndDefaultingWebhook(mgr, &kargoapi.Freight{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/freight/webhook.go
+++ b/pkg/webhook/kubernetes/freight/webhook.go
@@ -40,10 +40,6 @@ var (
 	}
 )
 
-// mutateWebhookPath must match the path configured for this webhook in the
-// Helm chart.
-const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-freight"
-
 type webhook struct {
 	client                client.Client
 	freightAliasGenerator moniker.Namer
@@ -95,11 +91,7 @@ func SetupWebhookWithManager(
 		Complete(); err != nil {
 		return err
 	}
-	mgr.GetWebhookServer().Register(
-		mutateWebhookPath,
-		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Freight{}, w),
-	)
-	return nil
+	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Freight{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/freight/webhook_test.go
+++ b/pkg/webhook/kubernetes/freight/webhook_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1382,6 +1384,74 @@ func Test_webhook_CompareFreight(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path, val, eq := compareFreight(tt.old, tt.new)
 			tt.assertions(t, tt.new, path, val, eq)
+		})
+	}
+}
+
+// Test_webhook_Handle_PreservesUnrelatedDurationFormatting is a regression
+// test for https://github.com/akuityio/akuity-platform/issues/12384: a
+// hand-written timestamp was rewritten to its canonical form in the
+// admission patch even though Default() never touched it. discoveredAt is
+// only backfilled when unset, so an explicit value must survive untouched
+// even though syncing the alias label forces a real mutation.
+func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	w := newWebhook(
+		libWebhook.Config{},
+		kubeClient,
+		k8sevent.NewEventSender(&fakeevent.EventRecorder{}),
+	)
+	wh, err := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Freight{}, w)
+	require.NoError(t, err)
+
+	// A +05:00 offset that metav1.Time remarshals in UTC ("...T05:30:00Z"),
+	// same class of lossy round-trip as metav1.Duration.
+	rawFreight := []byte(`{
+		"apiVersion": "kargo.akuity.io/v1alpha1",
+		"kind": "Freight",
+		"metadata": {"name": "fake-freight", "namespace": "fake-project"},
+		"alias": "fake-alias",
+		"discoveredAt": "2024-01-15T10:30:00+05:00"
+	}`)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Object:    runtime.RawExtension{Raw: rawFreight},
+		},
+	}
+
+	resp := wh.Handle(admission.NewContextWithRequest(context.Background(), req), req)
+	require.True(t, resp.Allowed)
+
+	testCases := []struct {
+		name    string
+		path    string
+		present bool
+	}{
+		{
+			// Sanity check: this mutation must still appear, or the test
+			// below would pass by suppressing every patch, not just the
+			// spurious ones.
+			name:    "alias label is patched",
+			path:    "/metadata/labels",
+			present: true,
+		},
+		{
+			name:    "untouched discoveredAt is not rewritten",
+			path:    "/discoveredAt",
+			present: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := slices.ContainsFunc(resp.Patches, func(p jsonpatch.JsonPatchOperation) bool {
+				return p.Path == testCase.path
+			})
+			require.Equalf(t, testCase.present, got, "patches: %+v", resp.Patches)
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -114,12 +114,7 @@ func SetupWebhookWithManager(
 		admission.NewDecoder(mgr.GetScheme()),
 		k8sevent.NewEventSender(libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), "promotion-webhook")),
 	)
-	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Promotion{}).
-		WithValidator(w).
-		Complete(); err != nil {
-		return err
-	}
-	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Promotion{}, w)
+	return libWebhook.SetupValidatingAndDefaultingWebhook(mgr, &kargoapi.Promotion{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -43,6 +43,10 @@ var (
 	}
 )
 
+// mutateWebhookPath must match the path configured for this webhook in the
+// Helm chart.
+const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-promotion"
+
 type webhook struct {
 	client  client.Client
 	decoder admission.Decoder
@@ -114,10 +118,16 @@ func SetupWebhookWithManager(
 		admission.NewDecoder(mgr.GetScheme()),
 		k8sevent.NewEventSender(libEvent.NewRecorder(ctx, mgr.GetScheme(), mgr.GetClient(), "promotion-webhook")),
 	)
-	return ctrl.NewWebhookManagedBy(mgr, &kargoapi.Promotion{}).
-		WithDefaulter(w).
+	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Promotion{}).
 		WithValidator(w).
-		Complete()
+		Complete(); err != nil {
+		return err
+	}
+	mgr.GetWebhookServer().Register(
+		mutateWebhookPath,
+		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Promotion{}, w),
+	)
+	return nil
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/promotion/webhook.go
+++ b/pkg/webhook/kubernetes/promotion/webhook.go
@@ -43,10 +43,6 @@ var (
 	}
 )
 
-// mutateWebhookPath must match the path configured for this webhook in the
-// Helm chart.
-const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-promotion"
-
 type webhook struct {
 	client  client.Client
 	decoder admission.Decoder
@@ -123,11 +119,7 @@ func SetupWebhookWithManager(
 		Complete(); err != nil {
 		return err
 	}
-	mgr.GetWebhookServer().Register(
-		mutateWebhookPath,
-		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Promotion{}, w),
-	)
-	return nil
+	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Promotion{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/promotion/webhook_test.go
+++ b/pkg/webhook/kubernetes/promotion/webhook_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -2765,6 +2767,81 @@ func Test_webhook_Authorize(t *testing.T) {
 					"create",
 				),
 			)
+		})
+	}
+}
+
+// Test_webhook_Handle_PreservesUnrelatedDurationFormatting is a regression
+// test for https://github.com/akuityio/akuity-platform/issues/12384: a
+// hand-written duration like "1h" was rewritten to its canonical form
+// ("1h0m0s") in the admission patch even though Default() never touched it.
+// On Update, Default() doesn't rewrite spec.steps (only Create does, from
+// the Stage's PromotionTemplate), so a step's retry timeout must survive
+// untouched even though syncing the shard label forces a real mutation.
+func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&kargoapi.Stage{
+		ObjectMeta: metav1.ObjectMeta{Name: "fake-stage", Namespace: "fake-project"},
+		Spec:       kargoapi.StageSpec{Shard: "fake-shard"},
+	}).Build()
+	w := newWebhook(
+		libWebhook.Config{},
+		kubeClient,
+		admission.NewDecoder(scheme),
+		k8sevent.NewEventSender(&fakeevent.EventRecorder{}),
+	)
+	wh, err := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Promotion{}, w)
+	require.NoError(t, err)
+
+	rawPromo := []byte(`{
+		"apiVersion": "kargo.akuity.io/v1alpha1",
+		"kind": "Promotion",
+		"metadata": {"name": "fake-promo", "namespace": "fake-project"},
+		"spec": {
+			"stage": "fake-stage",
+			"freight": "abc1234567",
+			"steps": [{"uses": "git-clone", "retry": {"timeout": "1h"}}]
+		}
+	}`)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Object:    runtime.RawExtension{Raw: rawPromo},
+			OldObject: runtime.RawExtension{Raw: rawPromo},
+		},
+	}
+
+	resp := wh.Handle(admission.NewContextWithRequest(context.Background(), req), req)
+	require.True(t, resp.Allowed)
+
+	testCases := []struct {
+		name    string
+		path    string
+		present bool
+	}{
+		{
+			// Sanity check: this mutation must still appear, or the test
+			// below would pass by suppressing every patch, not just the
+			// spurious ones.
+			name:    "shard label is patched",
+			path:    "/metadata/labels",
+			present: true,
+		},
+		{
+			name:    "untouched retry timeout is not rewritten",
+			path:    "/spec/steps/0/retry/timeout",
+			present: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := slices.ContainsFunc(resp.Patches, func(p jsonpatch.JsonPatchOperation) bool {
+				return p.Path == testCase.path
+			})
+			require.Equalf(t, testCase.present, got, "patches: %+v", resp.Patches)
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/stage/webhook.go
+++ b/pkg/webhook/kubernetes/stage/webhook.go
@@ -57,12 +57,7 @@ func SetupWebhookWithManager(
 		mgr.GetClient(),
 		admission.NewDecoder(mgr.GetScheme()),
 	)
-	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Stage{}).
-		WithValidator(w).
-		Complete(); err != nil {
-		return err
-	}
-	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Stage{}, w)
+	return libWebhook.SetupValidatingAndDefaultingWebhook(mgr, &kargoapi.Stage{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/stage/webhook.go
+++ b/pkg/webhook/kubernetes/stage/webhook.go
@@ -25,6 +25,10 @@ var (
 	}
 )
 
+// mutateWebhookPath must match the path configured for this webhook in the
+// Helm chart.
+const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-stage"
+
 type webhook struct {
 	client  client.Client
 	decoder admission.Decoder
@@ -57,10 +61,16 @@ func SetupWebhookWithManager(
 		mgr.GetClient(),
 		admission.NewDecoder(mgr.GetScheme()),
 	)
-	return ctrl.NewWebhookManagedBy(mgr, &kargoapi.Stage{}).
-		WithDefaulter(w).
+	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Stage{}).
 		WithValidator(w).
-		Complete()
+		Complete(); err != nil {
+		return err
+	}
+	mgr.GetWebhookServer().Register(
+		mutateWebhookPath,
+		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Stage{}, w),
+	)
+	return nil
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/stage/webhook.go
+++ b/pkg/webhook/kubernetes/stage/webhook.go
@@ -25,10 +25,6 @@ var (
 	}
 )
 
-// mutateWebhookPath must match the path configured for this webhook in the
-// Helm chart.
-const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-stage"
-
 type webhook struct {
 	client  client.Client
 	decoder admission.Decoder
@@ -66,11 +62,7 @@ func SetupWebhookWithManager(
 		Complete(); err != nil {
 		return err
 	}
-	mgr.GetWebhookServer().Register(
-		mutateWebhookPath,
-		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Stage{}, w),
-	)
-	return nil
+	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Stage{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/stage/webhook_test.go
+++ b/pkg/webhook/kubernetes/stage/webhook_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1481,6 +1483,87 @@ func Test_webhook_validatePromotionStepTaskRefs(t *testing.T) {
 					testCase.steps,
 				),
 			)
+		})
+	}
+}
+
+// Test_webhook_Handle_PreservesUnrelatedDurationFormatting is a regression
+// test for https://github.com/akuityio/akuity-platform/issues/12384: a
+// hand-written duration like "1h" was rewritten to its canonical form
+// ("1h0m0s") in the admission patch even though Default() never touched it,
+// causing perpetual Argo CD drift.
+func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	w := newWebhook(
+		libWebhook.Config{},
+		kubeClient,
+		admission.NewDecoder(scheme),
+	)
+	wh := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Stage{}, w)
+
+	// spec.shard is set so Default() makes a real mutation (the shard
+	// label), verified below as a sanity check.
+	rawStage := []byte(`{
+		"apiVersion": "kargo.akuity.io/v1alpha1",
+		"kind": "Stage",
+		"metadata": {"name": "drift-stage", "namespace": "dur-drift-repro"},
+		"spec": {
+			"shard": "us-east-01a",
+			"requestedFreight": [{
+				"origin": {"kind": "Warehouse", "name": "drift-wh"},
+				"sources": {"direct": true, "requiredSoakTime": "2h"}
+			}],
+			"promotionTemplate": {
+				"spec": {
+					"steps": [{"uses": "git-clone", "retry": {"timeout": "1h"}}]
+				}
+			}
+		}
+	}`)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: rawStage},
+		},
+	}
+
+	resp := wh.Handle(admission.NewContextWithRequest(context.Background(), req), req)
+	require.True(t, resp.Allowed)
+
+	testCases := []struct {
+		name    string
+		path    string
+		present bool
+	}{
+		{
+			// Sanity check: this mutation must still appear, or the test
+			// below would pass by suppressing every patch, not just the
+			// spurious ones.
+			name:    "shard label is patched",
+			path:    "/metadata/labels",
+			present: true,
+		},
+		{
+			name:    "untouched retry timeout is not rewritten",
+			path:    "/spec/promotionTemplate/spec/steps/0/retry/timeout",
+			present: false,
+		},
+		{
+			name:    "untouched required soak time is not rewritten",
+			path:    "/spec/requestedFreight/0/sources/requiredSoakTime",
+			present: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := slices.ContainsFunc(resp.Patches, func(p jsonpatch.JsonPatchOperation) bool {
+				return p.Path == testCase.path
+			})
+			require.Equalf(t, testCase.present, got, "patches: %+v", resp.Patches)
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/stage/webhook_test.go
+++ b/pkg/webhook/kubernetes/stage/webhook_test.go
@@ -1502,7 +1502,8 @@ func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
 		kubeClient,
 		admission.NewDecoder(scheme),
 	)
-	wh := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Stage{}, w)
+	wh, err := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Stage{}, w)
+	require.NoError(t, err)
 
 	// spec.shard is set so Default() makes a real mutation (the shard
 	// label), verified below as a sanity check.

--- a/pkg/webhook/kubernetes/warehouse/webhook.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook.go
@@ -26,6 +26,10 @@ var warehouseGroupKind = schema.GroupKind{
 	Kind:  "Warehouse",
 }
 
+// mutateWebhookPath must match the path configured for this webhook in the
+// Helm chart.
+const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-warehouse"
+
 type webhook struct {
 	client             client.Client
 	subscriberRegistry subscription.SubscriberRegistry
@@ -36,10 +40,16 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		mgr.GetClient(),
 		subscription.DefaultSubscriberRegistry,
 	)
-	return ctrl.NewWebhookManagedBy(mgr, &kargoapi.Warehouse{}).
-		WithDefaulter(w).
+	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Warehouse{}).
 		WithValidator(w).
-		Complete()
+		Complete(); err != nil {
+		return err
+	}
+	mgr.GetWebhookServer().Register(
+		mutateWebhookPath,
+		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Warehouse{}, w),
+	)
+	return nil
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/warehouse/webhook.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook.go
@@ -36,12 +36,7 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		mgr.GetClient(),
 		subscription.DefaultSubscriberRegistry,
 	)
-	if err := ctrl.NewWebhookManagedBy(mgr, &kargoapi.Warehouse{}).
-		WithValidator(w).
-		Complete(); err != nil {
-		return err
-	}
-	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Warehouse{}, w)
+	return libWebhook.SetupValidatingAndDefaultingWebhook(mgr, &kargoapi.Warehouse{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/warehouse/webhook.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook.go
@@ -26,10 +26,6 @@ var warehouseGroupKind = schema.GroupKind{
 	Kind:  "Warehouse",
 }
 
-// mutateWebhookPath must match the path configured for this webhook in the
-// Helm chart.
-const mutateWebhookPath = "/mutate-kargo-akuity-io-v1alpha1-warehouse"
-
 type webhook struct {
 	client             client.Client
 	subscriberRegistry subscription.SubscriberRegistry
@@ -45,11 +41,7 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete(); err != nil {
 		return err
 	}
-	mgr.GetWebhookServer().Register(
-		mutateWebhookPath,
-		libWebhook.NewDefaultingWebhook(mgr.GetScheme(), &kargoapi.Warehouse{}, w),
-	)
-	return nil
+	return libWebhook.RegisterDefaultingWebhook(mgr, &kargoapi.Warehouse{}, w)
 }
 
 func newWebhook(

--- a/pkg/webhook/kubernetes/warehouse/webhook_test.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook_test.go
@@ -3,20 +3,25 @@ package warehouse
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kargoapi "github.com/akuity/kargo/api/v1alpha1"
 	"github.com/akuity/kargo/pkg/credentials"
 	"github.com/akuity/kargo/pkg/subscription"
+	libWebhook "github.com/akuity/kargo/pkg/webhook/kubernetes"
 )
 
 // testRegistry is a subscriber registry for use in tests.
@@ -605,6 +610,69 @@ func TestValidateSpec(t *testing.T) {
 					&testCase.spec,
 				),
 			)
+		})
+	}
+}
+
+// Test_webhook_Handle_PreservesUnrelatedDurationFormatting is a regression
+// test for https://github.com/akuityio/akuity-platform/issues/12384, mirroring
+// the Warehouse repro from that issue: an image subscription with no
+// explicit discoveryLimit prompts a real Default() mutation, and
+// spec.interval must survive untouched even though it never gets read or
+// written by Default().
+func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kargoapi.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	w := newWebhook(kubeClient, subscription.DefaultSubscriberRegistry)
+	wh := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Warehouse{}, w)
+
+	rawWarehouse := []byte(`{
+		"apiVersion": "kargo.akuity.io/v1alpha1",
+		"kind": "Warehouse",
+		"metadata": {"name": "drift-wh", "namespace": "dur-drift-repro"},
+		"spec": {
+			"interval": "10m",
+			"subscriptions": [{"image": {"repoURL": "public.ecr.aws/docker/library/nginx"}}]
+		}
+	}`)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: rawWarehouse},
+		},
+	}
+
+	resp := wh.Handle(admission.NewContextWithRequest(context.Background(), req), req)
+	require.True(t, resp.Allowed)
+
+	testCases := []struct {
+		name    string
+		path    string
+		present bool
+	}{
+		{
+			// Sanity check: this mutation must still appear, or the test
+			// below would pass by suppressing every patch, not just the
+			// spurious ones.
+			name:    "image discoveryLimit is defaulted",
+			path:    "/spec/subscriptions/0/image/discoveryLimit",
+			present: true,
+		},
+		{
+			name:    "untouched interval is not rewritten",
+			path:    "/spec/interval",
+			present: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := slices.ContainsFunc(resp.Patches, func(p jsonpatch.JsonPatchOperation) bool {
+				return p.Path == testCase.path
+			})
+			require.Equalf(t, testCase.present, got, "patches: %+v", resp.Patches)
 		})
 	}
 }

--- a/pkg/webhook/kubernetes/warehouse/webhook_test.go
+++ b/pkg/webhook/kubernetes/warehouse/webhook_test.go
@@ -626,7 +626,8 @@ func Test_webhook_Handle_PreservesUnrelatedDurationFormatting(t *testing.T) {
 
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	w := newWebhook(kubeClient, subscription.DefaultSubscriberRegistry)
-	wh := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Warehouse{}, w)
+	wh, err := libWebhook.NewDefaultingWebhook(scheme, &kargoapi.Warehouse{}, w)
+	require.NoError(t, err)
 
 	rawWarehouse := []byte(`{
 		"apiVersion": "kargo.akuity.io/v1alpha1",


### PR DESCRIPTION
Closes: https://github.com/akuityio/akuity-platform/issues/12384
Closes: https://github.com/akuity/kargo/issues/6627

## Disclaimer

This does not heal existing damage, just prevents the reported behavior from occurring going forward.

### Before (reproducing the bug)


https://github.com/user-attachments/assets/a2c85cf6-3820-4b8c-96a1-044453a24a3e



### After (validating the fix)


https://github.com/user-attachments/assets/a949b79b-3bc7-4913-a0af-bbc63cc84db0


### Resources used in demo

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: Project
metadata:
  name: kargo-demo
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Warehouse
metadata:
  name: issue-12384-warehouse
  namespace: kargo-demo
spec:
  interval: 10m
  subscriptions:
  - image:
      repoURL: public.ecr.aws/docker/library/nginx
---
apiVersion: kargo.akuity.io/v1alpha1
kind: Stage
metadata:
  name: issue-12384
  namespace: kargo-demo
spec:
  shard: issue-12384-demo
  requestedFreight:
  - origin:
      kind: Warehouse
      name: issue-12384-warehouse
    sources:
      direct: true
      requiredSoakTime: 2h
  promotionTemplate:
    spec:
      steps:
      - uses: git-clone
        retry:
          timeout: 1h
```

### Script used in demo

```shell
#!/usr/bin/env bash

set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
MANIFEST="${SCRIPT_DIR}/issue-12384.yaml"

NAMESPACE="kargo-demo"
PROJECT="kargo-demo"
WAREHOUSE="issue-12384-warehouse"
STAGE="issue-12384"

DELETE_TIMEOUT=30 # seconds to wait for the old Warehouse/Stage to finish deleting

log() { printf '\n\033[1;36m[demo]\033[0m %s\n' "$*"; }
die() { printf '\n\033[1;31m[demo] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }

for bin in kubectl; do
  command -v "$bin" >/dev/null 2>&1 || die "'$bin' is required on PATH"
done

log "Ensuring the kargo-demo Project (and its namespace) exists"
kubectl apply -f - <<EOF
apiVersion: kargo.akuity.io/v1alpha1
kind: Project
metadata:
  name: ${PROJECT}
EOF
waited=0
while ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; do
  (( waited >= DELETE_TIMEOUT )) && die "namespace '$NAMESPACE' was not created within ${DELETE_TIMEOUT}s"
  sleep 1
  waited=$((waited + 1))
done

log "Deleting any pre-existing '$WAREHOUSE' / '$STAGE' so this run gets fresh Create-time defaulting"
kubectl delete stage "$STAGE" -n "$NAMESPACE" --ignore-not-found --wait=true --timeout="${DELETE_TIMEOUT}s"
kubectl delete warehouse "$WAREHOUSE" -n "$NAMESPACE" --ignore-not-found --wait=true --timeout="${DELETE_TIMEOUT}s"

log "Applying manifest"
kubectl apply -f "$MANIFEST"

log "Live resources (compare Interval / Retry / Required Soak Time below against manifests/issue-12384.yaml)"
# Trimmed to the Spec: block -- the Warehouse's Status: section grows a long
# Discovered Artifacts image-tag list once it's had time to reconcile, which
# only clutters this comparison.
kubectl describe warehouse "$WAREHOUSE" -n "$NAMESPACE" | awk '/^Spec:/{p=1} /^Status:/{p=0} p'
kubectl describe stage "$STAGE" -n "$NAMESPACE"

warehouse_interval="$(kubectl get warehouse "$WAREHOUSE" -n "$NAMESPACE" -o jsonpath='{.spec.interval}')"
warehouse_strategy="$(kubectl get warehouse "$WAREHOUSE" -n "$NAMESPACE" -o jsonpath='{.spec.subscriptions[0].image.imageSelectionStrategy}')"
stage_shard_label="$(kubectl get stage "$STAGE" -n "$NAMESPACE" -o jsonpath="{.metadata.labels['kargo\.akuity\.io/shard']}")"
stage_soak_time="$(kubectl get stage "$STAGE" -n "$NAMESPACE" -o jsonpath='{.spec.requestedFreight[0].sources.requiredSoakTime}')"
stage_retry_timeout="$(kubectl get stage "$STAGE" -n "$NAMESPACE" -o jsonpath='{.spec.promotionTemplate.spec.steps[0].retry.timeout}')"

log "Sanity check: Default() DOES intend to touch these, so they must actually be set --" \
    "otherwise a drift-free result below wouldn't mean anything"
[[ "$warehouse_strategy" == "SemVer" ]] ||
  die "expected the Warehouse's image subscription to be defaulted to strategy 'SemVer', got '$warehouse_strategy'"
log "  image subscription defaulted: imageSelectionStrategy=$warehouse_strategy"
[[ "$stage_shard_label" == "issue-12384-demo" ]] ||
  die "expected the Stage's shard label to be synced to 'issue-12384-demo', got '$stage_shard_label'"
log "  shard label synced: $stage_shard_label"

declare -a fields=()
declare -a desired=()
declare -a live=()

fields+=("Warehouse spec.interval");                        desired+=("10m"); live+=("$warehouse_interval")
fields+=("Stage spec.requestedFreight[0].sources.requiredSoakTime"); desired+=("2h");  live+=("$stage_soak_time")
fields+=("Stage spec.promotionTemplate.spec.steps[0].retry.timeout"); desired+=("1h");  live+=("$stage_retry_timeout")

drifted=0
echo
echo "============================================================"
for i in "${!fields[@]}"; do
  if [[ "${desired[$i]}" == "${live[$i]}" ]]; then
    printf '  OK     %-58s %s (unchanged)\n' "${fields[$i]}:" "${live[$i]}"
  else
    printf '  DRIFT  %-58s wrote %-6s -> live %s\n' "${fields[$i]}:" "${desired[$i]}" "${live[$i]}"
    drifted=$((drifted + 1))
  fi
done
echo "============================================================"

if (( drifted > 0 )); then
  echo "RESULT: BUG REPRODUCED ($drifted/${#fields[@]} fields rewritten)"
  echo "  Every one of these fields was admitted with a different value than"
  echo "  what's written above, even though Default() never reads or writes"
  echo "  any of them. An Argo CD Application syncing this manifest would show"
  echo "  Synced immediately after every sync, then flip back to OutOfSync as"
  echo "  soon as it re-diffs -- forever."
else
  echo "RESULT: FIX CONFIRMED"
  echo "  All fields came back exactly as written, even though the shard label"
  echo "  and image subscription defaults were still set in the same admission."
fi
```