### PR TITLE
fix(ui): validate OIDC authorization nonce

### DIFF
--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -4,6 +4,7 @@ import {
   discoveryRequest,
   processDiscoveryResponse,
   generateRandomCodeVerifier,
+  generateRandomNonce,
   generateRandomState,
   calculatePKCECodeChallenge,
   validateAuthResponse,
@@ -21,14 +22,13 @@ import { OIDCConfig } from '@ui/gen/api/v2/models';
 
 import { useAuthContext } from './context/use-auth-context';
 import {
+  consumeOIDCCallbackArtifacts,
   getOIDCScopes,
   oidcClientAuth,
+  oidcErrorMessage,
+  oidcSessionStorageKeys,
   shouldAllowIdpHttpRequest as shouldAllowHttpRequest
 } from './oidc-utils';
-
-const codeVerifierKey = 'PKCE_code_verifier';
-const stateKey = 'PKCE_state';
-const platformRedirectKey = 'platform_redirect';
 
 type Props = {
   oidcConfig: OIDCConfig;
@@ -83,10 +83,12 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
     }
 
     const code_verifier = generateRandomCodeVerifier();
-    sessionStorage.setItem(codeVerifierKey, code_verifier);
+    sessionStorage.setItem(oidcSessionStorageKeys.codeVerifier, code_verifier);
     const state = generateRandomState();
-    sessionStorage.setItem(stateKey, state);
-    sessionStorage.setItem(platformRedirectKey, window.location.search);
+    sessionStorage.setItem(oidcSessionStorageKeys.state, state);
+    const nonce = generateRandomNonce();
+    sessionStorage.setItem(oidcSessionStorageKeys.nonce, nonce);
+    sessionStorage.setItem(oidcSessionStorageKeys.platformRedirect, window.location.search);
 
     const code_challenge = await calculatePKCECodeChallenge(code_verifier);
     const url = new URL(as.authorization_endpoint);
@@ -97,6 +99,7 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('scope', getOIDCScopes(oidcConfig, as).join(' '));
     url.searchParams.set('state', state);
+    url.searchParams.set('nonce', nonce);
 
     window.location.replace(url.toString());
   };
