### PR TITLE
feat(ui): make the Stage drawer's active tab addressable by URL

### DIFF
--- a/ui/src/config/paths.ts
+++ b/ui/src/config/paths.ts
@@ -5,7 +5,7 @@ export const paths = {
   createProjectGuided: '/create-project',
   project: '/project/:name',
   projectEvents: '/project/:name/events',
-  stage: '/project/:name/stage/:stageName',
+  stage: '/project/:name/stage/:stageName/:tab?',
   warehouse: '/project/:name/warehouse/:warehouseName/:tab?',
   promotion: '/project/:name/promotion/:promotionId',
   promote: '/project/:name/promote/freight/:freight/stage/:stage',

--- a/ui/src/features/stage/stage-details.tsx
+++ b/ui/src/features/stage/stage-details.tsx
@@ -34,22 +34,15 @@ import { StageConditionIcon } from '../common/stage-status/stage-condition-icon'
 import { Promotions } from './promotions';
 import { RequestedFreight } from './requested-freight';
 import { StageActions } from './stage-actions';
+import { StageTab, extensionTabKey, resolveStageTab } from './stage-tabs';
 import { FreightHistory } from './tabs/freight-history/freight-history';
 import { useGetFreightMap } from './tabs/freight-history/use-get-freight-map';
 import { StageSettings } from './tabs/settings/stage-settings';
 import { useImages } from './use-images';
 import { Verifications } from './verifications';
 
-enum TabsTypes {
-  PROMOTION = 'Promotion',
-  VERIFICATIONS = 'Verification',
-  LIVE_MANIFEST = 'Live Manifest',
-  FREIGHT_HISTORY = 'Freight History',
-  SETTINGS = 'Settings'
-}
-
 export const StageDetails = ({ stage }: { stage: Stage }) => {
-  const { name: projectName, stageName } = useParams();
+  const { name: projectName, stageName, tab } = useParams();
   const navigate = useNavigate();
 
   const images = useImages([stage]);
@@ -83,10 +76,29 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
 
   const stageQuery = useGetStage(projectName || '', stage?.metadata?.name || '');
 
-  const [activeTab, setActiveTab] = useState(TabsTypes.PROMOTION);
+  const { stageTabs } = useExtensionsContext();
+
+  // Extension tabs are keyed by a slug of their label so they, too, can be
+  // addressed by URL. Keys are assigned in order so a duplicate label gets a
+  // distinct key.
+  const extensionTabKeys = useMemo(() => {
+    const taken = new Set<string>(Object.values(StageTab));
+    return stageTabs.map((data) => {
+      const key = extensionTabKey(data.label, taken);
+      taken.add(key);
+      return key;
+    });
+  }, [stageTabs]);
+
+  // The active tab lives in the URL (the optional :tab segment of the Stage
+  // route), so a tab can be linked to directly. Unknown segments show the
+  // default tab.
+  const activeTab = resolveStageTab(tab, extensionTabKeys);
+  const setActiveTab = (newTab: string) =>
+    navigate(generatePath(paths.stage, { name: projectName, stageName, tab: newTab }));
 
   useEffect(() => {
-    if (activeTab === TabsTypes.LIVE_MANIFEST) {
+    if (activeTab === StageTab.LIVE_MANIFEST) {
       stageQuery.refetch();
     }
   }, [stage, activeTab]);
@@ -98,8 +110,6 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
 
   const shardKey = stage?.metadata?.labels?.[SHARD_LABEL_KEY] || '';
   const argocdShard = config?.argocdShards?.[shardKey];
-
-  const { stageTabs } = useExtensionsContext();
 
   const stageConditions = useMemo(() => stage.status?.conditions || [], [stage.status?.conditions]);
 
@@ -153,19 +163,18 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
             <AutoPromotionHolds stage={stage} />
             <Tabs
               className='flex-1'
-              defaultActiveKey='1'
               style={{ minHeight: 'fit-content' }}
               activeKey={activeTab}
-              onChange={(newActiveTab) => setActiveTab(newActiveTab as TabsTypes)}
+              onChange={setActiveTab}
               items={[
                 {
-                  key: TabsTypes.PROMOTION,
+                  key: StageTab.PROMOTIONS,
                   label: 'Promotions',
                   icon: <FontAwesomeIcon icon={faCircleUp} />,
                   children: <Promotions stage={stage} argocdShard={argocdShard} />
                 },
                 {
-                  key: TabsTypes.VERIFICATIONS,
+                  key: StageTab.VERIFICATIONS,
                   label: 'Verifications',
                   icon: <FontAwesomeIcon icon={faCircleCheck} />,
                   children: (
@@ -176,7 +185,7 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
                   )
                 },
                 {
-                  key: TabsTypes.LIVE_MANIFEST,
+                  key: StageTab.LIVE_MANIFEST,
                   label: 'Live Manifest',
                   icon: <FontAwesomeIcon icon={faBarsStaggered} />,
                   className: 'h-full pb-2',
@@ -187,7 +196,7 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
                   )
                 },
                 {
-                  key: TabsTypes.FREIGHT_HISTORY,
+                  key: StageTab.FREIGHT_HISTORY,
                   label: 'Freight History',
                   icon: <FontAwesomeIcon icon={faHistory} />,
                   children: (
@@ -202,12 +211,12 @@ export const StageDetails = ({ stage }: { stage: Stage }) => {
                 },
                 ...stageTabs.map((data, index) => ({
                   children: <data.component stage={stage} />,
-                  key: String(data.label + index),
+                  key: extensionTabKeys[index],
                   label: data.label,
                   icon: data.icon
                 })),
                 {
-                  key: TabsTypes.SETTINGS,
+                  key: StageTab.SETTINGS,
                   label: 'Settings',
                   icon: <FontAwesomeIcon icon={faGear} />,
                   children: <StageSettings />

--- a/ui/src/features/stage/stage-tabs.test.ts
+++ b/ui/src/features/stage/stage-tabs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { DEFAULT_STAGE_TAB, StageTab, extensionTabKey, resolveStageTab } from './stage-tabs';
+
+describe('resolveStageTab()', () => {
+  test('no segment falls back to the default tab', () => {
+    expect(resolveStageTab(undefined)).toBe(DEFAULT_STAGE_TAB);
+    expect(resolveStageTab('')).toBe(DEFAULT_STAGE_TAB);
+  });
+
+  test.each(Object.values(StageTab))('built-in tab %s resolves to itself', (key) => {
+    expect(resolveStageTab(key)).toBe(key);
+  });
+
+  test('an extension tab resolves when its key is known', () => {
+    expect(resolveStageTab('argo-cd', ['argo-cd'])).toBe('argo-cd');
+  });
+
+  test('an unknown segment falls back to the default tab', () => {
+    expect(resolveStageTab('nope')).toBe(DEFAULT_STAGE_TAB);
+    expect(resolveStageTab('Promotions')).toBe(DEFAULT_STAGE_TAB);
+  });
+});
+
+describe('extensionTabKey()', () => {
+  test('slugifies the label', () => {
+    expect(extensionTabKey('Argo CD', new Set())).toBe('argo-cd');
+    expect(extensionTabKey('  Cost / Usage!  ', new Set())).toBe('cost-usage');
+  });
+
+  test('never collides with a built-in or earlier key', () => {
+    const taken = new Set<string>([...Object.values(StageTab), 'argo-cd']);
+    expect(extensionTabKey('Settings', taken)).toBe('settings-2');
+    expect(extensionTabKey('Argo CD', taken)).toBe('argo-cd-2');
+    taken.add('argo-cd-2');
+    expect(extensionTabKey('Argo CD', taken)).toBe('argo-cd-3');
+  });
+
+  test('a label with no usable characters still yields a key', () => {
+    expect(extensionTabKey('!!!', new Set())).toBe('tab');
+  });
+});

--- a/ui/src/features/stage/stage-tabs.ts
+++ b/ui/src/features/stage/stage-tabs.ts
@@ -1,0 +1,54 @@
+// The Stage drawer's tabs are addressable by URL: /project/:name/stage/:stageName/:tab.
+// Keys double as the URL segment, so they are lowercase slugs rather than the
+// labels shown on screen.
+export const StageTab = {
+  PROMOTIONS: 'promotions',
+  VERIFICATIONS: 'verifications',
+  LIVE_MANIFEST: 'live-manifest',
+  FREIGHT_HISTORY: 'freight-history',
+  SETTINGS: 'settings'
+} as const;
+
+export type StageTabKey = (typeof StageTab)[keyof typeof StageTab];
+
+export const DEFAULT_STAGE_TAB: StageTabKey = StageTab.PROMOTIONS;
+
+const builtInTabs = new Set<string>(Object.values(StageTab));
+
+// extensionTabKey derives a URL-safe key for a tab an extension contributes,
+// from its label. Keys already taken (by a built-in tab or an earlier
+// extension) get a numeric suffix so two extensions with the same label stay
+// distinct.
+export const extensionTabKey = (label: string, taken: Set<string>): string => {
+  const base =
+    label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'tab';
+  let key = base;
+  for (let n = 2; taken.has(key); n++) {
+    key = `${base}-${n}`;
+  }
+  return key;
+};
+
+// resolveStageTab maps the :tab route segment to the tab to show. An absent or
+// unrecognized segment falls back to the default rather than an empty pane, so
+// stale links still land somewhere useful.
+export const resolveStageTab = (
+  segment: string | undefined,
+  extensionKeys: Iterable<string> = []
+): string => {
+  if (!segment) {
+    return DEFAULT_STAGE_TAB;
+  }
+  if (builtInTabs.has(segment)) {
+    return segment;
+  }
+  for (const key of extensionKeys) {
+    if (key === segment) {
+      return segment;
+    }
+  }
+  return DEFAULT_STAGE_TAB;
+};


### PR DESCRIPTION
## Description

The Stage drawer kept its active tab in component state, so there was no way to link to a particular tab, and reloading lost the tab the user was on. The Warehouse drawer already carries its tab as an optional `:tab` segment of its route; this gives the Stage drawer the same treatment.

- The Stage route becomes `/project/:name/stage/:stageName/:tab?`. The drawer reads its active tab from the segment and navigates on change.
- Existing links that omit the segment are unaffected: `generatePath` drops an optional segment it is not given, and an absent segment resolves to Promotions as before.
- Tab keys become URL slugs (`promotions`, `verifications`, `live-manifest`, `freight-history`, `settings`) and move into `stage-tabs.ts`, so anything that builds a link to a tab shares one definition.
- Tabs contributed by extensions are keyed by a slug of their label, with a numeric suffix if that collides with a built-in or an earlier extension, so they can be linked to as well.
- An unrecognized segment shows the default tab rather than an empty pane, so a stale link still lands somewhere useful.

## Testing

- `stage-tabs.test.ts` covers default resolution, every built-in key, extension keys, unknown segments, and slug collisions.
- `pnpm typecheck`, `pnpm lint`, and `pnpm vitest run` pass.
- Verified against a live cluster: a deep link to `/stage/<name>/verifications` opens on Verifications; clicking Freight History updates the URL; no segment and a bogus segment both show Promotions; browser back returns to the previous tab.

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels.
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [ ] Are cryptographically signed (`git commit -S`) **(encouraged)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
