### PR TITLE
chore(ci): extend the release branch dependency freezes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,17 @@
 # them at all. Dependabot can neither tell the roles apart nor move a role's
 # pins in lock-step, so raising Go is a coordinated, whole-branch change made
 # by hand. The comment at each pin says which role it serves.
+#
+# golangci-lint is excluded from the gomod ecosystem on the release branches
+# that still have a hack/tools module. Nothing is built from that module;
+# hack/tools.mk greps it for the version of the prebuilt linter binary to
+# install. Raising the linter on a stable branch changes what CI enforces and
+# can only turn up new findings in code that is already frozen.
+#
+# google.golang.org/api is excluded on the release branches because its own
+# go.mod pins google.golang.org/grpc and google.golang.org/protobuf. Raising it
+# drags both past the versions frozen here, so ignoring those two by name does
+# not hold on its own.
 version: 2
 updates:
   # ----------------------------- main -----------------------------
@@ -212,8 +223,10 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -239,8 +252,10 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -268,8 +283,10 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -348,9 +365,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -376,9 +395,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -404,9 +425,12 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
+    - dependency-name: "github.com/golangci/golangci-lint*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -432,9 +456,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/client):"
     groups:
@@ -513,9 +539,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -541,9 +569,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -569,9 +599,12 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
+    - dependency-name: "github.com/golangci/golangci-lint*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:
@@ -650,9 +683,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps):"
     groups:
@@ -678,9 +713,11 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
     commit-message:
       prefix: "chore(deps/api):"
     groups:
@@ -706,9 +743,12 @@ updates:
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "github.com/grpc-ecosystem/*"
     - dependency-name: "*protobuf*"
+    - dependency-name: "google.golang.org/api"
     - dependency-name: "oras.land/*"
     - dependency-name: "helm.sh/helm/v3"
-    - dependency-name: "connectrpc.com/connect"
+    - dependency-name: "connectrpc.com/*"
+    - dependency-name: "github.com/bufbuild/buf"
+    - dependency-name: "github.com/golangci/golangci-lint*"
     commit-message:
       prefix: "chore(deps/hack):"
     groups:


### PR DESCRIPTION
Four freezes, batched into one change because every edit to this file draws a fresh flurry of update PRs.

**`google.golang.org/api`**, on all four release branches. This is the one that matters. Every `go-minor` group PR on every release branch — #7162, #7167, #7169, #7170 — moved `google.golang.org/grpc` from 1.82.1 to 1.83.2 and `google.golang.org/protobuf` from 1.36.11 to 1.36.12, and neither was among the listed updates. They came along for the ride: `google.golang.org/api@v0.297.0` requires exactly those two versions in its own `go.mod`, so minimum version selection raises the root module. Ignoring grpc and protobuf stops Dependabot proposing them and does nothing about the module graph dragging them, which is why those PRs were unmergeable however many ignore lines we added. None of the other subjects in those PRs requires anything newer, so this is the only dependency that needed to move. The cost is that GCP client library patches no longer reach the release branches.

**`connectrpc.com/*`**, widened from `connectrpc.com/connect`. `connectrpc.com/grpchealth` was a subject in every one of those group PRs and the exact name did not cover it.

**`github.com/bufbuild/buf`**, on all four branches, for the same reason gRPC and protobuf are frozen: `buf` drives protobuf code generation, and moving it on a branch whose protobuf story is deliberately pinned invites a regeneration we don't want. It lives in `/hack/tools` on release-1.8 through release-1.10 and in the root module — as a `tool` directive — on release-1.11.

**`github.com/golangci/golangci-lint`**, on release-1.8, release-1.9 and release-1.10 — the branches that still have a `hack/tools` module. Nothing is built from that module: `hack/tools.mk` greps `hack/tools/go.mod` for the version of the prebuilt linter binary to install. Raising the linter on a stable branch therefore changes what CI enforces, and can only turn up new findings in code that is already frozen. release-1.11 and `main` pin the version directly in `hack/tools.mk`, so Dependabot never sees it there.

As with the freezes already in this file, each ignore line goes on every `gomod` entry for the branches it applies to, rather than only the entry whose module currently has the dependency.

## Follow-ups, not in this PR

- The three `/hack/tools` `gomod` entries could be dropped outright. Everything in that module is a version pin for a dev or CI tool, none of it ships to users, and most of what remains unfrozen there — `go-swagger`, `swag`, `golang.org/x/tools` — regenerates checked-in code.
- #7151 bumped `github.com/go-openapi/validate` from 0.26.5 to 1.0.0 inside the **`go-patch`** group. A 0.x to 1.0 jump reached a branch that ignores `version-update:semver-major`, because Dependabot classified it as a patch. That applies to every 0.x dependency on these branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
