### PR TITLE
fix(chart): keep the chart version out of pod labels

### DIFF
--- a/charts/kargo/templates/_helpers.tpl
+++ b/charts/kargo/templates/_helpers.tpl
@@ -203,6 +203,21 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Pod labels: the common labels without helm.sh/chart. That label is the chart version, and
+including it in a pod template restarts every pod on a chart upgrade that changes nothing else.
+*/}}
+{{- define "kargo.podLabels" -}}
+{{ include "kargo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "kargo.selectorLabels" -}}

--- a/charts/kargo/templates/api/deployment.yaml
+++ b/charts/kargo/templates/api/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.api.labels" . | nindent 8 }}
       {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.api.podLabels) }}
         {{- range $key, $value := . }}

--- a/charts/kargo/templates/controller/deployment.yaml
+++ b/charts/kargo/templates/controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.controller.labels" . | nindent 8 }}
         {{- include "kargo.controller.idLabel" . | nindent 8 }}
       {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.controller.podLabels) }}

--- a/charts/kargo/templates/dex-server/deployment.yaml
+++ b/charts/kargo/templates/dex-server/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.dexServer.labels" . | nindent 8 }}
       annotations:
         secret/checksum: {{ pick ( include (print $.Template.BasePath "/dex-server/secret.yaml") . | fromYaml ) "stringData" | toYaml | sha256sum }}

--- a/charts/kargo/templates/external-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/external-webhooks-server/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.externalWebhooksServer.labels" . | nindent 8 }}
       {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.externalWebhooksServer.podLabels) }}
         {{- range $key, $value := . }}

--- a/charts/kargo/templates/garbage-collector/cron-job.yaml
+++ b/charts/kargo/templates/garbage-collector/cron-job.yaml
@@ -36,7 +36,7 @@ spec:
       template:
         metadata:
           labels:
-            {{- include "kargo.labels" . | nindent 12 }}
+            {{- include "kargo.podLabels" . | nindent 12 }}
             {{- include "kargo.garbageCollector.labels" . | nindent 12 }}
           {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.garbageCollector.podLabels) }}
             {{- range $key, $value := . }}

--- a/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
+++ b/charts/kargo/templates/kubernetes-webhooks-server/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.kubernetesWebhooksServer.labels" . | nindent 8 }}
       {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.webhooksServer.podLabels) }}
         {{- range $key, $value := . }}

--- a/charts/kargo/templates/management-controller/deployment.yaml
+++ b/charts/kargo/templates/management-controller/deployment.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kargo.labels" . | nindent 8 }}
+        {{- include "kargo.podLabels" . | nindent 8 }}
         {{- include "kargo.managementController.labels" . | nindent 8 }}
       {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.managementController.podLabels) }}
         {{- range $key, $value := . }}


### PR DESCRIPTION
## Description

Closes #7191

`kargo.labels` includes `helm.sh/chart` — the chart version — and it was applied to the pod templates as well as to the objects. Every chart version bump therefore rewrote the pod specs and Kubernetes restarted all Kargo pods on `helm upgrade`, even when nothing functional had changed.

This adds `kargo.podLabels`, the same label set without `helm.sh/chart`, and uses it in the six deployments (api, controller, management-controller, dex-server, kubernetes-webhooks-server, external-webhooks-server) and the garbage-collector CronJob's pod template. The objects keep the full `kargo.labels`, so the chart version is still visible where it belongs, and pods keep `app.kubernetes.io/version`, name, instance, managed-by and component.

The CronJob's `jobTemplate.metadata.labels` is deliberately left alone — those are Job object labels and don't cause restarts.

Verified by rendering the chart against a bumped version: no `helm.sh/chart` remains inside any pod template. `helm unittest` passes (154 tests, 48 suites).

## Checklist

### Eligibility

- [x] Linked to an existing issue with no blocking labels (`kind/proposal`, `needs discussion`, `needs research`, `maintainer only`, `area/security`, `size/large`, `size/x-large`, `size/xx-large`).
- [ ] Changes documentation only.
- [ ] Changes ten lines or fewer.

### Quality

- [ ] Adds or updates corresponding tests.
- [ ] Adds or updates corresponding documentation.

### AI Use Disclosure

This PR was written:

- [ ] By a human _without_ AI assistance.
- [ ] By a human _with_ AI assistance. A human has reviewed every line prior to opening the PR.
- [x] By an AI _with human supervision._ A human has reviewed every line prior to opening the PR.
- [ ] Entirely by an AI. No human has reviewed this prior to opening the PR.

### Sign-Off

All commits:

- [x] Are signed off by their author (`git commit -s`) **(required)**
- [x] Are cryptographically signed (`git commit -S`) **(encouraged)**