### PR TITLE
fix(ui): always leave the OIDC callback URL after a successful login

### DIFF
--- a/ui/src/features/auth/oidc-login.tsx
+++ b/ui/src/features/auth/oidc-login.tsx
@@ -16,7 +16,8 @@ import {
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { isSafeRedirectPath } from '@ui/config/auth';
+import { isSafeRedirectPath, redirectToQueryParam } from '@ui/config/auth';
+import { paths } from '@ui/config/paths';
 import { OIDCConfig } from '@ui/gen/api/v2/models';
 
 import { useAuthContext } from './context/use-auth-context';
@@ -149,13 +150,19 @@ export const OIDCLogin = ({ oidcConfig }: Props) => {
 
         onLogin(result.id_token, result.refresh_token);
 
-        if (platformRedirect) {
-          const redirectTo = new URLSearchParams(platformRedirect).get('redirectTo');
+        // Always leave the callback URL. Staying on /login?code=... renders
+        // the login button while a token is already stored, and a reload
+        // replays the authorization code, which the provider refuses and
+        // may answer by revoking the session it just issued (RFC 6749
+        // 4.1.2). Logout lands on a bare /login, so the next sign-in is
+        // exactly the case with no redirectTo: fall back to home.
+        const redirectTo = platformRedirect
+          ? new URLSearchParams(platformRedirect).get(redirectToQueryParam)
+          : null;
 
-          if (isSafeRedirectPath(redirectTo)) {
-            window.location.replace(window.location.origin + redirectTo);
-          }
-        }
+        window.location.replace(
+          window.location.origin + (isSafeRedirectPath(redirectTo) ? redirectTo : paths.home)
+        );
       } catch (err) {
         if (err instanceof AuthorizationResponseError) {
           notification.error({


### PR DESCRIPTION
## Description

Closes #7189

After a successful code exchange the login page only navigated away when a `redirectTo` had been carried into the flow. Logout lands on a bare `/login`, so the next sign-in carries none; when the provider still holds a session it admits the browser silently, and Kargo stores the tokens and then **stays on `/login?code=…` rendering the login button**. A reload of that URL replays the authorization code, which the provider refuses and may answer by revoking the session it just issued (RFC 6749 §4.1.2), so every reload produces a fresh session at the provider.

This always navigates after a successful exchange: to the safe `redirectTo` when there is one, otherwise to `paths.home`. No behaviour change for the path that already worked (a login started from `/login?redirectTo=…`).

Reproduced and verified headless against our OIDC provider on v1.11.2; the code is identical on `main`.

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests. (No existing tests cover `OIDCLogin`'s callback effect; the change is a fallback in a single `window.location.replace`. Happy to add one if a harness for this component is preferred.)