@@ -104,18 +107,26 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
   // Handle callback from OIDC provider
   React.useEffect(() => {
     (async () => {
-      const code_verifier = sessionStorage.getItem(codeVerifierKey);
-      const state = sessionStorage.getItem(stateKey);
-      const platformRedirect = sessionStorage.getItem(platformRedirectKey);
+      const code_verifier = sessionStorage.getItem(oidcSessionStorageKeys.codeVerifier);
+      const state = sessionStorage.getItem(oidcSessionStorageKeys.state);
+      const nonce = sessionStorage.getItem(oidcSessionStorageKeys.nonce);
+      const platformRedirect = sessionStorage.getItem(oidcSessionStorageKeys.platformRedirect);
       const searchParams = new URLSearchParams(location.search);
+      const isOIDCCallback = searchParams.has('code') || searchParams.has('error');
 
-      if (
-        !as ||
-        !code_verifier ||
-        !searchParams.get('code') ||
-        !state ||
-        !searchParams.get('state')
-      ) {
+      if (!as || !isOIDCCallback || !searchParams.get('state')) {
+        return;
+      }
+
+      consumeOIDCCallbackArtifacts(sessionStorage, new URL(window.location.href), (url) =>
+        window.history.replaceState(window.history.state, '', url)
+      );
+
+      if (!code_verifier || !state || !nonce) {
+        notification.error({
+          message: 'OIDC: Login state missing or expired',
+          placement: 'bottomRight'
+        });
         return;
       }
 
@@ -136,7 +147,8 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
         );
 
         const result = await processAuthorizationCodeResponse(as, client, response, {
-          requireIdToken: true
+          requireIdToken: true,
+          expectedNonce: nonce
         });
 
         if (!result.id_token) {
@@ -174,7 +186,7 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
         }
 
         notification.error({
-          message: `OIDC: ${JSON.stringify(err)}`,
+          message: `OIDC: ${oidcErrorMessage(err)}`,
           placement: 'bottomRight'
         });
       }

--- a/ui/src/features/auth/oidc-utils.test.ts
+++ b/ui/src/features/auth/oidc-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  consumeOIDCCallbackArtifacts,
+  oidcErrorMessage,
+  oidcSessionStorageKeys
+} from './oidc-utils';
+
+describe('consumeOIDCCallbackArtifacts', () => {
+  test('removes one-time browser state and callback parameters', () => {
+    const removedKeys: string[] = [];
+    let replacementURL = '';
+    const callbackURL = new URL(
+      'https://kargo.example.com/login?code=secret&state=nonce&session_state=session&iss=issuer&redirectTo=%2Fprojects#tab'
+    );
+
+    consumeOIDCCallbackArtifacts(
+      { removeItem: (key) => removedKeys.push(key) },
+      callbackURL,
+      (url) => {
+        replacementURL = url;
+      }
+    );
+
+    expect(removedKeys).toEqual(Object.values(oidcSessionStorageKeys));
+    expect(replacementURL).toBe('/login?redirectTo=%2Fprojects#tab');
+  });
+
+  test('removes OAuth error response parameters', () => {
+    let replacementURL = '';
+    const callbackURL = new URL(
+      'https://kargo.example.com/login?error=access_denied&error_description=Denied&error_uri=https%3A%2F%2Fidp.example.com%2Ferrors&state=nonce'
+    );
+
+    consumeOIDCCallbackArtifacts({ removeItem: () => undefined }, callbackURL, (url) => {
+      replacementURL = url;
+    });
+
+    expect(replacementURL).toBe('/login');
+  });
+});
+
+describe('oidcErrorMessage', () => {
+  test('shows safe comparison details without serializing claim values', () => {
+    const err = Object.assign(
+      new Error('unexpected JWT claim value', {
+        cause: {
+          claim: 'aud',
+          expected: 'client-id',
+          claims: { email: 'person@example.com' }
+        }
+      }),
+      { code: 'OAUTH_JWT_CLAIM_COMPARISON_FAILED' }
+    );
+
+    const message = oidcErrorMessage(err);
+
+    expect(message).toBe(
+      'unexpected JWT claim value (claim: aud, code: OAUTH_JWT_CLAIM_COMPARISON_FAILED)'
+    );
+    expect(message).not.toContain('client-id');
+    expect(message).not.toContain('person@example.com');
+  });
+
+  test('handles ordinary and unknown errors', () => {
+    expect(oidcErrorMessage(new Error('network failed'))).toBe('network failed');
+    expect(oidcErrorMessage({ message: 'not an Error' })).toBe('Unexpected error');
+  });
+});

--- a/ui/src/features/auth/oidc-utils.ts
+++ b/ui/src/features/auth/oidc-utils.ts
@@ -2,6 +2,54 @@ import { AuthorizationServer, ClientAuth } from 'oauth4webapi';
 
 import { OIDCConfig } from '@ui/gen/api/v2/models';
 
+export const oidcSessionStorageKeys = {
+  codeVerifier: 'PKCE_code_verifier',
+  state: 'PKCE_state',
+  nonce: 'OIDC_nonce',
+  platformRedirect: 'platform_redirect'
+} as const;
+
+const oidcCallbackQueryKeys = [
+  'code',
+  'state',
+  'session_state',
+  'iss',
+  'error',
+  'error_description',
+  'error_uri'
+] as const;
+
+export const consumeOIDCCallbackArtifacts = (
+  storage: Pick<Storage, 'removeItem'>,
+  callbackURL: URL,
+  replaceURL: (url: string) => void
+) => {
+  Object.values(oidcSessionStorageKeys).forEach((key) => storage.removeItem(key));
+  oidcCallbackQueryKeys.forEach((key) => callbackURL.searchParams.delete(key));
+  replaceURL(`${callbackURL.pathname}${callbackURL.search}${callbackURL.hash}`);
+};
+
+export const oidcErrorMessage = (err: unknown) => {
+  if (!(err instanceof Error)) {
+    return 'Unexpected error';
+  }
+
+  const details: string[] = [];
+  if (typeof err.cause === 'object' && err.cause !== null && 'claim' in err.cause) {
+    const claim = err.cause.claim;
+    if (typeof claim === 'string') {
+      details.push(`claim: ${claim}`);
+    }
+  }
+
+  if ('code' in err && typeof err.code === 'string') {
+    details.push(`code: ${err.code}`);
+  }
+
+  const message = err.message || err.name || 'Unexpected error';
+  return details.length ? `${message} (${details.join(', ')})` : message;
+};
+
 export const oidcClientAuth: ClientAuth = () => {
   // equivalent function for token_endpoint_auth_method: 'none'
 };


### PR DESCRIPTION
## Description

Closes #6797

Cognito can add a nonce claim to the ID token during a federated login. Kargo did not send or retain a nonce and therefore asked oauth4webapi to expect no nonce, causing the first federated login to fail claim validation.

This change:

- generates and persists a nonce with the existing PKCE and state values;
- sends the nonce in the authorization request and validates it in the ID token;
- consumes one-time callback state and removes callback parameters before processing; and
- reports the OAuth error message, claim name, and error code without serializing claim values.

The PR is opened as a draft because #6797 currently has the blocking area/security label.

## Checklist

### Eligibility

- [ ] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [x] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [ ] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [x] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**

## Verification

- `pnpm exec vitest run src/features/auth/oidc-utils.test.ts`
- `pnpm exec eslint src/features/auth/oidc-login.tsx src/features/auth/oidc-utils.ts src/features/auth/oidc-utils.test.ts --max-warnings=0`
- `pnpm run typecheck`
- `pnpm run build`